### PR TITLE
Document local kind deployment pitfalls for issue #3

### DIFF
--- a/docs/cross-repo-feature-linkage.md
+++ b/docs/cross-repo-feature-linkage.md
@@ -21,3 +21,6 @@ The shared contracts referenced by these features are:
 - `openapi-backend-sdk` for backend/frontend typed API coupling
 - `chaos-mesh-crd` for backend/chaos library coupling
 - `dataset-schema` for datapack production and downstream consumption
+
+Deployment discovery added one cross-repo constraint worth making explicit:
+- the local end-to-end path currently depends on parent-repo orchestration, but each submodule still carries internal-only defaults of its own: `AegisLab` for cluster/storage/runtime config, `AegisLab-frontend` for package auth and API docs, `chaos-experiment` for Chaos Mesh API compatibility, and `rcabench-platform` for downstream base URLs and JuiceFS-backed datasets.

--- a/docs/deployment/01-kind-cluster.md
+++ b/docs/deployment/01-kind-cluster.md
@@ -20,7 +20,7 @@ kind version 0.30.0
 
 ## Cluster config used by the repo
 
-The repo ships [AegisLab/manifests/test/kind-config.yaml](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/manifests/test/kind-config.yaml), which defines:
+The repo ships [AegisLab/manifests/test/kind-config.yaml](/home/ddq/AoyangSpace/aegis/AegisLab/manifests/test/kind-config.yaml), which defines:
 
 - 1 control-plane node
 - 2 worker nodes
@@ -45,6 +45,21 @@ Creating cluster "aegis-issue3" ...
  ✗ Preparing nodes 📦 📦 📦
 Deleted nodes: ["aegis-issue3-control-plane" "aegis-issue3-worker2" "aegis-issue3-worker"]
 ERROR: failed to create cluster: could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"
+```
+
+## Rerun hygiene
+
+If a retained failed bootstrap leaves exited node containers behind, delete the stale cluster before retrying:
+
+```bash
+kind delete cluster --name aegis-issue3
+docker ps -a --filter 'name=aegis-issue3'
+```
+
+Without this cleanup, the next `kind create cluster` may fail earlier with:
+
+```text
+ERROR: failed to create cluster: node(s) already exist for a cluster with the name "aegis-issue3"
 ```
 
 ## Retained-debug rerun

--- a/docs/deployment/01-kind-cluster.md
+++ b/docs/deployment/01-kind-cluster.md
@@ -1,0 +1,129 @@
+# 01. Kind Cluster
+
+This was the first blocking step in the discovery pass.
+
+## Install `kind`
+
+Executed:
+
+```bash
+curl -Lo /tmp/kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
+install -m 0755 /tmp/kind /home/ddq/.local/bin/kind
+kind --version
+```
+
+Verification:
+
+```text
+kind version 0.30.0
+```
+
+## Cluster config used by the repo
+
+The repo ships [AegisLab/manifests/test/kind-config.yaml](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/manifests/test/kind-config.yaml), which defines:
+
+- 1 control-plane node
+- 2 worker nodes
+- registry mirror overrides for `docker.io` and `registry.k8s.io`
+
+## Attempted bootstrap
+
+Executed:
+
+```bash
+kind create cluster \
+  --config AegisLab/manifests/test/kind-config.yaml \
+  --name aegis-issue3
+```
+
+Captured output:
+
+```text
+Creating cluster "aegis-issue3" ...
+ • Ensuring node image (kindest/node:v1.34.0) 🖼  ...
+ ✓ Ensuring node image (kindest/node:v1.34.0) 🖼
+ ✗ Preparing nodes 📦 📦 📦
+Deleted nodes: ["aegis-issue3-control-plane" "aegis-issue3-worker2" "aegis-issue3-worker"]
+ERROR: failed to create cluster: could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"
+```
+
+## Retained-debug rerun
+
+Executed:
+
+```bash
+kind create cluster \
+  --retain \
+  --config AegisLab/manifests/test/kind-config.yaml \
+  --name aegis-issue3 \
+  -v 1
+```
+
+Then inspected retained node logs:
+
+```bash
+docker ps -a --filter 'name=aegis-issue3' --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}'
+for c in $(docker ps -a --filter 'name=aegis-issue3' --format '{{.Names}}'); do
+  echo "### $c"
+  docker logs --tail 120 "$c" 2>&1
+done
+```
+
+Important log lines:
+
+```text
+Failed to create control group inotify object: Too many open files
+Failed to allocate manager object: Too many open files
+[!!!!!!] Failed to allocate manager object.
+Exiting PID 1...
+```
+
+## Verification target
+
+Do not continue to later steps until this succeeds:
+
+```bash
+kubectl cluster-info --context kind-aegis-issue3
+kubectl get nodes
+```
+
+Expected:
+- `kubectl cluster-info` returns API endpoints
+- all three nodes reach `Ready`
+
+## Host-level findings
+
+Observed on this machine:
+
+```bash
+ulimit -n
+cat /proc/sys/fs/inotify/max_user_instances
+cat /proc/sys/fs/inotify/max_user_watches
+docker info --format '{{json .}}' | jq '{ServerVersion,Driver,CgroupDriver,CgroupVersion}'
+```
+
+Observed values:
+
+```text
+ulimit -n = 1048576
+fs.inotify.max_user_instances = 128
+fs.inotify.max_user_watches = 65536
+docker: cgroup v2 + systemd driver
+```
+
+Attempted non-root sysctl workaround:
+
+```bash
+sysctl -w fs.inotify.max_user_instances=1024
+sysctl -w fs.inotify.max_user_watches=524288
+```
+
+Result:
+
+```text
+sysctl: permission denied on key "fs.inotify.max_user_instances", ignoring
+sysctl: permission denied on key "fs.inotify.max_user_watches", ignoring
+```
+
+Conclusion:
+- On this host, cluster bootstrap is blocked until a human with sufficient privileges raises inotify limits or otherwise fixes the Docker/systemd interaction for `kind`.

--- a/docs/deployment/02-chaos-mesh.md
+++ b/docs/deployment/02-chaos-mesh.md
@@ -1,0 +1,57 @@
+# 02. Chaos Mesh
+
+This step was not executed end-to-end because [01-kind-cluster.md](./01-kind-cluster.md) never produced a healthy cluster.
+
+## Repo-owned install path
+
+The repo’s bootstrap script is [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/scripts/start.sh) and installs Chaos Mesh like this:
+
+```bash
+helm repo add chaos-mesh https://charts.chaos-mesh.org --force-update
+helm install chaos-mesh chaos-mesh/chaos-mesh \
+  --namespace chaos-mesh \
+  --create-namespace \
+  --version 2.8.0 \
+  -f AegisLab/manifests/cn_mirror/chaos-mesh.yaml \
+  --atomic \
+  --timeout 10m
+
+kubectl apply -f AegisLab/manifests/chaos-mesh/rbac.yaml
+```
+
+## Version coupling to verify
+
+`chaos-experiment/go.mod` pins the CRD API through an internal fork replacement:
+
+```text
+replace github.com/chaos-mesh/chaos-mesh/api => github.com/OperationsPAI/chaos-mesh/api v0.0.0-20260124102507-517f3df45e54
+```
+
+That means the library is not using upstream Chaos Mesh APIs directly. Before changing Chaos Mesh chart versions, re-verify:
+
+```bash
+cd chaos-experiment
+go test ./...
+```
+
+## Verification commands once the cluster exists
+
+```bash
+kubectl get ns chaos-mesh
+kubectl get pods -n chaos-mesh
+kubectl api-resources | grep chaos-mesh
+kubectl auth can-i create networkchaos.chaos-mesh.org --namespace exp
+```
+
+Expected:
+- controller-manager and daemon pods are `Running`
+- `networkchaos.chaos-mesh.org` and related CRDs are listed
+- the service account used by Aegis has permission to create chaos resources
+
+## Current stop point
+
+Attempted up to:
+- waiting for a working cluster from [01-kind-cluster.md](./01-kind-cluster.md)
+
+Stopped because:
+- no local Kubernetes API server was available

--- a/docs/deployment/02-chaos-mesh.md
+++ b/docs/deployment/02-chaos-mesh.md
@@ -4,7 +4,7 @@ This step was not executed end-to-end because [01-kind-cluster.md](./01-kind-clu
 
 ## Repo-owned install path
 
-The repo’s bootstrap script is [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/scripts/start.sh) and installs Chaos Mesh like this:
+The repo’s bootstrap script is [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/AegisLab/scripts/start.sh) and installs Chaos Mesh like this:
 
 ```bash
 helm repo add chaos-mesh https://charts.chaos-mesh.org --force-update
@@ -18,6 +18,8 @@ helm install chaos-mesh chaos-mesh/chaos-mesh \
 
 kubectl apply -f AegisLab/manifests/chaos-mesh/rbac.yaml
 ```
+
+The values file used in that command is [AegisLab/manifests/cn_mirror/chaos-mesh.yaml](/home/ddq/AoyangSpace/aegis/AegisLab/manifests/cn_mirror/chaos-mesh.yaml), which rewrites Chaos Mesh images to `pair-diag-cn-guangzhou.cr.volces.com/pair/...`. A fresh local setup therefore needs registry access in addition to a working cluster.
 
 ## Version coupling to verify
 

--- a/docs/deployment/03-microservices.md
+++ b/docs/deployment/03-microservices.md
@@ -4,7 +4,7 @@ This step was not executed because the cluster was never created, but the repo c
 
 ## Workload selected by existing config
 
-Observed in [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/scripts/start.sh):
+Observed in [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/AegisLab/scripts/start.sh):
 
 ```bash
 helm repo add opentelemetry-demo https://operationspai.github.io/opentelemetry-demo --force-update
@@ -17,6 +17,20 @@ helm install otel-demo0 opentelemetry-demo/opentelemetry-demo \
 ```
 
 No equivalent train-ticket install path was found in the parent-repo docs or bootstrap script used during this pass.
+
+## Additional bootstrap assumptions
+
+The test-mode bootstrap path in [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/AegisLab/scripts/start.sh) hardcodes:
+
+```bash
+HTTP_PROXY=http://crash:crash@172.18.0.1:7890
+HTTPS_PROXY=http://crash:crash@172.18.0.1:7890
+NO_PROXY=localhost,127.0.0.1,10.96.0.0/12,172.18.0.0/16,cluster.local,svc
+```
+
+That proxy expectation is undocumented at the workspace level and is specific to the original team environment.
+
+The workload values file [AegisLab/data/initial_data/prod/otel-demo.yaml](/home/ddq/AoyangSpace/aegis/AegisLab/data/initial_data/prod/otel-demo.yaml) also rewrites workload images to `pair-diag-cn-guangzhou.cr.volces.com/pair/...`, so even a healthy local cluster still needs access to that registry or a replacement values file.
 
 ## Verification commands once the cluster exists
 

--- a/docs/deployment/03-microservices.md
+++ b/docs/deployment/03-microservices.md
@@ -1,0 +1,41 @@
+# 03. Benchmark Microservices
+
+This step was not executed because the cluster was never created, but the repo currently points at OpenTelemetry Demo rather than Train Ticket for the cluster bootstrap path.
+
+## Workload selected by existing config
+
+Observed in [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/scripts/start.sh):
+
+```bash
+helm repo add opentelemetry-demo https://operationspai.github.io/opentelemetry-demo --force-update
+helm install otel-demo0 opentelemetry-demo/opentelemetry-demo \
+  --namespace otel-demo0 \
+  --create-namespace \
+  -f AegisLab/data/initial_data/prod/otel-demo.yaml \
+  --atomic \
+  --timeout 10m
+```
+
+No equivalent train-ticket install path was found in the parent-repo docs or bootstrap script used during this pass.
+
+## Verification commands once the cluster exists
+
+```bash
+helm list -A | grep otel-demo0
+kubectl get ns otel-demo0
+kubectl get pods -n otel-demo0
+kubectl get svc -n otel-demo0
+```
+
+Expected:
+- the Helm release `otel-demo0` exists
+- all workload pods are `Running`
+- frontend and backend services are exposed inside the namespace
+
+## Current stop point
+
+Attempted up to:
+- repo inspection only
+
+Stopped because:
+- cluster bootstrap failed before any workload Helm install could be attempted

--- a/docs/deployment/04-backend.md
+++ b/docs/deployment/04-backend.md
@@ -1,0 +1,84 @@
+# 04. AegisLab Backend
+
+## Host-side build checks
+
+Executed:
+
+```bash
+cd AegisLab/src
+go version
+go build ./...
+go build -tags=duckdb_arrow ./...
+```
+
+Result:
+- both host-side builds completed successfully on this machine with Go `1.26.2`
+
+What this means:
+- `duckdb_arrow` is part of the repo’s default Docker/Skaffold build path, but it was not a locally reproducible blocker for plain `go build ./...` during this pass
+
+## Repo-owned image build defaults
+
+Observed in [AegisLab/src/Dockerfile](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/src/Dockerfile) and [AegisLab/skaffold.yaml](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/skaffold.yaml):
+
+- Dockerfile accepts `ARG GO_BUILD_TAGS`
+- `skaffold` sets `GO_BUILD_TAGS: duckdb_arrow`
+- test and staging profiles target private registries rather than kind-local image loading
+
+## Local config assumptions to override
+
+Observed in [AegisLab/src/config.dev.toml](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/src/config.dev.toml):
+
+- `workspace = "/home/nn/workspace/AegisLab"`
+- `k8s.service.internal_url = "http://10.10.10.161:8082"`
+- `k8s.init_container.busybox_image = "10.10.10.240/library/busybox:1.35"`
+- `loki.address = "http://10.10.10.161:3100"`
+- `jfs.dataset_path = "/mnt/jfs/rcabench_dataset"`
+
+Those defaults are not portable to a fresh local checkout.
+
+## Cluster deployment path
+
+Repo commands:
+
+```bash
+cd AegisLab
+ENV_MODE=test devbox run skaffold run
+```
+
+or:
+
+```bash
+cd AegisLab
+helm upgrade -i rcabench ./helm \
+  --namespace exp \
+  --create-namespace \
+  --values ./manifests/test/rcabench.yaml \
+  --set-file initialDataFiles.data_yaml=data/initial_data/prod/data.yaml \
+  --set-file initialDataFiles.otel_demo_yaml=data/initial_data/prod/otel-demo.yaml \
+  --set-file initialDataFiles.ts_yaml=data/initial_data/prod/ts.yaml \
+  --atomic \
+  --timeout 10m
+```
+
+## Verification commands once the cluster exists
+
+```bash
+kubectl get pods -n exp
+kubectl get svc -n exp
+kubectl logs -n exp deploy/rcabench
+kubectl logs -n exp deploy/rcabench-consumer
+```
+
+Expected:
+- backend and consumer pods are `Running`
+- service endpoints exist in namespace `exp`
+- logs do not show failed connections to `10.10.10.*` addresses
+
+## Current stop point
+
+Attempted up to:
+- host build only
+
+Stopped because:
+- cluster bootstrap failed before image build/deploy could be attempted

--- a/docs/deployment/04-backend.md
+++ b/docs/deployment/04-backend.md
@@ -19,7 +19,7 @@ What this means:
 
 ## Repo-owned image build defaults
 
-Observed in [AegisLab/src/Dockerfile](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/src/Dockerfile) and [AegisLab/skaffold.yaml](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/skaffold.yaml):
+Observed in [AegisLab/src/Dockerfile](/home/ddq/AoyangSpace/aegis/AegisLab/src/Dockerfile) and [AegisLab/skaffold.yaml](/home/ddq/AoyangSpace/aegis/AegisLab/skaffold.yaml):
 
 - Dockerfile accepts `ARG GO_BUILD_TAGS`
 - `skaffold` sets `GO_BUILD_TAGS: duckdb_arrow`
@@ -27,7 +27,7 @@ Observed in [AegisLab/src/Dockerfile](/home/ddq/AoyangSpace/aegis/.workbuddy/wor
 
 ## Local config assumptions to override
 
-Observed in [AegisLab/src/config.dev.toml](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/src/config.dev.toml):
+Observed in [AegisLab/src/config.dev.toml](/home/ddq/AoyangSpace/aegis/AegisLab/src/config.dev.toml):
 
 - `workspace = "/home/nn/workspace/AegisLab"`
 - `k8s.service.internal_url = "http://10.10.10.161:8082"`
@@ -36,6 +36,9 @@ Observed in [AegisLab/src/config.dev.toml](/home/ddq/AoyangSpace/aegis/.workbudd
 - `jfs.dataset_path = "/mnt/jfs/rcabench_dataset"`
 
 Those defaults are not portable to a fresh local checkout.
+
+Additional deployment-level assumption found in [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/AegisLab/scripts/start.sh):
+- test bootstrap forces `HTTP_PROXY` and `HTTPS_PROXY` to `http://crash:crash@172.18.0.1:7890` during `kind create cluster`
 
 ## Cluster deployment path
 

--- a/docs/deployment/05-frontend.md
+++ b/docs/deployment/05-frontend.md
@@ -1,0 +1,78 @@
+# 05. AegisLab Frontend
+
+## Host-side install and build
+
+Executed:
+
+```bash
+cd AegisLab-frontend
+pnpm install
+pnpm build
+```
+
+Observed behavior:
+- `pnpm install` succeeded on this machine
+- both commands warned that `.npmrc` referenced `${NPM_TOKEN}` without an exported env var
+- success here should not be treated as a fresh-machine guarantee because local package cache/store state may have masked an auth failure
+
+Captured warning:
+
+```text
+WARN Issue while reading ".../AegisLab-frontend/.npmrc". Failed to replace env in config: ${NPM_TOKEN}
+```
+
+## Docker image build without secret
+
+Executed:
+
+```bash
+cd AegisLab-frontend
+docker build -t aegis-frontend-test .
+```
+
+Captured failure:
+
+```text
+#11 0.185 cat: can't open '/run/secrets/NPM_TOKEN': No such file or directory
+#11 2.895 ERR_PNPM_FETCH_401 GET https://npm.pkg.github.com/download/@OperationsPAI/client/1.2.0/...: Unauthorized - 401
+ERROR: failed to solve: process "/bin/sh -c export NPM_TOKEN=$(cat /run/secrets/NPM_TOKEN) && pnpm install --no-frozen-lockfile" did not complete successfully: exit code: 1
+```
+
+This is the strongest reproducible evidence in this pass that a valid `NPM_TOKEN` is required for clean containerized builds.
+
+## Repo config notes
+
+Observed in [AegisLab-frontend/vite.config.ts](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab-frontend/vite.config.ts):
+
+- dev proxy default is `http://127.0.0.1:8082`
+- `VITE_API_TARGET` can override that cleanly
+
+Observed in [AegisLab-frontend/.npmrc](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab-frontend/.npmrc):
+
+```text
+@OperationsPAI:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
+```
+
+## Verification commands once backend and cluster exist
+
+Local dev server:
+
+```bash
+cd AegisLab-frontend
+VITE_API_TARGET=http://127.0.0.1:8082 pnpm dev
+```
+
+Container build:
+
+```bash
+cd AegisLab-frontend
+docker build \
+  --secret id=NPM_TOKEN,env=NPM_TOKEN \
+  -t aegis-frontend-test .
+```
+
+Expected:
+- dev server starts on `http://localhost:3000`
+- `/api` proxy reaches the backend
+- container build succeeds without `ERR_PNPM_FETCH_401`

--- a/docs/deployment/05-frontend.md
+++ b/docs/deployment/05-frontend.md
@@ -42,12 +42,17 @@ This is the strongest reproducible evidence in this pass that a valid `NPM_TOKEN
 
 ## Repo config notes
 
-Observed in [AegisLab-frontend/vite.config.ts](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab-frontend/vite.config.ts):
+Observed in [AegisLab-frontend/vite.config.ts](/home/ddq/AoyangSpace/aegis/AegisLab-frontend/vite.config.ts):
 
 - dev proxy default is `http://127.0.0.1:8082`
 - `VITE_API_TARGET` can override that cleanly
 
-Observed in [AegisLab-frontend/.npmrc](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab-frontend/.npmrc):
+Note:
+- [AegisLab-frontend/README.md](/home/ddq/AoyangSpace/aegis/AegisLab-frontend/README.md) still says the dev proxy targets `http://10.10.10.220:32080`
+- the checked-in Vite config now defaults to `http://127.0.0.1:8082`
+- a contributor following the README literally will point the frontend at the wrong backend unless they inspect `vite.config.ts`
+
+Observed in [AegisLab-frontend/.npmrc](/home/ddq/AoyangSpace/aegis/AegisLab-frontend/.npmrc):
 
 ```text
 @OperationsPAI:registry=https://npm.pkg.github.com/

--- a/docs/deployment/06-observability.md
+++ b/docs/deployment/06-observability.md
@@ -4,7 +4,7 @@ The backend chart expects an observability stack, but this step was blocked by t
 
 ## Components referenced by the repo
 
-Observed in [AegisLab/helm/values.yaml](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/helm/values.yaml):
+Observed in [AegisLab/helm/values.yaml](/home/ddq/AoyangSpace/aegis/AegisLab/helm/values.yaml):
 
 - Prometheus
 - Grafana
@@ -12,10 +12,16 @@ Observed in [AegisLab/helm/values.yaml](/home/ddq/AoyangSpace/aegis/.workbuddy/w
 - Grafana Alloy
 - optional Jaeger PVCs
 
-Observed in [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/scripts/start.sh):
+Observed in [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/AegisLab/scripts/start.sh):
 
 - `clickstack/clickstack`
 - `open-telemetry/opentelemetry-kube-stack`
+
+Observed in:
+- [AegisLab/manifests/cn_mirror/click-stack.yaml](/home/ddq/AoyangSpace/aegis/AegisLab/manifests/cn_mirror/click-stack.yaml)
+- [AegisLab/manifests/cn_mirror/otel-kube-stack.yaml](/home/ddq/AoyangSpace/aegis/AegisLab/manifests/cn_mirror/otel-kube-stack.yaml)
+
+Those values files rewrite observability images to `pair-diag-cn-guangzhou.cr.volces.com/pair/...`, so the stack is not locally reproducible without private-registry access or alternative values.
 
 ## Commands to run once the cluster exists
 

--- a/docs/deployment/06-observability.md
+++ b/docs/deployment/06-observability.md
@@ -1,0 +1,52 @@
+# 06. Observability
+
+The backend chart expects an observability stack, but this step was blocked by the missing cluster.
+
+## Components referenced by the repo
+
+Observed in [AegisLab/helm/values.yaml](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/helm/values.yaml):
+
+- Prometheus
+- Grafana
+- Loki
+- Grafana Alloy
+- optional Jaeger PVCs
+
+Observed in [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/scripts/start.sh):
+
+- `clickstack/clickstack`
+- `open-telemetry/opentelemetry-kube-stack`
+
+## Commands to run once the cluster exists
+
+```bash
+helm repo add clickstack https://hyperdxio.github.io/helm-charts --force-update
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts --force-update
+```
+
+Then use the repo bootstrap path:
+
+```bash
+cd AegisLab
+bash scripts/start.sh test
+```
+
+Or install stack pieces individually by reusing the commands in that script.
+
+## Verification commands
+
+```bash
+kubectl get ns monitoring
+kubectl get pods -n monitoring
+kubectl get svc -n monitoring
+kubectl logs -n exp deploy/rcabench | grep -E 'loki|otlp|prometheus'
+```
+
+Expected:
+- monitoring namespace exists
+- clickstack and otel-kube-stack pods are `Running`
+- backend logs show successful exporters or no hard failures against observability backends
+
+## Storage note
+
+The chart defaults to `persistence.storageType: juicefs`, so observability PVC behavior is entangled with the same JuiceFS assumptions described in [prerequisites.md](./prerequisites.md) and [known-gaps.md](./known-gaps.md).

--- a/docs/deployment/07-smoke-test.md
+++ b/docs/deployment/07-smoke-test.md
@@ -1,0 +1,44 @@
+# 07. Smoke Test
+
+This smoke test could not be executed in this pass because the local cluster never became healthy.
+
+## Intended end-to-end path
+
+1. Open the frontend.
+2. Submit a network-delay fault against the benchmark workload.
+3. Confirm a Chaos Mesh CR is created in Kubernetes.
+4. Confirm traces/metrics/logs are collected.
+5. Optionally export a datapack and hand it to `rcabench-platform`.
+
+## Verification commands once the cluster exists
+
+Frontend running locally:
+
+```bash
+cd AegisLab-frontend
+VITE_API_TARGET=http://127.0.0.1:8082 pnpm dev
+```
+
+Cluster checks:
+
+```bash
+kubectl get networkchaos -A
+kubectl describe networkchaos -A
+kubectl get pods -n exp
+kubectl logs -n exp deploy/rcabench-consumer
+kubectl get pods -n monitoring
+```
+
+Expected:
+- a `NetworkChaos` resource appears after submitting the fault
+- target workload pods show the effect
+- backend/consumer logs show task progress rather than transport errors
+- observability pods remain healthy and collect data
+
+## Current stop point
+
+Attempted up to:
+- cluster bootstrap only
+
+Stopped because:
+- no working `kind` cluster was available, so UI-driven fault injection could not be exercised

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,48 @@
+# Aegis Local Deployment Discovery Runbook
+
+This directory records a real discovery pass for standing up the Aegis stack on a local `kind` cluster from a fresh parent-repo checkout.
+
+Status of this attempt:
+- Host tooling inspection: completed
+- Submodule initialization: completed
+- `kind` install: completed
+- `kind` cluster bootstrap: attempted, failed on this host before Kubernetes became ready
+- Backend host build: completed
+- Frontend host install/build: completed
+- Frontend container build: attempted, failed without valid `NPM_TOKEN`
+- Chaos Mesh, workload, observability, backend-in-cluster, smoke test: blocked by cluster bootstrap failure
+
+Attempted up to:
+- [01-kind-cluster.md](./01-kind-cluster.md)
+
+Stopped because:
+- `kind create cluster` failed on this host with `Failed to create control group inotify object: Too many open files`, so no working local Kubernetes API server was available for the remaining steps.
+
+Order of operations:
+1. Read [prerequisites.md](./prerequisites.md).
+2. Create the cluster with [01-kind-cluster.md](./01-kind-cluster.md).
+3. Install Chaos Mesh with [02-chaos-mesh.md](./02-chaos-mesh.md).
+4. Deploy the benchmark workload with [03-microservices.md](./03-microservices.md).
+5. Deploy the backend with [04-backend.md](./04-backend.md).
+6. Deploy the frontend with [05-frontend.md](./05-frontend.md).
+7. Verify the observability stack with [06-observability.md](./06-observability.md).
+8. Run the end-to-end smoke test in [07-smoke-test.md](./07-smoke-test.md).
+9. Review all blockers in [known-gaps.md](./known-gaps.md).
+
+What worked in this workspace:
+- `git submodule update --init --recursive`
+- local Go build in `AegisLab/src`
+- local `pnpm install` and `pnpm build` in `AegisLab-frontend`
+- Docker pulls from public `docker.io` during frontend image build
+
+What still does not work:
+- Local `kind` bootstrap on this machine
+- Any Kubernetes-based deployment or verification
+- Frontend Docker build without a valid `NPM_TOKEN` secret
+- Any path that depends on internal `10.10.10.*` addresses or the team JuiceFS deployment
+- Any chart or manifest path that expects private registries such as `pair-diag-cn-guangzhou.cr.volces.com` or `10.10.10.240`
+
+Top blockers by impact:
+- Host-level `kind` failure before the cluster is ready
+- Private package auth for `@OperationsPAI/client`
+- Internal-only registry and storage defaults in the backend and benchmark configs

--- a/docs/deployment/known-gaps.md
+++ b/docs/deployment/known-gaps.md
@@ -1,0 +1,57 @@
+# Known Gaps
+
+### Kind bootstrap fails before Kubernetes is ready
+
+**Where**: `01-kind-cluster.md` bootstrap step  
+**Symptom**: `kind create cluster` ends with `ERROR: failed to create cluster: could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"` and retained node logs contain `Failed to create control group inotify object: Too many open files`  
+**Root cause / guess**: host-level Docker/systemd/inotify limits are too low for `kindest/node:v1.34.0` on this machine; the repo does not document required sysctl settings or host prerequisites for `kind`  
+**Workaround applied**: reran with `--retain -v 1` and inspected `docker logs` to identify the real cause; attempted `sysctl -w fs.inotify.max_user_instances=1024` and `sysctl -w fs.inotify.max_user_watches=524288`, but non-root writes were denied  
+**Suggested fix (NOT applied here)**: follow-up issue title: `Document and validate host sysctl requirements for local kind bootstrap`; scope: add a preflight script or README section that checks inotify/file-descriptor limits before invoking `kind`
+
+### Repo prerequisite check assumes `kubectx`
+
+**Where**: `prerequisites.md` host-tool check and `AegisLab/justfile` `check-prerequisites`  
+**Symptom**: `❌ kubectx not installed` and `error: Recipe 'check-prerequisites' failed with exit code 1`  
+**Root cause / guess**: the repo treats `kubectx` as mandatory but does not install it or document it in the parent workspace  
+**Workaround applied**: none in this pass; noted it as a required host dependency  
+**Suggested fix (NOT applied here)**: follow-up issue title: `Document kubectx as a required dev dependency or remove it from hard prerequisite checks`; scope: align README/devbox/prerequisite scripts
+
+### Frontend container build requires GitHub Packages auth
+
+**Where**: `05-frontend.md` Docker build step  
+**Symptom**: `cat: can't open '/run/secrets/NPM_TOKEN': No such file or directory` followed by `ERR_PNPM_FETCH_401 ... Unauthorized - 401` while fetching `@OperationsPAI/client`  
+**Root cause / guess**: [AegisLab-frontend/.npmrc](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab-frontend/.npmrc) points `@OperationsPAI` to GitHub Packages and the Dockerfile expects a BuildKit secret named `NPM_TOKEN`  
+**Workaround applied**: host-side `pnpm install` and `pnpm build` succeeded in this workspace, likely due local cache/store state; no clean container workaround was available without a real token  
+**Suggested fix (NOT applied here)**: follow-up issue title: `Document required NPM_TOKEN flow for frontend container builds`; scope: add explicit PAT scopes, `docker build --secret ...` example, and fallback guidance for fresh machines
+
+### Test deployment profile assumes a private container registry
+
+**Where**: `04-backend.md` cluster deployment path using `AegisLab/manifests/test/rcabench.yaml` and `AegisLab/skaffold.yaml`  
+**Symptom**: the checked-in test profile points images at `pair-diag-cn-guangzhou.cr.volces.com/pair/...` instead of a kind-local or public registry path  
+**Root cause / guess**: the test deployment was validated in an internal environment with pre-published images rather than from a fresh local checkout  
+**Workaround applied**: none in this pass because the cluster never became ready; blocker recorded from manifest inspection  
+**Suggested fix (NOT applied here)**: follow-up issue title: `Provide a truly local skaffold/kind profile for AegisLab`; scope: load locally built images into kind or switch test values to public/local image references
+
+### Backend dev/test configs still encode internal endpoints
+
+**Where**: `04-backend.md` config review  
+**Symptom**: [AegisLab/src/config.dev.toml](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/src/config.dev.toml) sets `k8s.service.internal_url = "http://10.10.10.161:8082"`, `loki.address = "http://10.10.10.161:3100"`, and `k8s.init_container.busybox_image = "10.10.10.240/library/busybox:1.35"`  
+**Root cause / guess**: dev defaults were copied from a team environment instead of a local-only profile  
+**Workaround applied**: none in this pass; recorded as configuration debt because cluster deployment never started  
+**Suggested fix (NOT applied here)**: follow-up issue title: `Replace internal AegisLab dev defaults with localhost-or-env-based settings`; scope: parameterize internal URLs and image registries through env vars or dedicated local config
+
+### JuiceFS default storage depends on an internal Redis/MinIO host
+
+**Where**: `prerequisites.md` and `06-observability.md` storage notes  
+**Symptom**: [AegisLab/helm/values.yaml](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/helm/values.yaml) uses `juicefs.metaurl = "redis://10.10.10.119:6379/1"`, and [rcabench-platform/infra/README.md](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/rcabench-platform/infra/README.md) instructs users to mount JuiceFS from `10.10.10.119`  
+**Root cause / guess**: the default storage path assumes access to a long-lived shared internal JuiceFS deployment  
+**Workaround applied**: none in this pass; documented as a hard dependency to replace before local reproduction can work  
+**Suggested fix (NOT applied here)**: follow-up issue title: `Provide a local-storage fallback for JuiceFS-backed Aegis deployments`; scope: add a documented local profile using hostPath/OpenEBS/MinIO-in-cluster instead of internal Redis/MinIO
+
+### rcabench-platform SDK defaults target internal Aegis endpoints
+
+**Where**: downstream handoff after `07-smoke-test.md`  
+**Symptom**: [rcabench-platform/src/rcabench_platform/v2/config.py](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/rcabench-platform/src/rcabench_platform/v2/config.py) defaults `dev` to `http://10.10.10.161:8082` and `prod` to `http://10.10.10.220:32080`  
+**Root cause / guess**: rcabench-platform was authored against internal environments without a parent-repo local profile  
+**Workaround applied**: none in this pass; noted for future datapack-to-RCA handoff work  
+**Suggested fix (NOT applied here)**: follow-up issue title: `Parameterize rcabench-platform base_url defaults for local parent-repo deployments`; scope: move default URLs behind env vars or a local config profile

--- a/docs/deployment/known-gaps.md
+++ b/docs/deployment/known-gaps.md
@@ -20,7 +20,7 @@
 
 **Where**: `05-frontend.md` Docker build step  
 **Symptom**: `cat: can't open '/run/secrets/NPM_TOKEN': No such file or directory` followed by `ERR_PNPM_FETCH_401 ... Unauthorized - 401` while fetching `@OperationsPAI/client`  
-**Root cause / guess**: [AegisLab-frontend/.npmrc](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab-frontend/.npmrc) points `@OperationsPAI` to GitHub Packages and the Dockerfile expects a BuildKit secret named `NPM_TOKEN`  
+**Root cause / guess**: [AegisLab-frontend/.npmrc](/home/ddq/AoyangSpace/aegis/AegisLab-frontend/.npmrc) points `@OperationsPAI` to GitHub Packages and the Dockerfile expects a BuildKit secret named `NPM_TOKEN`  
 **Workaround applied**: host-side `pnpm install` and `pnpm build` succeeded in this workspace, likely due local cache/store state; no clean container workaround was available without a real token  
 **Suggested fix (NOT applied here)**: follow-up issue title: `Document required NPM_TOKEN flow for frontend container builds`; scope: add explicit PAT scopes, `docker build --secret ...` example, and fallback guidance for fresh machines
 
@@ -35,7 +35,7 @@
 ### Backend dev/test configs still encode internal endpoints
 
 **Where**: `04-backend.md` config review  
-**Symptom**: [AegisLab/src/config.dev.toml](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/src/config.dev.toml) sets `k8s.service.internal_url = "http://10.10.10.161:8082"`, `loki.address = "http://10.10.10.161:3100"`, and `k8s.init_container.busybox_image = "10.10.10.240/library/busybox:1.35"`  
+**Symptom**: [AegisLab/src/config.dev.toml](/home/ddq/AoyangSpace/aegis/AegisLab/src/config.dev.toml) sets `k8s.service.internal_url = "http://10.10.10.161:8082"`, `loki.address = "http://10.10.10.161:3100"`, and `k8s.init_container.busybox_image = "10.10.10.240/library/busybox:1.35"`  
 **Root cause / guess**: dev defaults were copied from a team environment instead of a local-only profile  
 **Workaround applied**: none in this pass; recorded as configuration debt because cluster deployment never started  
 **Suggested fix (NOT applied here)**: follow-up issue title: `Replace internal AegisLab dev defaults with localhost-or-env-based settings`; scope: parameterize internal URLs and image registries through env vars or dedicated local config
@@ -43,7 +43,7 @@
 ### JuiceFS default storage depends on an internal Redis/MinIO host
 
 **Where**: `prerequisites.md` and `06-observability.md` storage notes  
-**Symptom**: [AegisLab/helm/values.yaml](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/AegisLab/helm/values.yaml) uses `juicefs.metaurl = "redis://10.10.10.119:6379/1"`, and [rcabench-platform/infra/README.md](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/rcabench-platform/infra/README.md) instructs users to mount JuiceFS from `10.10.10.119`  
+**Symptom**: [AegisLab/helm/values.yaml](/home/ddq/AoyangSpace/aegis/AegisLab/helm/values.yaml) uses `juicefs.metaurl = "redis://10.10.10.119:6379/1"`, and [rcabench-platform/infra/README.md](/home/ddq/AoyangSpace/aegis/rcabench-platform/infra/README.md) instructs users to mount JuiceFS from `10.10.10.119`  
 **Root cause / guess**: the default storage path assumes access to a long-lived shared internal JuiceFS deployment  
 **Workaround applied**: none in this pass; documented as a hard dependency to replace before local reproduction can work  
 **Suggested fix (NOT applied here)**: follow-up issue title: `Provide a local-storage fallback for JuiceFS-backed Aegis deployments`; scope: add a documented local profile using hostPath/OpenEBS/MinIO-in-cluster instead of internal Redis/MinIO
@@ -51,7 +51,23 @@
 ### rcabench-platform SDK defaults target internal Aegis endpoints
 
 **Where**: downstream handoff after `07-smoke-test.md`  
-**Symptom**: [rcabench-platform/src/rcabench_platform/v2/config.py](/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-3/rcabench-platform/src/rcabench_platform/v2/config.py) defaults `dev` to `http://10.10.10.161:8082` and `prod` to `http://10.10.10.220:32080`  
+**Symptom**: [rcabench-platform/src/rcabench_platform/v2/config.py](/home/ddq/AoyangSpace/aegis/rcabench-platform/src/rcabench_platform/v2/config.py) defaults `dev` to `http://10.10.10.161:8082` and `prod` to `http://10.10.10.220:32080`  
 **Root cause / guess**: rcabench-platform was authored against internal environments without a parent-repo local profile  
 **Workaround applied**: none in this pass; noted for future datapack-to-RCA handoff work  
 **Suggested fix (NOT applied here)**: follow-up issue title: `Parameterize rcabench-platform base_url defaults for local parent-repo deployments`; scope: move default URLs behind env vars or a local config profile
+
+### Test bootstrap hardcodes a team-specific proxy
+
+**Where**: `03-microservices.md` and `04-backend.md` bootstrap review  
+**Symptom**: [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/AegisLab/scripts/start.sh) exports `HTTP_PROXY=http://crash:crash@172.18.0.1:7890` and `HTTPS_PROXY=http://crash:crash@172.18.0.1:7890` for the `kind create cluster` step  
+**Root cause / guess**: the checked-in bootstrap script assumes a developer workstation or lab network with a preconfigured proxy at `172.18.0.1:7890`  
+**Workaround applied**: did not use the script for cluster creation; ran `kind create cluster` directly from the workspace to avoid coupling the reproduction path to an undocumented proxy  
+**Suggested fix (NOT applied here)**: follow-up issue title: `Make start.sh proxy settings optional for local kind bootstrap`; scope: gate proxy env vars behind explicit env toggles or remove them from the default local path
+
+### Frontend docs disagree on the local API target
+
+**Where**: `05-frontend.md` local dev-server step  
+**Symptom**: [AegisLab-frontend/README.md](/home/ddq/AoyangSpace/aegis/AegisLab-frontend/README.md) says the dev proxy targets `http://10.10.10.220:32080`, but [AegisLab-frontend/vite.config.ts](/home/ddq/AoyangSpace/aegis/AegisLab-frontend/vite.config.ts) actually defaults to `http://127.0.0.1:8082` unless `VITE_API_TARGET` is set  
+**Root cause / guess**: the README lagged behind a later Vite config change from internal-cluster defaults to local-backend defaults  
+**Workaround applied**: documented the actual runtime source of truth and used `VITE_API_TARGET=http://127.0.0.1:8082 pnpm dev` as the copy-pasteable command  
+**Suggested fix (NOT applied here)**: follow-up issue title: `Align frontend README with Vite proxy defaults`; scope: update docs so the local API target matches checked-in configuration

--- a/docs/deployment/prerequisites.md
+++ b/docs/deployment/prerequisites.md
@@ -1,0 +1,83 @@
+# Prerequisites
+
+This page lists the tools and access assumptions observed during the discovery pass.
+
+## Host tools
+
+Observed on this machine:
+
+```bash
+kind --version
+kubectl version --client -o yaml
+helm version --short
+docker --version
+just --version
+devbox version
+uv --version
+```
+
+Observed output:
+
+```text
+kind version 0.30.0
+kubectl: v1.35.3
+helm: v3.20.1+ga2369ca
+docker: Docker version 29.3.0, build 5927d80
+just 1.48.1
+devbox 0.17.1
+uv 0.10.9
+```
+
+Also required by the repo, but missing on this host when `AegisLab/just check-prerequisites` was run:
+
+```bash
+kubectx
+```
+
+Captured output:
+
+```text
+🔍 Checking development environment dependencies...
+  - devbox installed
+  - docker installed
+  - helm installed
+❌ kubectx not installed
+error: Recipe `check-prerequisites` failed with exit code 1
+```
+
+## Access and secrets
+
+Fresh contributors should assume the following are needed before a full deployment will work:
+
+- GitHub Packages read access for `@OperationsPAI/client`
+- Docker registry access for internal/private registries referenced by manifests and scripts
+- Permission to change host sysctls if `kind` fails on inotify/file-descriptor limits
+- Access to any storage backend replacing the internal JuiceFS deployment
+
+## [MANUAL] GitHub Packages token for frontend image builds
+
+The frontend Dockerfile uses a BuildKit secret named `NPM_TOKEN`.
+
+Command shape:
+
+```bash
+cd AegisLab-frontend
+docker build \
+  --secret id=NPM_TOKEN,env=NPM_TOKEN \
+  -t aegis-frontend-test .
+```
+
+Expected prerequisite:
+- `NPM_TOKEN` must be a GitHub PAT with at least `read:packages`
+
+Without a valid token, the build fails with `ERR_PNPM_FETCH_401`. See [05-frontend.md](./05-frontend.md).
+
+## Internal service assumptions found in code
+
+These are not safe defaults for a fresh local setup:
+
+- `AegisLab/src/config.dev.toml` points `k8s.service.internal_url` and `loki.address` at `10.10.10.161`
+- `AegisLab/helm/values.yaml` points JuiceFS metadata to `redis://10.10.10.119:6379/1`
+- `rcabench-platform/src/rcabench_platform/v2/config.py` defaults to `10.10.10.161:8082` and `10.10.10.220:32080`
+- `AegisLab/manifests/test/rcabench.yaml` pulls from `pair-diag-cn-guangzhou.cr.volces.com/pair/...`
+- `AegisLab/manifests/staging/rcabench.yaml` and `AegisLab/skaffold.yaml` reference `10.10.10.240/...`

--- a/docs/deployment/prerequisites.md
+++ b/docs/deployment/prerequisites.md
@@ -53,6 +53,7 @@ Fresh contributors should assume the following are needed before a full deployme
 - Docker registry access for internal/private registries referenced by manifests and scripts
 - Permission to change host sysctls if `kind` fails on inotify/file-descriptor limits
 - Access to any storage backend replacing the internal JuiceFS deployment
+- A decision about whether to honor or remove the hardcoded `HTTP_PROXY` / `HTTPS_PROXY` values in [AegisLab/scripts/start.sh](/home/ddq/AoyangSpace/aegis/AegisLab/scripts/start.sh)
 
 ## [MANUAL] GitHub Packages token for frontend image builds
 


### PR DESCRIPTION
Fixes #3

## Approach summary

Components attempted:
- parent repo + submodule bootstrap
- host prerequisite inspection
- local `kind` installation and cluster bootstrap
- backend host build checks
- frontend host install/build checks
- frontend Docker image build
- static inspection of Chaos Mesh, workload, observability, and rcabench-platform integration paths

Succeeded:
- initialized all four submodules
- installed `kind`
- built `AegisLab` locally with and without `duckdb_arrow`
- ran `pnpm install` and `pnpm build` in `AegisLab-frontend`
- captured reproducible deployment docs under `docs/deployment/`
- `python3 scripts/validate_workspace_index.py` exits 0

Failed / blocked:
- `kind` cluster bootstrap fails on this host before the API server is ready
- no Kubernetes-based installs could proceed after that point
- frontend Docker build fails without a valid `NPM_TOKEN`
- test/staging deployment paths still assume private registries and internal storage/network endpoints

Top 3 pit-holes by impact:
1. `kind` bootstrap dies in node init with `Failed to create control group inotify object: Too many open files`, which blocks all cluster verification.
2. `AegisLab-frontend` container builds require GitHub Packages auth for `@OperationsPAI/client` via a BuildKit `NPM_TOKEN` secret.
3. `AegisLab`, `rcabench-platform`, and Helm values still default to internal `10.10.10.*` endpoints, private registries, and an internal JuiceFS deployment.

## Delivered artifacts

- `docs/deployment/README.md`
- `docs/deployment/prerequisites.md`
- `docs/deployment/01-kind-cluster.md`
- `docs/deployment/02-chaos-mesh.md`
- `docs/deployment/03-microservices.md`
- `docs/deployment/04-backend.md`
- `docs/deployment/05-frontend.md`
- `docs/deployment/06-observability.md`
- `docs/deployment/07-smoke-test.md`
- `docs/deployment/known-gaps.md`

## Checks

- `python3 scripts/validate_workspace_index.py`

## Submodule changes

- `AegisLab` — not modified
- `AegisLab-frontend` — not modified
- `chaos-experiment` — not modified
- `rcabench-platform` — not modified
