### PR TITLE
feat(aegisctl+init): system enable/disable, regression ns auto-resolve, seed→etcd publish

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/regression.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/regression.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -61,7 +62,15 @@ var (
 	regressionAppLabelKey    string
 	regressionPodListerHook  PodLister // test injection seam; nil => real k8s client
 	regressionInstallerHook  chartInstaller
+	regressionSystemsHook    SystemsFetcher // test injection seam; nil => real HTTP client
 )
+
+// SystemsFetcher is the minimal /api/v2/systems surface
+// resolveRegressionNamespaces needs. Tests can inject a fake; production uses
+// an HTTP-backed implementation.
+type SystemsFetcher interface {
+	FetchSystem(ctx context.Context, name string) (nsPattern string, count int, err error)
+}
 
 // PodLister is the minimal k8s surface preflightRegressionCase needs. Tests
 // can inject a fake; production uses a client-go backed implementation.
@@ -116,6 +125,10 @@ var regressionRunCmd = &cobra.Command{
 			rc, casePath, err = loadRegressionCaseByName(regressionCasesDir, args[0])
 		}
 		if err != nil {
+			return err
+		}
+
+		if err := resolveRegressionNamespaces(cmd.Context(), &rc, regressionSystemsHook); err != nil {
 			return err
 		}
 
@@ -439,6 +452,157 @@ func requireOrderedSubsequence(label string, observed, required []string) error 
 	}
 	missing := required[idx:]
 	return fmt.Errorf("%s: missing ordered subsequence %q in observed sequence %q", label, strings.Join(missing, " -> "), strings.Join(observed, " -> "))
+}
+
+// resolveRegressionNamespaces rewrites every `spec.namespace` in rc.Submit.specs
+// in-place (on the in-memory copy only; the YAML on disk is untouched) so that
+// both preflight and the backend submit see a namespace that actually exists on
+// the cluster.
+//
+// For each spec that carries a `system` field:
+//   - fetch the system's ns_pattern once (per-run cache), via fetcher.
+//   - if spec.namespace is empty, fill with nsPatternToNamespace(pattern, 0).
+//   - if spec.namespace matches the pattern regex, leave it alone.
+//   - if spec.namespace equals the bare system name (no digit suffix), rewrite
+//     it to nsPatternToNamespace(pattern, 0) with a WARN on stderr.
+//   - otherwise fail with a clear error pointing at the expected form.
+//
+// Specs without a `system` field are left untouched (back-compat). When the
+// backend is unreachable we emit a warning and fall back to the current
+// verbatim behavior so existing --skip-preflight flows aren't regressed.
+func resolveRegressionNamespaces(ctx context.Context, rc *regressionCase, fetcher SystemsFetcher) error {
+	if rc == nil {
+		return nil
+	}
+	specsRaw, ok := rc.Submit["specs"]
+	if !ok {
+		return nil
+	}
+	groups, ok := specsRaw.([]any)
+	if !ok {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	type sysInfo struct {
+		pattern string
+		re      *regexp.Regexp
+		derived string
+		err     error
+	}
+	cache := map[string]*sysInfo{}
+	backendDown := false
+
+	lookup := func(sys string) *sysInfo {
+		if info, ok := cache[sys]; ok {
+			return info
+		}
+		info := &sysInfo{}
+		cache[sys] = info
+		if backendDown {
+			info.err = fmt.Errorf("backend unreachable")
+			return info
+		}
+		if fetcher == nil {
+			f, err := newLiveSystemsFetcher()
+			if err != nil {
+				backendDown = true
+				output.PrintInfo(fmt.Sprintf("WARN: cannot build systems fetcher (%v); falling back to verbatim spec.namespace", err))
+				info.err = err
+				return info
+			}
+			fetcher = f
+		}
+		pat, _, err := fetcher.FetchSystem(ctx, sys)
+		if err != nil {
+			backendDown = true
+			output.PrintInfo(fmt.Sprintf("WARN: cannot resolve system %q from /api/v2/systems (%v); falling back to verbatim spec.namespace", sys, err))
+			info.err = err
+			return info
+		}
+		info.pattern = pat
+		if pat != "" {
+			if re, reErr := regexp.Compile(pat); reErr == nil {
+				info.re = re
+			}
+			info.derived = nsPatternToNamespace(pat, 0)
+		}
+		return info
+	}
+
+	for _, g := range groups {
+		inner, ok := g.([]any)
+		if !ok {
+			continue
+		}
+		for _, s := range inner {
+			spec, ok := s.(map[string]any)
+			if !ok {
+				continue
+			}
+			sys := strings.TrimSpace(stringField(spec, "system"))
+			if sys == "" {
+				continue // back-compat: no system => leave namespace alone
+			}
+			info := lookup(sys)
+			if info.err != nil || info.pattern == "" {
+				continue // fallback: keep whatever was in YAML
+			}
+			ns := strings.TrimSpace(stringField(spec, "namespace"))
+			switch {
+			case ns == "":
+				if info.derived == "" {
+					return fmt.Errorf("regression: cannot derive namespace for system %q from ns_pattern %q", sys, info.pattern)
+				}
+				spec["namespace"] = info.derived
+			case info.re != nil && info.re.MatchString(ns):
+				// User already wrote a valid namespace — trust it.
+			case ns == sys:
+				if info.derived == "" {
+					return fmt.Errorf("regression: cannot derive namespace for system %q from ns_pattern %q", sys, info.pattern)
+				}
+				output.PrintInfo(fmt.Sprintf("WARN: namespace %q auto-resolved to %q from ns_pattern %q", ns, info.derived, info.pattern))
+				spec["namespace"] = info.derived
+			default:
+				expected := info.derived
+				if expected == "" {
+					expected = sys + "0"
+				}
+				return fmt.Errorf("regression: namespace %q does not match system %q ns_pattern %q; expected e.g. %q",
+					ns, sys, info.pattern, expected)
+			}
+		}
+	}
+	return nil
+}
+
+// liveSystemsFetcher is the real /api/v2/systems-backed SystemsFetcher. It
+// mirrors deriveNamespaceFromSystem's API call but returns the raw pattern +
+// count so callers can cache and run their own pattern logic.
+type liveSystemsFetcher struct{ c *client.Client }
+
+func newLiveSystemsFetcher() (*liveSystemsFetcher, error) {
+	return &liveSystemsFetcher{c: newClient()}, nil
+}
+
+func (l *liveSystemsFetcher) FetchSystem(_ context.Context, name string) (string, int, error) {
+	type systemItem struct {
+		Name      string `json:"name"`
+		NsPattern string `json:"ns_pattern"`
+		Count     int    `json:"count"`
+	}
+	var resp client.APIResponse[client.PaginatedData[systemItem]]
+	if err := l.c.Get("/api/v2/systems?page=1&size=500", &resp); err != nil {
+		return "", 0, err
+	}
+	for _, s := range resp.Data.Items {
+		if s.Name == name {
+			return s.NsPattern, s.Count, nil
+		}
+	}
+	return "", 0, fmt.Errorf("system %q not found via /api/v2/systems", name)
 }
 
 // extractRegressionTargets walks rc.Submit.specs (shape: [[{system, namespace,

--- a/AegisLab/src/cmd/aegisctl/cmd/regression_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/regression_test.go
@@ -49,6 +49,149 @@ func makePreflightCase() regressionCase {
 	}
 }
 
+type fakeSystemsFetcher struct {
+	byName map[string]struct {
+		pattern string
+		count   int
+	}
+	err error
+}
+
+func (f *fakeSystemsFetcher) FetchSystem(_ context.Context, name string) (string, int, error) {
+	if f.err != nil {
+		return "", 0, f.err
+	}
+	if e, ok := f.byName[name]; ok {
+		return e.pattern, e.count, nil
+	}
+	return "", 0, fmt.Errorf("system %q not found", name)
+}
+
+func firstSpec(rc regressionCase) map[string]any {
+	groups, _ := rc.Submit["specs"].([]any)
+	inner, _ := groups[0].([]any)
+	spec, _ := inner[0].(map[string]any)
+	return spec
+}
+
+func newRegressionCaseWithSpec(system, namespace string) regressionCase {
+	spec := map[string]any{
+		"system": system,
+		"app":    "frontend",
+	}
+	if namespace != "" {
+		spec["namespace"] = namespace
+	}
+	return regressionCase{
+		Name:        "ns-resolve",
+		ProjectName: "p",
+		Submit: map[string]any{
+			"specs": []any{[]any{spec}},
+		},
+		Validation: regressionValidation{
+			ExpectedFinalEvent: "x",
+			RequiredTaskChain:  []string{"y"},
+		},
+	}
+}
+
+func TestResolveRegressionNamespaces_BareSystemNameRewrites(t *testing.T) {
+	rc := newRegressionCaseWithSpec("otel-demo", "otel-demo")
+	fetcher := &fakeSystemsFetcher{byName: map[string]struct {
+		pattern string
+		count   int
+	}{"otel-demo": {pattern: `^otel-demo\d+$`, count: 1}}}
+
+	if err := resolveRegressionNamespaces(context.Background(), &rc, fetcher); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got, _ := firstSpec(rc)["namespace"].(string)
+	if got != "otel-demo0" {
+		t.Fatalf("expected namespace rewritten to otel-demo0, got %q", got)
+	}
+}
+
+func TestResolveRegressionNamespaces_AlreadyMatchingKept(t *testing.T) {
+	rc := newRegressionCaseWithSpec("otel-demo", "otel-demo0")
+	fetcher := &fakeSystemsFetcher{byName: map[string]struct {
+		pattern string
+		count   int
+	}{"otel-demo": {pattern: `^otel-demo\d+$`, count: 1}}}
+
+	if err := resolveRegressionNamespaces(context.Background(), &rc, fetcher); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got, _ := firstSpec(rc)["namespace"].(string)
+	if got != "otel-demo0" {
+		t.Fatalf("expected unchanged otel-demo0, got %q", got)
+	}
+}
+
+func TestResolveRegressionNamespaces_EmptyFilled(t *testing.T) {
+	rc := newRegressionCaseWithSpec("otel-demo", "")
+	fetcher := &fakeSystemsFetcher{byName: map[string]struct {
+		pattern string
+		count   int
+	}{"otel-demo": {pattern: `^otel-demo\d+$`, count: 1}}}
+
+	if err := resolveRegressionNamespaces(context.Background(), &rc, fetcher); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	got, _ := firstSpec(rc)["namespace"].(string)
+	if got != "otel-demo0" {
+		t.Fatalf("expected filled otel-demo0, got %q", got)
+	}
+}
+
+func TestResolveRegressionNamespaces_MismatchErrors(t *testing.T) {
+	rc := newRegressionCaseWithSpec("otel-demo", "nonsense")
+	fetcher := &fakeSystemsFetcher{byName: map[string]struct {
+		pattern string
+		count   int
+	}{"otel-demo": {pattern: `^otel-demo\d+$`, count: 1}}}
+
+	err := resolveRegressionNamespaces(context.Background(), &rc, fetcher)
+	if err == nil {
+		t.Fatal("expected error for mismatched namespace")
+	}
+	if !strings.Contains(err.Error(), "does not match system") {
+		t.Fatalf("expected clear mismatch error, got %v", err)
+	}
+}
+
+func TestResolveRegressionNamespaces_NoSystemLeftAlone(t *testing.T) {
+	spec := map[string]any{"namespace": "whatever", "app": "frontend"}
+	rc := regressionCase{
+		Name:        "n",
+		ProjectName: "p",
+		Submit:      map[string]any{"specs": []any{[]any{spec}}},
+		Validation: regressionValidation{
+			ExpectedFinalEvent: "x",
+			RequiredTaskChain:  []string{"y"},
+		},
+	}
+	fetcher := &fakeSystemsFetcher{err: fmt.Errorf("should not be called")}
+	if err := resolveRegressionNamespaces(context.Background(), &rc, fetcher); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if ns, _ := spec["namespace"].(string); ns != "whatever" {
+		t.Fatalf("expected unchanged namespace, got %q", ns)
+	}
+}
+
+func TestResolveRegressionNamespaces_BackendDownFallsBack(t *testing.T) {
+	rc := newRegressionCaseWithSpec("otel-demo", "otel-demo0")
+	fetcher := &fakeSystemsFetcher{err: fmt.Errorf("connection refused")}
+
+	if err := resolveRegressionNamespaces(context.Background(), &rc, fetcher); err != nil {
+		t.Fatalf("expected fallback no-op, got %v", err)
+	}
+	got, _ := firstSpec(rc)["namespace"].(string)
+	if got != "otel-demo0" {
+		t.Fatalf("expected namespace preserved on backend-down fallback, got %q", got)
+	}
+}
+
 func TestRegressionPreflight_AllPresent(t *testing.T) {
 	rc := makePreflightCase()
 	lister := &fakePodLister{byNSApp: map[string]int{

--- a/AegisLab/src/cmd/aegisctl/cmd/system.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/system.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"aegis/cmd/aegisctl/output"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 	"gopkg.in/yaml.v3"
 )
 
@@ -292,6 +294,158 @@ var systemUnregisterCmd = &cobra.Command{
 	},
 }
 
+// --- system enable / disable ---
+//
+// Both are thin wrappers around PUT /api/v2/systems/{id} with a single
+// `status` field. We intentionally do NOT add a dedicated enable/disable
+// sub-route on the backend — the generic update endpoint already handles the
+// mutation, and keeping the API surface narrow reduces drift.
+
+var systemDisableYes bool
+
+// setSystemStatusReq is the minimal PUT body the CLI sends. Using a tight
+// struct (instead of a map) makes the JSON shape explicit and lets the cobra
+// test pin the wire format.
+type setSystemStatusReq struct {
+	Status int `json:"status"`
+}
+
+// setSystemStatus resolves name -> id and issues PUT /api/v2/systems/{id}
+// with the given status. Shared by `enable` and `disable`.
+func setSystemStatus(c *client.Client, name string, status int) (*chaosSystemResp, error) {
+	existing, err := findSystemByName(c, name)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil {
+		known, lookupErr := listSystemNames(c)
+		if lookupErr != nil || len(known) == 0 {
+			return nil, notFoundErrorf("system %q is not registered", name)
+		}
+		return nil, notFoundErrorf("system %q is not registered; known systems: %s",
+			name, strings.Join(known, ", "))
+	}
+	var resp client.APIResponse[chaosSystemResp]
+	if err := c.Put(fmt.Sprintf("/api/v2/systems/%d", existing.ID), setSystemStatusReq{Status: status}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
+}
+
+// listSystemNames returns a sorted list of registered system names for use
+// in error messages. Never fatal: callers fall back to a generic message.
+func listSystemNames(c *client.Client) ([]string, error) {
+	var resp client.APIResponse[client.PaginatedData[chaosSystemResp]]
+	if err := c.Get("/api/v2/systems?page=1&size=500", &resp); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(resp.Data.Items))
+	for _, s := range resp.Data.Items {
+		names = append(names, s.Name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+var systemEnableCmd = &cobra.Command{
+	Use:   "enable <name>",
+	Short: "Enable a registered benchmark system (status=1)",
+	Long: `Flip injection.system.<name>.status to 1 via PUT /api/v2/systems/{id}.
+Name is resolved to the backend system ID by listing /api/v2/systems.
+Builtin systems cannot be enabled/disabled through this endpoint.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAPIContext(true); err != nil {
+			return err
+		}
+		name := strings.TrimSpace(args[0])
+		if name == "" {
+			return usageErrorf("system name is required")
+		}
+		c := newClient()
+		updated, err := setSystemStatus(c, name, 1)
+		if err != nil {
+			return err
+		}
+		if output.OutputFormat(flagOutput) == output.FormatJSON {
+			output.PrintJSON(updated)
+			return nil
+		}
+		output.PrintInfo(fmt.Sprintf("Enabled system %q (id %d)", updated.Name, updated.ID))
+		return nil
+	},
+}
+
+var systemDisableCmd = &cobra.Command{
+	Use:   "disable <name>",
+	Short: "Disable a registered benchmark system (status=0)",
+	Long: `Flip injection.system.<name>.status to 0 via PUT /api/v2/systems/{id}.
+Disabled systems stay visible in list responses so they can be re-enabled.
+Builtin systems cannot be enabled/disabled through this endpoint.
+Use --yes to skip the confirmation prompt.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAPIContext(true); err != nil {
+			return err
+		}
+		name := strings.TrimSpace(args[0])
+		if name == "" {
+			return usageErrorf("system name is required")
+		}
+		c := newClient()
+		existing, err := findSystemByName(c, name)
+		if err != nil {
+			return err
+		}
+		if existing == nil {
+			known, lookupErr := listSystemNames(c)
+			if lookupErr != nil || len(known) == 0 {
+				return notFoundErrorf("system %q is not registered", name)
+			}
+			return notFoundErrorf("system %q is not registered; known systems: %s",
+				name, strings.Join(known, ", "))
+		}
+		// Disable is reversible (unlike unregister) but still user-visible, so
+		// gate it behind the same TTY/--yes contract the delete commands use.
+		if err := confirmDisable(existing.Name, existing.ID, systemDisableYes); err != nil {
+			return err
+		}
+		var resp client.APIResponse[chaosSystemResp]
+		if err := c.Put(fmt.Sprintf("/api/v2/systems/%d", existing.ID), setSystemStatusReq{Status: 0}, &resp); err != nil {
+			return err
+		}
+		if output.OutputFormat(flagOutput) == output.FormatJSON {
+			output.PrintJSON(resp.Data)
+			return nil
+		}
+		output.PrintInfo(fmt.Sprintf("Disabled system %q (id %d)", resp.Data.Name, resp.Data.ID))
+		return nil
+	},
+}
+
+// confirmDisable mirrors confirmDeletion but phrased for a reversible flip.
+// Kept local to system.go so project.go's confirmDeletion stays narrowly
+// focused on delete flows.
+func confirmDisable(name string, id int, yes bool) error {
+	if yes {
+		return nil
+	}
+	if flagNonInteractive {
+		return usageErrorf("refusing to disable without --yes in non-interactive mode")
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return usageErrorf("refusing to disable without --yes when stdin is not a TTY")
+	}
+	fmt.Fprintf(os.Stderr, "Disable system %s (id %d)? [y/N] ", name, id)
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	line = strings.TrimSpace(strings.ToLower(line))
+	if line != "y" && line != "yes" {
+		return usageErrorf("aborted by user")
+	}
+	return nil
+}
+
 // --- Helpers ---
 
 // resolveSeedPath lets callers pass either an exact file path, a directory,
@@ -470,7 +624,12 @@ func init() {
 	systemUnregisterCmd.Flags().BoolVar(&systemUnregisterYes, "yes", false, "Skip confirmation prompt")
 	systemUnregisterCmd.Flags().BoolVar(&systemUnregisterYes, "force", false, "Alias for --yes")
 
+	systemDisableCmd.Flags().BoolVar(&systemDisableYes, "yes", false, "Skip confirmation prompt")
+	systemDisableCmd.Flags().BoolVar(&systemDisableYes, "force", false, "Alias for --yes")
+
 	systemCmd.AddCommand(systemRegisterCmd)
 	systemCmd.AddCommand(systemListCmd)
 	systemCmd.AddCommand(systemUnregisterCmd)
+	systemCmd.AddCommand(systemEnableCmd)
+	systemCmd.AddCommand(systemDisableCmd)
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/system_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/system_test.go
@@ -1,8 +1,15 @@
 package cmd
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"aegis/cmd/aegisctl/client"
 
 	"gopkg.in/yaml.v3"
 )
@@ -112,5 +119,143 @@ func TestSystemSeedWrongValueTypeRejected(t *testing.T) {
 	}
 	if !strings.Contains(msg, "value_type") {
 		t.Errorf("error should mention value_type; got: %v", err)
+	}
+}
+
+// fakeAPIResp is a minimal envelope that mirrors client.APIResponse[T] for
+// tests — avoids pulling generics-at-the-bench into the fake server.
+type fakeAPIResp struct {
+	Code    int            `json:"code"`
+	Message string         `json:"message"`
+	Data    any            `json:"data,omitempty"`
+}
+
+// newFakeSystemServer stubs the two endpoints the enable/disable path hits:
+// GET /api/v2/systems (for name→id resolution) and PUT /api/v2/systems/{id}.
+// The last PUT body is stored in the returned *capturedPut so tests can
+// assert the wire shape.
+type capturedPut struct {
+	path string
+	body map[string]any
+}
+
+func newFakeSystemServer(t *testing.T, systems []chaosSystemResp) (*httptest.Server, *capturedPut) {
+	t.Helper()
+	captured := &capturedPut{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/systems", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		resp := fakeAPIResp{
+			Code: 200,
+			Data: client.PaginatedData[chaosSystemResp]{
+				Items: systems,
+				Pagination: client.Pagination{
+					Page: 1, Size: len(systems), Total: len(systems), TotalPages: 1,
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/api/v2/systems/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		captured.path = r.URL.Path
+		captured.body = map[string]any{}
+		_ = json.Unmarshal(raw, &captured.body)
+		// Echo back a minimal system; the CLI only reads .data.Name/.data.ID.
+		var echo chaosSystemResp
+		if len(systems) > 0 {
+			echo = systems[0]
+		}
+		resp := fakeAPIResp{Code: 200, Data: echo}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, captured
+}
+
+// TestSystemEnableSendsStatusOne pins the wire shape: PUT to /{id} with
+// exactly {"status": 1}. If this ever changes, the backend contract pinned
+// by UpdateChaosSystemReq.Status must be revisited in lockstep.
+func TestSystemEnableSendsStatusOne(t *testing.T) {
+	srv, captured := newFakeSystemServer(t, []chaosSystemResp{
+		{ID: 42, Name: "ts"},
+	})
+	c := client.NewClient(srv.URL, "tok", 5*time.Second)
+
+	if _, err := setSystemStatus(c, "ts", 1); err != nil {
+		t.Fatalf("setSystemStatus(enable): %v", err)
+	}
+	if captured.path != "/api/v2/systems/42" {
+		t.Errorf("PUT path = %q, want /api/v2/systems/42", captured.path)
+	}
+	got, ok := captured.body["status"]
+	if !ok {
+		t.Fatalf("PUT body missing status: %+v", captured.body)
+	}
+	// JSON decodes numbers as float64 by default.
+	if n, _ := got.(float64); int(n) != 1 {
+		t.Errorf("PUT body status = %v, want 1", got)
+	}
+	if len(captured.body) != 1 {
+		t.Errorf("PUT body should only carry status; got %+v", captured.body)
+	}
+}
+
+// TestSystemDisableSendsStatusZero mirrors the enable test for the disable
+// wire shape ({"status": 0}).
+func TestSystemDisableSendsStatusZero(t *testing.T) {
+	srv, captured := newFakeSystemServer(t, []chaosSystemResp{
+		{ID: 7, Name: "hr"},
+	})
+	c := client.NewClient(srv.URL, "tok", 5*time.Second)
+
+	if _, err := setSystemStatus(c, "hr", 0); err != nil {
+		t.Fatalf("setSystemStatus(disable): %v", err)
+	}
+	if captured.path != "/api/v2/systems/7" {
+		t.Errorf("PUT path = %q, want /api/v2/systems/7", captured.path)
+	}
+	got, ok := captured.body["status"]
+	if !ok {
+		t.Fatalf("PUT body missing status: %+v", captured.body)
+	}
+	if n, _ := got.(float64); int(n) != 0 {
+		t.Errorf("PUT body status = %v, want 0", got)
+	}
+}
+
+// TestSystemEnableUnknownNameListsKnown pins that trying to enable an
+// unregistered system surfaces the registered names in the error. Keeps the
+// UX guard documented in the task brief.
+func TestSystemEnableUnknownNameListsKnown(t *testing.T) {
+	srv, _ := newFakeSystemServer(t, []chaosSystemResp{
+		{ID: 1, Name: "ts"}, {ID: 2, Name: "hr"},
+	})
+	c := client.NewClient(srv.URL, "tok", 5*time.Second)
+
+	_, err := setSystemStatus(c, "does-not-exist", 1)
+	if err == nil {
+		t.Fatal("setSystemStatus: expected error for unknown name, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "does-not-exist") {
+		t.Errorf("error should mention the missing name; got %v", err)
+	}
+	if !strings.Contains(msg, "ts") || !strings.Contains(msg, "hr") {
+		t.Errorf("error should list known names ts, hr; got %v", err)
 	}
 }

--- a/AegisLab/src/interface/worker/module.go
+++ b/AegisLab/src/interface/worker/module.go
@@ -62,6 +62,7 @@ func (r *Lifecycle) start(ctx context.Context) error {
 		params.Controller,
 		params.Monitor,
 		params.RedisGateway,
+		params.Etcd,
 		commonservice.NewConfigUpdateListener(ctx, params.DB, params.Etcd),
 		params.RestartLimiter,
 		params.BuildLimiter,

--- a/AegisLab/src/module/chaossystem/api_types.go
+++ b/AegisLab/src/module/chaossystem/api_types.go
@@ -24,6 +24,10 @@ type CreateChaosSystemReq struct {
 }
 
 // UpdateChaosSystemReq represents the request to update a chaos system.
+//
+// Status is a pointer so "unset" is distinguishable from the zero value
+// (disabled). Only 0/1 are accepted via this endpoint; -1 (CommonDeleted) is
+// reserved for DeleteSystem, which owns the tombstone transition.
 type UpdateChaosSystemReq struct {
 	DisplayName    *string `json:"display_name"`
 	NsPattern      *string `json:"ns_pattern"`
@@ -31,6 +35,7 @@ type UpdateChaosSystemReq struct {
 	AppLabelKey    *string `json:"app_label_key"`
 	Count          *int    `json:"count" binding:"omitempty,min=1"`
 	Description    *string `json:"description"`
+	Status         *int    `json:"status,omitempty" binding:"omitempty,oneof=0 1"`
 }
 
 // ChaosSystemResp represents a chaos system in API responses.

--- a/AegisLab/src/module/chaossystem/service.go
+++ b/AegisLab/src/module/chaossystem/service.go
@@ -306,6 +306,28 @@ func (s *Service) UpdateSystem(ctx context.Context, id int, req *UpdateChaosSyst
 			value string
 		}{fieldCount, strconv.Itoa(*req.Count)})
 	}
+	if req.Status != nil {
+		// -1 (CommonDeleted) is the tombstone marker written by DeleteSystem.
+		// Refuse it here so callers can't bypass the builtin guard / local
+		// chaos.UnregisterSystem side-effect by sneaking a status flip in
+		// through the generic update endpoint.
+		if *req.Status == int(consts.CommonDeleted) {
+			return nil, fmt.Errorf("status -1 is reserved for delete; use DELETE instead: %w", consts.ErrBadRequest)
+		}
+		if *req.Status != int(consts.CommonEnabled) && *req.Status != int(consts.CommonDisabled) {
+			return nil, fmt.Errorf("status must be 0 (disabled) or 1 (enabled), got %d: %w", *req.Status, consts.ErrBadRequest)
+		}
+		// Builtin systems are immutable w.r.t. deletion (see DeleteSystem).
+		// Mirror that guard for enable/disable so builtin benchmarks can't be
+		// silently turned off by a status PUT.
+		if view.Cfg.IsBuiltin {
+			return nil, fmt.Errorf("cannot change status of builtin system %s: %w", view.Cfg.System, consts.ErrBadRequest)
+		}
+		changes = append(changes, struct {
+			field systemField
+			value string
+		}{fieldStatus, strconv.Itoa(*req.Status)})
+	}
 
 	for _, change := range changes {
 		if err := s.applyChange(ctx, view.Cfg.System, change.field, change.value); err != nil {

--- a/AegisLab/src/module/chaossystem/service_test.go
+++ b/AegisLab/src/module/chaossystem/service_test.go
@@ -2,11 +2,14 @@ package chaossystem
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"aegis/consts"
 	"aegis/model"
 	"aegis/service/common"
 
+	"github.com/spf13/viper"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -89,5 +92,81 @@ func TestUpsertTopologyMetadataInvalidatesCache(t *testing.T) {
 	}
 	if len(pairs) != 1 || pairs[0].Source != "frontend" || pairs[0].Target != "checkout" {
 		t.Fatalf("GetNetworkPairs() = %+v, want frontend->checkout", pairs)
+	}
+}
+
+// seedSystemInViper installs a chaos-system entry into the global Viper tree
+// so lookupByID/lookupByName can find it. Returns a cleanup closure.
+func seedSystemInViper(t *testing.T, name string, isBuiltin bool) func() {
+	t.Helper()
+	key := "injection.system." + name
+	prev := viper.Get("injection.system")
+	viper.Set(key, map[string]any{
+		"count":           1,
+		"ns_pattern":      "^" + name + `\d+$`,
+		"extract_pattern": "^(" + name + `)(\d+)$`,
+		"display_name":    name,
+		"app_label_key":   "app",
+		"is_builtin":      isBuiltin,
+		"status":          int(consts.CommonEnabled),
+	})
+	return func() { viper.Set("injection.system", prev) }
+}
+
+// TestUpdateSystemStatusRejectsDeleteSentinel pins that the generic update
+// endpoint refuses status=-1 (CommonDeleted). -1 is the tombstone written by
+// DeleteSystem; callers must go through DELETE so the builtin guard and the
+// local chaos.UnregisterSystem hook run. This check fires before any etcd
+// round-trip, so a nil-etcd Service is safe.
+func TestUpdateSystemStatusRejectsDeleteSentinel(t *testing.T) {
+	service, db, _ := newMetadataService(t)
+	const systemName = "bench-update-status-delete"
+	cleanup := seedSystemInViper(t, systemName, false)
+	defer cleanup()
+
+	anchor := &model.DynamicConfig{
+		Key:          systemKey(systemName, fieldCount),
+		DefaultValue: "1",
+		ValueType:    consts.ConfigValueTypeInt,
+	}
+	if err := db.Create(anchor).Error; err != nil {
+		t.Fatalf("seed anchor: %v", err)
+	}
+
+	deleted := int(consts.CommonDeleted)
+	_, err := service.UpdateSystem(context.Background(), anchor.ID, &UpdateChaosSystemReq{Status: &deleted})
+	if err == nil {
+		t.Fatal("UpdateSystem: expected error for status=-1, got nil")
+	}
+	if !errors.Is(err, consts.ErrBadRequest) {
+		t.Errorf("UpdateSystem: error should wrap ErrBadRequest; got %v", err)
+	}
+}
+
+// TestUpdateSystemStatusRejectsBuiltin pins that builtin systems refuse
+// enable/disable through the generic update endpoint, mirroring the guard in
+// DeleteSystem.
+func TestUpdateSystemStatusRejectsBuiltin(t *testing.T) {
+	service, db, _ := newMetadataService(t)
+	const systemName = "bench-update-status-builtin"
+	cleanup := seedSystemInViper(t, systemName, true)
+	defer cleanup()
+
+	anchor := &model.DynamicConfig{
+		Key:          systemKey(systemName, fieldCount),
+		DefaultValue: "1",
+		ValueType:    consts.ConfigValueTypeInt,
+	}
+	if err := db.Create(anchor).Error; err != nil {
+		t.Fatalf("seed anchor: %v", err)
+	}
+
+	disabled := int(consts.CommonDisabled)
+	_, err := service.UpdateSystem(context.Background(), anchor.ID, &UpdateChaosSystemReq{Status: &disabled})
+	if err == nil {
+		t.Fatal("UpdateSystem: expected error disabling a builtin, got nil")
+	}
+	if !errors.Is(err, consts.ErrBadRequest) {
+		t.Errorf("UpdateSystem: error should wrap ErrBadRequest; got %v", err)
 	}
 }

--- a/AegisLab/src/service/initialization/consumer.go
+++ b/AegisLab/src/service/initialization/consumer.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"aegis/config"
 	"aegis/consts"
+	etcd "aegis/infra/etcd"
 	k8s "aegis/infra/k8s"
 	redis "aegis/infra/redis"
 	"aegis/model"
@@ -24,6 +27,7 @@ func InitializeConsumer(
 	controller *k8s.Controller,
 	monitor consumer.NamespaceMonitor,
 	publisher *redis.Gateway,
+	etcdGw *etcd.Gateway,
 	listener *common.ConfigUpdateListener,
 	restartLimiter *consumer.TokenBucketRateLimiter,
 	buildLimiter *consumer.TokenBucketRateLimiter,
@@ -36,7 +40,7 @@ func InitializeConsumer(
 
 	if len(consumerData.configs) == 0 {
 		logrus.Info("Seeding initial system data for consumer...")
-		if err := initializeConsumer(db); err != nil {
+		if err := initializeConsumer(ctx, db, etcdGw); err != nil {
 			return fmt.Errorf("failed to initialize system data for consumer: %w", err)
 		}
 		logrus.Info("Successfully seeded initial system data for consumer")
@@ -92,7 +96,7 @@ func InitializeConsumer(
 	return nil
 }
 
-func initializeConsumer(db *gorm.DB) error {
+func initializeConsumer(ctx context.Context, db *gorm.DB, etcdGw *etcd.Gateway) error {
 	dataPath := config.GetString("initialization.data_path")
 	filePath := filepath.Join(dataPath, consts.InitialFilename)
 	initialData, err := loadInitialDataFromFile(filePath)
@@ -100,19 +104,32 @@ func initializeConsumer(db *gorm.DB) error {
 		return fmt.Errorf("failed to load initial data from file: %w", err)
 	}
 
-	return withOptimizedDBSettings(db, func() error {
-		err := db.Transaction(func(tx *gorm.DB) error {
-			if _, err := initializeDynamicConfigs(tx, initialData); err != nil {
+	var seededConfigs []model.DynamicConfig
+	err = withOptimizedDBSettings(db, func() error {
+		txErr := db.Transaction(func(tx *gorm.DB) error {
+			configs, err := initializeDynamicConfigs(tx, initialData)
+			if err != nil {
 				return fmt.Errorf("failed to initialize dynamic configs for consumer: %w", err)
 			}
+			seededConfigs = configs
 			return nil
 		})
-		if err != nil {
-			return fmt.Errorf("failed to initialize consumer data: %w", err)
+		if txErr != nil {
+			return fmt.Errorf("failed to initialize consumer data: %w", txErr)
 		}
-
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	// Publish seeded defaults to etcd AFTER the DB transaction commits so we
+	// never leak pending DB state into etcd. Mirrors the legacy-migration
+	// publish path in legacy_systems_migration.go so a fresh cluster boots
+	// with /rcabench/config/<scope>/... populated for every seed row (else
+	// backend logs `loaded N systems (0 enabled)`).
+	publishSeededConfigsToEtcd(ctx, etcdGw, seededConfigs)
+	return nil
 }
 
 func initializeDynamicConfigs(tx *gorm.DB, data *InitialData) ([]model.DynamicConfig, error) {
@@ -131,4 +148,65 @@ func initializeDynamicConfigs(tx *gorm.DB, data *InitialData) ([]model.DynamicCo
 	}
 
 	return configs, nil
+}
+
+// seedEtcdPrefixForScope mirrors service/common.scopePrefix (and
+// module/system.etcdPrefixForScope) without pulling those packages in as a
+// dependency for seeding. Scopes without an etcd representation return "".
+func seedEtcdPrefixForScope(scope consts.ConfigScope) string {
+	switch scope {
+	case consts.ConfigScopeProducer:
+		return consts.ConfigEtcdProducerPrefix
+	case consts.ConfigScopeConsumer:
+		return consts.ConfigEtcdConsumerPrefix
+	case consts.ConfigScopeGlobal:
+		return consts.ConfigEtcdGlobalPrefix
+	default:
+		return ""
+	}
+}
+
+// publishSeededConfigsToEtcd writes each seeded row's DefaultValue to etcd
+// under `<scope-prefix><config_key>`, but only when the key is absent. This
+// keeps the operation idempotent across restarts and avoids stomping any
+// live override that may have been written between DB seed and this call.
+// Gateway errors are logged, not propagated — a missing etcd endpoint (e.g.
+// in unit tests) must not break the DB seed path.
+func publishSeededConfigsToEtcd(ctx context.Context, etcdGw *etcd.Gateway, configs []model.DynamicConfig) {
+	if etcdGw == nil {
+		logrus.Info("seed: etcd gateway unavailable, skipping default_value publish for seeded dynamic_configs")
+		return
+	}
+	for i := range configs {
+		cfg := &configs[i]
+		prefix := seedEtcdPrefixForScope(cfg.Scope)
+		if prefix == "" {
+			continue
+		}
+		etcdKey := prefix + cfg.Key
+
+		getCtx, getCancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err := etcdGw.Get(getCtx, etcdKey)
+		getCancel()
+		if err == nil {
+			// Key already present — never overwrite; a live operator value
+			// (or a previous seed) takes precedence.
+			continue
+		}
+		// Gateway.Get returns an ad-hoc "key not found: <key>" error when the
+		// key is absent. Any other error (connection, auth) — log and skip.
+		if !strings.Contains(err.Error(), "key not found") {
+			logrus.WithError(err).Warnf("seed: etcd lookup failed for %s, skipping publish", etcdKey)
+			continue
+		}
+
+		putCtx, putCancel := context.WithTimeout(ctx, 5*time.Second)
+		putErr := etcdGw.Put(putCtx, etcdKey, cfg.DefaultValue, 0)
+		putCancel()
+		if putErr != nil {
+			logrus.WithError(putErr).Warnf("seed: failed to publish %s to etcd", etcdKey)
+			continue
+		}
+		logrus.Infof("seed: published %s to etcd", etcdKey)
+	}
 }


### PR DESCRIPTION
## Summary

- **aegisctl system enable/disable** — new subcommands; backend `UpdateChaosSystemReq` gains `Status *int` with `binding:"omitempty,oneof=0 1"`; `UpdateSystem` rejects `-1 CommonDeleted` + builtin systems. Addresses part of #91.
- **aegisctl regression run — auto-resolve `spec.namespace`** — fetches `ns_pattern` via `GET /systems`, warn-rewrites bare names (`otel-demo` → `otel-demo0`), hard-fails on pattern mismatch, falls back verbatim when backend unreachable. Closes #92.1.
- **seed → etcd default publish** — `initializeDynamicConfigs` post-commit publishes each seeded row's `default_value` to `/rcabench/config/<scope>/<key>` (get-before-put, nil-gateway tolerant). Fixes the `0 enabled` / `Removed runtime-only system registration` gap surfaced during sockshop/hotelreservation onboarding; addresses the largest remaining friction item on #91.

Companion: #94–#98 closed (benchmark-charts wrappers shipped); big follow-ups split to #101–#110.

## Test plan
- [x] `go build -tags duckdb_arrow -o /dev/null ./main.go`
- [x] `go build -o /tmp/aegisctl ./cmd/aegisctl`
- [x] `go test ./module/chaossystem/... ./cmd/aegisctl/cmd/... ./service/initialization/... -count=1`
- [ ] Manual: `aegisctl system disable ob` / `enable ob` round-trip on a live cluster
- [ ] Manual: `aegisctl regression run` with `namespace: ob` in the YAML → observe the warn-rewrite to `ob0`
- [ ] Manual: fresh-cluster boot → backend log no longer prints `loaded N systems (0 enabled)` for seed-declared systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)