### PR TITLE
feat(aegisctl): standardize automation CLI contract

### DIFF
--- a/AegisLab/docs/aegisctl-cli-contract.md
+++ b/AegisLab/docs/aegisctl-cli-contract.md
@@ -1,0 +1,81 @@
+# aegisctl CLI Contract
+
+This document defines the automation-facing contract for `aegisctl` commands
+used in CI, scripts, and agent-driven workflows. It is the baseline that new
+commands such as `cluster prepare` and `regression run` must inherit.
+
+## Global automation mode
+
+- `aegisctl --non-interactive ...` enables fail-fast, prompt-free execution.
+- `AEGIS_NON_INTERACTIVE=true` provides the same behavior through the
+  environment.
+- Automation-facing commands must never pause for hidden stdin input when
+  required values are missing. They must exit with a deterministic non-zero
+  code and a stderr diagnostic instead.
+
+## Stdout / stderr contract
+
+- `stdout` is reserved for business data only.
+- `stderr` is reserved for progress updates, warnings, and diagnostics.
+- Commands that support `--output json` must keep `stdout` as valid JSON even
+  while they are running.
+- Human-readable tables are business data and therefore also belong on
+  `stdout`.
+
+## Exit codes
+
+These codes apply to validation-oriented and automation-facing command paths:
+
+| Code | Meaning | Typical examples |
+| --- | --- | --- |
+| `0` | Success | `auth login` succeeds, `trace get` returns data, `wait` completes successfully |
+| `2` | Usage / validation error | Missing required flags or arguments, invalid `--check`, missing `--project` |
+| `3` | Authentication / authorization failure | Missing token for an authenticated command, API returns `401` / `403` |
+| `4` | Missing environment / dependency | `cluster preflight` finds required dependencies unavailable, missing config or required runtime environment |
+| `5` | Terminal workflow failure | `wait` reaches `Failed`, `Error`, or `Cancelled` |
+| `6` | Timeout | `wait` exceeds `--timeout` |
+
+## Covered commands
+
+The contract is currently enforced and covered for the following commands:
+
+- `auth login`
+- `cluster preflight`
+- `inject guided`
+- `wait`
+- `trace get`
+
+## Command-specific notes
+
+### `auth login`
+
+- Requires an explicit server plus credentials from flags or environment:
+  `--server`, `--key-id`, `--key-secret` (or `AEGIS_KEY_ID`,
+  `AEGIS_KEY_SECRET`).
+- On validation failure it exits with code `2` and prints the reason on
+  `stderr`.
+
+### `cluster preflight`
+
+- Emits the result table on `stdout`.
+- Uses exit code `4` when a prerequisite is missing or failing.
+- Uses exit code `2` for CLI validation issues such as an unknown `--check`
+  value.
+
+### `inject guided`
+
+- The guided session response is emitted on `stdout` as JSON or YAML.
+- `--apply` fails fast when envelope inputs such as `--project`,
+  `--pedestal-tag`, or `--benchmark-tag` are missing.
+
+### `wait`
+
+- Prints progress messages to `stderr`.
+- Prints only the terminal payload to `stdout`; with `--output json`, stdout
+  stays parseable JSON.
+- Uses exit code `5` for terminal workflow failure and `6` for timeout.
+
+### `trace get`
+
+- Prints trace business data to `stdout`.
+- Authentication failures surface through exit code `3`.

--- a/AegisLab/src/cmd/aegisctl/README.md
+++ b/AegisLab/src/cmd/aegisctl/README.md
@@ -2,6 +2,9 @@
 
 Command-line client for the AegisLab (RCABench) platform. Designed for both human operators and AI agents to drive the RCA workflow from the terminal.
 
+For the automation-facing CLI contract used by CI and agent workflows, see
+`docs/aegisctl-cli-contract.md`.
+
 ## Build
 
 ```bash

--- a/AegisLab/src/cmd/aegisctl/cmd/auth.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/auth.go
@@ -28,13 +28,14 @@ var authLoginContext string
 var authLoginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Exchange Key ID / Key Secret for a bearer token",
+	Args:  requireNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		server := authLoginServer
 		if server == "" {
 			server = flagServer
 		}
 		if server == "" {
-			return fmt.Errorf("--server is required for login")
+			return usageErrorf("--server is required for login")
 		}
 
 		keyID := authLoginKeyID
@@ -42,7 +43,7 @@ var authLoginCmd = &cobra.Command{
 			keyID = os.Getenv("AEGIS_KEY_ID")
 		}
 		if keyID == "" {
-			return fmt.Errorf("--key-id is required")
+			return usageErrorf("--key-id is required")
 		}
 
 		keySecret := authLoginKeySecret
@@ -50,7 +51,7 @@ var authLoginCmd = &cobra.Command{
 			keySecret = os.Getenv("AEGIS_KEY_SECRET")
 		}
 		if keySecret == "" {
-			return fmt.Errorf("--key-secret is required")
+			return usageErrorf("--key-secret is required")
 		}
 
 		output.PrintInfo(fmt.Sprintf("Exchanging API key token with %s using %s...", server, keyID))
@@ -77,7 +78,7 @@ var authLoginCmd = &cobra.Command{
 		cfg.CurrentContext = ctxName
 
 		if err := config.SaveConfig(cfg); err != nil {
-			return fmt.Errorf("save config: %w", err)
+			return missingEnvErrorf("save config: %v", err)
 		}
 
 		if output.OutputFormat(flagOutput) == output.FormatJSON {
@@ -234,7 +235,7 @@ var authSignDebugCmd = &cobra.Command{
 			keyID = os.Getenv("AEGIS_KEY_ID")
 		}
 		if keyID == "" {
-			return fmt.Errorf("--key-id is required")
+			return usageErrorf("--key-id is required")
 		}
 
 		keySecret := authSignDebugKeySecret
@@ -242,7 +243,7 @@ var authSignDebugCmd = &cobra.Command{
 			keySecret = os.Getenv("AEGIS_KEY_SECRET")
 		}
 		if keySecret == "" {
-			return fmt.Errorf("--key-secret is required")
+			return usageErrorf("--key-secret is required")
 		}
 
 		signTime := time.Now().UTC()
@@ -362,7 +363,7 @@ var authTokenCmd = &cobra.Command{
 		cfg.CurrentContext = ctxName
 
 		if err := config.SaveConfig(cfg); err != nil {
-			return fmt.Errorf("save config: %w", err)
+			return missingEnvErrorf("save config: %v", err)
 		}
 
 		output.PrintInfo(fmt.Sprintf("Token set for context %q", ctxName))
@@ -460,7 +461,7 @@ func saveAPIKeyContext(server string, executeResp map[string]any) error {
 	cfg.Contexts[ctxName] = ctx
 	cfg.CurrentContext = ctxName
 	if err := config.SaveConfig(cfg); err != nil {
-		return fmt.Errorf("save config: %w", err)
+		return missingEnvErrorf("save config: %v", err)
 	}
 
 	output.PrintInfo(fmt.Sprintf("Saved token to context %q", ctxName))

--- a/AegisLab/src/cmd/aegisctl/cmd/cluster.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/cluster.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"aegis/cmd/aegisctl/cluster"
@@ -28,6 +29,7 @@ cluster and its backing services (Kubernetes, MySQL, ClickHouse, Redis, etcd).`,
 var clusterPreflightCmd = &cobra.Command{
 	Use:   "preflight",
 	Short: "Verify that every dependency required by AegisLab is reachable and configured",
+	Args:  requireNoArgs,
 	Long: `Runs a catalog of checks against the cluster and the services referenced
 by config.dev.toml. The command prints one row per check with status
 [OK] / [FAIL] / [WARN] and a suggested fix on failure.
@@ -36,14 +38,22 @@ Use --check <id> to run a single check, or --fix to apply idempotent
 remediation for the subset of checks that support it (currently:
 k8s.rcabench-sa and redis.token-bucket-leaks).
 
-Exit code is 0 when every executed check is OK, 1 otherwise.`,
+Exit code is 0 when every executed check is OK and 4 when a dependency
+or environment prerequisite is missing or failing.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := cluster.LoadConfig(clusterPreflightConfig)
 		if err != nil {
-			return fmt.Errorf("load config: %w", err)
+			return missingEnvErrorf("load config: %v", err)
 		}
 		env := cluster.NewLiveEnv(cfg)
 		reg := cluster.NewRegistry(cluster.DefaultChecks())
+		if clusterPreflightCheck != "" {
+			if _, ok := reg.Get(clusterPreflightCheck); !ok {
+				ids := reg.IDs()
+				sort.Strings(ids)
+				return usageErrorf("unknown --check %q (available: %s)", clusterPreflightCheck, strings.Join(ids, ", "))
+			}
+		}
 		runner := &cluster.Runner{Registry: reg}
 		opts := cluster.RunOptions{
 			OnlyID:          clusterPreflightCheck,
@@ -54,7 +64,7 @@ Exit code is 0 when every executed check is OK, 1 otherwise.`,
 		defer cancel()
 		allOK, _ := runner.Run(ctx, env, opts, os.Stdout)
 		if !allOK {
-			os.Exit(1)
+			return silentExit(ExitCodeMissingEnv)
 		}
 		return nil
 	},

--- a/AegisLab/src/cmd/aegisctl/cmd/contract.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/contract.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"aegis/cmd/aegisctl/client"
+	"aegis/cmd/aegisctl/output"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	ExitCodeSuccess         = 0
+	ExitCodeUnexpected      = 1
+	ExitCodeUsage           = 2
+	ExitCodeAuthFailure     = 3
+	ExitCodeMissingEnv      = 4
+	ExitCodeWorkflowFailure = 5
+	ExitCodeTimeout         = 6
+)
+
+type exitError struct {
+	Code    int
+	Message string
+	Cause   error
+}
+
+func (e *exitError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Cause != nil {
+		return e.Cause.Error()
+	}
+	return fmt.Sprintf("command failed with exit code %d", e.Code)
+}
+
+func (e *exitError) Unwrap() error {
+	return e.Cause
+}
+
+func usageErrorf(format string, args ...any) error {
+	return &exitError{Code: ExitCodeUsage, Message: fmt.Sprintf(format, args...)}
+}
+
+func authErrorf(format string, args ...any) error {
+	return &exitError{Code: ExitCodeAuthFailure, Message: fmt.Sprintf(format, args...)}
+}
+
+func missingEnvErrorf(format string, args ...any) error {
+	return &exitError{Code: ExitCodeMissingEnv, Message: fmt.Sprintf(format, args...)}
+}
+
+func workflowFailureErrorf(format string, args ...any) error {
+	return &exitError{Code: ExitCodeWorkflowFailure, Message: fmt.Sprintf(format, args...)}
+}
+
+func timeoutErrorf(format string, args ...any) error {
+	return &exitError{Code: ExitCodeTimeout, Message: fmt.Sprintf(format, args...)}
+}
+
+func silentExit(code int) error {
+	return &exitError{Code: code}
+}
+
+func exactArgs(count int, usage string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) != count {
+			if usage == "" {
+				usage = cmd.Use
+			}
+			return usageErrorf("expected %d argument(s); usage: %s", count, usage)
+		}
+		return nil
+	}
+}
+
+func requireNoArgs(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return usageErrorf("unexpected arguments: %s", strings.Join(args, " "))
+	}
+	return nil
+}
+
+func requireServer() error {
+	if flagServer == "" {
+		return missingEnvErrorf("--server or AEGIS_SERVER is required")
+	}
+	return nil
+}
+
+func requireToken() error {
+	if flagToken == "" {
+		return authErrorf("--token, AEGIS_TOKEN, or an authenticated aegisctl context is required")
+	}
+	return nil
+}
+
+func requireAPIContext(needsToken bool) error {
+	if err := requireServer(); err != nil {
+		return err
+	}
+	if needsToken {
+		return requireToken()
+	}
+	return nil
+}
+
+func executeArgs(args []string) int {
+	rootCmd.SetArgs(args)
+	err := rootCmd.Execute()
+	rootCmd.SetArgs(nil)
+	if err == nil {
+		return ExitCodeSuccess
+	}
+
+	if msg := errorMessage(err); msg != "" {
+		output.PrintError(msg)
+	}
+	return exitCodeFor(err)
+}
+
+func errorMessage(err error) string {
+	var ee *exitError
+	if errors.As(err, &ee) {
+		return ee.Message
+	}
+	return err.Error()
+}
+
+func exitCodeFor(err error) int {
+	var ee *exitError
+	if errors.As(err, &ee) {
+		return ee.Code
+	}
+
+	var apiErr *client.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.StatusCode {
+		case 401, 403:
+			return ExitCodeAuthFailure
+		}
+	}
+
+	var execErr *exec.Error
+	if errors.As(err, &execErr) || errors.Is(err, exec.ErrNotFound) {
+		return ExitCodeMissingEnv
+	}
+	if os.IsNotExist(err) {
+		return ExitCodeMissingEnv
+	}
+
+	if strings.Contains(err.Error(), "unknown flag") ||
+		strings.Contains(err.Error(), "unknown command") ||
+		strings.Contains(err.Error(), "requires a subcommand") ||
+		strings.Contains(err.Error(), "expected ") ||
+		strings.Contains(err.Error(), "requires at least") ||
+		strings.Contains(err.Error(), "accepts ") {
+		return ExitCodeUsage
+	}
+
+	return ExitCodeUnexpected
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
@@ -131,8 +131,16 @@ func runCLI(t *testing.T, args ...string) cliRunResult {
 		}
 	}
 
-	stdoutR, stdoutW, _ := os.Pipe()
-	stderrR, stderrW, _ := os.Pipe()
+	stdoutR, stdoutW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		_ = stdoutR.Close()
+		_ = stdoutW.Close()
+		t.Fatalf("stderr pipe: %v", err)
+	}
 	os.Stdout = stdoutW
 	os.Stderr = stderrW
 
@@ -140,8 +148,16 @@ func runCLI(t *testing.T, args ...string) cliRunResult {
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()
-	stdoutBytes, _ := io.ReadAll(stdoutR)
-	stderrBytes, _ := io.ReadAll(stderrR)
+	stdoutBytes, err := io.ReadAll(stdoutR)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	stderrBytes, err := io.ReadAll(stderrR)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	_ = stdoutR.Close()
+	_ = stderrR.Close()
 
 	os.Stdout = oldStdout
 	os.Stderr = oldStderr

--- a/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
@@ -1,0 +1,286 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"aegis/cmd/aegisctl/client"
+	"aegis/cmd/aegisctl/output"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type cliRunResult struct {
+	code   int
+	stdout string
+	stderr string
+}
+
+func resetCLIState() {
+	flagServer = ""
+	flagToken = ""
+	flagProject = ""
+	flagOutput = ""
+	flagRequestTimeout = 0
+	flagQuiet = false
+	flagNonInteractive = false
+	flagDryRun = false
+	output.Quiet = false
+
+	authLoginServer = ""
+	authLoginKeyID = ""
+	authLoginKeySecret = ""
+	authLoginContext = ""
+
+	clusterPreflightCheck = ""
+	clusterPreflightFix = false
+	clusterPreflightConfig = ""
+	clusterPreflightTimeout = 0
+
+	guidedCfgPath = ""
+	guidedResetConfig = false
+	guidedNoSaveConfig = false
+	guidedNamespace = ""
+	guidedSystem = ""
+	guidedSystemType = ""
+	guidedApp = ""
+	guidedChaosType = ""
+	guidedContainer = ""
+	guidedTargetService = ""
+	guidedDomain = ""
+	guidedClass = ""
+	guidedMethod = ""
+	guidedMutatorConfig = ""
+	guidedRoute = ""
+	guidedHTTPMethod = ""
+	guidedDatabase = ""
+	guidedTable = ""
+	guidedOperation = ""
+	guidedDirection = ""
+	guidedReturnType = ""
+	guidedReturnOpt = ""
+	guidedExceptionOpt = ""
+	guidedMemType = ""
+	guidedBodyType = ""
+	guidedReplaceMethod = ""
+	guidedNext = ""
+	guidedOutput = ""
+	guidedApply = false
+	guidedApplyPedestalName = ""
+	guidedApplyPedestalTag = ""
+	guidedApplyBenchmarkName = ""
+	guidedApplyBenchmarkTag = ""
+	guidedApplyInterval = 0
+	guidedApplyPreDuration = 0
+
+	waitTimeout = 0
+	waitInterval = 0
+
+	resetCommandFlags(rootCmd)
+}
+
+func resetFlagSet(fs *pflag.FlagSet) {
+	fs.VisitAll(func(f *pflag.Flag) {
+		_ = f.Value.Set(f.DefValue)
+		f.Changed = false
+	})
+}
+
+func resetCommandFlags(cmd *cobra.Command) {
+	resetFlagSet(cmd.PersistentFlags())
+	resetFlagSet(cmd.Flags())
+	for _, child := range cmd.Commands() {
+		resetCommandFlags(child)
+	}
+}
+
+func runCLI(t *testing.T, args ...string) cliRunResult {
+	t.Helper()
+
+	resetCLIState()
+
+	oldHome := os.Getenv("HOME")
+	oldServer := os.Getenv("AEGIS_SERVER")
+	oldToken := os.Getenv("AEGIS_TOKEN")
+	oldProject := os.Getenv("AEGIS_PROJECT")
+	oldOutput := os.Getenv("AEGIS_OUTPUT")
+	oldTimeout := os.Getenv("AEGIS_TIMEOUT")
+	oldNonInteractive := os.Getenv("AEGIS_NON_INTERACTIVE")
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+
+	home := t.TempDir()
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	for _, key := range []string{
+		"AEGIS_SERVER",
+		"AEGIS_TOKEN",
+		"AEGIS_PROJECT",
+		"AEGIS_OUTPUT",
+		"AEGIS_TIMEOUT",
+		"AEGIS_NON_INTERACTIVE",
+	} {
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("unset %s: %v", key, err)
+		}
+	}
+
+	stdoutR, stdoutW, _ := os.Pipe()
+	stderrR, stderrW, _ := os.Pipe()
+	os.Stdout = stdoutW
+	os.Stderr = stderrW
+
+	code := executeArgs(args)
+
+	_ = stdoutW.Close()
+	_ = stderrW.Close()
+	stdoutBytes, _ := io.ReadAll(stdoutR)
+	stderrBytes, _ := io.ReadAll(stderrR)
+
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	if err := os.Setenv("HOME", oldHome); err != nil {
+		t.Fatalf("restore HOME: %v", err)
+	}
+	restoreEnv := func(key, value string) {
+		var err error
+		if value == "" {
+			err = os.Unsetenv(key)
+		} else {
+			err = os.Setenv(key, value)
+		}
+		if err != nil {
+			t.Fatalf("restore %s: %v", key, err)
+		}
+	}
+	restoreEnv("AEGIS_SERVER", oldServer)
+	restoreEnv("AEGIS_TOKEN", oldToken)
+	restoreEnv("AEGIS_PROJECT", oldProject)
+	restoreEnv("AEGIS_OUTPUT", oldOutput)
+	restoreEnv("AEGIS_TIMEOUT", oldTimeout)
+	restoreEnv("AEGIS_NON_INTERACTIVE", oldNonInteractive)
+
+	return cliRunResult{
+		code:   code,
+		stdout: string(stdoutBytes),
+		stderr: string(stderrBytes),
+	}
+}
+
+func TestRootPersistentFlagsExposeNonInteractiveMode(t *testing.T) {
+	f := rootCmd.PersistentFlags().Lookup("non-interactive")
+	if f == nil {
+		t.Fatalf("expected --non-interactive persistent flag to be registered")
+	}
+}
+
+func TestAuthLoginMissingSecretUsesUsageExitCode(t *testing.T) {
+	res := runCLI(t, "auth", "login", "--server", "http://example.test", "--key-id", "pk_test")
+	if res.code != ExitCodeUsage {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", res.code, ExitCodeUsage, res.stderr)
+	}
+	if !strings.Contains(res.stderr, "--key-secret is required") {
+		t.Fatalf("stderr = %q, want missing key-secret diagnostic", res.stderr)
+	}
+	if strings.TrimSpace(res.stdout) != "" {
+		t.Fatalf("stdout should be empty on validation failure, got %q", res.stdout)
+	}
+}
+
+func TestClusterPreflightUnknownCheckUsesUsageExitCode(t *testing.T) {
+	res := runCLI(t, "cluster", "preflight", "--check", "does-not-exist")
+	if res.code != ExitCodeUsage {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", res.code, ExitCodeUsage, res.stderr)
+	}
+	if !strings.Contains(res.stderr, "unknown --check") {
+		t.Fatalf("stderr = %q, want unknown check diagnostic", res.stderr)
+	}
+}
+
+func TestClusterPreflightFailingCheckUsesMissingEnvExitCode(t *testing.T) {
+	cfgPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(""), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	res := runCLI(t, "cluster", "preflight", "--config", cfgPath, "--check", "db.mysql")
+	if res.code != ExitCodeMissingEnv {
+		t.Fatalf("exit code = %d, want %d; stdout=%q stderr=%q", res.code, ExitCodeMissingEnv, res.stdout, res.stderr)
+	}
+	if !strings.Contains(res.stdout, "db.mysql") || !strings.Contains(res.stdout, "[FAIL]") {
+		t.Fatalf("stdout = %q, want failing preflight row", res.stdout)
+	}
+	if strings.TrimSpace(res.stderr) != "" {
+		t.Fatalf("stderr should stay empty when preflight emits result table on stdout, got %q", res.stderr)
+	}
+}
+
+func TestInjectGuidedApplyFailsFastWithoutProject(t *testing.T) {
+	res := runCLI(
+		t,
+		"inject", "guided", "--apply",
+		"--server", "http://example.test",
+		"--token", "token",
+		"--pedestal-name", "pedestal",
+		"--pedestal-tag", "v1",
+		"--benchmark-name", "benchmark",
+		"--benchmark-tag", "v1",
+		"--interval", "10",
+		"--pre-duration", "2",
+	)
+	if res.code != ExitCodeUsage {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", res.code, ExitCodeUsage, res.stderr)
+	}
+	if !strings.Contains(res.stderr, "--project is required") {
+		t.Fatalf("stderr = %q, want missing project diagnostic", res.stderr)
+	}
+}
+
+func TestWaitJSONKeepsStdoutCleanAndUsesWorkflowExitCode(t *testing.T) {
+	origDetect := waitDetectResourceType
+	origPoll := waitPollState
+	waitDetectResourceType = func(_ *client.Client, _ string) (string, error) {
+		return "trace", nil
+	}
+	waitPollState = func(_ *client.Client, _, _ string) (string, any, error) {
+		return "Failed", map[string]any{"trace_id": "trace-1", "state": "Failed"}, nil
+	}
+	defer func() {
+		waitDetectResourceType = origDetect
+		waitPollState = origPoll
+	}()
+
+	res := runCLI(t, "wait", "trace-1", "--server", "http://example.test", "--token", "token", "--output", "json", "--interval", "0", "--timeout", "1")
+	if res.code != ExitCodeWorkflowFailure {
+		t.Fatalf("exit code = %d, want %d; stdout=%q stderr=%q", res.code, ExitCodeWorkflowFailure, res.stdout, res.stderr)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(res.stdout), &payload); err != nil {
+		t.Fatalf("stdout should stay valid JSON, got %q: %v", res.stdout, err)
+	}
+	if payload["state"] != "Failed" {
+		t.Fatalf("stdout JSON = %v, want state Failed", payload)
+	}
+	if !strings.Contains(res.stderr, "Waiting for trace-1") {
+		t.Fatalf("stderr = %q, want progress diagnostics", res.stderr)
+	}
+}
+
+func TestTraceGetMissingTokenUsesAuthExitCode(t *testing.T) {
+	res := runCLI(t, "trace", "get", "trace-1", "--server", "http://example.test")
+	if res.code != ExitCodeAuthFailure {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", res.code, ExitCodeAuthFailure, res.stderr)
+	}
+	if !strings.Contains(res.stderr, "AEGIS_TOKEN") {
+		t.Fatalf("stderr = %q, want token diagnostic", res.stderr)
+	}
+	if strings.TrimSpace(res.stdout) != "" {
+		t.Fatalf("stdout should be empty on auth failure, got %q", res.stdout)
+	}
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/inject.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject.go
@@ -71,7 +71,7 @@ type ParameterSpec struct {
 
 func requireProjectName() (string, error) {
 	if flagProject == "" {
-		return "", fmt.Errorf("--project is required")
+		return "", usageErrorf("--project is required")
 	}
 	return flagProject, nil
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/inject_guided.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_guided.go
@@ -86,6 +86,7 @@ var (
 var injectGuidedCmd = &cobra.Command{
 	Use:   "guided",
 	Short: "Step through a guided fault-injection session (AI-friendly, enum-driven)",
+	Args:  requireNoArgs,
 	Long: `Step through a guided fault-injection session backed by chaos-experiment's
 pkg/guidedcli. Each invocation returns a GuidedResponse describing the next
 field to fill, with its allowed values, until the config is ready to apply.
@@ -294,13 +295,16 @@ func submitGuidedApply(cfg guidedcli.GuidedConfig) error {
 	// Validate required envelope flags up front so the user gets a clear
 	// message instead of a 400 from the backend.
 	if guidedApplyPedestalName == "" || guidedApplyPedestalTag == "" || guidedApplyBenchmarkName == "" || guidedApplyBenchmarkTag == "" {
-		return fmt.Errorf("--apply requires --pedestal-name, --pedestal-tag, --benchmark-name, and --benchmark-tag")
+		return usageErrorf("--apply requires --pedestal-name, --pedestal-tag, --benchmark-name, and --benchmark-tag")
 	}
 	if guidedApplyInterval <= 0 || guidedApplyPreDuration <= 0 {
-		return fmt.Errorf("--apply requires --interval and --pre-duration (positive minutes)")
+		return usageErrorf("--apply requires --interval and --pre-duration (positive minutes)")
 	}
 	if guidedApplyInterval <= guidedApplyPreDuration {
-		return fmt.Errorf("--interval must be greater than --pre-duration")
+		return usageErrorf("--interval must be greater than --pre-duration")
+	}
+	if err := requireAPIContext(true); err != nil {
+		return err
 	}
 
 	pid, err := resolveProjectIDByName()

--- a/AegisLab/src/cmd/aegisctl/cmd/root.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/root.go
@@ -150,7 +150,7 @@ NAMING CONVENTION:
 			flagRequestTimeout = 30
 		}
 
-		if !flagNonInteractive {
+		if !cmd.Flags().Lookup("non-interactive").Changed {
 			if v := os.Getenv("AEGIS_NON_INTERACTIVE"); v != "" {
 				if b, err := strconv.ParseBool(v); err == nil {
 					flagNonInteractive = b

--- a/AegisLab/src/cmd/aegisctl/cmd/root.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/root.go
@@ -57,7 +57,7 @@ QUICK START:
   aegisctl task list --state Running
   aegisctl task logs <task-id> --follow
 
-  # 6. Wait for completion (blocks until terminal state, exit code 0=ok, 2=fail, 3=timeout)
+  # 6. Wait for completion (blocks until terminal state, exit code 0=ok, 5=fail, 6=timeout)
   aegisctl wait <trace-id> --timeout 600
 
   # 7. View results

--- a/AegisLab/src/cmd/aegisctl/cmd/root.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/root.go
@@ -19,6 +19,7 @@ var (
 	flagOutput         string
 	flagRequestTimeout int
 	flagQuiet          bool
+	flagNonInteractive bool
 	flagDryRun         bool
 
 	// Resolved at PersistentPreRun time.
@@ -27,8 +28,10 @@ var (
 
 // rootCmd is the top-level aegisctl command.
 var rootCmd = &cobra.Command{
-	Use:   "aegisctl",
-	Short: "CLI client for the AegisLab platform",
+	Use:           "aegisctl",
+	Short:         "CLI client for the AegisLab platform",
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	Long: `aegisctl is a command-line interface for managing the AegisLab (RCABench)
 fault-injection and root-cause-analysis benchmarking platform.
 
@@ -66,6 +69,8 @@ OUTPUT:
   All commands support --output json (or -o json) for machine-parseable output.
   Table output goes to stdout; informational messages go to stderr.
   Use --quiet (-q) to suppress informational messages.
+  Use --non-interactive to lock automation-facing commands into fail-fast,
+  prompt-free behavior suitable for CI and agent execution.
 
 ENVIRONMENT VARIABLES:
   AEGIS_SERVER      - Server URL (overridden by --server flag)
@@ -75,6 +80,7 @@ ENVIRONMENT VARIABLES:
   AEGIS_PROJECT     - Default project name (overridden by --project flag)
   AEGIS_OUTPUT      - Output format: table|json (overridden by --output flag)
   AEGIS_TIMEOUT     - Request timeout in seconds (overridden by --request-timeout flag)
+  AEGIS_NON_INTERACTIVE - Set true/1 to disable prompts and require explicit input
 
 NAMING CONVENTION:
   Most commands accept human-readable names instead of numeric IDs.
@@ -144,6 +150,14 @@ NAMING CONVENTION:
 			flagRequestTimeout = 30
 		}
 
+		if !flagNonInteractive {
+			if v := os.Getenv("AEGIS_NON_INTERACTIVE"); v != "" {
+				if b, err := strconv.ParseBool(v); err == nil {
+					flagNonInteractive = b
+				}
+			}
+		}
+
 		// Forward quiet flag into the output package.
 		output.Quiet = flagQuiet
 
@@ -158,6 +172,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&flagOutput, "output", "o", "", "Output format: table|json (env: AEGIS_OUTPUT)")
 	rootCmd.PersistentFlags().IntVar(&flagRequestTimeout, "request-timeout", 0, "Request timeout in seconds (env: AEGIS_TIMEOUT)")
 	rootCmd.PersistentFlags().BoolVarP(&flagQuiet, "quiet", "q", false, "Suppress informational output")
+	rootCmd.PersistentFlags().BoolVar(&flagNonInteractive, "non-interactive", false, "Disable prompts and require explicit input (env: AEGIS_NON_INTERACTIVE)")
 	rootCmd.PersistentFlags().BoolVar(&flagDryRun, "dry-run", false, "Show what would be done without executing")
 
 	// Register subcommands.
@@ -179,9 +194,7 @@ func init() {
 	rootCmd.AddCommand(pedestalCmd)
 }
 
-// Execute runs the root command.
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		os.Exit(1)
-	}
+// Execute runs the root command and returns the process exit code.
+func Execute() int {
+	return executeArgs(os.Args[1:])
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/trace.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/trace.go
@@ -50,6 +50,9 @@ var traceListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List traces with optional filters",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAPIContext(true); err != nil {
+			return err
+		}
 		c := newClient()
 
 		// Resolve project name to ID if given.
@@ -115,8 +118,11 @@ var traceListCmd = &cobra.Command{
 var traceGetCmd = &cobra.Command{
 	Use:   "get <trace-id>",
 	Short: "Show detailed trace information",
-	Args:  cobra.ExactArgs(1),
+	Args:  exactArgs(1, "trace get <trace-id>"),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAPIContext(true); err != nil {
+			return err
+		}
 		c := newClient()
 
 		path := fmt.Sprintf("/api/v2/traces/%s", args[0])
@@ -171,7 +177,7 @@ var traceGetCmd = &cobra.Command{
 var traceWatchCmd = &cobra.Command{
 	Use:   "watch <trace-id>",
 	Short: "Watch trace events via SSE stream",
-	Args:  cobra.ExactArgs(1),
+	Args:  exactArgs(1, "trace get <trace-id>"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		traceID := args[0]
 		ssePath := fmt.Sprintf("/api/v2/traces/%s/stream", traceID)

--- a/AegisLab/src/cmd/aegisctl/cmd/trace.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/trace.go
@@ -177,7 +177,7 @@ var traceGetCmd = &cobra.Command{
 var traceWatchCmd = &cobra.Command{
 	Use:   "watch <trace-id>",
 	Short: "Watch trace events via SSE stream",
-	Args:  exactArgs(1, "trace get <trace-id>"),
+	Args:  exactArgs(1, "trace watch <trace-id>"),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		traceID := args[0]
 		ssePath := fmt.Sprintf("/api/v2/traces/%s/stream", traceID)

--- a/AegisLab/src/cmd/aegisctl/cmd/wait.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/wait.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"aegis/cmd/aegisctl/client"
@@ -16,6 +15,11 @@ var (
 	waitInterval int
 )
 
+var (
+	waitDetectResourceType = detectResourceType
+	waitPollState          = pollState
+)
+
 var waitCmd = &cobra.Command{
 	Use:   "wait <trace-id|task-id>",
 	Short: "Block until a trace or task reaches a terminal state",
@@ -26,8 +30,8 @@ Polls the API at regular intervals and prints status updates to stderr.
 
 EXIT CODES:
   0 — Completed successfully
-  2 — Failed, Error, or Cancelled
-  3 — Timeout (exceeded --timeout)
+  5 — Failed, Error, or Cancelled
+  6 — Timeout (exceeded --timeout)
 
 EXAMPLES:
   # Wait for a trace to complete (default timeout: 600s)
@@ -39,13 +43,16 @@ EXAMPLES:
   # Use in scripts to chain operations
   aegisctl inject submit --spec inject.yaml --project my_project -o json | \
     jq -r '.trace_id' | xargs aegisctl wait`,
-	Args: cobra.ExactArgs(1),
+	Args: exactArgs(1, "wait <trace-id|task-id>"),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAPIContext(true); err != nil {
+			return err
+		}
 		id := args[0]
 		c := newClient()
 
 		// Determine resource type: try trace first, then task.
-		resourceType, err := detectResourceType(c, id)
+		resourceType, err := waitDetectResourceType(c, id)
 		if err != nil {
 			return err
 		}
@@ -55,7 +62,7 @@ EXAMPLES:
 		start := time.Now()
 
 		for {
-			state, data, err := pollState(c, resourceType, id)
+			state, data, err := waitPollState(c, resourceType, id)
 			if err != nil {
 				return fmt.Errorf("poll %s %s: %w", resourceType, id, err)
 			}
@@ -79,16 +86,15 @@ EXAMPLES:
 				case "Completed":
 					return nil
 				case "Failed", "Error":
-					os.Exit(2)
+					return workflowFailureErrorf("%s %s reached terminal state %s", resourceType, id, state)
 				case "Cancelled":
-					os.Exit(2)
+					return workflowFailureErrorf("%s %s reached terminal state %s", resourceType, id, state)
 				}
 				return nil
 			}
 
 			if time.Now().After(deadline) {
-				output.PrintError(fmt.Sprintf("timeout after %ds waiting for %s %s (last state: %s)", waitTimeout, resourceType, id, state))
-				os.Exit(3)
+				return timeoutErrorf("timeout after %ds waiting for %s %s (last state: %s)", waitTimeout, resourceType, id, state)
 			}
 
 			time.Sleep(interval)

--- a/AegisLab/src/cmd/aegisctl/main.go
+++ b/AegisLab/src/cmd/aegisctl/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"aegis/cmd/aegisctl/cmd"
+	"os"
 )
 
 func main() {
-	cmd.Execute()
+	os.Exit(cmd.Execute())
 }


### PR DESCRIPTION
## Summary
- add an explicit automation-facing CLI contract for `aegisctl`
- make automation commands fail fast with stable exit codes and stdout/stderr behavior
- cover the contract with focused CLI tests, including env-isolated command execution

## Testing
- `cd AegisLab/src && GOCACHE=/tmp/gocache go test ./cmd/aegisctl/output ./cmd/aegisctl/cmd -count=1`

Closes #78