### PR TITLE
Rebuild workspace project index with cross-repo linkage

### DIFF
--- a/docs/cross-repo-feature-linkage.md
+++ b/docs/cross-repo-feature-linkage.md
@@ -1,0 +1,23 @@
+# Cross-Repo Feature Linkage
+
+This workspace index now models three feature parents that cut across the four submodules instead of treating each repository as an isolated code map.
+
+`REQ-900` tracks the fault injection lifecycle:
+- `chaos-experiment` owns CRD builders, target discovery, and registration.
+- `AegisLab` owns API submission, translation, task orchestration, and callback-driven execution.
+- `AegisLab-frontend` owns injection authoring and datapack inspection.
+
+`REQ-901` tracks dataset collection and schema flow:
+- `AegisLab` owns datapack build/upload and dataset management.
+- `AegisLab-frontend` owns datapack browsing and download UX.
+- `rcabench-platform` owns normalized dataset conversion, indexing, and artifact validation.
+
+`REQ-902` tracks RCA evaluation and benchmarking:
+- `AegisLab` owns execution submission, persistence, and evaluation endpoints.
+- `AegisLab-frontend` owns execution launch, result drill-down, and evaluation configuration.
+- `rcabench-platform` owns algorithm registries, benchmark metrics, and report aggregation.
+
+The shared contracts referenced by these features are:
+- `openapi-backend-sdk` for backend/frontend typed API coupling
+- `chaos-mesh-crd` for backend/chaos library coupling
+- `dataset-schema` for datapack production and downstream consumption

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -1,2768 +1,2963 @@
-# Unified requirements index for the aegis workspace.
-# Source of truth — symlinked from each of the 4 repos.
-# See workspace.yaml (same directory) for repo layout and contracts.
-
 workspace:
   root: .
   manifest: workspace.yaml
-  schema_version: 2
-
+  schema_version: 3
 project:
   name: AegisLab
-  languages: [go, python, typescript]
-  description: >
-    Full-stack RCA benchmarking platform. Backend (Go) + Frontend (React/TypeScript).
-    Provides automated fault injection via Chaos Mesh CRDs, RCA algorithm
-    execution and evaluation, dataset/datapack management, project/team
-    management with RBAC, observability stack integration, and a React-based
-    web UI for managing all platform features.
-
+  languages:
+  - go
+  - python
+  - typescript
+  description: Full-stack RCA benchmarking workspace spanning AegisLab backend, AegisLab-frontend UI, chaos-experiment fault injection libraries, and rcabench-platform evaluation/data consumers.
 requirements:
-  # ===========================================================================
-  # REQ-0xx: Core Platform (Auth, Users, RBAC, Teams, Projects, Labels, Audit, Config)
-  # ===========================================================================
-
-  - id: REQ-001
-    title: User Authentication (JWT)
-    description: >
-      Users authenticate via username/password login to obtain JWT access tokens.
-      Backend supports user registration, login, and token refresh. Two token types:
-      user tokens (carry user_id, username, email, is_admin, roles) and service
-      tokens (carry task_id, used by K8s jobs). OptionalJWTAuth allows
-      unauthenticated access on select endpoints.
-      Frontend provides login page with username/password form, JWT token storage
-      in localStorage, automatic token refresh on 401 via Axios interceptor,
-      logout with token cleanup, and route guards that redirect unauthenticated
-      users to /login.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "src/middleware/auth.go, src/handlers/v2/auth.go, AegisLab-frontend/src/store/auth.ts, AegisLab-frontend/src/api/auth.ts"
-
-    code:
-      - path: AegisLab/src/middleware/auth.go
-        description: "JWTAuth, OptionalJWTAuth middlewares; helper functions for extracting user/service context from JWT claims"
-      - path: AegisLab/src/handlers/v2/auth.go
-        description: "Register, Login endpoints with Swagger annotations and SDK marking"
-      - path: AegisLab/src/service/producer/auth.go
-        description: "Business logic for registration and login"
-
-    frontend:
-      - path: AegisLab-frontend/src/store/auth.ts
-        description: "Zustand store managing user, tokens, isAuthenticated state; login/logout/refresh/loadUser actions"
-      - path: AegisLab-frontend/src/api/auth.ts
-        description: "Auth API client with login, register, logout, getProfile, changePassword, refreshToken endpoints"
-      - path: AegisLab-frontend/src/api/client.ts
-        description: "Axios instance with request interceptor (attach Bearer token) and response interceptor (auto-refresh on 401)"
-      - path: AegisLab-frontend/src/pages/auth/Login.tsx
-        description: "Login form page with username/password fields, navigates to /dashboard on success"
-      - path: AegisLab-frontend/src/App.tsx
-        description: "Route guards checking isAuthenticated, redirecting to /login when not authenticated"
-    has_mock: false
-
-    tests:
-      - path: src/utils/password_test.go
-        description: "Tests password hashing utility used by auth"
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: >
-      Service tokens enable K8s jobs to call back into the API securely.
-      Login page has Chinese UI strings (localized). Token refresh stores same
-      token for both access and refresh (backend returns single token).
-
-  - id: REQ-002
-    title: User Management (CRUD)
-    description: >
-      Admin-level CRUD for user accounts: create, list, get detail, update,
-      delete. Includes activation/deactivation and password management.
-      Frontend provides an admin users page at /admin/users.
-    priority: P0
-    status: implemented
-    confidence: inferred
-    source: "src/handlers/v2/users.go, src/repository/user.go, AegisLab-frontend/src/pages/admin/AdminUsersPage.tsx"
-
-    code:
-      - path: AegisLab/src/handlers/v2/users.go
-        description: "CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser handlers"
-      - path: AegisLab/src/database/entity.go
-        description: "User entity with username, email, password, full_name, avatar, phone, status, soft delete"
-      - path: AegisLab/src/repository/user.go
-        description: "Data access layer for user operations"
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/admin/AdminUsersPage.tsx
-        description: "Admin user management page"
-      - path: AegisLab-frontend/src/api/users.ts
-        description: "Users API client"
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001]
-    conflicts: []
-    notes: "Password is hashed via BeforeCreate GORM hook"
-
-  - id: REQ-003
-    title: Role-Based Access Control (RBAC)
-    description: >
-      Comprehensive RBAC system with roles, permissions, and resources.
-      Permissions are scoped (system, team, project, own) with actions
-      (read, create, update, delete, manage, execute, etc.). Permission
-      inheritance is implemented (manage inherits all lower permissions).
-      System admin, team admin, project admin, and ownership checks are supported.
-      Frontend has API clients for roles, permissions, and resources but no
-      dedicated admin UI page for RBAC management yet.
-    priority: P0
-    status: implemented
-    confidence: inferred
-    source: "src/middleware/permission.go, src/handlers/v2/roles.go, AegisLab-frontend/src/api/roles.ts"
-
-    code:
-      - path: AegisLab/src/middleware/permission.go
-        description: >
-          Decorator-pattern permission middleware: singlePermission, anyPermission,
-          allPermissions, ownershipCheck, adminOrOwnership, teamAccessCheck,
-          projectAccessCheck. Pre-built permission variables for every domain.
-      - path: AegisLab/src/database/entity.go
-        description: "Role, Permission, Resource entities with hierarchical resource categories"
-      - path: AegisLab/src/handlers/v2/roles.go
-        description: "CRUD for roles with permission assignment"
-      - path: AegisLab/src/handlers/v2/permissions.go
-        description: "Permission listing and detail endpoints"
-      - path: AegisLab/src/handlers/v2/resources.go
-        description: "Resource listing and detail endpoints"
-
-    frontend:
-      - path: AegisLab-frontend/src/api/roles.ts
-        description: "Roles API client"
-      - path: AegisLab-frontend/src/api/permissions.ts
-        description: "Permissions API client"
-      - path: AegisLab-frontend/src/api/resources.ts
-        description: "Resources API client"
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001, REQ-002]
-    conflicts:
-      - "Backend has full RBAC admin endpoints but frontend lacks a dedicated RBAC management UI page"
-      - "Frontend admin check in MainSidebarContent.tsx uses unsafe cast hack instead of proper role field from UserInfo type"
-    notes: >
-      Permission rules cover: system, audit, configuration, user, role,
-      permission, team, project, container, container_version, dataset,
-      dataset_version, label, task, trace domains.
-
-  - id: REQ-004
-    title: Team Management
-    description: >
-      Teams group users and own projects. Supports CRUD, membership management
-      (join/leave, admin promotion), and public/private visibility. Team access
-      checks verify membership, admin status, or public access.
-      Frontend provides a team detail page with tabs for overview, projects,
-      users, and settings, plus a team creation modal in the sidebar.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/handlers/v2/teams.go, AegisLab-frontend/src/pages/teams/TeamDetailPage.tsx"
-
-    code:
-      - path: AegisLab/src/handlers/v2/teams.go
-        description: "CreateTeam, DeleteTeam, ListTeams, GetTeam, UpdateTeam handlers"
-      - path: AegisLab/src/database/entity.go
-        description: "Team entity with name, description, is_public, status, projects relationship"
-      - path: AegisLab/src/middleware/permission.go
-        description: "RequireTeamAccess, RequireTeamAdminAccess, RequireTeamMemberAccess middlewares"
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/teams/TeamDetailPage.tsx
-        description: "Team detail page with tab navigation"
-      - path: AegisLab-frontend/src/pages/teams/tabs/OverviewTab.tsx
-        description: "Team overview tab"
-      - path: AegisLab-frontend/src/pages/teams/tabs/ProjectsTab.tsx
-        description: "Team projects listing tab"
-      - path: AegisLab-frontend/src/pages/teams/tabs/UsersTab.tsx
-        description: "Team members management tab"
-      - path: AegisLab-frontend/src/pages/teams/tabs/SettingsTab.tsx
-        description: "Team settings tab"
-      - path: AegisLab-frontend/src/api/teams.ts
-        description: "Teams API client"
-      - path: AegisLab-frontend/src/hooks/useTeams.ts
-        description: "TanStack Query hook for teams"
-      - path: AegisLab-frontend/src/hooks/useTeamContext.ts
-        description: "Hook for team context from URL params"
-      - path: AegisLab-frontend/src/components/teams/TeamSidebar.tsx
-        description: "Team sidebar component"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001, REQ-003]
-    conflicts: []
-    notes: >
-      FIXED (2026-04-13): addMember now sends {username, role_id}. Star toggle removed.
-      member_count maps from backend user_count via useTeamContext hook.
-
-  - id: REQ-005
-    title: Project Management
-    description: >
-      Projects are the primary organizational unit. They belong to optional teams,
-      have many-to-many relationships with containers and datasets, and support
-      RBAC via project-level permissions. CRUD with public/private visibility.
-      Frontend provides project listing, creation/editing forms, project overview
-      page, and project settings within the workspace layout.
-    priority: P0
-    status: implemented
-    confidence: inferred
-    source: "src/handlers/v2/projects.go, AegisLab-frontend/src/pages/projects/ProjectList.tsx"
-
-    code:
-      - path: AegisLab/src/handlers/v2/projects.go
-        description: "CreateProject, DeleteProject, ListProjects, GetProject, UpdateProject handlers"
-      - path: AegisLab/src/database/entity.go
-        description: "Project entity with team FK, containers and datasets M2M, labels M2M"
-      - path: AegisLab/src/middleware/permission.go
-        description: "RequireProjectAccess, RequireProjectAdminAccess, RequireProjectMemberAccess middlewares"
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/projects/ProjectList.tsx
-        description: "Project listing with table/card view"
-      - path: AegisLab-frontend/src/pages/projects/ProjectEdit.tsx
-        description: "Project creation/edit form"
-      - path: AegisLab-frontend/src/pages/projects/ProjectOverview.tsx
-        description: "Project overview page with summary statistics and recent runs"
-      - path: AegisLab-frontend/src/pages/projects/ProjectSettings.tsx
-        description: "Project settings page"
-      - path: AegisLab-frontend/src/api/projects.ts
-        description: "Project API client (CRUD, injections, executions, labels)"
-      - path: AegisLab-frontend/src/hooks/useProjects.ts
-        description: "TanStack Query hook with automatic name-to-ID cache updates"
-      - path: AegisLab-frontend/src/hooks/useProjectContext.ts
-        description: "Hook for project context from URL params"
-      - path: AegisLab-frontend/src/utils/projectNameMap.ts
-        description: "localStorage-based name-to-ID cache for project URL resolution"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001, REQ-003, REQ-004]
-    conflicts:
-      - "totalExperiments stat hardcoded to 0 (TODO: needs API support)"
-    notes: "FIXED (2026-04-13): Star toggle removed from ProjectList."
-
-  - id: REQ-006
-    title: Label System
-    description: >
-      Unified label management supporting key-value pairs with categories
-      (dataset, fault_injection, algorithm, container, etc.), colors, usage
-      counts, and system labels. Labels are attached to containers, datasets,
-      projects, configs, injections, and executions via M2M relationships.
-      Frontend provides label API client and AddLabelDropdown workspace component.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/handlers/v2/labels.go, AegisLab-frontend/src/api/labels.ts"
-
-    code:
-      - path: AegisLab/src/handlers/v2/labels.go
-        description: "BatchDeleteLabels, CRUD for labels"
-      - path: AegisLab/src/database/entity.go
-        description: "Label entity with key, value, category, color, usage count; M2M join tables"
-
-    frontend:
-      - path: AegisLab-frontend/src/api/labels.ts
-        description: "Labels API client"
-      - path: AegisLab-frontend/src/components/workspace/AddLabelDropdown.tsx
-        description: "Dropdown component for adding labels to workspace items"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: >
-      Labels use ActiveKeyValue virtual column for uniqueness enforcement.
-      FIXED (2026-04-13): AddLabelDropdown now fetches real labels via GET /api/v2/labels.
-
-  - id: REQ-007
-    title: Audit Logging
-    description: >
-      Automatic audit logging of all non-GET API requests. Captures HTTP method,
-      path, query, status code, duration, user ID, resource type, and sanitized
-      request body. Sensitive paths (auth/login, password) are excluded from body
-      logging. Async logging to avoid blocking requests.
-      No dedicated frontend UI for viewing audit logs yet.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "src/middleware/audit.go, src/database/entity.go, src/repository/audit.go"
-
-    code:
-      - path: AegisLab/src/middleware/audit.go
-        description: "AuditMiddleware captures request/response details, determines action and resource, logs asynchronously"
-      - path: AegisLab/src/database/entity.go
-        description: "AuditLog entity with IP, user agent, action, details, error_msg, resource associations"
-      - path: AegisLab/src/service/producer/audit.go
-        description: "LogUserAction, LogFailedAction service methods"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001]
-    conflicts:
-      - "Backend has audit logging but frontend has no UI to view audit logs"
-    notes: "Sensitive fields (password, token, secret) are redacted from logged request bodies"
-
-  - id: REQ-008
-    title: Rate Limiting
-    description: >
-      In-memory sliding-window rate limiting with three tiers: general (1000/min),
-      auth (100/min), strict (20/min). Supports IP-based, user-based, and
-      API-key-based rate limiting with periodic cleanup.
-      Backend-only infrastructure; no frontend representation needed.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "src/middleware/ratelimit.go"
-
-    code:
-      - path: AegisLab/src/middleware/ratelimit.go
-        description: "RateLimiter struct with sliding window, IP/user/API-key based middleware variants"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: "Most comment/code mismatches fixed (2026-04-13). Remaining: GeneralRateLimit var comment still says '100 requests per minute per IP' but code sets 1000."
-
-  - id: REQ-009
-    title: Dynamic Configuration
-    description: >
-      Runtime-modifiable configuration system stored in MySQL. Supports typed
-      values (string, bool, int, float64, string array), validation (min/max,
-      regex, allowed options), secret masking, and full change history with
-      rollback support. Scoped to producer or consumer.
-      Frontend provides a system settings admin page.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/database/entity.go, src/service/producer/dynamic_config.go, AegisLab-frontend/src/pages/system/SystemSettings.tsx"
-
-    code:
-      - path: AegisLab/src/database/entity.go
-        description: "DynamicConfig and ConfigHistory entities with validation fields"
-      - path: AegisLab/src/service/producer/dynamic_config.go
-        description: "Config update logic with history tracking and context"
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/system/SystemSettings.tsx
-        description: "System settings admin page"
-      - path: AegisLab-frontend/src/api/system.ts
-        description: "System API client with getSystemMetrics and getSystemMetricsHistory"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001, REQ-003]
-    conflicts: []
-    notes: ""
-
-  # ===========================================================================
-  # REQ-1xx: Fault Injection & Chaos Engineering
-  # ===========================================================================
-
-  - id: REQ-100
-    title: Fault Injection (Chaos Mesh CRD)
-    description: >
-      Core fault injection via Chaos Mesh Kubernetes CRDs. Supports multiple
-      chaos types (network, pod, stress, etc.) across registered system categories.
-      FaultInjection entity is the same as Datapack (different views of same data).
-      Includes display config (user-facing), engine config (runtime), groundtruths,
-      pre-duration, and time windows.
-      Frontend provides injection listing, detail view (with overview, files,
-      artifacts, config, charts, logs tabs), and a multi-step injection creation
-      form with visual canvas for fault node configuration.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "src/handlers/v2/injections.go, AegisLab-frontend/src/pages/projects/ProjectInjectionList.tsx"
-
-    code:
-      - path: AegisLab/src/handlers/v2/injections.go
-        description: "CRUD handlers for injections including batch delete, get, list, create"
-      - path: AegisLab/src/service/consumer/fault_injection.go
-        description: "executeFaultInjection task handler with batch manager for parallel injections"
-      - path: AegisLab/src/database/entity.go
-        description: "FaultInjection entity with chaos type, category, groundtruths, engine config, benchmark/pedestal FKs"
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/projects/ProjectInjectionList.tsx
-        description: "Project-scoped injection listing with workspace table"
-      - path: AegisLab-frontend/src/pages/projects/ProjectInjectionDetail.tsx
-        description: "Injection detail page with tabbed view"
-      - path: AegisLab-frontend/src/pages/injections/InjectionCreate.tsx
-        description: "Multi-step injection creation form"
-      - path: AegisLab-frontend/src/pages/injections/components/FaultConfigPanel.tsx
-        description: "Fault configuration panel component"
-      - path: AegisLab-frontend/src/pages/injections/components/FaultTypePanel.tsx
-        description: "Fault type selection panel"
-      - path: AegisLab-frontend/src/pages/injections/components/FaultNode.tsx
-        description: "Visual fault node component"
-      - path: AegisLab-frontend/src/pages/injections/components/VisualCanvas.tsx
-        description: "Visual canvas for fault injection topology"
-      - path: AegisLab-frontend/src/pages/injections/components/AlgorithmSelector.tsx
-        description: "Algorithm selection component for injection pipeline"
-      - path: AegisLab-frontend/src/pages/injections/components/TagManager.tsx
-        description: "Tag/label manager for injections"
-      - path: AegisLab-frontend/src/api/injections.ts
-        description: "Injections API client"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/DetailView.tsx
-        description: "Reusable detail view component with tabs (overview, files, artifacts, config, charts, logs)"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/OverviewTab.tsx
-        description: "Overview tab showing injection/execution summary"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/FilesTab.tsx
-        description: "Files tab showing datapack parquet files"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/ArtifactsTab.tsx
-        description: "Artifacts tab"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/FaultInjectionPanel.tsx
-        description: "Fault injection config display panel"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/ConfigTree.tsx
-        description: "Config tree viewer"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/ChartsTab.tsx
-        description: "Charts tab for data visualization"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/LogsTab.tsx
-        description: "Logs tab with log viewer"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/PipelineLogsViewer.tsx
-        description: "Real-time pipeline log streaming viewer"
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-005, REQ-300, REQ-400]
-    conflicts: []
-    notes: >
-      FaultInjection = Datapack is a key architectural fact. Source can be
-      'injection' (auto-generated) or 'manual' (uploaded).
-      FIXED (2026-04-13): GetInjectionLogs now queries Loki for real historical logs.
-
-  - id: REQ-101
-    title: Batch Fault Injection
-    description: >
-      Support for parallel fault injection of multiple nodes simultaneously.
-      batchManager tracks batch progress and waits for all CRDs to complete
-      before triggering the next pipeline stage (BuildDatapack).
-      No separate frontend UI; batch behavior is part of the injection creation form.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "src/service/consumer/fault_injection.go, src/service/consumer/k8s_handler.go"
-
-    code:
-      - path: AegisLab/src/service/consumer/fault_injection.go
-        description: "batchManager singleton with mutex-protected batch tracking"
-      - path: AegisLab/src/service/consumer/k8s_handler.go
-        description: "HandleCRDSucceeded checks batch completion before submitting next task"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-100]
-    conflicts: []
-    notes: ""
-
-  - id: REQ-102
-    title: Chaos System Registration
-    description: >
-      Registry of chaos target systems (e.g., train-ticket, sock-shop) with
-      namespace patterns, service extraction patterns, display names, and
-      builtin/custom designation. SystemMetadata stores per-system service
-      endpoints and Java methods.
-      Backend-only; system selection is embedded in the injection creation form.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/handlers/v2/systems.go, src/database/entity.go, src/service/producer/chaos_system.go"
-
-    code:
-      - path: AegisLab/src/handlers/v2/systems.go
-        description: "ListChaosSystemsHandler, GetChaosSystemHandler and CRUD for chaos systems"
-      - path: AegisLab/src/database/entity.go
-        description: "System and SystemMetadata entities"
-      - path: AegisLab/src/service/initialization/systems.go
-        description: "System initialization/seeding on startup"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: ""
-
-  - id: REQ-103
-    title: Pedestal Restart
-    description: >
-      Ability to restart the target pedestal system (the microservice system
-      under test) as part of the fault injection pipeline. Uses rate limiting
-      to avoid overloading the cluster.
-      Backend-only task; no dedicated frontend UI.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/service/consumer/restart_pedestal.go, src/service/consumer/rate_limiter.go"
-
-    code:
-      - path: AegisLab/src/service/consumer/restart_pedestal.go
-        description: "executeRestartPedestal task handler with rate limiter integration"
-      - path: AegisLab/src/service/consumer/rate_limiter.go
-        description: "TokenBucketRateLimiter for pedestal restart operations"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-100, REQ-400]
-    conflicts: []
-    notes: ""
-
-  - id: REQ-104
-    title: Manual Datapack Upload
-    description: >
-      Upload pre-built datapacks (ZIP archives containing parquet files) without
-      going through the fault injection pipeline. Supports labels, groundtruths,
-      and validation of parquet file structure.
-      No dedicated frontend upload UI yet.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/service/producer/upload.go, src/handlers/v2/injections.go"
-
-    code:
-      - path: AegisLab/src/service/producer/upload.go
-        description: "UploadDatapack validates ZIP structure (6 recognized parquet files), parses labels/groundtruths"
-      - path: AegisLab/src/handlers/v2/injections.go
-        description: "Upload handler endpoint"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-100]
-    conflicts:
-      - "Backend has datapack upload endpoint but frontend has no upload UI"
-    notes: "Valid parquet files: abnormal/normal traces, metrics, logs"
-
-  - id: REQ-105
-    title: JVM Runtime Mutator (Disabled)
-    description: >
-      JVM-level chaos injection targeting specific classes and methods with
-      value mutations. Currently disabled due to dependency issues.
-    priority: P2
-    status: disabled
-    confidence: uncertain
-    source: "src/service/consumer/jvm_runtime_mutator.go"
-
-    code:
-      - path: AegisLab/src/service/consumer/jvm_runtime_mutator.go
-        description: "Commented-out JVM runtime mutator implementation"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-100]
-    conflicts: []
-    notes: "Entire file is commented out with a note about dependency issues. Status changed from 'implemented' to 'disabled' per 2026-04-13 audit."
-
-  # ===========================================================================
-  # REQ-2xx: Algorithm Execution & Evaluation
-  # ===========================================================================
-
-  - id: REQ-200
-    title: Algorithm Execution
-    description: >
-      Execute RCA algorithms against datapacks by spawning K8s jobs. Creates
-      Execution records linking algorithm version to datapack, tracks state
-      (pending, running, completed, failed), and stores duration.
-      Frontend provides execution listing, detail view, and creation form
-      within the workspace layout.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "src/handlers/v2/executions.go, AegisLab-frontend/src/pages/projects/ProjectExecutionList.tsx"
-
-    code:
-      - path: AegisLab/src/handlers/v2/executions.go
-        description: "CRUD handlers for executions: batch delete, get, list, create"
-      - path: AegisLab/src/service/consumer/algo_execution.go
-        description: "executeAlgorithm task handler creating K8s jobs with algorithm container"
-      - path: AegisLab/src/database/entity.go
-        description: "Execution entity with algorithm_version, datapack, dataset_version FKs"
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/projects/ProjectExecutionList.tsx
-        description: "Project-scoped execution listing with workspace table"
-      - path: AegisLab-frontend/src/pages/projects/ProjectExecutionDetail.tsx
-        description: "Execution detail page"
-      - path: AegisLab-frontend/src/pages/executions/ExecutionForm.tsx
-        description: "Execution creation form"
-      - path: AegisLab-frontend/src/api/executions.ts
-        description: "Executions API client"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-100, REQ-300, REQ-400]
-    conflicts: []
-    notes: ""
-
-  - id: REQ-201
-    title: Result Collection
-    description: >
-      After algorithm execution completes, a CollectResult task gathers output
-      from the K8s job. Handles different result types including detector results
-      and granularity results. Special handling for built-in detector algorithms.
-      Backend-only task processing; results are displayed in the execution detail view.
-    priority: P0
-    status: implemented
-    confidence: inferred
-    source: "src/service/consumer/collect_result.go, src/database/entity.go"
-
-    code:
-      - path: AegisLab/src/service/consumer/collect_result.go
-        description: "executeCollectResult parses algorithm output, distinguishes detector vs general algorithms"
-      - path: AegisLab/src/database/entity.go
-        description: "DetectorResult (span metrics) and GranularityResult (localization at service/pod/span/metric levels)"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-200]
-    conflicts: []
-    notes: ""
-
-  - id: REQ-202
-    title: Evaluation (Datapack-level)
-    description: >
-      Evaluate algorithm performance on individual datapacks. Supports batch
-      evaluation of multiple algorithm-datapack pairs with label filtering.
-      Uses the analyzer service for computation.
-      Frontend provides evaluation listing and detail pages within workspace.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "src/handlers/v2/evaluations.go, AegisLab-frontend/src/pages/evaluations/EvaluationList.tsx"
-
-    code:
-      - path: AegisLab/src/handlers/v2/evaluations.go
-        description: "ListDatapackEvaluationResults endpoint (SDK-enabled)"
-      - path: AegisLab/src/service/analyzer/evaluation.go
-        description: "Batch evaluation logic mapping container refs to versions and computing results"
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/evaluations/EvaluationList.tsx
-        description: "Evaluation listing page"
-      - path: AegisLab-frontend/src/pages/evaluations/EvaluationDetail.tsx
-        description: "Evaluation detail page"
-      - path: AegisLab-frontend/src/pages/evaluations/EvaluationForm.tsx
-        description: "Evaluation creation/configuration form"
-      - path: AegisLab-frontend/src/api/evaluations.ts
-        description: "Evaluations API client"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-200, REQ-201]
-    conflicts: []
-    notes: ""
-
-  - id: REQ-203
-    title: Evaluation (Dataset-level)
-    description: >
-      Evaluate algorithm performance across entire datasets (collections of
-      datapacks). Supports batch evaluation of multiple algorithm-dataset pairs.
-      Frontend evaluation pages support both datapack and dataset level.
-    priority: P0
-    status: implemented
-    confidence: inferred
-    source: "src/handlers/v2/evaluations.go, src/service/analyzer/evaluation.go"
-
-    code:
-      - path: AegisLab/src/handlers/v2/evaluations.go
-        description: "ListDatasetEvaluationResults endpoint (SDK-enabled)"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-202, REQ-301]
-    conflicts: []
-    notes: "Frontend evaluation pages (covered by REQ-202) handle both datapack and dataset level"
-
-  - id: REQ-204
-    title: Datapack Querying (DuckDB Arrow)
-    description: >
-      Query parquet files within datapacks using DuckDB with Apache Arrow IPC
-      streaming. Requires build tag 'duckdb_arrow'. Provides file content
-      streaming for analysis.
-      Frontend has an ArrowViewer component for rendering Arrow IPC data.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "src/service/producer/query_datapack_arrow.go, AegisLab-frontend/src/components/workspace/DetailView/tabs/ArrowViewer.tsx"
-
-    code:
-      - path: AegisLab/src/service/producer/query_datapack_arrow.go
-        description: "QueryDatapackFileContent using DuckDB Arrow connector (build tag: duckdb_arrow)"
-      - path: AegisLab/src/service/producer/query_datapack_noarrow.go
-        description: "Stub returning error when duckdb_arrow tag is not set"
-
-    frontend:
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/ArrowViewer.tsx
-        description: "Arrow IPC data viewer component for parquet file contents"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/FilesTab.tsx
-        description: "Files tab listing datapack parquet files with viewer"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/FilesTable.tsx
-        description: "Table component for file listing"
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-100]
-    conflicts: []
-    notes: "Build MUST include -tags duckdb_arrow for this feature"
-
-  - id: REQ-205
-    title: SDK Evaluations
-    description: >
-      Read-only access to evaluation data created by the Python SDK. Lists and
-      retrieves SDKEvaluationSample records from a table managed by the SDK
-      (not auto-migrated by AegisLab). Supports filtering by exp_id and stage.
-      No dedicated frontend UI.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/handlers/v2/sdk_evaluations.go, src/database/sdk_entities.go"
-
-    code:
-      - path: AegisLab/src/handlers/v2/sdk_evaluations.go
-        description: "ListSDKEvaluations, GetSDKEvaluation handlers"
-      - path: AegisLab/src/database/sdk_entities.go
-        description: "SDKEvaluationSample and SDKDatasetSample entities (read-only, SDK-managed tables)"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-600]
-    conflicts: []
-    notes: "Tables created/managed by Python SDK, AegisLab only reads them"
-
-  - id: REQ-206
-    title: Database Views for Evaluation
-    description: >
-      Pre-computed MySQL views for efficient evaluation queries: FaultInjectionNoIssues
-      and FaultInjectionWithIssues, aggregating injection data with detector results.
-      Backend-only infrastructure.
-    priority: P2
-    status: implemented
-    confidence: inferred
-    source: "src/database/view.go"
-
-    code:
-      - path: AegisLab/src/database/view.go
-        description: "View model structs for fault_injection_no_issues and fault_injection_with_issues"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-100, REQ-201]
-    conflicts: []
-    notes: ""
-
-  # ===========================================================================
-  # REQ-3xx: Data Management (Datasets, Datapacks, Containers)
-  # ===========================================================================
-
-  - id: REQ-300
-    title: Container Management
-    description: >
-      Containers are versioned registry images (algorithms, benchmarks, pedestals).
-      CRUD with type classification (algorithm, benchmark, pedestal). ContainerVersions
-      track semantic versioning, image references (registry/namespace/repo:tag),
-      GitHub links, and usage counts. Includes HelmConfig for deployment and
-      ParameterConfig for env vars.
-      Frontend provides admin container listing, detail, creation/editing, and
-      version management pages.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "src/handlers/v2/containers.go, AegisLab-frontend/src/pages/containers/ContainerList.tsx"
-
-    code:
-      - path: AegisLab/src/handlers/v2/containers.go
-        description: "CreateContainer, CRUD for containers and container versions"
-      - path: AegisLab/src/database/entity.go
-        description: >
-          Container (type, public, labels), ContainerVersion (semantic versioning,
-          image ref parsing, Helm config, env vars), HelmConfig (chart, repo, values),
-          ParameterConfig (fixed/dynamic params with validation)
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/containers/ContainerList.tsx
-        description: "Container listing page (admin)"
-      - path: AegisLab-frontend/src/pages/containers/ContainerDetail.tsx
-        description: "Container detail page"
-      - path: AegisLab-frontend/src/pages/containers/ContainerForm.tsx
-        description: "Container creation/editing form"
-      - path: AegisLab-frontend/src/pages/containers/ContainerVersions.tsx
-        description: "Container version management page"
-      - path: AegisLab-frontend/src/api/containers.ts
-        description: "Containers API client"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001, REQ-003]
-    conflicts: []
-    notes: "Pedestal names are validated against chaos.SystemType"
-
-  - id: REQ-301
-    title: Dataset Management
-    description: >
-      Datasets are versioned collections of datapacks. CRUD with type classification,
-      semantic versioning, file count tracking, and checksums. DatasetVersions link
-      to FaultInjections (datapacks) via M2M relationship.
-      Frontend provides admin dataset listing, detail, and creation/editing pages.
-    priority: P0
-    status: implemented
-    confidence: inferred
-    source: "src/handlers/v2/datasets.go, AegisLab-frontend/src/pages/datasets/DatasetList.tsx"
-
-    code:
-      - path: AegisLab/src/handlers/v2/datasets.go
-        description: "CreateDataset, CRUD for datasets and dataset versions"
-      - path: AegisLab/src/database/entity.go
-        description: "Dataset and DatasetVersion entities with datapacks M2M relationship"
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/datasets/DatasetList.tsx
-        description: "Dataset listing page (admin)"
-      - path: AegisLab-frontend/src/pages/datasets/DatasetDetail.tsx
-        description: "Dataset detail page"
-      - path: AegisLab-frontend/src/pages/datasets/DatasetForm.tsx
-        description: "Dataset creation/editing form"
-      - path: AegisLab-frontend/src/api/datasets.ts
-        description: "Datasets API client"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001, REQ-003, REQ-100]
-    conflicts: []
-    notes: "DatasetVersion.Datapacks links to FaultInjection via dataset_version_injections join table"
-
-  - id: REQ-302
-    title: Container Image Building (BuildKit)
-    description: >
-      Build container images from source code using BuildKit. Supports custom
-      Dockerfile, build context, and registry push. Uses BuildKit client library
-      with Docker auth and progress tracking.
-      Backend-only infrastructure.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/service/consumer/build_container.go"
-
-    code:
-      - path: AegisLab/src/service/consumer/build_container.go
-        description: "executeBuildContainer task handler using BuildKit client with Docker registry auth"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-300, REQ-400]
-    conflicts: []
-    notes: "Requires BuildKit daemon (buildkitd) running"
-
-  - id: REQ-303
-    title: Datapack Building (K8s Job)
-    description: >
-      After fault injection completes, a K8s job builds the datapack by collecting
-      observability data (traces, metrics, logs) from the time window. Creates
-      parquet files and stores them for algorithm consumption.
-      Backend-only task processing.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "src/service/consumer/build_datapack.go, src/service/consumer/k8s_handler.go"
-
-    code:
-      - path: AegisLab/src/service/consumer/build_datapack.go
-        description: "executeBuildDatapack creates K8s job to collect and package observability data"
-      - path: AegisLab/src/service/consumer/k8s_handler.go
-        description: "HandleCRDSucceeded triggers BuildDatapack after CRD completion"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-100, REQ-400]
-    conflicts: []
-    notes: ""
-
-  - id: REQ-304
-    title: Harbor Registry Integration
-    description: >
-      Integration with Harbor container registry for image management. Supports
-      artifact listing, tag management, and sorted retrieval.
-      Backend-only infrastructure.
-    priority: P2
-    status: implemented
-    confidence: inferred
-    source: "src/client/harbor_client.go"
-
-    code:
-      - path: AegisLab/src/client/harbor_client.go
-        description: "Singleton HarborClient wrapping go-harbor SDK for artifact operations"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-300]
-    conflicts: []
-    notes: ""
-
-  # ===========================================================================
-  # REQ-4xx: Task Processing & Workflow Orchestration
-  # ===========================================================================
-
-  - id: REQ-400
-    title: Redis Task Queue System
-    description: >
-      Sophisticated Redis-based task queue with three queues: Delayed (sorted set
-      by timestamp), Ready (list), and Dead Letter (sorted set). Max 20 concurrent
-      tasks with Prometheus metrics (counter, histogram). Task cancellation
-      registry enables stopping running tasks.
-      Frontend provides task listing and detail pages for monitoring.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "src/service/consumer/task.go, AegisLab-frontend/src/pages/tasks/TaskList.tsx"
-
-    code:
-      - path: AegisLab/src/service/consumer/task.go
-        description: >
-          Redis queue constants, concurrency control, Prometheus metrics,
-          task cancellation registry, event publishing
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/tasks/TaskList.tsx
-        description: "Task listing page with status filters"
-      - path: AegisLab-frontend/src/pages/tasks/TaskDetail.tsx
-        description: "Task detail page with real-time log streaming"
-      - path: AegisLab-frontend/src/api/tasks.ts
-        description: "Tasks API client"
-      - path: AegisLab-frontend/src/hooks/useTaskLogs.ts
-        description: "Hook for real-time task log streaming"
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: >
-      Queue keys: task:delayed, task:ready, task:dead, task:index, task:concurrency_lock.
-      FIXED (2026-04-13): GetTaskDetail now queries Loki for real logs; executeTaskWithRetry
-      implements fixed-interval backoff via RetryPolicy.BackoffSec.
-
-  - id: REQ-401
-    title: Task Dispatch & Routing
-    description: >
-      Central task dispatcher routes tasks to appropriate handlers based on type:
-      BuildContainer, RestartPedestal, FaultInjection, BuildDatapack, RunAlgorithm,
-      CollectResult. Includes panic recovery.
-      Backend-only infrastructure.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "src/service/consumer/distribute_tasks.go"
-
-    code:
-      - path: AegisLab/src/service/consumer/distribute_tasks.go
-        description: "dispatchTask switch on task type to route to correct executor"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-400]
-    conflicts: []
-    notes: "Six task types handled; unknown types return error"
-
-  - id: REQ-402
-    title: Workflow Orchestration via CRD Callbacks
-    description: >
-      Workflow orchestration is NOT a separate entity but implemented through K8s
-      CRD event callbacks. The chain: FaultInjection CRD completes ->
-      HandleCRDSucceeded -> SubmitTask(BuildDatapack) -> Job completes ->
-      HandleJobSucceeded -> SubmitTask(RunAlgorithm) -> Job completes ->
-      HandleJobSucceeded -> SubmitTask(CollectResult). Context propagation via
-      K8s annotations (OTel trace) and labels (task metadata).
-      Backend-only infrastructure.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "src/service/consumer/k8s_handler.go, src/client/k8s/controller.go"
-
-    code:
-      - path: AegisLab/src/service/consumer/k8s_handler.go
-        description: "HandleCRDSucceeded, HandleJobSucceeded implement callback-driven workflow chain"
-      - path: AegisLab/src/client/k8s/controller.go
-        description: "Callback interface: HandleCRD{Add,Delete,Failed,Succeeded}, HandleJob{Add,Failed,Succeeded}"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-400, REQ-100, REQ-200]
-    conflicts: []
-    notes: "Critical architectural pattern - documented extensively in CLAUDE.md"
-
-  - id: REQ-403
-    title: Task Management API
-    description: >
-      REST API for task lifecycle management: batch delete, list, get detail,
-      cancel running tasks, and WebSocket-based real-time task monitoring.
-      Frontend task pages consume this API.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/handlers/v2/tasks.go, AegisLab-frontend/src/api/tasks.ts"
-
-    code:
-      - path: AegisLab/src/handlers/v2/tasks.go
-        description: "BatchDeleteTasks and other task management handlers; WebSocket upgrader for real-time updates"
-
-    frontend:
-      - path: AegisLab-frontend/src/api/tasks.ts
-        description: "Tasks API client consuming task management endpoints"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-400, REQ-001]
-    conflicts: []
-    notes: "WebSocket support indicates real-time task status streaming"
-
-  - id: REQ-404
-    title: Trace & Group Management
-    description: >
-      Traces represent execution workflows containing multiple tasks in a DAG.
-      Groups aggregate related traces (batch operations). Supports SSE streaming
-      for real-time trace updates via Redis streams. Trace types: datapack_build,
-      algorithm_run, full_pipeline.
-      Frontend provides traces listing and detail pages within workspace, plus
-      SSE-based real-time updates.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "src/handlers/v2/traces.go, AegisLab-frontend/src/pages/traces/TracesPage.tsx"
-
-    code:
-      - path: AegisLab/src/handlers/v2/traces.go
-        description: "GetTrace handler with SSE streaming support via Redis"
-      - path: AegisLab/src/handlers/v2/groups.go
-        description: "GetGroupStats with SSE streaming for group-level monitoring"
-      - path: AegisLab/src/database/entity.go
-        description: "Trace (type, state, group_id, leaf_num) and Task (parent-child, level, sequence) entities"
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/traces/TracesPage.tsx
-        description: "Traces listing page within workspace"
-      - path: AegisLab-frontend/src/pages/traces/TraceDetailPage.tsx
-        description: "Trace detail page with task DAG visualization"
-      - path: AegisLab-frontend/src/api/traces.ts
-        description: "Traces API client"
-      - path: AegisLab-frontend/src/api/groups.ts
-        description: "Groups API client"
-      - path: AegisLab-frontend/src/hooks/useTraceSSE.ts
-        description: "Hook for real-time trace updates via SSE"
-      - path: AegisLab-frontend/src/hooks/useSSE.ts
-        description: "Generic SSE hook"
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-400]
-    conflicts: []
-    notes: "Hierarchical tracing: group (grandfather) -> trace (father) -> task"
-
-  - id: REQ-405
-    title: Namespace Monitoring & Locking
-    description: >
-      Monitor K8s namespaces for active fault injections. Namespace locks prevent
-      concurrent experiments on the same target. Supports refresh, disable, and
-      recovery of namespace states.
-      Backend-only infrastructure.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/service/consumer/monitor.go"
-
-    code:
-      - path: AegisLab/src/service/consumer/monitor.go
-        description: "MonitorItem, LockMessage, NamespaceRefreshResult for namespace state management"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-100, REQ-400]
-    conflicts: []
-    notes: ""
-
-  - id: REQ-406
-    title: Consumer Rate Limiting (Token Bucket)
-    description: >
-      Redis-based token bucket rate limiter for consumer-side operations
-      (e.g., pedestal restarts). Configurable max tokens and wait timeout
-      with dynamic config support.
-      Backend-only infrastructure.
-    priority: P2
-    status: implemented
-    confidence: inferred
-    source: "src/service/consumer/rate_limiter.go"
-
-    code:
-      - path: AegisLab/src/service/consumer/rate_limiter.go
-        description: "TokenBucketRateLimiter with Redis backing and configurable limits"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-400]
-    conflicts: []
-    notes: ""
-
-  # ===========================================================================
-  # REQ-5xx: Observability & Monitoring
-  # ===========================================================================
-
-  - id: REQ-500
-    title: OpenTelemetry Tracing Integration
-    description: >
-      Distributed tracing via OpenTelemetry with OTLP HTTP exporter to Jaeger.
-      TracerMiddleware creates spans for HTTP requests with group_id attributes.
-      Task processing uses hierarchical span contexts propagated through K8s
-      annotations.
-      Backend-only infrastructure.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "src/middleware/middleware.go, src/client/jaeger.go"
-
-    code:
-      - path: AegisLab/src/middleware/middleware.go
-        description: "TracerMiddleware creates OTel spans; GroupID middleware assigns UUIDs to POST requests"
-      - path: AegisLab/src/client/jaeger.go
-        description: "InitTraceProvider configures OTLP HTTP exporter for Jaeger"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: ""
-
-  - id: REQ-501
-    title: System Metrics & Health
-    description: >
-      System health monitoring with current and historical (24h) CPU, memory,
-      and disk usage metrics. Prometheus metrics for task processing (counter
-      and histogram).
-      Frontend home dashboard displays system status via real API calls.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "src/handlers/v2/system.go, AegisLab-frontend/src/pages/home/HomePage.tsx"
-
-    code:
-      - path: AegisLab/src/handlers/v2/system.go
-        description: "GetSystemMetrics (current) and GetSystemMetricsHistory (24h) endpoints"
-      - path: AegisLab/src/service/consumer/task.go
-        description: "Prometheus task_processed_total counter and task_duration_seconds histogram"
-
-    frontend:
-      - path: AegisLab-frontend/src/api/system.ts
-        description: "System API client with getSystemMetrics and getSystemMetricsHistory"
-      - path: AegisLab-frontend/src/api/metrics.ts
-        description: "Metrics API client with getInjectionMetrics, getExecutionMetrics, getAlgorithmMetrics"
-      - path: AegisLab-frontend/src/pages/home/HomePage.tsx
-        description: "Home dashboard displaying real system metrics"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001]
-    conflicts:
-      - "Legacy backend endpoints /system/monitor/metrics and /system/monitor/info return fabricated data (v2 endpoint is real)"
-    notes: >
-      FIXED (2026-04-13): Deleted SystemMetrics.tsx (100% mock). HomePage uses real v2 API.
-      The legacy /system/monitor/* endpoints are mock — should be deprecated.
-
-  - id: REQ-502
-    title: Injection & Execution Metrics
-    description: >
-      Aggregated analytics for injections and executions: success rates, duration
-      stats, state distributions, filtered by time range and fault type.
-      Frontend home dashboard displays these metrics.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/handlers/v2/metrics.go, AegisLab-frontend/src/api/metrics.ts"
-
-    code:
-      - path: AegisLab/src/handlers/v2/metrics.go
-        description: "GetInjectionMetrics and GetExecutionMetrics endpoints (SDK-enabled)"
-
-    frontend:
-      - path: AegisLab-frontend/src/api/metrics.ts
-        description: "Metrics API client"
-      - path: AegisLab-frontend/src/pages/home/HomePage.tsx
-        description: "Home dashboard displaying injection/execution metrics"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-100, REQ-200]
-    conflicts: []
-    notes: ""
-
-  - id: REQ-503
-    title: Real-Time Notifications (SSE)
-    description: >
-      Server-Sent Events streaming for global workflow notifications. Streams
-      events like injection completed, datapack ready, execution completed via
-      Redis pub/sub. Supports last_id for resuming missed events.
-      REMOVED (2026-04-13): Frontend notification feature removed as non-core.
-      Backend SSE endpoint remains for SDK/API consumers.
-    priority: P2
-    status: removed-frontend
-    confidence: confirmed
-    source: "src/handlers/v2/notifications.go"
-
-    code:
-      - path: AegisLab/src/handlers/v2/notifications.go
-        description: "GetNotificationStream SSE endpoint with Redis stream consumption (backend retained)"
-      - path: AegisLab/src/middleware/middleware.go
-        description: "SSEPath middleware sets event-stream headers"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: not-applicable
-      date: "2026-04-13"
-      notes: "Frontend notification feature intentionally removed — not core to researcher workflow"
-
-    depends_on: [REQ-400]
-    conflicts: []
-    notes: >
-      REMOVED (2026-04-13): Deleted NotificationsPage.tsx, notifications.ts API, useNotifications.ts hook.
-      Removed notification bell from AppHeader and sidebar. SSE hook (useSSE.ts) retained for trace/group streaming.
-
-  - id: REQ-504
-    title: Loki Log Integration
-    description: >
-      HTTP client for querying historical logs from Loki. Supports time-range
-      queries with configurable limits and direction (forward/backward).
-      Backend-only client; frontend log viewing uses pipeline logs viewer.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/client/loki.go"
-
-    code:
-      - path: AegisLab/src/client/loki.go
-        description: "LokiClient wrapping Loki HTTP API for log queries"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: ""
-
-  - id: REQ-505
-    title: OTLP Log Receiver
-    description: >
-      Built-in OTLP log receiver accepting protobuf-encoded log data
-      (gzip-compressed). Parses OpenTelemetry log records from resource logs.
-      Backend-only infrastructure.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/service/logreceiver/receiver.go, src/service/logreceiver/parser.go"
-
-    code:
-      - path: AegisLab/src/service/logreceiver/receiver.go
-        description: "HTTP server receiving OTLP log export requests with protobuf/gzip support"
-      - path: AegisLab/src/service/logreceiver/parser.go
-        description: "Parser for OTLP log records"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: "Default port 4319"
-
-  # ===========================================================================
-  # REQ-6xx: SDK & API Generation
-  # ===========================================================================
-
-  - id: REQ-600
-    title: Python SDK (Auto-generated)
-    description: >
-      Python SDK auto-generated from Swagger/OpenAPI specs. Provides REST client
-      and model classes for programmatic access to AegisLab APIs.
-      Backend-only tooling.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "sdk/python/, scripts/command/src/swagger.py"
-
-    code:
-      - path: AegisLab/sdk/python/src/rcabench/client
-        description: "Auto-generated Python REST client"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-602]
-    conflicts: []
-    notes: "Generated via 'make generate-python-sdk'"
-
-  - id: REQ-601
-    title: TypeScript SDK (Auto-generated)
-    description: >
-      TypeScript SDK auto-generated from Swagger/OpenAPI specs for frontend
-      consumption. Not always present in repo (generated on demand).
-      Used by frontend via @rcabench/client package.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "CLAUDE.md"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/api/client.ts
-        description: "Axios client that may use generated SDK types"
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-602]
-    conflicts: []
-    notes: "Generated via 'make generate-typescript-sdk SDK_VERSION=x.x.x'; sdk/typescript/ directory"
-
-  - id: REQ-602
-    title: Swagger/OpenAPI Documentation
-    description: >
-      API documentation via Swagger annotations on all handler functions.
-      APIs marked with @x-api-type {"sdk":"true"} are included in generated SDKs.
-      Generated via swag init with dependency parsing.
-      Backend-only tooling.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "src/handlers/v2/*.go"
-
-    code:
-      - path: AegisLab/src/handlers/v2/auth.go
-        description: "Example of Swagger annotations with @x-api-type SDK marking"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: "scripts/command/src/swagger.py filters APIs by x-api-type.sdk field"
-
-  # ===========================================================================
-  # REQ-7xx: Deployment & Infrastructure (Backend)
-  # ===========================================================================
-
-  - id: REQ-700
-    title: Kubernetes Deployment (Helm)
-    description: >
-      Helm chart for deploying AegisLab to Kubernetes clusters with TLS certs,
-      configurable values, and environment-specific manifests.
-      Backend-only infrastructure.
-    priority: P0
-    status: implemented
-    confidence: inferred
-    source: "helm/"
-
-    code:
-      - path: AegisLab/helm/Chart.yaml
-        description: "Helm chart metadata"
-      - path: AegisLab/helm/values.yaml
-        description: "Default deployment configuration"
-      - path: AegisLab/helm/templates/
-        description: "K8s resource templates"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: "helm/certs/ for TLS, helm/files/ for additional deployment files"
-
-  - id: REQ-701
-    title: Skaffold Development Workflow
-    description: >
-      Skaffold configuration for iterative development with automatic build
-      and deploy to K8s clusters.
-      Backend-only infrastructure.
-    priority: P2
-    status: implemented
-    confidence: inferred
-    source: "skaffold.yaml"
-
-    code:
-      - path: AegisLab/skaffold.yaml
-        description: "Skaffold development and deployment configuration"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-700]
-    conflicts: []
-    notes: "'make run' uses Skaffold for build+deploy"
-
-  - id: REQ-702
-    title: Cobra CLI (Multi-mode Application)
-    description: >
-      Application runs in three modes via Cobra CLI: producer (HTTP API server),
-      consumer (background workers + K8s controllers), or both (combined for
-      local development). Default local development runs 'both --port 8082'.
-      Backend-only infrastructure.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "src/main.go, CLAUDE.md"
-
-    code:
-      - path: AegisLab/src/main.go
-        description: "Cobra CLI with producer, consumer, and both commands"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: ""
-
-  - id: REQ-703
-    title: Kubernetes CRD Controller
-    description: >
-      Controller-runtime based K8s controller watching Chaos Mesh CRDs and
-      batch Jobs. Uses informers with rate-limited work queues. Manages CRD
-      lifecycle (add, delete, failed, succeeded) and job lifecycle.
-      Supports namespace-scoped CRD informers with dynamic registration.
-      Backend-only infrastructure.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "src/client/k8s/controller.go, src/client/k8s/crd.go, src/client/k8s/job.go"
-
-    code:
-      - path: AegisLab/src/client/k8s/controller.go
-        description: >
-          Controller struct with CRD/job informers, namespace management,
-          work queue with CheckRecovery/DeleteCRD/DeleteJob actions
-      - path: AegisLab/src/client/k8s/crd.go
-        description: "CRD-specific informer setup and event handlers"
-      - path: AegisLab/src/client/k8s/job.go
-        description: "Job informer setup and event handlers"
-
-    frontend: []
-    has_mock: false
-
-    tests:
-      - path: src/client/k8s/k8s_test.go
-        description: "K8s client tests"
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: "Watches multiple GVRs from chaos-experiment library"
-
-  - id: REQ-704
-    title: Docker Compose Local Infrastructure
-    description: >
-      Docker Compose setup for local development providing Redis, MySQL, Jaeger,
-      and BuildKit daemon services.
-      Backend-only infrastructure.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "docker-compose.yaml"
-
-    code:
-      - path: AegisLab/docker-compose.yaml
-        description: "Redis, MySQL, Jaeger, BuildKit service definitions"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: ""
-
-  - id: REQ-705
-    title: Data Initialization & Seeding
-    description: >
-      System initialization on startup: seeding roles, permissions, resources,
-      default users, and chaos systems. Separate initialization paths for
-      producer and consumer modes.
-      Backend-only infrastructure.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/service/initialization/, data/initial_data/"
-
-    code:
-      - path: AegisLab/src/service/initialization/producer.go
-        description: "Producer-mode initialization (DB migration, seed data)"
-      - path: AegisLab/src/service/initialization/consumer.go
-        description: "Consumer-mode initialization (K8s controllers, task queue)"
-      - path: AegisLab/src/service/initialization/systems.go
-        description: "Chaos system seeding"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: "data/initial_data/ contains environment-specific seed data"
-
-  - id: REQ-706
-    title: Devbox & Lefthook Toolchain
-    description: >
-      Nix-based development environment via devbox for reproducible tooling.
-      Lefthook for pre-commit hooks. Justfile for task automation.
-      Backend-only infrastructure.
-    priority: P2
-    status: implemented
-    confidence: confirmed
-    source: "devbox.json, lefthook.yml, justfile"
-
-    code:
-      - path: AegisLab/devbox.json
-        description: "Nix package definitions for development tools"
-      - path: AegisLab/lefthook.yml
-        description: "Pre-commit hook configuration"
-      - path: AegisLab/justfile
-        description: "Task runner recipes"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: ""
-
-  - id: REQ-707
-    title: Redis Client & etcd Client
-    description: >
-      Redis client for task queues, caching, pub/sub, and stream operations.
-      etcd client for distributed coordination.
-      Backend-only infrastructure.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "src/client/redis_client.go, src/client/etcd_client.go"
-
-    code:
-      - path: AegisLab/src/client/redis_client.go
-        description: "Redis client initialization and connection management"
-      - path: AegisLab/src/client/etcd_client.go
-        description: "etcd client for distributed coordination"
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: ""
-
-  # ===========================================================================
-  # REQ-8xx: Frontend-Only (Layout, Routing, Theme, Visualization, Build Tooling)
-  # ===========================================================================
-
-  - id: REQ-800
-    title: Dual Layout System (Main + Workspace)
-    description: >
-      Two mutually exclusive layout modes: MainLayout with global navigation
-      sidebar for top-level pages (home, projects list, teams, admin), and
-      WorkspaceLayout with project-scoped sidebar for workspace pages
-      (injections, executions, evaluations, traces, settings). Layouts share
-      a unified AppHeader component with breadcrumbs.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "AegisLab-frontend/src/components/layout/MainLayout.tsx, AegisLab-frontend/src/components/layout/WorkspaceLayout.tsx"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/components/layout/MainLayout.tsx
-        description: "Main layout with collapsible sidebar (240px) and content area; renders Outlet for child routes"
-      - path: AegisLab-frontend/src/components/layout/WorkspaceLayout.tsx
-        description: "Workspace layout with project-scoped sidebar (200px); provides ProjectOutletContext to child routes"
-      - path: AegisLab-frontend/src/components/layout/AppHeader.tsx
-        description: "Unified header with hamburger menu, logo, breadcrumbs, theme toggle, user dropdown"
-      - path: AegisLab-frontend/src/components/layout/MainSidebarContent.tsx
-        description: "Main sidebar navigation with Home, Projects, Teams, Admin sections"
-      - path: AegisLab-frontend/src/components/layout/WorkspaceSidebar.tsx
-        description: "Workspace sidebar: Overview, Datapacks, Executions, Evaluations, Algorithms, Traces, Settings"
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: AegisLab-frontend/workspace.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001]
-    conflicts: []
-    notes: >
-      UPDATED (2026-04-13): Notification badge removed from AppHeader. Notifications removed from sidebar.
-      WorkspaceSidebar: "Injections" renamed to "Datapacks", "Algorithms" entry added.
-      Hamburger button in header can open main sidebar as drawer in workspace mode.
-
-  - id: REQ-801
-    title: Client-Side Routing
-    description: >
-      React Router v6 route structure with lazy-loaded pages. Top-level routes
-      under MainLayout (/home, /projects, /profile, /settings, /tasks,
-      /:teamName, /admin/*). Nested project-scoped routes under WorkspaceLayout
-      (/:teamName/:projectName/* including algorithms). Fallback redirects
-      to /home or /login.
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "AegisLab-frontend/src/App.tsx, AegisLab-frontend/src/main.tsx"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/App.tsx
-        description: "Complete route definitions with lazy imports, Suspense boundaries, and auth guards"
-      - path: AegisLab-frontend/src/main.tsx
-        description: "BrowserRouter setup with React Router v7 future flags enabled"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001, REQ-800]
-    conflicts: []
-    notes: >
-      UPDATED (2026-04-13): /notifications route removed. /algorithms route added under workspace.
-      All pages are lazy-loaded with React.lazy + Suspense. Route structure uses team/project name URL params (not IDs).
-
-  - id: REQ-802
-    title: Theme System (Light/Dark)
-    description: >
-      Light/dark theme toggle with persisted preference in localStorage via
-      Zustand persist middleware. Sets data-theme attribute on document root.
-      Custom Ant Design theme configuration with sky-blue primary color (#0ea5e9).
-      CSS variables for theming defined in styles directory.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "AegisLab-frontend/src/store/theme.ts, AegisLab-frontend/src/components/ui/ThemeToggle.tsx"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/store/theme.ts
-        description: "Zustand store with persist middleware; manages theme (light/dark) and sidebarCollapsed"
-      - path: AegisLab-frontend/src/components/ui/ThemeToggle.tsx
-        description: "Toggle button component for switching between light and dark themes"
-      - path: AegisLab-frontend/src/main.tsx
-        description: "Ant Design ConfigProvider with custom theme tokens"
-      - path: AegisLab-frontend/src/styles/theme.css
-        description: "CSS variables for theming"
-      - path: AegisLab-frontend/src/utils/theme.ts
-        description: "Theme utility functions"
-      - path: AegisLab-frontend/src/utils/colors.ts
-        description: "Color utility functions"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: "Ant Design locale is set to zh_CN. Primary color is #0ea5e9 in main.tsx but CLAUDE.md says #2563eb -- minor inconsistency."
-
-  - id: REQ-803
-    title: Home Dashboard
-    description: >
-      Personal dashboard page showing welcome banner, recent projects list,
-      injection/execution metrics, system status, and quick action buttons.
-      Fetches all data from real metrics and projects APIs. Getting Started
-      card shown conditionally only when user has no projects.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "AegisLab-frontend/src/pages/home/HomePage.tsx"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/home/HomePage.tsx
-        description: "Dashboard with welcome, quick actions, 3 metric cards (Injections, Executions, System Status), recent projects, conditional Getting Started"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001, REQ-800]
-    conflicts: []
-    notes: >
-      CLEANED (2026-04-13): Deleted ActivityFeed.tsx, QuickActions.tsx, SystemMetrics.tsx (all mock/unused).
-      Removed Algorithms metric card and Execution Metrics Summary row (redundant).
-      Getting Started card now conditional on empty project list.
-
-  - id: REQ-804
-    title: User Profile Page
-    description: >
-      Simplified user profile page showing basic user information: avatar,
-      username, full name, email, phone, role, member since, last login.
-      All data fetched from GET /api/v2/auth/profile. Single Card layout
-      with Descriptions component, no tabs or sidebar.
-    priority: P2
-    status: implemented
-    confidence: confirmed
-    source: "AegisLab-frontend/src/pages/profile/ProfilePage.tsx"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/profile/ProfilePage.tsx
-        description: "Simplified profile page with Card + Descriptions showing user info from real API"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001]
-    conflicts: []
-    notes: >
-      SIMPLIFIED (2026-04-13): Deleted ProfileTab, ProjectsTab, StarsTab, ProfileSidebar,
-      ActivityGraph, ProjectCard, RecentRuns (7 files + CSS). All were mock/stub code.
-      Profile is now a single page with real API data, no tabs.
-
-  - id: REQ-805
-    title: User Settings Page
-    description: >
-      User settings page for personal preferences and account configuration.
-    priority: P2
-    status: implemented
-    confidence: inferred
-    source: "AegisLab-frontend/src/pages/settings/Settings.tsx"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/settings/Settings.tsx
-        description: "User settings page"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-001]
-    conflicts: []
-    notes: ""
-
-  - id: REQ-806
-    title: Workspace Table & Components
-    description: >
-      Reusable workspace table system for displaying injections, executions,
-      and other workspace-scoped data. Includes column management, sorting,
-      filtering, bulk actions, and run list panels. Supports column resizing,
-      persistence, and customizable toolbar.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "AegisLab-frontend/src/components/workspace/"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/components/workspace/WorkspaceTable.tsx
-        description: "Core workspace table component with sortable/filterable columns"
-      - path: AegisLab-frontend/src/components/workspace/WorkspacePageHeader.tsx
-        description: "Workspace page header with breadcrumbs and actions"
-      - path: AegisLab-frontend/src/components/workspace/WorkspaceSelector.tsx
-        description: "Workspace selector for switching contexts"
-      - path: AegisLab-frontend/src/components/workspace/TableToolbar.tsx
-        description: "Table toolbar with search, filter, and action buttons"
-      - path: AegisLab-frontend/src/components/workspace/BulkActionBar.tsx
-        description: "Bulk action bar for multi-select operations"
-      - path: AegisLab-frontend/src/components/workspace/ColumnManager.tsx
-        description: "Column visibility and order manager"
-      - path: AegisLab-frontend/src/components/workspace/ColumnsDropdown.tsx
-        description: "Dropdown for column selection"
-      - path: AegisLab-frontend/src/components/workspace/ColumnHeaderDropdown.tsx
-        description: "Column header dropdown with sort/filter options"
-      - path: AegisLab-frontend/src/components/workspace/SortDropdown.tsx
-        description: "Sort configuration dropdown"
-      - path: AegisLab-frontend/src/components/workspace/GroupDropdown.tsx
-        description: "Group configuration dropdown"
-      - path: AegisLab-frontend/src/components/workspace/NameColumnDropdown.tsx
-        description: "Name column configuration"
-      - path: AegisLab-frontend/src/components/workspace/RunsPanel.tsx
-        description: "Runs panel showing execution/injection runs"
-      - path: AegisLab-frontend/src/components/workspace/RunListItem.tsx
-        description: "Individual run list item component"
-      - path: AegisLab-frontend/src/components/workspace/RunListDropdown.tsx
-        description: "Run list dropdown"
-      - path: AegisLab-frontend/src/components/workspace/ChartCard.tsx
-        description: "Chart card component for workspace visualizations"
-      - path: AegisLab-frontend/src/components/workspace/ChartsPanel.tsx
-        description: "Charts panel for workspace data visualization"
-      - path: AegisLab-frontend/src/hooks/useColumnResize.ts
-        description: "Hook for column resize functionality"
-      - path: AegisLab-frontend/src/hooks/useTableColumns.ts
-        description: "Hook for table column management"
-      - path: AegisLab-frontend/src/hooks/useTablePersistence.ts
-        description: "Hook for persisting table configuration"
-      - path: AegisLab-frontend/src/hooks/useRunListSettings.ts
-        description: "Hook for run list display settings"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-800]
-    conflicts:
-      - "WorkspaceSelector.tsx:35-44 uses hardcoded mock workspace list instead of API call (HIGH priority)"
-    notes: ""
-
-  - id: REQ-807
-    title: Charts & Visualization
-    description: >
-      Chart components for data visualization using ECharts. Includes a
-      reusable LabChart component and workspace chart cards/panels.
-    priority: P1
-    status: implemented
-    confidence: inferred
-    source: "AegisLab-frontend/src/components/charts/"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/components/charts/LabChart.tsx
-        description: "Reusable ECharts-based chart component"
-      - path: AegisLab-frontend/src/components/workspace/ChartCard.tsx
-        description: "Chart card wrapper component"
-      - path: AegisLab-frontend/src/components/workspace/ChartsPanel.tsx
-        description: "Charts panel with multiple chart displays"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: "ECharts, D3.js, and Cytoscape.js available per CLAUDE.md"
-
-  - id: REQ-808
-    title: Reusable UI Components
-    description: >
-      Shared UI components used across the application: StatCard for metric
-      display, StatusBadge for state indicators, ThemeToggle for dark/light
-      mode switching.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "AegisLab-frontend/src/components/ui/"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/components/ui/StatCard.tsx
-        description: "Statistics card component for dashboards"
-      - path: AegisLab-frontend/src/components/ui/StatusBadge.tsx
-        description: "Status badge component for state indicators"
-      - path: AegisLab-frontend/src/components/ui/ThemeToggle.tsx
-        description: "Theme toggle button component"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: ""
-
-  - id: REQ-809
-    title: Frontend Build Tooling (Vite)
-    description: >
-      Vite 5 build configuration with React plugin, TypeScript strict mode,
-      path aliases (@/ for src/), API proxy to backend, ESLint, and Prettier.
-      Devbox provides pnpm 8 for package management. Private @OperationsPAI/client
-      package requires NPM_TOKEN for GitHub Packages authentication.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "AegisLab-frontend/vite.config.ts, AegisLab-frontend/package.json"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/vite.config.ts
-        description: "Vite configuration with React plugin, proxy, and aliases"
-      - path: AegisLab-frontend/package.json
-        description: "Package dependencies and scripts"
-      - path: AegisLab-frontend/tsconfig.json
-        description: "TypeScript configuration with strict mode"
-    has_mock: false
-
-    tests: []
-
-    docs:
-      - path: AegisLab-frontend/CLAUDE.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts: []
-    notes: "API proxy in dev server points to backend. pnpm dev starts on port 3000."
-
-  - id: REQ-810
-    title: Detail View System
-    description: >
-      Reusable detail view component with tabbed layout for displaying injection
-      and execution details. Tabs include overview, files, artifacts, config tree,
-      charts, logs, fault injection panel, and ground truth table. Features a
-      JSON viewer and pipeline log streaming viewer for real-time log display.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "AegisLab-frontend/src/components/workspace/DetailView/"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/components/workspace/DetailView/DetailView.tsx
-        description: "Main detail view container with tab navigation"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/DetailViewHeader.tsx
-        description: "Detail view header component"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/OverviewTab.tsx
-        description: "Overview summary tab"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/FilesTab.tsx
-        description: "Files listing tab"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/ArtifactsTab.tsx
-        description: "Artifacts tab"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/ConfigTree.tsx
-        description: "Configuration tree viewer"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/ChartsTab.tsx
-        description: "Charts visualization tab"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/LogsTab.tsx
-        description: "Logs tab"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/LogViewer/LogViewer.tsx
-        description: "Log viewer component"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/PipelineLogsViewer.tsx
-        description: "Real-time pipeline log streaming viewer"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/FaultInjectionPanel.tsx
-        description: "Fault injection configuration display"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/GroundTruthTable.tsx
-        description: "Ground truth data table"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/JsonViewer.tsx
-        description: "JSON data viewer component"
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/ArrowViewer.tsx
-        description: "Apache Arrow IPC data viewer"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-806]
-    conflicts: []
-    notes: ""
-
-  - id: REQ-811
-    title: Frontend Utility Libraries
-    description: >
-      Shared utility functions and type definitions for the frontend application.
-      Includes ID/name resolution utilities, state management helpers, text
-      processing, workspace types, and API type definitions that match
-      backend entities exactly.
-    priority: P2
-    status: implemented
-    confidence: confirmed
-    source: "AegisLab-frontend/src/utils/, AegisLab-frontend/src/types/"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/utils/idUtils.ts
-        description: "ID utility functions"
-      - path: AegisLab-frontend/src/utils/projectNameMap.ts
-        description: "Project name-to-ID mapping cache"
-      - path: AegisLab-frontend/src/utils/teamNameMap.ts
-        description: "Team name-to-ID mapping cache"
-      - path: AegisLab-frontend/src/utils/state.ts
-        description: "State utility functions"
-      - path: AegisLab-frontend/src/utils/textCrop.ts
-        description: "Text truncation utilities"
-      - path: AegisLab-frontend/src/types/api.ts
-        description: "TypeScript type definitions matching backend API exactly"
-      - path: AegisLab-frontend/src/types/workspace.ts
-        description: "Workspace-specific type definitions"
-    has_mock: false
-
-    tests: []
-    docs: []
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: []
-    conflicts:
-      - "types/api.ts has TODO comments about migrating hand-written types (Team, TeamMember, etc.) to SDK-generated types"
-    notes: "API types in api.ts must match backend snake_case field names exactly"
-
-  # ===========================================================================
-  # REQ-8xx (continued): New Requirements from Frontend Redesign (2026-04-13)
-  # ===========================================================================
-
-  - id: REQ-812
-    title: Pipeline Progress Component
-    description: >
-      New PipelineProgress component displaying injection pipeline stages
-      (Inject Fault → Build Datapack → Run Algorithm → Collect Result) with
-      real-time state updates via SSE. Shown at top of Injection Detail page.
-      Maps FaultInjection.state + associated Execution states to pipeline stages.
-      Data source: GET /api/v2/traces/:trace_id/stream (SSE).
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "docs/frontend-redesign.md section 5.6"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/components/workspace/PipelineProgress.tsx
-        description: "Pipeline progress bar component with SSE-driven Steps display"
-    has_mock: false
-
-    tests: []
-    docs:
-      - path: docs/frontend-redesign.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-100, REQ-402, REQ-404]
-    conflicts: []
-    notes: "Core UX component for Workflow A. Uses Ant Design Steps or custom progress bar."
-
-  - id: REQ-813
-    title: Algorithm Management (Researcher)
-    description: >
-      Workspace-scoped page for researchers to manage RCA algorithm containers.
-      Lists containers filtered by type=algorithm, supports registration of new
-      algorithms and version management. Reuses Container CRUD API with type filter.
-      Route: /:teamName/:projectName/algorithms
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "docs/frontend-redesign.md sections 4.3, 5.11"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/projects/algorithms/AlgorithmListPage.tsx
-        description: "Algorithm listing page with register/version modals and expandable version rows"
-    has_mock: false
-
-    tests: []
-    docs:
-      - path: docs/frontend-redesign.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-300, REQ-800]
-    conflicts: []
-    notes: "Filters GET /api/v2/containers by type=algorithm. Separate from admin /admin/containers which manages all types."
-
-  - id: REQ-814
-    title: Algorithm Benchmark Page (Workflow B)
-    description: >
-      Page for researchers to batch-test RCA algorithms against existing datapacks
-      or datasets. Two modes via tab switch: Datapack mode (select individual
-      datapacks) and Dataset mode (select entire dataset). Builds SubmitExecutionReq
-      with multiple ExecutionSpecs. Returns group_id for batch progress tracking.
-      Route: /:teamName/:projectName/executions/new
-    priority: P0
-    status: implemented
-    confidence: confirmed
-    source: "docs/frontend-redesign.md section 5.9"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/executions/ExecutionCreatePage.tsx
-        description: "Algorithm benchmark page with Datapack/Dataset mode tabs, multi-select, label support"
-    has_mock: false
-
-    tests: []
-    docs:
-      - path: docs/frontend-redesign.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-200, REQ-300, REQ-301]
-    conflicts: []
-    notes: >
-      Core page for Workflow B. Uses POST /api/v2/projects/:id/executions/execute.
-      Datapack mode: one spec per selected datapack. Dataset mode: one spec with dataset ref.
-
-  - id: REQ-815
-    title: Batch Execution Progress Banner
-    description: >
-      Progress banner shown at top of Execution List page when a batch execution
-      (group) is active. Shows real-time progress via SSE from
-      GET /api/v2/groups/:group_id/stream. Displays completed/total count and
-      failure count. Collapsible/dismissible.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "docs/frontend-redesign.md section 5.7"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/components/workspace/BatchProgressBanner.tsx
-        description: "SSE-driven batch execution progress banner with collapse/dismiss"
-      - path: AegisLab-frontend/src/pages/projects/ProjectExecutionList.tsx
-        description: "Execution list page with batch progress banner integration"
-    has_mock: false
-
-    tests: []
-    docs:
-      - path: docs/frontend-redesign.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-200, REQ-404]
-    conflicts: []
-    notes: "Uses existing group SSE infrastructure from REQ-404."
-
-  - id: REQ-816
-    title: Manual Datapack Upload UI
-    description: >
-      Frontend UI for uploading pre-built datapacks (ZIP archives containing
-      parquet files) without going through fault injection pipeline.
-      Uses POST /api/v2/injections/upload endpoint (already implemented in backend).
-    priority: P2
-    status: implemented
-    confidence: confirmed
-    source: "docs/frontend-redesign.md section 10 (API Coverage)"
-
-    code: []
-
-    frontend: []
-    has_mock: false
-
-    tests: []
-    docs:
-      - path: docs/frontend-redesign.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    frontend:
-      - path: AegisLab-frontend/src/pages/projects/ProjectInjectionList.tsx
-        description: "Upload Datapack button and modal added to injection list page"
-
-    depends_on: [REQ-104]
-    conflicts: []
-    notes: "Backend upload endpoint at POST /api/v2/injections/upload. Frontend uploads via Ant Design Dragger."
-
-  - id: REQ-817
-    title: Execution Detail Results Display
-    description: >
-      Enhanced Execution Detail page showing DetectorResults and GranularityResults
-      from algorithm execution. DetectorResults: table of span-level normal vs
-      abnormal metrics. GranularityResults: hierarchical display by level
-      (service/pod/span/metric) of localization results.
-    priority: P1
-    status: implemented
-    confidence: confirmed
-    source: "docs/frontend-redesign.md section 5.8"
-
-    code: []
-
-    frontend:
-      - path: AegisLab-frontend/src/components/workspace/DetailView/tabs/ArtifactsTab.tsx
-        description: "ArtifactsTab aligned with SDK DetectorResultItem/GranularityResultItem types, p90/p95/p99 columns"
-      - path: AegisLab-frontend/src/pages/projects/ProjectExecutionDetail.tsx
-        description: "Execution detail page with SDK-aligned artifacts display"
-    has_mock: false
-
-    tests: []
-    docs:
-      - path: docs/frontend-redesign.md
-
-    acceptance:
-      status: pending
-      date: ""
-      notes: ""
-
-    depends_on: [REQ-200, REQ-201]
-    conflicts: []
-    notes: "Backend already returns DetectorResult and GranularityResult in ExecutionDetailResp."
-
-# =============================================================================
-# Cross-Repo Audit Summary (2026-04-13, updated after full frontend implementation)
-# =============================================================================
-#
-# FRONTEND REDESIGN (2026-04-13 — Phase 1: Cleanup & Design):
-#   - 18 files deleted (notifications, stars, mock components, profile stubs)
-#   - 8 files edited (App.tsx, AppHeader, MainSidebar, WorkspaceSidebar, etc.)
-#   - 4 bugs fixed (team addMember, label mock, star toggles)
-#   - 6 new requirements added (REQ-812 through REQ-817)
-#   - 1 requirement removed (REQ-503 notifications frontend)
-#   - 7 requirements simplified/cleaned (REQ-004/005/006/501/800/803/804)
-#   - Design docs: docs/frontend-redesign.md, docs/frontend-ui-guidelines.md
-#
-# FRONTEND IMPLEMENTATION (2026-04-13 — Phase 2: All REQ-812~817 implemented):
-#   - REQ-812: PipelineProgress.tsx — SSE-driven pipeline stages in Injection Detail ✓
-#   - REQ-813: AlgorithmListPage.tsx — Register/version/delete modals ✓
-#   - REQ-814: ExecutionCreatePage.tsx — Datapack/Dataset dual-mode benchmark page ✓
-#   - REQ-815: BatchProgressBanner.tsx — SSE group progress in Execution List ✓
-#   - REQ-816: Upload modal in ProjectInjectionList.tsx — POST /injections/upload ✓
-#   - REQ-817: ArtifactsTab.tsx aligned with SDK DetectorResultItem/GranularityResultItem ✓
-#   - ExecutionCreatePage passes group_id via URL params to Execution List ✓
-#   - Orphaned ExecutionForm.tsx deleted ✓
-#   - Build verification: pnpm type-check && pnpm build — 0 errors ✓
-#
-# RUNTIME BUGS (REMAINING):
-#   - totalExperiments stat hardcoded to 0 in ProjectList (REQ-005)
-#   - WorkspaceSelector.tsx:35-44 has hardcoded mock workspace list (no API call)
-#
-# RUNTIME BUGS (FIXED 2026-04-13):
-#   - teamApi.addMember now sends {username} (was {email}) (REQ-004) ✓
-#   - AddLabelDropdown now uses real API (was mock) (REQ-006) ✓
-#   - Star toggles removed from ProjectList and teams/ProjectsTab ✓
-#   - GetInjectionLogs now queries Loki for real logs (REQ-100) ✓
-#   - GetTaskDetail now queries Loki for real logs (REQ-400) ✓
-#   - executeTaskWithRetry backoff implemented via RetryPolicy.BackoffSec (REQ-400) ✓
-#   - traceApi.getTrace → GET /traces/:trace_id confirmed working (was false alarm) ✓
-#
-# MOCK/STUB COUNT (AFTER 2026-04-13 AUDIT):
-#   - Frontend: 0 has_mock: true requirements (was 6)
-#   - Backend: 1 finding (LOW) — deprecated monitor.go hardcoded data (REQ-100/400 fixed)
-#   - Frontend remaining mocks: WorkspaceSelector.tsx (HIGH), ProjectList totalExperiments (MEDIUM)
-#
-# MISSING FRONTEND COVERAGE (24 backend endpoints):
-#   - /systems/* (7 endpoints) — Chaos Systems management, no frontend
-#   - /sdk/evaluations/* (4 endpoints) — SDK evaluations, no frontend
-#   - /system/audit/* (2 endpoints) — Audit log viewer, no frontend (REQ-007 conflict)
-#   - /system/configs/* (5 endpoints) — Dynamic config admin, no frontend
-#   - /system/health + /system/monitor/* (5 endpoints) — Health/monitor, no frontend
-#   - PUT /injections/:id/groundtruth — Ground truth editing, no frontend
-#
-# ORPHAN FRONTEND CALLS:
-#   - (none — traceApi.getTrace confirmed working as of 2026-04-13 audit)
-#
-# SDK USAGE:
-#   - @rcabench/client used for TYPE IMPORTS and direct types (DetectorResultItem, GranularityResultItem)
-#   - All HTTP calls use raw axios via src/api/client.ts
-#
-# DATA INCONSISTENCIES:
-#   - Theme color: main.tsx uses #0ea5e9, CLAUDE.md says #2563eb (REQ-802)
-#   - Rate limit: GeneralRateLimit var comment still says 100, code sets 1000 (REQ-008, partially fixed)
-#   - REQ-105: was marked 'implemented' but code is commented out → changed to 'disabled'
-#
-# REQUIREMENT STATUS SUMMARY:
-#   - implemented: 67 (was 61)
-#   - planned: 0 (was 6)
-#   - disabled: 1
-#   - removed-frontend: 1
-#   - not-applicable: 1
-#
-# TESTING GAP: 61/69 requirements have tests: [] — only REQ-001 and REQ-703 have tests
-# ACCEPTANCE GAP: 0/69 requirements have acceptance passed (1 not-applicable: REQ-503)
+- id: REQ-001
+  title: User Authentication (JWT)
+  description: 'Users authenticate via username/password login to obtain JWT access tokens. Backend supports user registration, login, and token refresh. Two token types: user tokens (carry user_id, username, email, is_admin, roles) and service tokens (carry task_id, used by K8s jobs). OptionalJWTAuth allows unauthenticated access on select endpoints. Frontend provides login page with username/password form, JWT token storage in localStorage, automatic token refresh on 401 via Axios interceptor, logout with token cleanup, and route guards that redirect unauthenticated users to /login.
+
+    '
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: src/middleware/auth.go, src/handlers/v2/auth.go, AegisLab-frontend/src/store/auth.ts, AegisLab-frontend/src/api/auth.ts
+  code:
+  - path: AegisLab/src/middleware/auth.go
+    description: JWTAuth, OptionalJWTAuth middlewares; helper functions for extracting user/service context from JWT claims
+  - path: AegisLab/src/handlers/v2/auth.go
+    description: Register, Login endpoints with Swagger annotations and SDK marking
+  - path: AegisLab/src/service/producer/auth.go
+    description: Business logic for registration and login
+  frontend:
+  - path: AegisLab-frontend/src/store/auth.ts
+    description: Zustand store managing user, tokens, isAuthenticated state; login/logout/refresh/loadUser actions
+  - path: AegisLab-frontend/src/api/auth.ts
+    description: Auth API client with login, register, logout, getProfile, changePassword, refreshToken endpoints
+  - path: AegisLab-frontend/src/api/client.ts
+    description: Axios instance with request interceptor (attach Bearer token) and response interceptor (auto-refresh on 401)
+  - path: AegisLab-frontend/src/pages/auth/Login.tsx
+    description: Login form page with username/password fields, navigates to /dashboard on success
+  - path: AegisLab-frontend/src/App.tsx
+    description: Route guards checking isAuthenticated, redirecting to /login when not authenticated
+  has_mock: false
+  tests:
+  - path: src/utils/password_test.go
+    description: Tests password hashing utility used by auth
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: 'Service tokens enable K8s jobs to call back into the API securely. Login page has Chinese UI strings (localized). Token refresh stores same token for both access and refresh (backend returns single token).
+
+    '
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-002
+  title: User Management (CRUD)
+  description: 'Admin-level CRUD for user accounts: create, list, get detail, update, delete. Includes activation/deactivation and password management. Frontend provides an admin users page at /admin/users.
+
+    '
+  priority: P0
+  status: implemented
+  confidence: inferred
+  source: src/handlers/v2/users.go, src/repository/user.go, AegisLab-frontend/src/pages/admin/AdminUsersPage.tsx
+  code:
+  - path: AegisLab/src/handlers/v2/users.go
+    description: CreateUser, ListUsers, GetUser, UpdateUser, DeleteUser handlers
+  - path: AegisLab/src/database/entity.go
+    description: User entity with username, email, password, full_name, avatar, phone, status, soft delete
+  - path: AegisLab/src/repository/user.go
+    description: Data access layer for user operations
+  frontend:
+  - path: AegisLab-frontend/src/pages/admin/AdminUsersPage.tsx
+    description: Admin user management page
+  - path: AegisLab-frontend/src/api/users.ts
+    description: Users API client
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  conflicts: []
+  notes: Password is hashed via BeforeCreate GORM hook
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-003
+  title: Role-Based Access Control (RBAC)
+  description: 'Comprehensive RBAC system with roles, permissions, and resources. Permissions are scoped (system, team, project, own) with actions (read, create, update, delete, manage, execute, etc.). Permission inheritance is implemented (manage inherits all lower permissions). System admin, team admin, project admin, and ownership checks are supported. Frontend has API clients for roles, permissions, and resources but no dedicated admin UI page for RBAC management yet.
+
+    '
+  priority: P0
+  status: implemented
+  confidence: inferred
+  source: src/middleware/permission.go, src/handlers/v2/roles.go, AegisLab-frontend/src/api/roles.ts
+  code:
+  - path: AegisLab/src/middleware/permission.go
+    description: 'Decorator-pattern permission middleware: singlePermission, anyPermission, allPermissions, ownershipCheck, adminOrOwnership, teamAccessCheck, projectAccessCheck. Pre-built permission variables for every domain.
+
+      '
+  - path: AegisLab/src/database/entity.go
+    description: Role, Permission, Resource entities with hierarchical resource categories
+  - path: AegisLab/src/handlers/v2/roles.go
+    description: CRUD for roles with permission assignment
+  - path: AegisLab/src/handlers/v2/permissions.go
+    description: Permission listing and detail endpoints
+  - path: AegisLab/src/handlers/v2/resources.go
+    description: Resource listing and detail endpoints
+  frontend:
+  - path: AegisLab-frontend/src/api/roles.ts
+    description: Roles API client
+  - path: AegisLab-frontend/src/api/permissions.ts
+    description: Permissions API client
+  - path: AegisLab-frontend/src/api/resources.ts
+    description: Resources API client
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  - REQ-002
+  conflicts:
+  - Backend has full RBAC admin endpoints but frontend lacks a dedicated RBAC management UI page
+  - Frontend admin check in MainSidebarContent.tsx uses unsafe cast hack instead of proper role field from UserInfo type
+  notes: 'Permission rules cover: system, audit, configuration, user, role, permission, team, project, container, container_version, dataset, dataset_version, label, task, trace domains.
+
+    '
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-004
+  title: Team Management
+  description: 'Teams group users and own projects. Supports CRUD, membership management (join/leave, admin promotion), and public/private visibility. Team access checks verify membership, admin status, or public access. Frontend provides a team detail page with tabs for overview, projects, users, and settings, plus a team creation modal in the sidebar.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: inferred
+  source: src/handlers/v2/teams.go, AegisLab-frontend/src/pages/teams/TeamDetailPage.tsx
+  code:
+  - path: AegisLab/src/handlers/v2/teams.go
+    description: CreateTeam, DeleteTeam, ListTeams, GetTeam, UpdateTeam handlers
+  - path: AegisLab/src/database/entity.go
+    description: Team entity with name, description, is_public, status, projects relationship
+  - path: AegisLab/src/middleware/permission.go
+    description: RequireTeamAccess, RequireTeamAdminAccess, RequireTeamMemberAccess middlewares
+  frontend:
+  - path: AegisLab-frontend/src/api/teams.ts
+    description: Team CRUD client still exposed from the current frontend
+  - path: AegisLab-frontend/src/hooks/useTeams.ts
+    description: Shared team query hook used by current pages and selectors
+  - path: AegisLab-frontend/src/utils/teamNameMap.ts
+    description: Team display-name helpers retained after the layout refactor
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  - REQ-003
+  conflicts: []
+  notes: 'FIXED (2026-04-13): addMember now sends {username, role_id}. Star toggle removed. member_count maps from backend user_count via useTeamContext hook.
+
+
+    Workspace/detail-view era frontend paths were replaced with current route-based pages and API clients during the index rebuild.'
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-005
+  title: Project Management
+  description: 'Projects are the primary organizational unit. They belong to optional teams, have many-to-many relationships with containers and datasets, and support RBAC via project-level permissions. CRUD with public/private visibility. Frontend provides project listing, creation/editing forms, project overview page, and project settings within the workspace layout.
+
+    '
+  priority: P0
+  status: implemented
+  confidence: inferred
+  source: src/handlers/v2/projects.go, AegisLab-frontend/src/pages/projects/ProjectList.tsx
+  code:
+  - path: AegisLab/src/handlers/v2/projects.go
+    description: CreateProject, DeleteProject, ListProjects, GetProject, UpdateProject handlers
+  - path: AegisLab/src/database/entity.go
+    description: Project entity with team FK, containers and datasets M2M, labels M2M
+  - path: AegisLab/src/middleware/permission.go
+    description: RequireProjectAccess, RequireProjectAdminAccess, RequireProjectMemberAccess middlewares
+  frontend:
+  - path: AegisLab-frontend/src/pages/projects/ProjectList.tsx
+    description: Project listing and entry point for workspace navigation
+  - path: AegisLab-frontend/src/pages/projects/ProjectDetail.tsx
+    description: Project detail shell and overview cards
+  - path: AegisLab-frontend/src/pages/projects/ProjectSettings.tsx
+    description: Project settings view
+  - path: AegisLab-frontend/src/pages/projects/CreateProjectModal.tsx
+    description: Project creation flow exposed from the current layout
+  - path: AegisLab-frontend/src/api/projects.ts
+    description: Project API bindings generated from the backend contract
+  - path: AegisLab-frontend/src/hooks/useProjectContext.ts
+    description: Project context resolution used across project pages
+  - path: AegisLab-frontend/src/hooks/useProjects.ts
+    description: Project collection query hook
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  - REQ-003
+  - REQ-004
+  conflicts:
+  - 'totalExperiments stat hardcoded to 0 (TODO: needs API support)'
+  notes: 'FIXED (2026-04-13): Star toggle removed from ProjectList.'
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-006
+  title: Label System
+  description: 'Unified label management supporting key-value pairs with categories (dataset, fault_injection, algorithm, container, etc.), colors, usage counts, and system labels. Labels are attached to containers, datasets, projects, configs, injections, and executions via M2M relationships. Frontend provides label API client and AddLabelDropdown workspace component.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: inferred
+  source: src/handlers/v2/labels.go, AegisLab-frontend/src/api/labels.ts
+  code:
+  - path: AegisLab/src/handlers/v2/labels.go
+    description: BatchDeleteLabels, CRUD for labels
+  - path: AegisLab/src/database/entity.go
+    description: Label entity with key, value, category, color, usage count; M2M join tables
+  frontend:
+  - path: AegisLab-frontend/src/api/labels.ts
+    description: Frontend label CRUD and attachment APIs
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: 'Labels use ActiveKeyValue virtual column for uniqueness enforcement. FIXED (2026-04-13): AddLabelDropdown now fetches real labels via GET /api/v2/labels.
+
+
+    Workspace/detail-view era frontend paths were replaced with current route-based pages and API clients during the index rebuild.'
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-007
+  title: Audit Logging
+  description: 'Automatic audit logging of all non-GET API requests. Captures HTTP method, path, query, status code, duration, user ID, resource type, and sanitized request body. Sensitive paths (auth/login, password) are excluded from body logging. Async logging to avoid blocking requests. No dedicated frontend UI for viewing audit logs yet.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: confirmed
+  source: src/middleware/audit.go, src/database/entity.go, src/repository/audit.go
+  code:
+  - path: AegisLab/src/middleware/audit.go
+    description: AuditMiddleware captures request/response details, determines action and resource, logs asynchronously
+  - path: AegisLab/src/database/entity.go
+    description: AuditLog entity with IP, user agent, action, details, error_msg, resource associations
+  - path: AegisLab/src/service/producer/audit.go
+    description: LogUserAction, LogFailedAction service methods
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  conflicts:
+  - Backend has audit logging but frontend has no UI to view audit logs
+  notes: 'Sensitive fields (password, token, secret) are redacted from logged request bodies
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-008
+  title: Rate Limiting
+  description: 'In-memory sliding-window rate limiting with three tiers: general (1000/min), auth (100/min), strict (20/min). Supports IP-based, user-based, and API-key-based rate limiting with periodic cleanup. Backend-only infrastructure; no frontend representation needed.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: confirmed
+  source: src/middleware/ratelimit.go
+  code:
+  - path: AegisLab/src/middleware/ratelimit.go
+    description: RateLimiter struct with sliding window, IP/user/API-key based middleware variants
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: 'Most comment/code mismatches fixed (2026-04-13). Remaining: GeneralRateLimit var comment still says ''100 requests per minute per IP'' but code sets 1000.
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: service
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-009
+  title: Dynamic Configuration
+  description: 'Runtime-modifiable configuration system stored in MySQL. Supports typed values (string, bool, int, float64, string array), validation (min/max, regex, allowed options), secret masking, and full change history with rollback support. Scoped to producer or consumer. Frontend provides a system settings admin page.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: inferred
+  source: src/database/entity.go, src/service/producer/dynamic_config.go, AegisLab-frontend/src/pages/system/SystemSettings.tsx
+  code:
+  - path: AegisLab/src/database/entity.go
+    description: DynamicConfig and ConfigHistory entities with validation fields
+  - path: AegisLab/src/service/producer/dynamic_config.go
+    description: Config update logic with history tracking and context
+  frontend:
+  - path: AegisLab-frontend/src/pages/system/SystemSettings.tsx
+    description: Current system settings screen for dynamic config values
+  - path: AegisLab-frontend/src/api/system.ts
+    description: System and config API client
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  - REQ-003
+  conflicts: []
+  notes: ''
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-100
+  title: Fault Injection (Chaos Mesh CRD)
+  description: 'Core fault injection via Chaos Mesh Kubernetes CRDs. Supports multiple chaos types (network, pod, stress, etc.) across registered system categories. FaultInjection entity is the same as Datapack (different views of same data). Includes display config (user-facing), engine config (runtime), groundtruths, pre-duration, and time windows. Frontend provides injection listing, detail view (with overview, files, artifacts, config, charts, logs tabs), and a multi-step injection creation form with visual canvas for fault node configuration.
+
+    '
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: src/handlers/v2/injections.go, AegisLab-frontend/src/pages/projects/ProjectInjectionList.tsx
+  code:
+  - path: AegisLab/src/handlers/v2/injections.go
+    description: CRUD handlers for injections including batch delete, get, list, create
+  - path: AegisLab/src/service/consumer/fault_injection.go
+    description: executeFaultInjection task handler with batch manager for parallel injections
+  - path: AegisLab/src/database/entity.go
+    description: FaultInjection entity with chaos type, category, groundtruths, engine config, benchmark/pedestal FKs
+  frontend: &id001
+  - path: AegisLab-frontend/src/pages/injections/InjectionWizard.tsx
+    description: Current multi-step fault injection authoring flow
+  - path: AegisLab-frontend/src/pages/injections/components/FaultTypePanel.tsx
+    description: Fault type selection backed by backend metadata
+  - path: AegisLab-frontend/src/pages/injections/components/FaultConfigPanel.tsx
+    description: Fault parameter editor for generated chaos specs
+  - path: AegisLab-frontend/src/pages/injections/components/VisualCanvas.tsx
+    description: Visualization canvas for configured faults
+  - path: AegisLab-frontend/src/pages/projects/ProjectDatapacks.tsx
+    description: Project-scoped datapack list with inject/upload entry points
+  - path: AegisLab-frontend/src/pages/datapacks/DatapackDetail.tsx
+    description: Datapack detail page with files, logs, and state stepper
+  - path: AegisLab-frontend/src/api/injections.ts
+    description: Injection metadata, CRUD, download, and datapack file APIs
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-005
+  - REQ-300
+  - REQ-400
+  conflicts: []
+  notes: 'FaultInjection = Datapack is a key architectural fact. Source can be ''injection'' (auto-generated) or ''manual'' (uploaded). FIXED (2026-04-13): GetInjectionLogs now queries Loki for real historical logs.
+
+
+    Workspace/detail-view era frontend paths were replaced with current route-based pages and API clients during the index rebuild.'
+  type: capability
+  repo: aegislab
+  chaos_code:
+  - path: chaos-experiment/handler/handler.go
+    description: System-aware chaos generation entrypoint
+  - path: chaos-experiment/handler/network_chaos.go
+    description: Network fault generation helpers
+  - path: chaos-experiment/chaos/network_chaos.go
+    description: Network chaos CRD builders
+  - path: chaos-experiment/controllers/network_chao.go
+    description: Network chaos controller helpers
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+  - chaos-mesh-crd
+  parent: REQ-900
+- id: REQ-101
+  title: Batch Fault Injection
+  description: 'Support for parallel fault injection of multiple nodes simultaneously. batchManager tracks batch progress and waits for all CRDs to complete before triggering the next pipeline stage (BuildDatapack). No separate frontend UI; batch behavior is part of the injection creation form.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: confirmed
+  source: src/service/consumer/fault_injection.go, src/service/consumer/k8s_handler.go
+  code:
+  - path: AegisLab/src/service/consumer/fault_injection.go
+    description: batchManager singleton with mutex-protected batch tracking
+  - path: AegisLab/src/service/consumer/k8s_handler.go
+    description: HandleCRDSucceeded checks batch completion before submitting next task
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: pipeline
+  repo: aegislab
+  chaos_code:
+  - path: chaos-experiment/controllers/workflow.go
+    description: Workflow batching and serial/parallel orchestration
+  - path: chaos-experiment/chaos/workflow_chaos.go
+    description: Workflow chaos spec builders
+  rcabench_code: []
+  contracts:
+  - chaos-mesh-crd
+- id: REQ-102
+  title: Chaos System Registration
+  description: 'Registry of chaos target systems (e.g., train-ticket, sock-shop) with namespace patterns, service extraction patterns, display names, and builtin/custom designation. SystemMetadata stores per-system service endpoints and Java methods. Backend-only; system selection is embedded in the injection creation form.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: inferred
+  source: src/handlers/v2/systems.go, src/database/entity.go, src/service/producer/chaos_system.go
+  code:
+  - path: AegisLab/src/handlers/v2/systems.go
+    description: ListChaosSystemsHandler, GetChaosSystemHandler and CRUD for chaos systems
+  - path: AegisLab/src/database/entity.go
+    description: System and SystemMetadata entities
+  - path: AegisLab/src/service/initialization/systems.go
+    description: System initialization/seeding on startup
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: capability
+  repo: aegislab
+  chaos_code:
+  - path: chaos-experiment/handler/registration.go
+    description: Dynamic system registration hooks consumed by AegisLab
+  - path: chaos-experiment/handler/model.go
+    description: System metadata models used by registration
+  rcabench_code: []
+  contracts:
+  - chaos-mesh-crd
+  parent: REQ-900
+- id: REQ-103
+  title: Pedestal Restart
+  description: 'Ability to restart the target pedestal system (the microservice system under test) as part of the fault injection pipeline. Uses rate limiting to avoid overloading the cluster. Backend-only task; no dedicated frontend UI.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: inferred
+  source: src/service/consumer/restart_pedestal.go, src/service/consumer/rate_limiter.go
+  code:
+  - path: AegisLab/src/service/consumer/restart_pedestal.go
+    description: executeRestartPedestal task handler with rate limiter integration
+  - path: AegisLab/src/service/consumer/rate_limiter.go
+    description: TokenBucketRateLimiter for pedestal restart operations
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  - REQ-400
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: pipeline
+  repo: aegislab
+  chaos_code:
+  - path: chaos-experiment/handler/pod_chaos.go
+    description: Pod-level restart targeting helpers
+  - path: chaos-experiment/controllers/pod_chaos.go
+    description: Pod chaos controller wrappers
+  rcabench_code: []
+  contracts:
+  - chaos-mesh-crd
+- id: REQ-104
+  title: Manual Datapack Upload
+  description: 'Upload pre-built datapacks (ZIP archives containing parquet files) without going through the fault injection pipeline. Supports labels, groundtruths, and validation of parquet file structure. No dedicated frontend upload UI yet.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: inferred
+  source: src/service/producer/upload.go, src/handlers/v2/injections.go
+  code:
+  - path: AegisLab/src/service/producer/upload.go
+    description: UploadDatapack validates ZIP structure (6 recognized parquet files), parses labels/groundtruths
+  - path: AegisLab/src/handlers/v2/injections.go
+    description: Upload handler endpoint
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  conflicts:
+  - Backend has datapack upload endpoint but frontend has no upload UI
+  notes: 'Valid parquet files: abnormal/normal traces, metrics, logs
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: pipeline
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - dataset-schema
+  parent: REQ-901
+- id: REQ-105
+  title: JVM Runtime Mutator (Disabled)
+  description: 'JVM-level chaos injection targeting specific classes and methods with value mutations. Currently disabled due to dependency issues.
+
+    '
+  priority: P2
+  status: removed-frontend
+  confidence: uncertain
+  source: src/service/consumer/jvm_runtime_mutator.go
+  code:
+  - path: AegisLab/src/service/consumer/jvm_runtime_mutator.go
+    description: Commented-out JVM runtime mutator implementation
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  conflicts: []
+  notes: 'Entire file is commented out with a note about dependency issues. Status changed from ''implemented'' to ''disabled'' per 2026-04-13 audit.
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: capability
+  repo: aegislab
+  chaos_code:
+  - path: chaos-experiment/chaos/jvm_runtime_mutator.go
+    description: JVM runtime mutator spec builder retained in the chaos library
+  - path: chaos-experiment/controllers/jvm_runtime_mutator.go
+    description: Controller entrypoint for JVM runtime mutator
+  rcabench_code: []
+  contracts:
+  - chaos-mesh-crd
+- id: REQ-200
+  title: Algorithm Execution
+  description: 'Execute RCA algorithms against datapacks by spawning K8s jobs. Creates Execution records linking algorithm version to datapack, tracks state (pending, running, completed, failed), and stores duration. Frontend provides execution listing, detail view, and creation form within the workspace layout.
+
+    '
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: src/handlers/v2/executions.go, AegisLab-frontend/src/pages/projects/ProjectExecutionList.tsx
+  code:
+  - path: AegisLab/src/handlers/v2/executions.go
+    description: 'CRUD handlers for executions: batch delete, get, list, create'
+  - path: AegisLab/src/service/consumer/algo_execution.go
+    description: executeAlgorithm task handler creating K8s jobs with algorithm container
+  - path: AegisLab/src/database/entity.go
+    description: Execution entity with algorithm_version, datapack, dataset_version FKs
+  frontend:
+  - &id002
+    path: AegisLab-frontend/src/pages/projects/ProjectExecutions.tsx
+    description: Project execution list and launch entry point
+  - &id003
+    path: AegisLab-frontend/src/pages/executions/CreateExecutionForm.tsx
+    description: Execution submission flow for algorithms against datapacks
+  - &id004
+    path: AegisLab-frontend/src/pages/executions/ExecutionDetail.tsx
+    description: Execution detail and result drill-down
+  - &id005
+    path: AegisLab-frontend/src/api/executions.ts
+    description: Execution API client
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  - REQ-300
+  - REQ-400
+  conflicts: []
+  notes: Workspace/detail-view era frontend paths were replaced with current route-based pages and API clients during the index rebuild.
+  type: pipeline
+  repo: aegislab
+  chaos_code: []
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/algorithms/spec.py
+    description: Algorithm registry contract
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/experiments/single.py
+    description: Single datapack execution pipeline
+  contracts:
+  - openapi-backend-sdk
+  - dataset-schema
+  parent: REQ-902
+- id: REQ-201
+  title: Result Collection
+  description: 'After algorithm execution completes, a CollectResult task gathers output from the K8s job. Handles different result types including detector results and granularity results. Special handling for built-in detector algorithms. Backend-only task processing; results are displayed in the execution detail view.
+
+    '
+  priority: P0
+  status: removed-frontend
+  confidence: inferred
+  source: src/service/consumer/collect_result.go, src/database/entity.go
+  code:
+  - path: AegisLab/src/service/consumer/collect_result.go
+    description: executeCollectResult parses algorithm output, distinguishes detector vs general algorithms
+  - path: AegisLab/src/database/entity.go
+    description: DetectorResult (span metrics) and GranularityResult (localization at service/pod/span/metric levels)
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-200
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: pipeline
+  repo: aegislab
+  chaos_code: []
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/experiments/report.py
+    description: Result aggregation and report generation
+  contracts:
+  - dataset-schema
+- id: REQ-202
+  title: Evaluation (Datapack-level)
+  description: 'Evaluate algorithm performance on individual datapacks. Supports batch evaluation of multiple algorithm-datapack pairs with label filtering. Uses the analyzer service for computation. Frontend provides evaluation listing and detail pages within workspace.
+
+    '
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: src/handlers/v2/evaluations.go, AegisLab-frontend/src/pages/evaluations/EvaluationList.tsx
+  code:
+  - path: AegisLab/src/handlers/v2/evaluations.go
+    description: ListDatapackEvaluationResults endpoint (SDK-enabled)
+  - path: AegisLab/src/service/analyzer/evaluation.go
+    description: Batch evaluation logic mapping container refs to versions and computing results
+  frontend: &id006
+  - path: AegisLab-frontend/src/pages/projects/ProjectEvaluations.tsx
+    description: Project evaluation landing page
+  - path: AegisLab-frontend/src/pages/evaluations/EvaluationForm.tsx
+    description: Evaluation configuration flow
+  - path: AegisLab-frontend/src/api/evaluations.ts
+    description: Evaluation API client for datapack and dataset queries
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-200
+  - REQ-201
+  conflicts: []
+  notes: Workspace/detail-view era frontend paths were replaced with current route-based pages and API clients during the index rebuild.
+  type: pipeline
+  repo: aegislab
+  chaos_code: []
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/ranking.py
+    description: Ranking metrics for datapack and dataset evaluation
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/experiments/report.py
+    description: Evaluation report generation
+  contracts:
+  - openapi-backend-sdk
+  - dataset-schema
+  parent: REQ-902
+- id: REQ-203
+  title: Evaluation (Dataset-level)
+  description: 'Evaluate algorithm performance across entire datasets (collections of datapacks). Supports batch evaluation of multiple algorithm-dataset pairs. Frontend evaluation pages support both datapack and dataset level.
+
+    '
+  priority: P0
+  status: removed-frontend
+  confidence: inferred
+  source: src/handlers/v2/evaluations.go, src/service/analyzer/evaluation.go
+  code:
+  - path: AegisLab/src/handlers/v2/evaluations.go
+    description: ListDatasetEvaluationResults endpoint (SDK-enabled)
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-202
+  - REQ-301
+  conflicts: []
+  notes: 'Frontend evaluation pages (covered by REQ-202) handle both datapack and dataset level
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: pipeline
+  repo: aegislab
+  chaos_code: []
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/experiments/batch.py
+    description: Dataset-level experiment batching
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/ranking.py
+    description: Dataset-level aggregation metrics
+  contracts:
+  - dataset-schema
+- id: REQ-204
+  title: Datapack Querying (DuckDB Arrow)
+  description: 'Query parquet files within datapacks using DuckDB with Apache Arrow IPC streaming. Requires build tag ''duckdb_arrow''. Provides file content streaming for analysis. Frontend has an ArrowViewer component for rendering Arrow IPC data.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: confirmed
+  source: src/service/producer/query_datapack_arrow.go, AegisLab-frontend/src/components/workspace/DetailView/tabs/ArrowViewer.tsx
+  code:
+  - path: AegisLab/src/service/producer/query_datapack_arrow.go
+    description: 'QueryDatapackFileContent using DuckDB Arrow connector (build tag: duckdb_arrow)'
+  - path: AegisLab/src/service/producer/query_datapack_noarrow.go
+    description: Stub returning error when duckdb_arrow tag is not set
+  frontend:
+  - path: AegisLab-frontend/src/pages/datapacks/DatapackDetail.tsx
+    description: Datapack detail page used to browse generated artifacts
+  - path: AegisLab-frontend/src/api/injections.ts
+    description: File listing, download, and content query methods for datapacks
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  conflicts: []
+  notes: 'Build MUST include -tags duckdb_arrow for this feature
+
+    Workspace/detail-view era frontend paths were replaced with current route-based pages and API clients during the index rebuild.'
+  type: capability
+  repo: aegislab
+  chaos_code:
+  - path: chaos-experiment/cmd/faultpoints/main.go
+    description: Fault point generator used to inspect available injection targets
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/datasets/spec.py
+    description: Canonical datapack folder and metadata layout
+  - path: rcabench-platform/src/rcabench_platform/v3/internal/sources/convert.py
+    description: Converter that writes normalized parquet/json datapacks
+  contracts:
+  - openapi-backend-sdk
+  - dataset-schema
+- id: REQ-205
+  title: SDK Evaluations
+  description: 'Read-only access to evaluation data created by the Python SDK. Lists and retrieves SDKEvaluationSample records from a table managed by the SDK (not auto-migrated by AegisLab). Supports filtering by exp_id and stage. No dedicated frontend UI.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: inferred
+  source: src/handlers/v2/sdk_evaluations.go, src/database/sdk_entities.go
+  code:
+  - path: AegisLab/src/handlers/v2/sdk_evaluations.go
+    description: ListSDKEvaluations, GetSDKEvaluation handlers
+  - path: AegisLab/src/database/sdk_entities.go
+    description: SDKEvaluationSample and SDKDatasetSample entities (read-only, SDK-managed tables)
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-600
+  conflicts: []
+  notes: 'Tables created/managed by Python SDK, AegisLab only reads them
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: pipeline
+  repo: aegislab
+  chaos_code: []
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/__init__.py
+    description: Python evaluation surface exported to downstream callers
+  contracts:
+  - dataset-schema
+- id: REQ-206
+  title: Database Views for Evaluation
+  description: 'Pre-computed MySQL views for efficient evaluation queries: FaultInjectionNoIssues and FaultInjectionWithIssues, aggregating injection data with detector results. Backend-only infrastructure.
+
+    '
+  priority: P2
+  status: removed-frontend
+  confidence: inferred
+  source: src/database/view.go
+  code:
+  - path: AegisLab/src/database/view.go
+    description: View model structs for fault_injection_no_issues and fault_injection_with_issues
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  - REQ-201
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/ranking.py
+    description: Evaluation outputs shaped for persisted reporting views
+  contracts:
+  - dataset-schema
+- id: REQ-300
+  title: Container Management
+  description: 'Containers are versioned registry images (algorithms, benchmarks, pedestals). CRUD with type classification (algorithm, benchmark, pedestal). ContainerVersions track semantic versioning, image references (registry/namespace/repo:tag), GitHub links, and usage counts. Includes HelmConfig for deployment and ParameterConfig for env vars. Frontend provides admin container listing, detail, creation/editing, and version management pages.
+
+    '
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: src/handlers/v2/containers.go, AegisLab-frontend/src/pages/containers/ContainerList.tsx
+  code:
+  - path: AegisLab/src/handlers/v2/containers.go
+    description: CreateContainer, CRUD for containers and container versions
+  - path: AegisLab/src/database/entity.go
+    description: 'Container (type, public, labels), ContainerVersion (semantic versioning, image ref parsing, Helm config, env vars), HelmConfig (chart, repo, values), ParameterConfig (fixed/dynamic params with validation)
+
+      '
+  frontend:
+  - path: AegisLab-frontend/src/pages/containers/ContainerList.tsx
+    description: Container listing page (admin)
+  - path: AegisLab-frontend/src/pages/containers/ContainerDetail.tsx
+    description: Container detail page
+  - path: AegisLab-frontend/src/pages/containers/ContainerForm.tsx
+    description: Container creation/editing form
+  - path: AegisLab-frontend/src/pages/containers/ContainerVersions.tsx
+    description: Container version management page
+  - path: AegisLab-frontend/src/api/containers.ts
+    description: Containers API client
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  - REQ-003
+  conflicts: []
+  notes: Pedestal names are validated against chaos.SystemType
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-301
+  title: Dataset Management
+  description: 'Datasets are versioned collections of datapacks. CRUD with type classification, semantic versioning, file count tracking, and checksums. DatasetVersions link to FaultInjections (datapacks) via M2M relationship. Frontend provides admin dataset listing, detail, and creation/editing pages.
+
+    '
+  priority: P0
+  status: implemented
+  confidence: inferred
+  source: src/handlers/v2/datasets.go, AegisLab-frontend/src/pages/datasets/DatasetList.tsx
+  code:
+  - path: AegisLab/src/handlers/v2/datasets.go
+    description: CreateDataset, CRUD for datasets and dataset versions
+  - path: AegisLab/src/database/entity.go
+    description: Dataset and DatasetVersion entities with datapacks M2M relationship
+  frontend:
+  - path: AegisLab-frontend/src/pages/datasets/DatasetList.tsx
+    description: Dataset listing page (admin)
+  - path: AegisLab-frontend/src/pages/datasets/DatasetDetail.tsx
+    description: Dataset detail page
+  - path: AegisLab-frontend/src/pages/datasets/DatasetForm.tsx
+    description: Dataset creation/editing form
+  - path: AegisLab-frontend/src/api/datasets.ts
+    description: Datasets API client
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  - REQ-003
+  - REQ-100
+  conflicts: []
+  notes: DatasetVersion.Datapacks links to FaultInjection via dataset_version_injections join table
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/datasets/spec.py
+    description: Dataset and datapack discovery API used by consumers
+  contracts:
+  - dataset-schema
+  parent: REQ-901
+- id: REQ-302
+  title: Container Image Building (BuildKit)
+  description: 'Build container images from source code using BuildKit. Supports custom Dockerfile, build context, and registry push. Uses BuildKit client library with Docker auth and progress tracking. Backend-only infrastructure.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: inferred
+  source: src/service/consumer/build_container.go
+  code:
+  - path: AegisLab/src/service/consumer/build_container.go
+    description: executeBuildContainer task handler using BuildKit client with Docker registry auth
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-300
+  - REQ-400
+  conflicts: []
+  notes: 'Requires BuildKit daemon (buildkitd) running
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-303
+  title: Datapack Building (K8s Job)
+  description: 'After fault injection completes, a K8s job builds the datapack by collecting observability data (traces, metrics, logs) from the time window. Creates parquet files and stores them for algorithm consumption. Backend-only task processing.
+
+    '
+  priority: P0
+  status: removed-frontend
+  confidence: confirmed
+  source: src/service/consumer/build_datapack.go, src/service/consumer/k8s_handler.go
+  code:
+  - path: AegisLab/src/service/consumer/build_datapack.go
+    description: executeBuildDatapack creates K8s job to collect and package observability data
+  - path: AegisLab/src/service/consumer/k8s_handler.go
+    description: HandleCRDSucceeded triggers BuildDatapack after CRD completion
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  - REQ-400
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: pipeline
+  repo: aegislab
+  chaos_code: []
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/internal/sources/convert.py
+    description: Datapack conversion and file validation pipeline
+  contracts:
+  - dataset-schema
+  parent: REQ-901
+- id: REQ-304
+  title: Harbor Registry Integration
+  description: 'Integration with Harbor container registry for image management. Supports artifact listing, tag management, and sorted retrieval. Backend-only infrastructure.
+
+    '
+  priority: P2
+  status: removed-frontend
+  confidence: inferred
+  source: src/client/harbor_client.go
+  code:
+  - path: AegisLab/src/client/harbor_client.go
+    description: Singleton HarborClient wrapping go-harbor SDK for artifact operations
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-300
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-400
+  title: Redis Task Queue System
+  description: 'Sophisticated Redis-based task queue with three queues: Delayed (sorted set by timestamp), Ready (list), and Dead Letter (sorted set). Max 20 concurrent tasks with Prometheus metrics (counter, histogram). Task cancellation registry enables stopping running tasks. Frontend provides task listing and detail pages for monitoring.
+
+    '
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: src/service/consumer/task.go, AegisLab-frontend/src/pages/tasks/TaskList.tsx
+  code:
+  - path: AegisLab/src/service/consumer/task.go
+    description: 'Redis queue constants, concurrency control, Prometheus metrics, task cancellation registry, event publishing
+
+      '
+  frontend:
+  - path: AegisLab-frontend/src/pages/tasks/TaskList.tsx
+    description: Task queue monitoring with filters and SSE refresh
+  - path: AegisLab-frontend/src/pages/tasks/TaskDetail.tsx
+    description: Task detail page with timeline and live logs
+  - path: AegisLab-frontend/src/components/pipeline/TaskLogViewer.tsx
+    description: Reusable task log viewer
+  - path: AegisLab-frontend/src/api/tasks.ts
+    description: Task queue API client
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: 'Queue keys: task:delayed, task:ready, task:dead, task:index, task:concurrency_lock. FIXED (2026-04-13): GetTaskDetail now queries Loki for real logs; executeTaskWithRetry implements fixed-interval backoff via RetryPolicy.BackoffSec.
+
+
+    Workspace/detail-view era frontend paths were replaced with current route-based pages and API clients during the index rebuild.'
+  type: service
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-401
+  title: Task Dispatch & Routing
+  description: 'Central task dispatcher routes tasks to appropriate handlers based on type: BuildContainer, RestartPedestal, FaultInjection, BuildDatapack, RunAlgorithm, CollectResult. Includes panic recovery. Backend-only infrastructure.
+
+    '
+  priority: P0
+  status: removed-frontend
+  confidence: confirmed
+  source: src/service/consumer/distribute_tasks.go
+  code:
+  - path: AegisLab/src/service/consumer/distribute_tasks.go
+    description: dispatchTask switch on task type to route to correct executor
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-400
+  conflicts: []
+  notes: 'Six task types handled; unknown types return error
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: pipeline
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-402
+  title: Workflow Orchestration via CRD Callbacks
+  description: 'Workflow orchestration is NOT a separate entity but implemented through K8s CRD event callbacks. The chain: FaultInjection CRD completes -> HandleCRDSucceeded -> SubmitTask(BuildDatapack) -> Job completes -> HandleJobSucceeded -> SubmitTask(RunAlgorithm) -> Job completes -> HandleJobSucceeded -> SubmitTask(CollectResult). Context propagation via K8s annotations (OTel trace) and labels (task metadata). Backend-only infrastructure.
+
+    '
+  priority: P0
+  status: removed-frontend
+  confidence: confirmed
+  source: src/service/consumer/k8s_handler.go, src/client/k8s/controller.go
+  code:
+  - path: AegisLab/src/service/consumer/k8s_handler.go
+    description: HandleCRDSucceeded, HandleJobSucceeded implement callback-driven workflow chain
+  - path: AegisLab/src/client/k8s/controller.go
+    description: 'Callback interface: HandleCRD{Add,Delete,Failed,Succeeded}, HandleJob{Add,Failed,Succeeded}'
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-400
+  - REQ-100
+  - REQ-200
+  conflicts: []
+  notes: 'Critical architectural pattern - documented extensively in CLAUDE.md
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: pipeline
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-403
+  title: Task Management API
+  description: 'REST API for task lifecycle management: batch delete, list, get detail, cancel running tasks, and WebSocket-based real-time task monitoring. Frontend task pages consume this API.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: inferred
+  source: src/handlers/v2/tasks.go, AegisLab-frontend/src/api/tasks.ts
+  code:
+  - path: AegisLab/src/handlers/v2/tasks.go
+    description: BatchDeleteTasks and other task management handlers; WebSocket upgrader for real-time updates
+  frontend:
+  - path: AegisLab-frontend/src/api/tasks.ts
+    description: Tasks API client consuming task management endpoints
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-400
+  - REQ-001
+  conflicts: []
+  notes: WebSocket support indicates real-time task status streaming
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-404
+  title: Trace & Group Management
+  description: 'Traces represent execution workflows containing multiple tasks in a DAG. Groups aggregate related traces (batch operations). Supports SSE streaming for real-time trace updates via Redis streams. Trace types: datapack_build, algorithm_run, full_pipeline. Frontend provides traces listing and detail pages within workspace, plus SSE-based real-time updates.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: confirmed
+  source: src/handlers/v2/traces.go, AegisLab-frontend/src/pages/traces/TracesPage.tsx
+  code:
+  - path: AegisLab/src/handlers/v2/traces.go
+    description: GetTrace handler with SSE streaming support via Redis
+  - path: AegisLab/src/handlers/v2/groups.go
+    description: GetGroupStats with SSE streaming for group-level monitoring
+  - path: AegisLab/src/database/entity.go
+    description: Trace (type, state, group_id, leaf_num) and Task (parent-child, level, sequence) entities
+  frontend:
+  - path: AegisLab-frontend/src/api/traces.ts
+    description: Trace stream and trace lookup client
+  - path: AegisLab-frontend/src/api/groups.ts
+    description: Trace group API client
+  - path: AegisLab-frontend/src/hooks/useTraceSSE.ts
+    description: Trace streaming hook used by task and pipeline views
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-400
+  conflicts: []
+  notes: 'Hierarchical tracing: group (grandfather) -> trace (father) -> task
+
+    Workspace/detail-view era frontend paths were replaced with current route-based pages and API clients during the index rebuild.'
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-405
+  title: Namespace Monitoring & Locking
+  description: 'Monitor K8s namespaces for active fault injections. Namespace locks prevent concurrent experiments on the same target. Supports refresh, disable, and recovery of namespace states. Backend-only infrastructure.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: inferred
+  source: src/service/consumer/monitor.go
+  code:
+  - path: AegisLab/src/service/consumer/monitor.go
+    description: MonitorItem, LockMessage, NamespaceRefreshResult for namespace state management
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  - REQ-400
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: service
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-406
+  title: Consumer Rate Limiting (Token Bucket)
+  description: 'Redis-based token bucket rate limiter for consumer-side operations (e.g., pedestal restarts). Configurable max tokens and wait timeout with dynamic config support. Backend-only infrastructure.
+
+    '
+  priority: P2
+  status: removed-frontend
+  confidence: inferred
+  source: src/service/consumer/rate_limiter.go
+  code:
+  - path: AegisLab/src/service/consumer/rate_limiter.go
+    description: TokenBucketRateLimiter with Redis backing and configurable limits
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-400
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: service
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-500
+  title: OpenTelemetry Tracing Integration
+  description: 'Distributed tracing via OpenTelemetry with OTLP HTTP exporter to Jaeger. TracerMiddleware creates spans for HTTP requests with group_id attributes. Task processing uses hierarchical span contexts propagated through K8s annotations. Backend-only infrastructure.
+
+    '
+  priority: P0
+  status: removed-frontend
+  confidence: confirmed
+  source: src/middleware/middleware.go, src/client/jaeger.go
+  code:
+  - path: AegisLab/src/middleware/middleware.go
+    description: TracerMiddleware creates OTel spans; GroupID middleware assigns UUIDs to POST requests
+  - path: AegisLab/src/client/jaeger.go
+    description: InitTraceProvider configures OTLP HTTP exporter for Jaeger
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: service
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-501
+  title: System Metrics & Health
+  description: 'System health monitoring with current and historical (24h) CPU, memory, and disk usage metrics. Prometheus metrics for task processing (counter and histogram). Frontend home dashboard displays system status via real API calls.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: confirmed
+  source: src/handlers/v2/system.go, AegisLab-frontend/src/pages/home/HomePage.tsx
+  code:
+  - path: AegisLab/src/handlers/v2/system.go
+    description: GetSystemMetrics (current) and GetSystemMetricsHistory (24h) endpoints
+  - path: AegisLab/src/service/consumer/task.go
+    description: Prometheus task_processed_total counter and task_duration_seconds histogram
+  frontend:
+  - path: AegisLab-frontend/src/pages/system/SystemSettings.tsx
+    description: System monitoring and health settings view
+  - path: AegisLab-frontend/src/api/metrics.ts
+    description: Metrics API client
+  - path: AegisLab-frontend/src/pages/home/HomePage.tsx
+    description: Home dashboard surfaces quick health and workload stats
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  conflicts:
+  - Legacy backend endpoints /system/monitor/metrics and /system/monitor/info return fabricated data (v2 endpoint is real)
+  notes: "FIXED (2026-04-13): Deleted SystemMetrics.tsx (100% mock). HomePage uses real v2 API. The legacy /system/monitor/* endpoints are mock \u2014 should be deprecated.\n"
+  type: service
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-502
+  title: Injection & Execution Metrics
+  description: 'Aggregated analytics for injections and executions: success rates, duration stats, state distributions, filtered by time range and fault type. Frontend home dashboard displays these metrics.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: inferred
+  source: src/handlers/v2/metrics.go, AegisLab-frontend/src/api/metrics.ts
+  code:
+  - path: AegisLab/src/handlers/v2/metrics.go
+    description: GetInjectionMetrics and GetExecutionMetrics endpoints (SDK-enabled)
+  frontend:
+  - path: AegisLab-frontend/src/pages/executions/ExecutionDetail.tsx
+    description: Execution detail surfaces detector and granularity results
+  - path: AegisLab-frontend/src/pages/datapacks/DatapackDetail.tsx
+    description: Datapack detail shows pipeline state progression
+  - path: AegisLab-frontend/src/api/metrics.ts
+    description: Metrics API client
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  - REQ-200
+  conflicts: []
+  notes: ''
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-503
+  title: Real-Time Notifications (SSE)
+  description: 'Server-Sent Events streaming for global workflow notifications. Streams events like injection completed, datapack ready, execution completed via Redis pub/sub. Supports last_id for resuming missed events. REMOVED (2026-04-13): Frontend notification feature removed as non-core. Backend SSE endpoint remains for SDK/API consumers.
+
+    '
+  priority: P2
+  status: removed-frontend
+  confidence: confirmed
+  source: src/handlers/v2/notifications.go
+  code:
+  - path: AegisLab/src/handlers/v2/notifications.go
+    description: GetNotificationStream SSE endpoint with Redis stream consumption (backend retained)
+  - path: AegisLab/src/middleware/middleware.go
+    description: SSEPath middleware sets event-stream headers
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: not-applicable
+    date: '2026-04-13'
+    notes: "Frontend notification feature intentionally removed \u2014 not core to researcher workflow"
+  depends_on:
+  - REQ-400
+  conflicts: []
+  notes: 'REMOVED (2026-04-13): Deleted NotificationsPage.tsx, notifications.ts API, useNotifications.ts hook. Removed notification bell from AppHeader and sidebar. SSE hook (useSSE.ts) retained for trace/group streaming.
+
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: service
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-504
+  title: Loki Log Integration
+  description: 'HTTP client for querying historical logs from Loki. Supports time-range queries with configurable limits and direction (forward/backward). Backend-only client; frontend log viewing uses pipeline logs viewer.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: inferred
+  source: src/client/loki.go
+  code:
+  - path: AegisLab/src/client/loki.go
+    description: LokiClient wrapping Loki HTTP API for log queries
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: service
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-505
+  title: OTLP Log Receiver
+  description: 'Built-in OTLP log receiver accepting protobuf-encoded log data (gzip-compressed). Parses OpenTelemetry log records from resource logs. Backend-only infrastructure.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: inferred
+  source: src/service/logreceiver/receiver.go, src/service/logreceiver/parser.go
+  code:
+  - path: AegisLab/src/service/logreceiver/receiver.go
+    description: HTTP server receiving OTLP log export requests with protobuf/gzip support
+  - path: AegisLab/src/service/logreceiver/parser.go
+    description: Parser for OTLP log records
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: 'Default port 4319
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: service
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-600
+  title: Python SDK (Auto-generated)
+  description: 'Python SDK auto-generated from Swagger/OpenAPI specs. Provides REST client and model classes for programmatic access to AegisLab APIs. Backend-only tooling.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: inferred
+  source: sdk/python/, scripts/command/src/swagger.py
+  code:
+  - path: AegisLab/sdk/python/src/rcabench/client
+    description: Auto-generated Python REST client
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-602
+  conflicts: []
+  notes: 'Generated via ''make generate-python-sdk''
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: contract
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-601
+  title: TypeScript SDK (Auto-generated)
+  description: 'TypeScript SDK auto-generated from Swagger/OpenAPI specs for frontend consumption. Not always present in repo (generated on demand). Used by frontend via @rcabench/client package.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: inferred
+  source: CLAUDE.md
+  code: []
+  frontend:
+  - path: AegisLab-frontend/package.json
+    description: Frontend consumes the generated TypeScript client package
+  - path: AegisLab-frontend/src/api/client.ts
+    description: Shared typed API wrapper built on the generated SDK models
+  - path: AegisLab-frontend/src/types/api.ts
+    description: Frontend-side type surface aligned to the SDK contract
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-602
+  conflicts: []
+  notes: Generated via 'make generate-typescript-sdk SDK_VERSION=x.x.x'; sdk/typescript/ directory
+  type: contract
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-602
+  title: Swagger/OpenAPI Documentation
+  description: 'API documentation via Swagger annotations on all handler functions. APIs marked with @x-api-type {"sdk":"true"} are included in generated SDKs. Generated via swag init with dependency parsing. Backend-only tooling.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: confirmed
+  source: src/handlers/v2/*.go
+  code:
+  - path: AegisLab/src/handlers/v2/auth.go
+    description: Example of Swagger annotations with @x-api-type SDK marking
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: 'scripts/command/src/swagger.py filters APIs by x-api-type.sdk field
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: contract
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-700
+  title: Kubernetes Deployment (Helm)
+  description: 'Helm chart for deploying AegisLab to Kubernetes clusters with TLS certs, configurable values, and environment-specific manifests. Backend-only infrastructure.
+
+    '
+  priority: P0
+  status: removed-frontend
+  confidence: inferred
+  source: helm/
+  code:
+  - path: AegisLab/helm/Chart.yaml
+    description: Helm chart metadata
+  - path: AegisLab/helm/values.yaml
+    description: Default deployment configuration
+  - path: AegisLab/helm/templates/
+    description: K8s resource templates
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: 'helm/certs/ for TLS, helm/files/ for additional deployment files
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: service
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-701
+  title: Skaffold Development Workflow
+  description: 'Skaffold configuration for iterative development with automatic build and deploy to K8s clusters. Backend-only infrastructure.
+
+    '
+  priority: P2
+  status: removed-frontend
+  confidence: inferred
+  source: skaffold.yaml
+  code:
+  - path: AegisLab/skaffold.yaml
+    description: Skaffold development and deployment configuration
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-700
+  conflicts: []
+  notes: '''make run'' uses Skaffold for build+deploy
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-702
+  title: Cobra CLI (Multi-mode Application)
+  description: 'Application runs in three modes via Cobra CLI: producer (HTTP API server), consumer (background workers + K8s controllers), or both (combined for local development). Default local development runs ''both --port 8082''. Backend-only infrastructure.
+
+    '
+  priority: P0
+  status: removed-frontend
+  confidence: confirmed
+  source: src/main.go, CLAUDE.md
+  code:
+  - path: AegisLab/src/main.go
+    description: Cobra CLI with producer, consumer, and both commands
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-703
+  title: Kubernetes CRD Controller
+  description: 'Controller-runtime based K8s controller watching Chaos Mesh CRDs and batch Jobs. Uses informers with rate-limited work queues. Manages CRD lifecycle (add, delete, failed, succeeded) and job lifecycle. Supports namespace-scoped CRD informers with dynamic registration. Backend-only infrastructure.
+
+    '
+  priority: P0
+  status: removed-frontend
+  confidence: confirmed
+  source: src/client/k8s/controller.go, src/client/k8s/crd.go, src/client/k8s/job.go
+  code:
+  - path: AegisLab/src/client/k8s/controller.go
+    description: 'Controller struct with CRD/job informers, namespace management, work queue with CheckRecovery/DeleteCRD/DeleteJob actions
+
+      '
+  - path: AegisLab/src/client/k8s/crd.go
+    description: CRD-specific informer setup and event handlers
+  - path: AegisLab/src/client/k8s/job.go
+    description: Job informer setup and event handlers
+  frontend: []
+  has_mock: false
+  tests:
+  - path: src/client/k8s/k8s_test.go
+    description: K8s client tests
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: 'Watches multiple GVRs from chaos-experiment library
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: service
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-704
+  title: Docker Compose Local Infrastructure
+  description: 'Docker Compose setup for local development providing Redis, MySQL, Jaeger, and BuildKit daemon services. Backend-only infrastructure.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: confirmed
+  source: docker-compose.yaml
+  code:
+  - path: AegisLab/docker-compose.yaml
+    description: Redis, MySQL, Jaeger, BuildKit service definitions
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-705
+  title: Data Initialization & Seeding
+  description: 'System initialization on startup: seeding roles, permissions, resources, default users, and chaos systems. Separate initialization paths for producer and consumer modes. Backend-only infrastructure.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: inferred
+  source: src/service/initialization/, data/initial_data/
+  code:
+  - path: AegisLab/src/service/initialization/producer.go
+    description: Producer-mode initialization (DB migration, seed data)
+  - path: AegisLab/src/service/initialization/consumer.go
+    description: Consumer-mode initialization (K8s controllers, task queue)
+  - path: AegisLab/src/service/initialization/systems.go
+    description: Chaos system seeding
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: 'data/initial_data/ contains environment-specific seed data
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-706
+  title: Devbox & Lefthook Toolchain
+  description: 'Nix-based development environment via devbox for reproducible tooling. Lefthook for pre-commit hooks. Justfile for task automation. Backend-only infrastructure.
+
+    '
+  priority: P2
+  status: removed-frontend
+  confidence: confirmed
+  source: devbox.json, lefthook.yml, justfile
+  code:
+  - path: AegisLab/devbox.json
+    description: Nix package definitions for development tools
+  - path: AegisLab/lefthook.yml
+    description: Pre-commit hook configuration
+  - path: AegisLab/justfile
+    description: Task runner recipes
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: capability
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-707
+  title: Redis Client & etcd Client
+  description: 'Redis client for task queues, caching, pub/sub, and stream operations. etcd client for distributed coordination. Backend-only infrastructure.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: inferred
+  source: src/client/redis_client.go, src/client/etcd_client.go
+  code:
+  - path: AegisLab/src/client/redis_client.go
+    description: Redis client initialization and connection management
+  - path: AegisLab/src/client/etcd_client.go
+    description: etcd client for distributed coordination
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: service
+  repo: aegislab
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-800
+  title: Dual Layout System (Main + Workspace)
+  description: 'Two mutually exclusive layout modes: MainLayout with global navigation sidebar for top-level pages (home, projects list, teams, admin), and WorkspaceLayout with project-scoped sidebar for workspace pages (injections, executions, evaluations, traces, settings). Layouts share a unified AppHeader component with breadcrumbs.
+
+    '
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: AegisLab-frontend/src/components/layout/MainLayout.tsx, AegisLab-frontend/src/components/layout/WorkspaceLayout.tsx
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/components/layout/MainLayout.tsx
+    description: Current single-layout shell after workspace layout removal
+  - path: AegisLab-frontend/src/components/layout/MainSidebarContent.tsx
+    description: Current sidebar navigation for the main shell
+  - path: AegisLab-frontend/src/components/layout/AppHeader.tsx
+    description: Header shared by all protected routes
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab-frontend/workspace.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  conflicts: []
+  notes: 'UPDATED (2026-04-13): Notification badge removed from AppHeader. Notifications removed from sidebar. WorkspaceSidebar: "Injections" renamed to "Datapacks", "Algorithms" entry added. Hamburger button in header can open main sidebar as drawer in workspace mode.
+
+
+    Workspace/detail-view era frontend paths were replaced with current route-based pages and API clients during the index rebuild.'
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-801
+  title: Client-Side Routing
+  description: 'React Router v6 route structure with lazy-loaded pages. Top-level routes under MainLayout (/home, /projects, /profile, /settings, /tasks, /:teamName, /admin/*). Nested project-scoped routes under WorkspaceLayout (/:teamName/:projectName/* including algorithms). Fallback redirects to /home or /login.
+
+    '
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: AegisLab-frontend/src/App.tsx, AegisLab-frontend/src/main.tsx
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/App.tsx
+    description: Route tree and route guards
+  - path: AegisLab-frontend/src/components/layout/MainLayout.tsx
+    description: Route outlet host for protected pages
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  - REQ-800
+  conflicts: []
+  notes: 'UPDATED (2026-04-13): /notifications route removed. /algorithms route added under workspace. All pages are lazy-loaded with React.lazy + Suspense. Route structure uses team/project name URL params (not IDs).
+
+    '
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-802
+  title: Theme System (Light/Dark)
+  description: 'Light/dark theme toggle with persisted preference in localStorage via Zustand persist middleware. Sets data-theme attribute on document root. Custom Ant Design theme configuration with sky-blue primary color (#0ea5e9). CSS variables for theming defined in styles directory.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: confirmed
+  source: AegisLab-frontend/src/store/theme.ts, AegisLab-frontend/src/components/ui/ThemeToggle.tsx
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/store/theme.ts
+    description: Persisted theme and sidebar state store
+  - path: AegisLab-frontend/src/components/ui/ThemeToggle.tsx
+    description: Theme toggle control
+  - path: AegisLab-frontend/src/utils/theme.ts
+    description: Theme helper functions
+  - path: AegisLab-frontend/src/styles/theme.css
+    description: Theme variable definitions
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: 'Ant Design locale is set to zh_CN. Primary color is #0ea5e9 in main.tsx but CLAUDE.md says #2563eb -- minor inconsistency.'
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-803
+  title: Home Dashboard
+  description: 'Personal dashboard page showing welcome banner, recent projects list, injection/execution metrics, system status, and quick action buttons. Fetches all data from real metrics and projects APIs. Getting Started card shown conditionally only when user has no projects.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: confirmed
+  source: AegisLab-frontend/src/pages/home/HomePage.tsx
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/pages/home/HomePage.tsx
+    description: Current home dashboard
+  - path: AegisLab-frontend/src/pages/home/HomePage.css
+    description: Home dashboard styling
+  - path: AegisLab-frontend/src/components/ui/StatCard.tsx
+    description: Reusable stats card used by dashboard flows
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  - REQ-800
+  conflicts: []
+  notes: 'CLEANED (2026-04-13): Deleted ActivityFeed.tsx, QuickActions.tsx, SystemMetrics.tsx (all mock/unused). Removed Algorithms metric card and Execution Metrics Summary row (redundant). Getting Started card now conditional on empty project list.
+
+    '
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-804
+  title: User Profile Page
+  description: 'Simplified user profile page showing basic user information: avatar, username, full name, email, phone, role, member since, last login. All data fetched from GET /api/v2/auth/profile. Single Card layout with Descriptions component, no tabs or sidebar.
+
+    '
+  priority: P2
+  status: implemented
+  confidence: confirmed
+  source: AegisLab-frontend/src/pages/profile/ProfilePage.tsx
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/pages/profile/ProfilePage.tsx
+    description: Current profile page
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  conflicts: []
+  notes: 'SIMPLIFIED (2026-04-13): Deleted ProfileTab, ProjectsTab, StarsTab, ProfileSidebar, ActivityGraph, ProjectCard, RecentRuns (7 files + CSS). All were mock/stub code. Profile is now a single page with real API data, no tabs.
+
+    '
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-805
+  title: User Settings Page
+  description: 'User settings page for personal preferences and account configuration.
+
+    '
+  priority: P2
+  status: implemented
+  confidence: inferred
+  source: AegisLab-frontend/src/pages/settings/Settings.tsx
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/pages/settings/Settings.tsx
+    description: Current user settings page
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-001
+  conflicts: []
+  notes: ''
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-806
+  title: Workspace Table & Components
+  description: 'Reusable workspace table system for displaying injections, executions, and other workspace-scoped data. Includes column management, sorting, filtering, bulk actions, and run list panels. Supports column resizing, persistence, and customizable toolbar.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: confirmed
+  source: AegisLab-frontend/src/components/workspace/
+  code: []
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-800
+  conflicts:
+  - WorkspaceSelector.tsx:35-44 uses hardcoded mock workspace list instead of API call (HIGH priority)
+  notes: Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-807
+  title: Charts & Visualization
+  description: 'Chart components for data visualization using ECharts. Includes a reusable LabChart component and workspace chart cards/panels.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: inferred
+  source: AegisLab-frontend/src/components/charts/
+  code: []
+  frontend: []
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: 'ECharts, D3.js, and Cytoscape.js available per CLAUDE.md
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-808
+  title: Reusable UI Components
+  description: 'Shared UI components used across the application: StatCard for metric display, StatusBadge for state indicators, ThemeToggle for dark/light mode switching.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: confirmed
+  source: AegisLab-frontend/src/components/ui/
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/components/ui/StatCard.tsx
+    description: Reusable stats card component
+  - path: AegisLab-frontend/src/components/ui/StatusBadge.tsx
+    description: Reusable status badge
+  - path: AegisLab-frontend/src/components/ui/ThemeToggle.tsx
+    description: Reusable theme toggle
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: ''
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-809
+  title: Frontend Build Tooling (Vite)
+  description: 'Vite 5 build configuration with React plugin, TypeScript strict mode, path aliases (@/ for src/), API proxy to backend, ESLint, and Prettier. Devbox provides pnpm 8 for package management. Private @OperationsPAI/client package requires NPM_TOKEN for GitHub Packages authentication.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: confirmed
+  source: AegisLab-frontend/vite.config.ts, AegisLab-frontend/package.json
+  code: []
+  frontend:
+  - path: AegisLab-frontend/vite.config.ts
+    description: Vite configuration, proxy, and path aliases
+  - path: AegisLab-frontend/package.json
+    description: Frontend build, lint, and type-check scripts
+  - path: AegisLab-frontend/tsconfig.json
+    description: TypeScript compiler configuration
+  has_mock: false
+  tests: []
+  docs:
+  - path: AegisLab-frontend/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  notes: API proxy in dev server points to backend. pnpm dev starts on port 3000.
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-810
+  title: Detail View System
+  description: 'Reusable detail view component with tabbed layout for displaying injection and execution details. Tabs include overview, files, artifacts, config tree, charts, logs, fault injection panel, and ground truth table. Features a JSON viewer and pipeline log streaming viewer for real-time log display.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: confirmed
+  source: AegisLab-frontend/src/components/workspace/DetailView/
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/pages/datapacks/DatapackDetail.tsx
+    description: Datapack detail replacement for the old workspace detail view
+  - path: AegisLab-frontend/src/pages/executions/ExecutionDetail.tsx
+    description: Execution detail replacement for the old result drill-down
+  - path: AegisLab-frontend/src/pages/tasks/TaskDetail.tsx
+    description: Task detail with logs and timeline
+  - path: AegisLab-frontend/src/components/pipeline/StateStepper.tsx
+    description: Reusable state progression component
+  - path: AegisLab-frontend/src/components/pipeline/TaskLogViewer.tsx
+    description: Reusable task log viewer
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-806
+  conflicts: []
+  notes: Workspace/detail-view era frontend paths were replaced with current route-based pages and API clients during the index rebuild.
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-811
+  title: Frontend Utility Libraries
+  description: 'Shared utility functions and type definitions for the frontend application. Includes ID/name resolution utilities, state management helpers, text processing, workspace types, and API type definitions that match backend entities exactly.
+
+    '
+  priority: P2
+  status: implemented
+  confidence: confirmed
+  source: AegisLab-frontend/src/utils/, AegisLab-frontend/src/types/
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/utils/colors.ts
+    description: Color utilities
+  - path: AegisLab-frontend/src/utils/projectNameMap.ts
+    description: Project display-name helpers
+  - path: AegisLab-frontend/src/utils/state.ts
+    description: State label helpers shared across pages
+  - path: AegisLab-frontend/src/utils/teamNameMap.ts
+    description: Team display-name helpers
+  - path: AegisLab-frontend/src/types/api.ts
+    description: Frontend API type declarations
+  has_mock: false
+  tests: []
+  docs: []
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts:
+  - types/api.ts has TODO comments about migrating hand-written types (Team, TeamMember, etc.) to SDK-generated types
+  notes: API types in api.ts must match backend snake_case field names exactly
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-812
+  title: Pipeline Progress Component
+  description: "New PipelineProgress component displaying injection pipeline stages (Inject Fault \u2192 Build Datapack \u2192 Run Algorithm \u2192 Collect Result) with real-time state updates via SSE. Shown at top of Injection Detail page. Maps FaultInjection.state + associated Execution states to pipeline stages. Data source: GET /api/v2/traces/:trace_id/stream (SSE).\n"
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: docs/frontend-redesign.md section 5.6
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/components/pipeline/StateStepper.tsx
+    description: Pipeline progress / state stepper component
+  has_mock: false
+  tests: []
+  docs:
+  - path: docs/frontend-redesign.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  - REQ-402
+  - REQ-404
+  conflicts: []
+  notes: Core UX component for Workflow A. Uses Ant Design Steps or custom progress bar.
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-813
+  title: Algorithm Management (Researcher)
+  description: 'Workspace-scoped page for researchers to manage RCA algorithm containers. Lists containers filtered by type=algorithm, supports registration of new algorithms and version management. Reuses Container CRUD API with type filter. Route: /:teamName/:projectName/algorithms
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: confirmed
+  source: docs/frontend-redesign.md sections 4.3, 5.11
+  code: []
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: docs/frontend-redesign.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-300
+  - REQ-800
+  conflicts: []
+  notes: 'Filters GET /api/v2/containers by type=algorithm. Separate from admin /admin/containers which manages all types.
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-814
+  title: Algorithm Benchmark Page (Workflow B)
+  description: 'Page for researchers to batch-test RCA algorithms against existing datapacks or datasets. Two modes via tab switch: Datapack mode (select individual datapacks) and Dataset mode (select entire dataset). Builds SubmitExecutionReq with multiple ExecutionSpecs. Returns group_id for batch progress tracking. Route: /:teamName/:projectName/executions/new
+
+    '
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: docs/frontend-redesign.md section 5.9
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/pages/executions/CreateExecutionForm.tsx
+    description: Benchmark-oriented algorithm execution submission flow
+  - path: AegisLab-frontend/src/pages/projects/ProjectExecutions.tsx
+    description: Project execution list used as the benchmark workflow hub
+  has_mock: false
+  tests: []
+  docs:
+  - path: docs/frontend-redesign.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-200
+  - REQ-300
+  - REQ-301
+  conflicts: []
+  notes: 'Core page for Workflow B. Uses POST /api/v2/projects/:id/executions/execute. Datapack mode: one spec per selected datapack. Dataset mode: one spec with dataset ref.
+
+    '
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-815
+  title: Batch Execution Progress Banner
+  description: 'Progress banner shown at top of Execution List page when a batch execution (group) is active. Shows real-time progress via SSE from GET /api/v2/groups/:group_id/stream. Displays completed/total count and failure count. Collapsible/dismissible.
+
+    '
+  priority: P1
+  status: removed-frontend
+  confidence: confirmed
+  source: docs/frontend-redesign.md section 5.7
+  code: []
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: docs/frontend-redesign.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-200
+  - REQ-404
+  conflicts: []
+  notes: 'Uses existing group SSE infrastructure from REQ-404.
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-816
+  title: Manual Datapack Upload UI
+  description: 'Frontend UI for uploading pre-built datapacks (ZIP archives containing parquet files) without going through fault injection pipeline. Uses POST /api/v2/injections/upload endpoint (already implemented in backend).
+
+    '
+  priority: P2
+  status: removed-frontend
+  confidence: confirmed
+  source: docs/frontend-redesign.md section 10 (API Coverage)
+  code: []
+  frontend: []
+  has_mock: false
+  tests: []
+  docs:
+  - path: docs/frontend-redesign.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-104
+  conflicts: []
+  notes: 'Backend upload endpoint at POST /api/v2/injections/upload. Frontend uploads via Ant Design Dragger.
+
+    Frontend implementation was removed or consolidated in the current React refactor; backend or contract behavior remains tracked elsewhere where applicable.'
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts: []
+- id: REQ-817
+  title: Execution Detail Results Display
+  description: 'Enhanced Execution Detail page showing DetectorResults and GranularityResults from algorithm execution. DetectorResults: table of span-level normal vs abnormal metrics. GranularityResults: hierarchical display by level (service/pod/span/metric) of localization results.
+
+    '
+  priority: P1
+  status: implemented
+  confidence: confirmed
+  source: docs/frontend-redesign.md section 5.8
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/pages/executions/ExecutionDetail.tsx
+    description: Execution detail renders detector and granularity results
+  - path: AegisLab-frontend/src/pages/projects/ProjectExecutions.tsx
+    description: Execution list routes into result detail
+  has_mock: false
+  tests: []
+  docs:
+  - path: docs/frontend-redesign.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-200
+  - REQ-201
+  conflicts: []
+  notes: Backend already returns DetectorResult and GranularityResult in ExecutionDetailResp.
+  type: ui
+  repo: aegislab-frontend
+  chaos_code: []
+  rcabench_code: []
+  contracts:
+  - openapi-backend-sdk
+- id: REQ-110
+  title: Chaos Experiment Builders and Controllers
+  description: chaos-experiment provides the low-level Chaos Mesh CRD builders and controller helpers used by AegisLab fault injection tasks to create network, pod, HTTP, JVM, stress, DNS, time, and workflow chaos resources.
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: chaos/*.go, controllers/*.go
+  type: library
+  repo: chaos-experiment
+  code: []
+  frontend: []
+  chaos_code:
+  - path: chaos-experiment/chaos/base_chaos.go
+    description: Base CRD construction helpers
+  - path: chaos-experiment/chaos/network_chaos.go
+    description: Network chaos spec builders
+  - path: chaos-experiment/chaos/pod_chaos.go
+    description: Pod chaos spec builders
+  - path: chaos-experiment/controllers/network_chao.go
+    description: Network chaos controller wrappers
+  - path: chaos-experiment/controllers/workflow.go
+    description: Workflow orchestration helpers
+  rcabench_code: []
+  tests: []
+  docs:
+  - chaos-experiment/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  contracts:
+  - chaos-mesh-crd
+  parent: REQ-900
+  notes: Owns the reusable fault-construction layer that the AegisLab backend imports rather than reimplementing locally.
+- id: REQ-111
+  title: System-Aware Chaos Targeting and Registration
+  description: chaos-experiment exposes handler-layer registration, metadata lookup, and system-aware target discovery so AegisLab can translate platform metadata into concrete chaos candidates for a selected benchmark system.
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: handler/*.go
+  type: library
+  repo: chaos-experiment
+  code: []
+  frontend: []
+  chaos_code:
+  - path: chaos-experiment/handler/handler.go
+    description: High-level chaos generation entrypoint
+  - path: chaos-experiment/handler/registration.go
+    description: System registration hooks
+  - path: chaos-experiment/handler/action_space.go
+    description: Action-space discovery for valid targets
+  - path: chaos-experiment/handler/groundtruth.go
+    description: Ground-truth generation helpers
+  rcabench_code: []
+  tests: []
+  docs:
+  - chaos-experiment/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-110
+  conflicts: []
+  contracts:
+  - chaos-mesh-crd
+  parent: REQ-900
+  notes: This requirement explains why fault metadata and target names are shared across the backend API and chaos library.
+- id: REQ-112
+  title: Chaos Analysis and Probe CLI Tools
+  description: chaos-experiment ships auxiliary command-line tools for fault-point generation, handler configuration probing, Java method analysis, ClickHouse trace analysis, and internal metadata extraction.
+  priority: P1
+  status: implemented
+  confidence: confirmed
+  source: cmd/**/main.go
+  type: capability
+  repo: chaos-experiment
+  code: []
+  frontend: []
+  chaos_code:
+  - path: chaos-experiment/cmd/faultpoints/main.go
+    description: Enumerates candidate fault points
+  - path: chaos-experiment/cmd/handlerconfigprobe/main.go
+    description: Probes handler configuration
+  - path: chaos-experiment/cmd/javaanalyzer/main.go
+    description: Java method analyzer for JVM targets
+  - path: chaos-experiment/cmd/clickhouseanalyzer/main.go
+    description: Trace analyzer for service endpoints
+  rcabench_code: []
+  tests: []
+  docs:
+  - chaos-experiment/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-111
+  conflicts: []
+  contracts:
+  - chaos-mesh-crd
+  notes: These tools inform metadata generation and troubleshooting but are not directly invoked by the workspace validator.
+- id: REQ-210
+  title: RCA Algorithm Registry and Implementations
+  description: rcabench-platform defines the algorithm plugin contract and ships built-in RCA algorithms such as Random, RCAEval baselines, and TraceBack variants for benchmark execution.
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: v3/sdk/algorithms/**/*.py
+  type: library
+  repo: rcabench-platform
+  code: []
+  frontend: []
+  chaos_code: []
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/algorithms/spec.py
+    description: Algorithm base contract and registry
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/algorithms/random_.py
+    description: Baseline random algorithm
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/algorithms/rcaeval/baro.py
+    description: BARO baseline
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/algorithms/traceback/A10.py
+    description: TraceBack A10 implementation
+  tests: []
+  docs:
+  - rcabench-platform/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  contracts:
+  - dataset-schema
+  parent: REQ-902
+  notes: Algorithm registration is the downstream consumer of the datapacks built by AegisLab.
+- id: REQ-211
+  title: Dataset Conversion and Schema Validation
+  description: rcabench-platform converts external sources into normalized dataset/datapack folders, validates parquet and JSON artifact schemas, and writes dataset indexes and label metadata for later evaluation.
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: v3/internal/sources/convert.py, v3/sdk/datasets/spec.py
+  type: pipeline
+  repo: rcabench-platform
+  code: []
+  frontend: []
+  chaos_code: []
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/internal/sources/convert.py
+    description: Dataset and datapack conversion pipeline
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/datasets/spec.py
+    description: Canonical dataset/datapack layout and metadata accessors
+  - path: rcabench-platform/src/rcabench_platform/v3/tools/label/config.py
+    description: Expected artifact set for labeled datapacks
+  tests: []
+  docs:
+  - rcabench-platform/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  contracts:
+  - dataset-schema
+  parent: REQ-901
+  notes: This is the clearest workspace-level owner for the dataset-schema contract on the consumer side.
+- id: REQ-212
+  title: Evaluation Metrics and Benchmark Reporting
+  description: rcabench-platform computes datapack- and dataset-level RCA metrics such as MRR, AC@k, Avg@k, MAP@k, runtime, and aggregated reports for benchmark comparison.
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: v3/sdk/evaluation/*.py, v3/sdk/experiments/report.py
+  type: capability
+  repo: rcabench-platform
+  code: []
+  frontend: []
+  chaos_code: []
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/ranking.py
+    description: Ranking and accuracy metrics
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/experiments/report.py
+    description: Batch report generation and aggregation
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/experiments/batch.py
+    description: Batch benchmark execution over datasets
+  tests: []
+  docs:
+  - rcabench-platform/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-210
+  - REQ-211
+  conflicts: []
+  contracts:
+  - dataset-schema
+  parent: REQ-902
+  notes: AegisLab currently orchestrates and stores evaluations, while rcabench-platform defines the benchmark math and report shapes.
+- id: REQ-213
+  title: Trace Sampling and Metrics SLI Preparation
+  description: rcabench-platform provides trace sampler registries, event/path encoders, and metrics-sli generation to prepare datapacks for alternate RCA execution modes and sampled benchmark reports.
+  priority: P1
+  status: implemented
+  confidence: confirmed
+  source: v3/sdk/samplers/**/*.py
+  type: pipeline
+  repo: rcabench-platform
+  code: []
+  frontend: []
+  chaos_code: []
+  rcabench_code:
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/samplers/registry.py
+    description: Sampler registry
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/samplers/metrics_sli.py
+    description: Metrics SLI preparation
+  - path: rcabench-platform/src/rcabench_platform/v3/sdk/samplers/experiments/single.py
+    description: Single sampler execution flow
+  tests: []
+  docs:
+  - rcabench-platform/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-211
+  conflicts: []
+  contracts:
+  - dataset-schema
+  notes: Sampling remains repo-local today but influences how downstream reports interpret datapack completeness.
+- id: REQ-820
+  title: Fault Injection Authoring UI
+  description: The frontend exposes a guided injection authoring experience that fetches backend metadata, lets users configure multi-step fault batches, and routes into datapack detail views after submission.
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: src/pages/injections/**/*.tsx, src/api/injections.ts
+  type: ui
+  repo: aegislab-frontend
+  code: []
+  frontend: *id001
+  chaos_code: []
+  rcabench_code: []
+  tests: []
+  docs:
+  - AegisLab-frontend/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  - REQ-601
+  conflicts: []
+  contracts:
+  - openapi-backend-sdk
+  parent: REQ-900
+  notes: Owns the frontend side of the fault injection flow after the workspace-detail refactor.
+- id: REQ-821
+  title: Datapack Browsing and Download UI
+  description: The frontend provides project-scoped datapack browsing, standalone datapack detail pages, file-tree exploration, cloning, and download actions for built datapacks.
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: src/pages/projects/ProjectDatapacks.tsx, src/pages/datapacks/DatapackDetail.tsx
+  type: ui
+  repo: aegislab-frontend
+  code: []
+  frontend:
+  - path: AegisLab-frontend/src/pages/projects/ProjectDatapacks.tsx
+    description: Project datapack list
+  - path: AegisLab-frontend/src/pages/datapacks/DatapackDetail.tsx
+    description: Datapack file and log browser
+  - path: AegisLab-frontend/src/api/injections.ts
+    description: Datapack download and file browsing API client
+  chaos_code: []
+  rcabench_code: []
+  tests: []
+  docs:
+  - AegisLab-frontend/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-100
+  - REQ-204
+  conflicts: []
+  contracts:
+  - openapi-backend-sdk
+  - dataset-schema
+  parent: REQ-901
+  notes: This is the active frontend replacement for the removed workspace detail views around datapacks.
+- id: REQ-822
+  title: Execution Launch and Result UI
+  description: The frontend lets users choose an algorithm, select usable datapacks, submit execution batches, and inspect resulting detector and granularity outputs.
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: src/pages/projects/ProjectExecutions.tsx, src/pages/executions/*.tsx
+  type: ui
+  repo: aegislab-frontend
+  code: []
+  frontend:
+  - *id002
+  - *id003
+  - *id004
+  - *id005
+  - path: AegisLab-frontend/src/pages/projects/stateLabels.ts
+    description: Execution/datapack state labels used by the execution UI
+  chaos_code: []
+  rcabench_code: []
+  tests: []
+  docs:
+  - AegisLab-frontend/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-200
+  - REQ-601
+  conflicts: []
+  contracts:
+  - openapi-backend-sdk
+  - dataset-schema
+  parent: REQ-902
+  notes: This requirement isolates the current execution UX from the older workspace-component requirements.
+- id: REQ-823
+  title: Evaluation Configuration UI
+  description: The frontend exposes evaluation configuration and project-level evaluation browsing so users can compare algorithm performance over datapacks and datasets.
+  priority: P1
+  status: implemented
+  confidence: confirmed
+  source: src/pages/evaluations/*.tsx, src/pages/projects/ProjectEvaluations.tsx
+  type: ui
+  repo: aegislab-frontend
+  code: []
+  frontend: *id006
+  chaos_code: []
+  rcabench_code: []
+  tests: []
+  docs:
+  - AegisLab-frontend/CLAUDE.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-202
+  - REQ-601
+  conflicts: []
+  contracts:
+  - openapi-backend-sdk
+  - dataset-schema
+  parent: REQ-902
+  notes: Project-level evaluation browsing exists today even though the dedicated evaluation route tree remains incomplete.
+- id: REQ-900
+  title: Cross-Repo Fault Injection Lifecycle
+  description: Fault injection is an end-to-end workspace feature spanning chaos-experiment library builders, AegisLab API/orchestration, and frontend authoring and datapack inspection flows.
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: Reverse-engineered from chaos-experiment handler/controller packages, AegisLab injection services, and AegisLab-frontend injection/datapack pages.
+  type: feature
+  repo: null
+  code: []
+  frontend: []
+  chaos_code: []
+  rcabench_code: []
+  tests: []
+  docs:
+  - docs/cross-repo-feature-linkage.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on: []
+  conflicts: []
+  contracts:
+  - chaos-mesh-crd
+  - openapi-backend-sdk
+  decomposes_into:
+  - REQ-100
+  - REQ-102
+  - REQ-110
+  - REQ-111
+  - REQ-820
+  notes: This parent requirement connects the previously disconnected library, API, and UI slices of the fault injection workflow.
+- id: REQ-901
+  title: Cross-Repo Dataset Collection and Schema Flow
+  description: Dataset collection is a cross-repo feature spanning AegisLab datapack build/upload management, frontend datapack browsing, and rcabench-platform schema-aware dataset conversion and validation.
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: Reverse-engineered from AegisLab datapack build/upload services, frontend datapack pages, and rcabench-platform dataset conversion code.
+  type: feature
+  repo: null
+  code: []
+  frontend: []
+  chaos_code: []
+  rcabench_code: []
+  tests: []
+  docs:
+  - docs/cross-repo-feature-linkage.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-900
+  conflicts: []
+  contracts:
+  - dataset-schema
+  - openapi-backend-sdk
+  decomposes_into:
+  - REQ-104
+  - REQ-301
+  - REQ-303
+  - REQ-821
+  - REQ-211
+  notes: This feature parent is anchored on the shared datapack artifact contract rather than a single repository.
+- id: REQ-902
+  title: Cross-Repo RCA Evaluation and Benchmarking Flow
+  description: RCA evaluation is a workspace-level feature spanning AegisLab execution/evaluation orchestration, frontend execution and evaluation UX, and rcabench-platform algorithm, metrics, and reporting libraries.
+  priority: P0
+  status: implemented
+  confidence: confirmed
+  source: Reverse-engineered from AegisLab execution/evaluation handlers, frontend execution/evaluation pages, and rcabench-platform algorithms/evaluation packages.
+  type: feature
+  repo: null
+  code: []
+  frontend: []
+  chaos_code: []
+  rcabench_code: []
+  tests: []
+  docs:
+  - docs/cross-repo-feature-linkage.md
+  acceptance:
+    status: pending
+    date: ''
+    notes: ''
+  depends_on:
+  - REQ-901
+  conflicts: []
+  contracts:
+  - dataset-schema
+  - openapi-backend-sdk
+  decomposes_into:
+  - REQ-200
+  - REQ-202
+  - REQ-210
+  - REQ-212
+  - REQ-822
+  - REQ-823
+  notes: This parent requirement turns execution and evaluation from isolated repo maps into one benchmark feature graph.

--- a/scripts/validate_workspace_index.py
+++ b/scripts/validate_workspace_index.py
@@ -13,8 +13,9 @@ then validates:
   D. every `contracts:` reference on a requirement resolves to a contract
      key declared in workspace.yaml,
   E. every requirement has a `status` value that matches the allowed set,
-  F. (warning only) requirements whose `frontend` / `code` fields are
-     empty vs. `source:` hint mismatch.
+  F. every requirement has a valid `type`, every non-feature requirement
+     has a valid `repo`, and every referenced repo key exists in workspace.yaml,
+  G. every `parent` / `decomposes_into` relationship is internally consistent.
 
 Exit codes:
   0  clean
@@ -37,6 +38,9 @@ import yaml
 ALLOWED_STATUS = {
     "draft", "planned", "implementing", "implemented", "tested",
     "blocked", "deferred", "disabled", "removed-frontend",
+}
+ALLOWED_TYPES = {
+    "feature", "capability", "api", "ui", "library", "pipeline", "contract", "service",
 }
 PATH_FIELDS = ("code", "frontend", "chaos_code", "rcabench_code")
 
@@ -69,6 +73,7 @@ def validate(workspace_root: str) -> dict:
     index = load_yaml(index_path)
 
     # Build field-name → expected path prefix (repo root) map
+    declared_repos = set((manifest.get("repos") or {}).keys())
     field_to_prefix: dict[str, str] = {}
     for repo_key, repo in (manifest.get("repos") or {}).items():
         field = repo.get("path_field")
@@ -77,16 +82,27 @@ def validate(workspace_root: str) -> dict:
             field_to_prefix[field] = pfx.rstrip("/") + "/"
 
     declared_contracts = set((manifest.get("contracts") or {}).keys())
-    req_ids = {r.get("id") for r in index.get("requirements", [])}
+    requirements = index.get("requirements", [])
+    req_ids = {r.get("id") for r in requirements}
 
     missing_paths: list[tuple[str, str, str]] = []   # (req_id, field, path)
     prefix_mismatches: list[tuple[str, str, str, str]] = []  # (req_id, field, path, expected_prefix)
     bad_depends_on: list[tuple[str, str]] = []        # (req_id, target_id)
     bad_contract_refs: list[tuple[str, str]] = []     # (req_id, contract_key)
     bad_status: list[tuple[str, str]] = []            # (req_id, status)
+    bad_type: list[tuple[str, str]] = []              # (req_id, type)
+    bad_repo: list[tuple[str, str]] = []              # (req_id, repo)
+    bad_parent_refs: list[tuple[str, str]] = []       # (req_id, parent_id)
+    bad_parent_links: list[tuple[str, str]] = []      # (req_id, parent_id)
+    bad_decompose_refs: list[tuple[str, str]] = []    # (req_id, child_id)
+    bad_feature_shape: list[tuple[str, str]] = []     # (req_id, issue)
 
-    for req in index.get("requirements", []):
+    req_map = {r.get("id"): r for r in requirements}
+
+    for req in requirements:
         rid = req.get("id", "<no id>")
+        req_type = req.get("type")
+        repo = req.get("repo")
 
         for field in PATH_FIELDS:
             expected_prefix = field_to_prefix.get(field)
@@ -109,19 +125,60 @@ def validate(workspace_root: str) -> dict:
         if status not in ALLOWED_STATUS:
             bad_status.append((rid, status or "<unset>"))
 
+        if req_type not in ALLOWED_TYPES:
+            bad_type.append((rid, req_type or "<unset>"))
+
+        if req_type == "feature":
+            if repo not in (None, "null"):
+                bad_feature_shape.append((rid, "feature requirements must omit repo or set it to null"))
+            children = req.get("decomposes_into") or []
+            if not children:
+                bad_feature_shape.append((rid, "feature requirements must declare decomposes_into"))
+            for child_id in children:
+                if child_id not in req_ids:
+                    bad_decompose_refs.append((rid, child_id))
+                    continue
+                child = req_map[child_id]
+                if child.get("parent") != rid:
+                    bad_parent_links.append((child_id, rid))
+        else:
+            if repo not in declared_repos:
+                bad_repo.append((rid, repo or "<unset>"))
+            if req.get("decomposes_into"):
+                bad_feature_shape.append((rid, "only feature requirements may declare decomposes_into"))
+
+        parent = req.get("parent")
+        if parent:
+            if parent not in req_ids:
+                bad_parent_refs.append((rid, parent))
+            else:
+                parent_req = req_map[parent]
+                if parent_req.get("type") != "feature":
+                    bad_parent_links.append((rid, parent))
+                elif rid not in (parent_req.get("decomposes_into") or []):
+                    bad_parent_links.append((rid, parent))
+
     report = {
         "workspace_root": workspace_root,
-        "requirements_total": len(index.get("requirements", [])),
+        "requirements_total": len(requirements),
         "missing_paths": missing_paths,
         "prefix_mismatches": prefix_mismatches,
         "bad_depends_on": bad_depends_on,
         "bad_contract_refs": bad_contract_refs,
         "bad_status": bad_status,
+        "bad_type": bad_type,
+        "bad_repo": bad_repo,
+        "bad_parent_refs": bad_parent_refs,
+        "bad_parent_links": bad_parent_links,
+        "bad_decompose_refs": bad_decompose_refs,
+        "bad_feature_shape": bad_feature_shape,
     }
     report["violations_total"] = sum(
         len(report[k]) for k in
         ("missing_paths", "prefix_mismatches", "bad_depends_on",
-         "bad_contract_refs", "bad_status")
+         "bad_contract_refs", "bad_status", "bad_type", "bad_repo",
+         "bad_parent_refs", "bad_parent_links", "bad_decompose_refs",
+         "bad_feature_shape")
     )
     return report
 
@@ -158,6 +215,36 @@ def print_text(report: dict) -> None:
         print(f"\n[E] bad_status ({len(report['bad_status'])}):")
         for rid, s in report["bad_status"]:
             print(f"  {rid}  status={s}  (allowed: {sorted(ALLOWED_STATUS)})")
+
+    if report["bad_type"]:
+        print(f"\n[F] bad_type ({len(report['bad_type'])}):")
+        for rid, req_type in report["bad_type"]:
+            print(f"  {rid}  type={req_type}  (allowed: {sorted(ALLOWED_TYPES)})")
+
+    if report["bad_repo"]:
+        print(f"\n[G] bad_repo ({len(report['bad_repo'])}):")
+        for rid, repo in report["bad_repo"]:
+            print(f"  {rid}  repo={repo}")
+
+    if report["bad_parent_refs"]:
+        print(f"\n[H] bad_parent_refs ({len(report['bad_parent_refs'])}):")
+        for rid, parent in report["bad_parent_refs"]:
+            print(f"  {rid}  -> unknown parent {parent}")
+
+    if report["bad_parent_links"]:
+        print(f"\n[I] bad_parent_links ({len(report['bad_parent_links'])}):")
+        for rid, parent in report["bad_parent_links"]:
+            print(f"  {rid}  parent/decomposes_into mismatch with {parent}")
+
+    if report["bad_decompose_refs"]:
+        print(f"\n[J] bad_decompose_refs ({len(report['bad_decompose_refs'])}):")
+        for rid, child in report["bad_decompose_refs"]:
+            print(f"  {rid}  -> unknown child {child}")
+
+    if report["bad_feature_shape"]:
+        print(f"\n[K] bad_feature_shape ({len(report['bad_feature_shape'])}):")
+        for rid, issue in report["bad_feature_shape"]:
+            print(f"  {rid}  {issue}")
 
 
 def main() -> int:


### PR DESCRIPTION
Fixes #1

## Approach summary
I rebuilt `project-index.yaml` from the workspace root by re-scanning the four submodules and reconciling the existing 69 requirements against current code layout. For AegisLab and AegisLab-frontend, I preserved requirement intent where it still matched the code, replaced stale frontend paths with current route/API files where possible, and explicitly marked removed frontend-only slices when the old workspace/detail-view implementation no longer exists. I then added new repo-local requirements for `chaos-experiment` and `rcabench-platform` so the index covers the fault-injection library, dataset conversion/schema handling, algorithm registries, and evaluation/reporting code paths that were previously unindexed.

To reflect end-to-end design intent, I introduced three `type: feature` parents: fault injection lifecycle, dataset collection/schema flow, and RCA evaluation/benchmarking flow. Each parent decomposes into children across multiple repos and links the relevant workspace contracts: `openapi-backend-sdk`, `chaos-mesh-crd`, and `dataset-schema`. I also updated `scripts/validate_workspace_index.py` so it validates the new schema fields (`type`, `repo`, `parent`, `decomposes_into`) in addition to the existing path, dependency, contract, and status checks.

## Validation
- `python3 scripts/validate_workspace_index.py`

## Submodule changes
- `AegisLab` — not modified
- `AegisLab-frontend` — not modified
- `chaos-experiment` — not modified
- `rcabench-platform` — not modified
