### PR TITLE
rbac: upsert newly-added permissions + role grants on every startup (#104)

### DIFF
--- a/AegisLab/src/service/initialization/bootstrap_store.go
+++ b/AegisLab/src/service/initialization/bootstrap_store.go
@@ -114,6 +114,14 @@ func (s *bootstrapStore) listPermissionsByNames(names []string) ([]model.Permiss
 	return permissions, nil
 }
 
+func (s *bootstrapStore) listRolePermissionsByRole(roleID int) ([]model.RolePermission, error) {
+	var links []model.RolePermission
+	if err := s.db.Where("role_id = ?", roleID).Find(&links).Error; err != nil {
+		return nil, fmt.Errorf("failed to list role_permissions for role %d: %w", roleID, err)
+	}
+	return links, nil
+}
+
 func (s *bootstrapStore) createRolePermissions(rolePermissions []model.RolePermission) error {
 	if len(rolePermissions) == 0 {
 		return nil

--- a/AegisLab/src/service/initialization/permissions.go
+++ b/AegisLab/src/service/initialization/permissions.go
@@ -1,0 +1,326 @@
+package initialization
+
+import (
+	"fmt"
+
+	"aegis/consts"
+	"aegis/model"
+	"aegis/utils"
+
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// ReconcileSystemPermissions upserts the RBAC baseline — system resources,
+// permissions, system roles, and role-permission bindings — derived from
+// consts.SystemRolePermissions. It runs on EVERY startup (issue #104), so a
+// newly-added permission (via consts/system.go or a module-contributed
+// RoleGrants registrar aggregated by rbac.AggregatePermissions) shows up in
+// the DB without requiring a fresh install.
+//
+// Idempotency contract:
+//   - Resources: ON CONFLICT(name) DO NOTHING (no writable columns).
+//   - Permissions: ON CONFLICT(name) DO NOTHING.
+//   - Roles: ON CONFLICT(name) DO NOTHING.
+//   - RolePermissions: ON CONFLICT(role_id, permission_id) DO NOTHING.
+//
+// This is important because the permissions-table upsert alone does not
+// guarantee a role_permissions link exists — if the permissions row was
+// created on an earlier boot but role_permissions was not, the link would
+// never be backfilled. The workaround for that gap was a manual
+// `INSERT IGNORE INTO role_permissions`. This function folds that step into
+// every startup.
+//
+// Callers must ensure rbac.AggregatePermissions has already merged module-
+// contributed grants into consts.SystemRolePermissions. In the production
+// fx graph that holds because AggregatePermissions is an fx.Invoke that
+// runs before any lifecycle OnStart hook.
+func ReconcileSystemPermissions(db *gorm.DB) error {
+	resources := systemResources()
+
+	return withOptimizedDBSettings(db, func() error {
+		return db.Transaction(func(tx *gorm.DB) error {
+			store := newBootstrapStore(tx)
+			return reconcileSystemPermissionsTx(store, resources)
+		})
+	})
+}
+
+// systemResources is the canonical list of RBAC resources. It mirrors the
+// list used by initializeProducer (first-boot seed) so both paths produce
+// identical rows.
+func systemResources() []model.Resource {
+	resources := []model.Resource{
+		{Name: consts.ResourceSystem, Type: consts.ResourceTypeSystem, Category: consts.ResourceCategorySystem},
+		{Name: consts.ResourceAudit, Type: consts.ResourceTypeTable, Category: consts.ResourceCategorySystem},
+		{Name: consts.ResourceConfiguration, Type: consts.ResourceTypeTable, Category: consts.ResourceCategorySystem},
+		{Name: consts.ResourceContainer, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryAsset},
+		{Name: consts.ResourceContainerVersion, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryAsset},
+		{Name: consts.ResourceDataset, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryAsset},
+		{Name: consts.ResourceDatasetVersion, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryAsset},
+		{Name: consts.ResourceProject, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryPlatform},
+		{Name: consts.ResourceTeam, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryPlatform},
+		{Name: consts.ResourceLabel, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryAsset},
+		{Name: consts.ResourceUser, Type: consts.ResourceTypeTable, Category: consts.ResourceCategorySystem},
+		{Name: consts.ResourceRole, Type: consts.ResourceTypeTable, Category: consts.ResourceCategorySystem},
+		{Name: consts.ResourcePermission, Type: consts.ResourceTypeTable, Category: consts.ResourceCategorySystem},
+		{Name: consts.ResourceTask, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryChaos},
+		{Name: consts.ResourceTrace, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryChaos},
+		{Name: consts.ResourceInjection, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryChaos},
+		{Name: consts.ResourceExecution, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryChaos},
+	}
+	for i := range resources {
+		resources[i].DisplayName = consts.GetResourceDisplayName(resources[i].Name)
+	}
+	return resources
+}
+
+// systemRoles is the set of system roles derived from
+// consts.SystemRoleDisplayNames. Kept as a helper so
+// reconcileSystemPermissionsTx and initializeProducer agree on the list.
+func systemRoles() []model.Role {
+	roles := make([]model.Role, 0, len(consts.SystemRoleDisplayNames))
+	for role, displayName := range consts.SystemRoleDisplayNames {
+		roles = append(roles, model.Role{
+			Name:        role.String(),
+			DisplayName: displayName,
+			IsSystem:    true,
+			Status:      consts.CommonEnabled,
+		})
+	}
+	return roles
+}
+
+// reconcileSystemPermissionsTx performs the idempotent reconciliation inside
+// an existing transaction. Used both by ReconcileSystemPermissions (the
+// every-boot entry point) and by initializeProducer (the first-boot seeder).
+//
+// Logs newly-inserted permissions and role grants for operability: in the
+// most common case (no new permissions added) all counts are zero and the
+// function emits a single debug-level line; when a new permission is being
+// picked up for the first time, the Info log makes the event greppable
+// without reading SQL.
+func reconcileSystemPermissionsTx(store *bootstrapStore, resources []model.Resource) error {
+	// --- Resources ---------------------------------------------------------
+	beforeResources, err := store.listResourcesByNames(resourceNames(resources))
+	if err != nil {
+		return fmt.Errorf("list resources (before): %w", err)
+	}
+	if err := store.upsertResources(resources); err != nil {
+		return fmt.Errorf("upsert resources: %w", err)
+	}
+	afterResources, err := store.listResourcesByNames(resourceNames(resources))
+	if err != nil {
+		return fmt.Errorf("list resources (after): %w", err)
+	}
+	if len(afterResources) != len(resources) {
+		return fmt.Errorf("resource reconcile mismatch: want %d rows, got %d", len(resources), len(afterResources))
+	}
+
+	resourceIDMap := make(map[consts.ResourceName]int, len(afterResources))
+	resourceMap := make(map[consts.ResourceName]*model.Resource, len(afterResources))
+	for i := range afterResources {
+		resourceIDMap[afterResources[i].Name] = afterResources[i].ID
+		resourceMap[afterResources[i].Name] = &afterResources[i]
+	}
+
+	// Parent links (container_version -> container, dataset_version -> dataset)
+	// — upserted only when the post-state row is missing the parent.
+	if cv, ok := resourceMap[consts.ResourceContainerVersion]; ok {
+		cv.ParentID = utils.IntPtr(resourceIDMap[consts.ResourceContainer])
+	}
+	if dv, ok := resourceMap[consts.ResourceDatasetVersion]; ok {
+		dv.ParentID = utils.IntPtr(resourceIDMap[consts.ResourceDataset])
+	}
+	parentUpdates := []model.Resource{}
+	if cv, ok := resourceMap[consts.ResourceContainerVersion]; ok {
+		parentUpdates = append(parentUpdates, *cv)
+	}
+	if dv, ok := resourceMap[consts.ResourceDatasetVersion]; ok {
+		parentUpdates = append(parentUpdates, *dv)
+	}
+	if len(parentUpdates) > 0 {
+		if err := store.upsertResources(parentUpdates); err != nil {
+			return fmt.Errorf("upsert resource parents: %w", err)
+		}
+	}
+
+	newResources := 0
+	existingNames := make(map[consts.ResourceName]struct{}, len(beforeResources))
+	for _, r := range beforeResources {
+		existingNames[r.Name] = struct{}{}
+	}
+	for _, r := range resources {
+		if _, ok := existingNames[r.Name]; !ok {
+			newResources++
+		}
+	}
+
+	// --- Permissions -------------------------------------------------------
+	uniquePermissions := make(map[string]permMeta)
+	for _, permissionRules := range consts.SystemRolePermissions {
+		for _, rule := range permissionRules {
+			resourceID, ok := resourceIDMap[rule.Resource]
+			if !ok {
+				return fmt.Errorf("resource %s referenced by permission rule not found", rule.Resource)
+			}
+			key := rule.String()
+			if _, exists := uniquePermissions[key]; !exists {
+				uniquePermissions[key] = permMeta{
+					action:        rule.Action,
+					resourceID:    resourceID,
+					resourceName:  rule.Resource,
+					resourceScope: rule.Scope,
+				}
+			}
+		}
+	}
+
+	permNames := make([]string, 0, len(uniquePermissions))
+	for k := range uniquePermissions {
+		permNames = append(permNames, k)
+	}
+	existingPerms, err := store.listPermissionsByNames(permNames)
+	if err != nil {
+		return fmt.Errorf("list permissions (before): %w", err)
+	}
+	existingPermNames := make(map[string]struct{}, len(existingPerms))
+	for _, p := range existingPerms {
+		existingPermNames[p.Name] = struct{}{}
+	}
+
+	permissionsToCreate := make([]model.Permission, 0, len(uniquePermissions))
+	newPermissionNames := make([]string, 0)
+	for permName, permData := range uniquePermissions {
+		permissionsToCreate = append(permissionsToCreate, model.Permission{
+			Name:        permName,
+			DisplayName: permData.String(),
+			Action:      permData.action,
+			Scope:       permData.resourceScope,
+			ResourceID:  permData.resourceID,
+			IsSystem:    true,
+			Status:      consts.CommonEnabled,
+		})
+		if _, ok := existingPermNames[permName]; !ok {
+			newPermissionNames = append(newPermissionNames, permName)
+		}
+	}
+	if len(permissionsToCreate) > 0 {
+		if err := store.upsertPermissions(permissionsToCreate); err != nil {
+			return fmt.Errorf("upsert permissions: %w", err)
+		}
+	}
+
+	// --- Roles -------------------------------------------------------------
+	roles := systemRoles()
+	if err := store.upsertRoles(roles); err != nil {
+		return fmt.Errorf("upsert roles: %w", err)
+	}
+
+	// --- Role permissions --------------------------------------------------
+	// Crucially, this step runs even for pre-existing permission rows — that
+	// is the bug fix for issue #104. A new permission added to an existing
+	// role's grant list must be linked here even if the permissions row was
+	// inserted by an earlier boot.
+	newLinks, err := assignSystemRolePermissionsReturningNew(store)
+	if err != nil {
+		return fmt.Errorf("assign role permissions: %w", err)
+	}
+
+	if newResources > 0 || len(newPermissionNames) > 0 || newLinks > 0 {
+		logrus.WithFields(logrus.Fields{
+			"new_resources":       newResources,
+			"new_permissions":     len(newPermissionNames),
+			"new_role_grants":     newLinks,
+			"permission_examples": truncateStrings(newPermissionNames, 8),
+		}).Info("rbac: reconciled system permissions")
+	} else {
+		logrus.Debug("rbac: system permissions already in sync")
+	}
+
+	return nil
+}
+
+func resourceNames(resources []model.Resource) []consts.ResourceName {
+	out := make([]consts.ResourceName, 0, len(resources))
+	for _, r := range resources {
+		out = append(out, r.Name)
+	}
+	return out
+}
+
+func truncateStrings(s []string, max int) []string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max]
+}
+
+// assignSystemRolePermissionsReturningNew mirrors assignSystemRolePermissions
+// but counts how many role_permissions rows did not exist before this call.
+// The count is best-effort: we query existing links per role once, then
+// compare against the target set. Conflicts in the INSERT are still handled
+// by `ON CONFLICT DO NOTHING` as a safety net.
+func assignSystemRolePermissionsReturningNew(store *bootstrapStore) (int, error) {
+	newLinks := 0
+	for roleName, permissionRules := range consts.SystemRolePermissions {
+		role, err := store.getRoleByName(roleName.String())
+		if err != nil {
+			return 0, fmt.Errorf("role %s not found: %w", roleName, err)
+		}
+
+		var targetPerms []model.Permission
+		if roleName == consts.RoleSuperAdmin {
+			targetPerms, err = store.listSystemPermissions()
+			if err != nil {
+				return 0, fmt.Errorf("list system permissions: %w", err)
+			}
+		} else {
+			permStrs := make([]string, 0, len(permissionRules))
+			seen := make(map[string]struct{}, len(permissionRules))
+			for _, rule := range permissionRules {
+				s := rule.String()
+				if _, ok := seen[s]; ok {
+					continue
+				}
+				seen[s] = struct{}{}
+				permStrs = append(permStrs, s)
+			}
+			targetPerms, err = store.listPermissionsByNames(permStrs)
+			if err != nil {
+				return 0, fmt.Errorf("list permissions for role %s: %w", roleName, err)
+			}
+		}
+
+		existingLinks, err := store.listRolePermissionsByRole(role.ID)
+		if err != nil {
+			return 0, fmt.Errorf("list role_permissions for role %s: %w", roleName, err)
+		}
+		existingSet := make(map[int]struct{}, len(existingLinks))
+		for _, l := range existingLinks {
+			existingSet[l.PermissionID] = struct{}{}
+		}
+
+		toCreate := make([]model.RolePermission, 0, len(targetPerms))
+		for _, p := range targetPerms {
+			if _, ok := existingSet[p.ID]; ok {
+				continue
+			}
+			toCreate = append(toCreate, model.RolePermission{
+				RoleID:       role.ID,
+				PermissionID: p.ID,
+			})
+		}
+		if len(toCreate) > 0 {
+			if err := store.createRolePermissions(toCreate); err != nil {
+				return 0, fmt.Errorf("create role_permissions for role %s: %w", roleName, err)
+			}
+			newLinks += len(toCreate)
+			logrus.WithFields(logrus.Fields{
+				"role":      roleName.String(),
+				"new_links": len(toCreate),
+			}).Info("rbac: linked new permissions to role")
+		}
+	}
+	return newLinks, nil
+}

--- a/AegisLab/src/service/initialization/permissions_test.go
+++ b/AegisLab/src/service/initialization/permissions_test.go
@@ -1,0 +1,196 @@
+package initialization
+
+import (
+	"testing"
+
+	"aegis/consts"
+	"aegis/model"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// newPermTestDB spins up an in-memory sqlite DB with the RBAC tables
+// migrated. SQLite accepts the `GENERATED ALWAYS AS ... VIRTUAL` clause on
+// Permission.ActiveName, but since uniqueness there is enforced by the
+// MySQL-only computed column, the tests below also seed via Create and rely
+// on ON CONFLICT(name) for the upsertPermissions path.
+func newPermTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&model.Resource{},
+		&model.Permission{},
+		&model.Role{},
+		&model.RolePermission{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	// SQLite doesn't enforce the computed-column uniqueness the same way
+	// MySQL does, so add a plain unique index on Permission.Name. This is
+	// what upsertPermissions(ON CONFLICT {name}) needs to hit.
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_perm_name ON permissions(name)").Error; err != nil {
+		t.Fatalf("index permissions.name: %v", err)
+	}
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_role_name ON roles(name)").Error; err != nil {
+		t.Fatalf("index roles.name: %v", err)
+	}
+	return db
+}
+
+// withInjectedPermission saves + restores consts.SystemRolePermissions so
+// tests can declare a fresh grant without leaking state.
+func withInjectedPermission(t *testing.T, role consts.RoleName, rule consts.PermissionRule) {
+	t.Helper()
+	original := make(map[consts.RoleName][]consts.PermissionRule, len(consts.SystemRolePermissions))
+	for k, v := range consts.SystemRolePermissions {
+		original[k] = append([]consts.PermissionRule(nil), v...)
+	}
+	t.Cleanup(func() {
+		consts.SystemRolePermissions = original
+	})
+
+	if consts.SystemRolePermissions == nil {
+		consts.SystemRolePermissions = map[consts.RoleName][]consts.PermissionRule{}
+	}
+	consts.SystemRolePermissions[role] = append(consts.SystemRolePermissions[role], rule)
+}
+
+// TestReconcileSystemPermissions_FreshDBCreatesPermissionAndLink exercises
+// the first scenario from issue #104: permission X and its role_permissions
+// link are both absent; running reconcile creates both.
+func TestReconcileSystemPermissions_FreshDBCreatesPermissionAndLink(t *testing.T) {
+	db := newPermTestDB(t)
+
+	// Inject a new rule on a plain system role (not super_admin — super_admin
+	// receives ALL permissions by design and would obscure the link assertion).
+	newRule := consts.PermissionRule{
+		Resource: consts.ResourceTrace,
+		Action:   consts.ActionName("stop"),
+		Scope:    consts.ScopeAll,
+	}
+	withInjectedPermission(t, consts.RoleAdmin, newRule)
+
+	if err := ReconcileSystemPermissions(db); err != nil {
+		t.Fatalf("ReconcileSystemPermissions: %v", err)
+	}
+
+	var perm model.Permission
+	if err := db.Where("name = ?", newRule.String()).First(&perm).Error; err != nil {
+		t.Fatalf("new permission %q not inserted: %v", newRule.String(), err)
+	}
+	if !perm.IsSystem || perm.Status != consts.CommonEnabled {
+		t.Fatalf("permission row unexpected: %+v", perm)
+	}
+
+	var role model.Role
+	if err := db.Where("name = ?", consts.RoleAdmin.String()).First(&role).Error; err != nil {
+		t.Fatalf("admin role not created: %v", err)
+	}
+
+	var link model.RolePermission
+	if err := db.Where("role_id = ? AND permission_id = ?", role.ID, perm.ID).First(&link).Error; err != nil {
+		t.Fatalf("role_permissions link missing for admin -> %s: %v", newRule.String(), err)
+	}
+}
+
+// TestReconcileSystemPermissions_ExistingPermissionBackfillsLink is the
+// precise scenario the INSERT IGNORE workaround addressed: the permission
+// row was inserted on an earlier boot, but the role_permissions join was
+// not. On the next boot, the link must be backfilled.
+func TestReconcileSystemPermissions_ExistingPermissionBackfillsLink(t *testing.T) {
+	db := newPermTestDB(t)
+
+	newRule := consts.PermissionRule{
+		Resource: consts.ResourceTrace,
+		Action:   consts.ActionName("cancel"),
+		Scope:    consts.ScopeAll,
+	}
+	withInjectedPermission(t, consts.RoleAdmin, newRule)
+
+	// First boot: both permission + link created.
+	if err := ReconcileSystemPermissions(db); err != nil {
+		t.Fatalf("first ReconcileSystemPermissions: %v", err)
+	}
+
+	// Simulate the bug state: delete the role_permissions link but leave the
+	// permission row in place, as if a previous (buggy) boot had inserted
+	// only the permission.
+	var role model.Role
+	if err := db.Where("name = ?", consts.RoleAdmin.String()).First(&role).Error; err != nil {
+		t.Fatalf("admin role missing: %v", err)
+	}
+	var perm model.Permission
+	if err := db.Where("name = ?", newRule.String()).First(&perm).Error; err != nil {
+		t.Fatalf("permission missing: %v", err)
+	}
+	if err := db.Where("role_id = ? AND permission_id = ?", role.ID, perm.ID).
+		Delete(&model.RolePermission{}).Error; err != nil {
+		t.Fatalf("delete link for bug simulation: %v", err)
+	}
+
+	var count int64
+	db.Model(&model.RolePermission{}).
+		Where("role_id = ? AND permission_id = ?", role.ID, perm.ID).
+		Count(&count)
+	if count != 0 {
+		t.Fatalf("precondition: expected 0 link rows, got %d", count)
+	}
+
+	// Second boot: reconcile must backfill the link WITHOUT duplicating the
+	// permission row.
+	if err := ReconcileSystemPermissions(db); err != nil {
+		t.Fatalf("second ReconcileSystemPermissions: %v", err)
+	}
+
+	var linkCount int64
+	db.Model(&model.RolePermission{}).
+		Where("role_id = ? AND permission_id = ?", role.ID, perm.ID).
+		Count(&linkCount)
+	if linkCount != 1 {
+		t.Fatalf("expected 1 backfilled link, got %d", linkCount)
+	}
+
+	var permCount int64
+	db.Model(&model.Permission{}).Where("name = ?", newRule.String()).Count(&permCount)
+	if permCount != 1 {
+		t.Fatalf("expected exactly 1 permission row, got %d (duplicate from non-idempotent upsert?)", permCount)
+	}
+}
+
+// TestReconcileSystemPermissions_IdempotentOnRerun guards against the
+// reconciler doing writes that accumulate rows across boots.
+func TestReconcileSystemPermissions_IdempotentOnRerun(t *testing.T) {
+	db := newPermTestDB(t)
+
+	if err := ReconcileSystemPermissions(db); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+
+	var permsBefore, rolesBefore, linksBefore int64
+	db.Model(&model.Permission{}).Count(&permsBefore)
+	db.Model(&model.Role{}).Count(&rolesBefore)
+	db.Model(&model.RolePermission{}).Count(&linksBefore)
+
+	if err := ReconcileSystemPermissions(db); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	var permsAfter, rolesAfter, linksAfter int64
+	db.Model(&model.Permission{}).Count(&permsAfter)
+	db.Model(&model.Role{}).Count(&rolesAfter)
+	db.Model(&model.RolePermission{}).Count(&linksAfter)
+
+	if permsAfter != permsBefore {
+		t.Fatalf("permissions grew on rerun: %d -> %d", permsBefore, permsAfter)
+	}
+	if rolesAfter != rolesBefore {
+		t.Fatalf("roles grew on rerun: %d -> %d", rolesBefore, rolesAfter)
+	}
+	if linksAfter != linksBefore {
+		t.Fatalf("role_permissions grew on rerun: %d -> %d", linksBefore, linksAfter)
+	}
+}

--- a/AegisLab/src/service/initialization/producer.go
+++ b/AegisLab/src/service/initialization/producer.go
@@ -15,7 +15,6 @@ import (
 	dataset "aegis/module/dataset"
 	label "aegis/module/label"
 	"aegis/service/common"
-	"aegis/utils"
 
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
@@ -48,6 +47,16 @@ func InitializeProducer(db *gorm.DB, publisher *redis.Gateway, etcdGw *etcd.Gate
 		logrus.Info("Successfully seeded initial system data for producer")
 	} else {
 		logrus.Info("Initial system data for producer already seeded, skipping initialization")
+	}
+
+	// Issue #104: even after first-boot seeding, a new permission added to
+	// consts.SystemRolePermissions (or contributed via a module's RoleGrants
+	// registrar and merged by rbac.AggregatePermissions) must reach the
+	// permissions + role_permissions tables. Running ReconcileSystemPermissions
+	// unconditionally is the canonical place — it is idempotent and only
+	// writes rows that are missing.
+	if err := ReconcileSystemPermissions(db); err != nil {
+		return fmt.Errorf("failed to reconcile system permissions: %w", err)
 	}
 
 	// Best-effort one-shot migration for issue #75:
@@ -84,141 +93,18 @@ func initializeProducer(db *gorm.DB) error {
 		return fmt.Errorf("failed to load initial data from file: %w", err)
 	}
 
-	// System resources (following the order in system.go)
-	resources := []model.Resource{
-		{Name: consts.ResourceSystem, Type: consts.ResourceTypeSystem, Category: consts.ResourceCategorySystem},
-		{Name: consts.ResourceAudit, Type: consts.ResourceTypeTable, Category: consts.ResourceCategorySystem},
-		{Name: consts.ResourceConfiguration, Type: consts.ResourceTypeTable, Category: consts.ResourceCategorySystem},
-		{Name: consts.ResourceContainer, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryAsset},
-		{Name: consts.ResourceContainerVersion, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryAsset},
-		{Name: consts.ResourceDataset, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryAsset},
-		{Name: consts.ResourceDatasetVersion, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryAsset},
-		{Name: consts.ResourceProject, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryPlatform},
-		{Name: consts.ResourceTeam, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryPlatform},
-		{Name: consts.ResourceLabel, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryAsset},
-		{Name: consts.ResourceUser, Type: consts.ResourceTypeTable, Category: consts.ResourceCategorySystem},
-		{Name: consts.ResourceRole, Type: consts.ResourceTypeTable, Category: consts.ResourceCategorySystem},
-		{Name: consts.ResourcePermission, Type: consts.ResourceTypeTable, Category: consts.ResourceCategorySystem},
-		{Name: consts.ResourceTask, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryChaos},
-		{Name: consts.ResourceTrace, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryChaos},
-		{Name: consts.ResourceInjection, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryChaos},
-		{Name: consts.ResourceExecution, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryChaos},
-	}
-
-	for i := range resources {
-		resources[i].DisplayName = consts.GetResourceDisplayName(resources[i].Name)
-	}
-
-	systemRoles := make([]model.Role, 0)
-	for role, displayName := range consts.SystemRoleDisplayNames {
-		systemRoles = append(systemRoles, model.Role{
-			Name:        role.String(),
-			DisplayName: displayName,
-			IsSystem:    true,
-			Status:      consts.CommonEnabled,
-		})
-	}
+	resources := systemResources()
 
 	return withOptimizedDBSettings(db, func() error {
 		return db.Transaction(func(tx *gorm.DB) error {
 			txStore := newBootstrapStore(tx)
 
-			if err := txStore.upsertResources(resources); err != nil {
-				return fmt.Errorf("failed to create system resources: %w", err)
-			}
-
-			resourceNames := make([]consts.ResourceName, 0, len(resources))
-			for _, res := range resources {
-				resourceNames = append(resourceNames, res.Name)
-			}
-
-			allResourcesInDB, err := txStore.listResourcesByNames(resourceNames)
-			if err != nil {
-				return fmt.Errorf("failed to get system resources from database: %w", err)
-			}
-
-			if len(allResourcesInDB) != len(resources) {
-				return fmt.Errorf("mismatch in number of resources created and fetched")
-			}
-
-			resourceMap := make(map[consts.ResourceName]*model.Resource, len(allResourcesInDB))
-			resourceIDMap := make(map[consts.ResourceName]int, len(allResourcesInDB))
-			for _, res := range allResourcesInDB {
-				resourceIDMap[res.Name] = res.ID
-				resourceMap[res.Name] = &res
-			}
-
-			resourceMap[consts.ResourceContainerVersion].ParentID = utils.IntPtr(resourceIDMap[consts.ResourceContainer])
-			resourceMap[consts.ResourceDatasetVersion].ParentID = utils.IntPtr(resourceIDMap[consts.ResourceDataset])
-
-			toUpdatedResources := []model.Resource{
-				*resourceMap[consts.ResourceContainerVersion],
-				*resourceMap[consts.ResourceDatasetVersion],
-			}
-
-			if err := txStore.upsertResources(toUpdatedResources); err != nil {
-				return fmt.Errorf("failed to update resource parent IDs: %w", err)
-			}
-
-			// Extract unique permissions from SystemRolePermissions to avoid creating unused permissions
-			uniquePermissions := make(map[string]permMeta)
-
-			for _, permissionRules := range consts.SystemRolePermissions {
-				for _, rule := range permissionRules {
-					resourceID, ok := resourceIDMap[rule.Resource]
-					if !ok {
-						return fmt.Errorf("resource %s not found in resourceIDMap", rule.Resource)
-					}
-
-					key := rule.String()
-					if _, exists := uniquePermissions[key]; !exists {
-						uniquePermissions[key] = permMeta{
-							action:        rule.Action,
-							resourceID:    resourceID,
-							resourceName:  rule.Resource,
-							resourceScope: rule.Scope,
-						}
-					}
-				}
-			}
-
-			var permissionsToCreate []model.Permission
-			for permName, permData := range uniquePermissions {
-				resource, ok := resourceMap[permData.resourceName]
-				if !ok {
-					for _, res := range allResourcesInDB {
-						if res.ID == permData.resourceID {
-							resource = &res
-							break
-						}
-					}
-					if resource == nil {
-						return fmt.Errorf("resource with ID %d not found", permData.resourceID)
-					}
-				}
-
-				permission := model.Permission{
-					Name:        permName,
-					DisplayName: permData.String(),
-					Action:      permData.action,
-					Scope:       permData.resourceScope,
-					ResourceID:  permData.resourceID,
-					IsSystem:    true,
-					Status:      consts.CommonEnabled,
-				}
-				permissionsToCreate = append(permissionsToCreate, permission)
-			}
-
-			if err := txStore.upsertPermissions(permissionsToCreate); err != nil {
-				return fmt.Errorf("failed to create system permissions: %w", err)
-			}
-
-			if err := txStore.upsertRoles(systemRoles); err != nil {
-				return fmt.Errorf("failed to create system roles: %w", err)
-			}
-
-			if err := assignSystemRolePermissions(txStore); err != nil {
-				return fmt.Errorf("failed to assign system role permissions: %w", err)
+			// Reconcile the RBAC baseline (resources + permissions + roles +
+			// role_permissions) via the shared idempotent path so first-boot
+			// seeding and every-boot upserts write identical rows. See
+			// reconcileSystemPermissionsTx for the idempotency contract.
+			if err := reconcileSystemPermissionsTx(txStore, resources); err != nil {
+				return fmt.Errorf("failed to reconcile RBAC baseline: %w", err)
 			}
 
 			adminUser, err := initializeAdminUser(txStore, initialData)
@@ -249,61 +135,6 @@ func initializeProducer(db *gorm.DB) error {
 			return nil
 		})
 	})
-}
-
-func assignSystemRolePermissions(store *bootstrapStore) error {
-	for roleName, permissionRules := range consts.SystemRolePermissions {
-		role, err := store.getRoleByName(roleName.String())
-		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return fmt.Errorf("role %s not found", roleName)
-			}
-			return err
-		}
-
-		if roleName == consts.RoleSuperAdmin {
-			permissions, err := store.listSystemPermissions()
-			if err != nil {
-				return fmt.Errorf("failed to list system permissions: %w", err)
-			}
-
-			var rolePermissions []model.RolePermission
-			for _, perm := range permissions {
-				rolePermissions = append(rolePermissions, model.RolePermission{
-					RoleID:       role.ID,
-					PermissionID: perm.ID,
-				})
-			}
-
-			if err := store.createRolePermissions(rolePermissions); err != nil {
-				return fmt.Errorf("failed to assign all permissions to super admin role: %w", err)
-			}
-		} else {
-			var permissionStrs []string
-			for _, rule := range permissionRules {
-				permissionStrs = append(permissionStrs, rule.String())
-			}
-
-			permissions, err := store.listPermissionsByNames(permissionStrs)
-			if err != nil {
-				return fmt.Errorf("failed to list permissions for role %s: %w", roleName, err)
-			}
-
-			var rolePermissions []model.RolePermission
-			for _, perm := range permissions {
-				rolePermissions = append(rolePermissions, model.RolePermission{
-					RoleID:       role.ID,
-					PermissionID: perm.ID,
-				})
-			}
-
-			if err := store.createRolePermissions(rolePermissions); err != nil {
-				return fmt.Errorf("failed to assign permissions to role %s: %w", roleName, err)
-			}
-		}
-	}
-
-	return nil
 }
 
 func initializeAdminUser(store *bootstrapStore, data *InitialData) (*model.User, error) {


### PR DESCRIPTION
Closes #104

## Summary
Producer init used to skip the permissions/roles/role_permissions seed on every boot after the first (gated on `dynamic_configs` empty). Adding a permission → rebuild → 403 at runtime, workaround was `INSERT IGNORE`.

Fix: extract `ReconcileSystemPermissions(db)` — idempotent upsert of resources/permissions/roles + diff-based role_permissions backfill. Called unconditionally on every producer startup. The first-boot seed delegates to the same helper so both paths write identical rows.

Aggregator ordering was already correct — `fx.Invoke` runs before any `OnStart`.

## Test plan
- [x] `go build -tags duckdb_arrow -o /dev/null ./main.go`
- [x] 3 new sqlite tests: fresh-DB creates, existing-permission-missing-link backfills, rerun idempotent
- [x] `go test ./module/rbac/... ./service/initialization/... -count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)