### PR TITLE
aegisctl: warn on stale PodChaos in target ns before guided submit (#110)

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/inject_guided.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_guided.go
@@ -45,6 +45,7 @@ var (
 	guidedNext          string
 	guidedOutput        string
 	guidedApply         bool
+	guidedSkipStaleCheck bool
 
 	guidedDuration        int
 	guidedMemorySize      int
@@ -254,6 +255,7 @@ func init() {
 	f.StringVar(&guidedNext, "next", "", "Apply a single next-step selection using the current session state")
 	f.StringVar(&guidedOutput, "output", "json", "Output format: json|yaml")
 	f.BoolVar(&guidedApply, "apply", false, "Finalize the session and attempt to submit")
+	f.BoolVar(&guidedSkipStaleCheck, "skip-stale-check", false, "Skip the pre-submit warning about orphaned PodChaos CRs in the target namespace")
 
 	// --apply envelope flags (mirror the injection YAML contract)
 	f.StringVar(&guidedApplyPedestalName, "pedestal-name", "", "Pedestal container name (required with --apply)")
@@ -304,6 +306,11 @@ func submitGuidedApply(cfg guidedcli.GuidedConfig) error {
 	}
 	if err := requireAPIContext(true); err != nil {
 		return err
+	}
+	if !guidedSkipStaleCheck {
+		// Non-blocking: any error from the check itself is silently downgraded
+		// to an info line by warnStalePodChaos. We still ignore its return.
+		_ = warnStalePodChaos(context.Background(), cfg.Namespace, guidedStalePodChaosListerHook, os.Stderr)
 	}
 	opts := guidedApplyOptions{
 		PedestalName:  guidedApplyPedestalName,

--- a/AegisLab/src/cmd/aegisctl/cmd/inject_guided_stale.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_guided_stale.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// StalePodChaosLister is the minimal chaos-mesh PodChaos surface the stale-CRD
+// warning path needs. Tests inject a fake; production uses the dynamic-client
+// backed implementation.
+type StalePodChaosLister interface {
+	ListPodChaosTraceIDs(ctx context.Context, namespace string) ([]string, error)
+}
+
+// guidedStalePodChaosListerHook is the test injection seam. nil => build a
+// real dynamic-client-backed lister.
+var guidedStalePodChaosListerHook StalePodChaosLister
+
+// podChaosGVR is the chaos-mesh v1alpha1 PodChaos resource.
+var podChaosGVR = schema.GroupVersionResource{
+	Group:    "chaos-mesh.org",
+	Version:  "v1alpha1",
+	Resource: "podchaos",
+}
+
+// warnStalePodChaos lists PodChaos CRs in `namespace` and, if any carry a
+// non-empty `trace_id` label, emits a single WARN block to `stderr`. If the
+// cluster is unreachable an `info:` line is emitted and nil returned — the
+// submit must proceed.
+//
+// This is intentionally non-blocking: orphaned CRs do not prevent a new
+// submit, they only confuse `kubectl get podchaos` until the owning trace is
+// cancelled.
+func warnStalePodChaos(ctx context.Context, namespace string, lister StalePodChaosLister, stderr io.Writer) error {
+	if namespace == "" {
+		return nil
+	}
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	if lister == nil {
+		l, err := newLiveStalePodChaosLister()
+		if err != nil {
+			fmt.Fprintf(stderr, "info: skipped stale-CRD check (k8s unreachable: %v)\n", err)
+			return nil
+		}
+		lister = l
+	}
+	traces, err := lister.ListPodChaosTraceIDs(ctx, namespace)
+	if err != nil {
+		fmt.Fprintf(stderr, "info: skipped stale-CRD check (k8s unreachable: %v)\n", err)
+		return nil
+	}
+	// Filter empties and dedupe.
+	seen := make(map[string]struct{})
+	uniq := make([]string, 0, len(traces))
+	for _, t := range traces {
+		if t == "" {
+			continue
+		}
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		uniq = append(uniq, t)
+	}
+	if len(uniq) == 0 {
+		return nil
+	}
+	sort.Strings(uniq)
+
+	total := len(uniq)
+	display := uniq
+	extra := 0
+	if total > 10 {
+		display = uniq[:10]
+		extra = total - 10
+	}
+	listStr := joinTraceList(display)
+	if extra > 0 {
+		listStr = fmt.Sprintf("%s, … and %d more", listStr, extra)
+	}
+	fmt.Fprintf(stderr, "WARN: %d PodChaos CR(s) in ns=%s from prior trace(s): %s\n", total, namespace, listStr)
+	fmt.Fprintf(stderr, "      These will not block the new submit but may confuse kubectl get podchaos.\n")
+	fmt.Fprintf(stderr, "      Run `aegisctl trace cancel <id>` to clean up.\n")
+	return nil
+}
+
+func joinTraceList(ts []string) string {
+	out := ""
+	for i, t := range ts {
+		if i > 0 {
+			out += ", "
+		}
+		out += t
+	}
+	return out
+}
+
+// liveStalePodChaosLister is the real dynamic-client-backed PodChaos lister,
+// mirroring newLivePodLister's in-cluster-or-kubeconfig resolution pattern.
+type liveStalePodChaosLister struct {
+	dyn dynamic.Interface
+}
+
+func newLiveStalePodChaosLister() (*liveStalePodChaosLister, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		home, _ := os.UserHomeDir()
+		path := filepath.Join(home, ".kube", "config")
+		cfg, err = clientcmd.BuildConfigFromFlags("", path)
+		if err != nil {
+			return nil, err
+		}
+	}
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &liveStalePodChaosLister{dyn: dyn}, nil
+}
+
+func (l *liveStalePodChaosLister) ListPodChaosTraceIDs(ctx context.Context, namespace string) ([]string, error) {
+	list, err := l.dyn.Resource(podChaosGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(list.Items))
+	for i := range list.Items {
+		labels := list.Items[i].GetLabels()
+		if labels == nil {
+			continue
+		}
+		if tid := labels["trace_id"]; tid != "" {
+			out = append(out, tid)
+		}
+	}
+	return out, nil
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/inject_guided_stale_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_guided_stale_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeStalePodChaosLister struct {
+	traces []string
+	err    error
+}
+
+func (f *fakeStalePodChaosLister) ListPodChaosTraceIDs(_ context.Context, _ string) ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.traces, nil
+}
+
+func TestWarnStalePodChaos_NoneSilent(t *testing.T) {
+	var buf bytes.Buffer
+	err := warnStalePodChaos(context.Background(), "ob0", &fakeStalePodChaosLister{}, &buf)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected silent stderr, got %q", buf.String())
+	}
+}
+
+func TestWarnStalePodChaos_EmptyNamespaceNoOp(t *testing.T) {
+	var buf bytes.Buffer
+	lister := &fakeStalePodChaosLister{err: errors.New("should not be called")}
+	if err := warnStalePodChaos(context.Background(), "", lister, &buf); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("expected silent stderr, got %q", buf.String())
+	}
+}
+
+func TestWarnStalePodChaos_WithTraces(t *testing.T) {
+	var buf bytes.Buffer
+	lister := &fakeStalePodChaosLister{traces: []string{"a1b2c3", "d4e5f6", "7890ab"}}
+	if err := warnStalePodChaos(context.Background(), "ob0", lister, &buf); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "WARN: 3 PodChaos CR(s) in ns=ob0") {
+		t.Fatalf("missing WARN header: %q", out)
+	}
+	for _, id := range []string{"a1b2c3", "d4e5f6", "7890ab"} {
+		if !strings.Contains(out, id) {
+			t.Fatalf("missing trace id %s in output: %q", id, out)
+		}
+	}
+	if !strings.Contains(out, "aegisctl trace cancel") {
+		t.Fatalf("missing cleanup hint: %q", out)
+	}
+}
+
+func TestWarnStalePodChaos_DedupesAndFiltersEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	lister := &fakeStalePodChaosLister{traces: []string{"aaa", "", "bbb", "aaa"}}
+	if err := warnStalePodChaos(context.Background(), "ob0", lister, &buf); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "WARN: 2 PodChaos CR(s)") {
+		t.Fatalf("expected count=2 after dedupe/filter, got: %q", out)
+	}
+}
+
+func TestWarnStalePodChaos_TruncatesOverTen(t *testing.T) {
+	traces := []string{}
+	for i := 0; i < 13; i++ {
+		traces = append(traces, string(rune('a'+i))+"00000")
+	}
+	var buf bytes.Buffer
+	lister := &fakeStalePodChaosLister{traces: traces}
+	if err := warnStalePodChaos(context.Background(), "ob0", lister, &buf); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "WARN: 13 PodChaos CR(s)") {
+		t.Fatalf("expected total=13: %q", out)
+	}
+	if !strings.Contains(out, "and 3 more") {
+		t.Fatalf("expected truncation marker: %q", out)
+	}
+}
+
+func TestWarnStalePodChaos_ClusterUnreachableInfoAndContinues(t *testing.T) {
+	var buf bytes.Buffer
+	lister := &fakeStalePodChaosLister{err: errors.New("connection refused")}
+	if err := warnStalePodChaos(context.Background(), "ob0", lister, &buf); err != nil {
+		t.Fatalf("must not fail submit on unreachable cluster, got: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "info: skipped stale-CRD check") {
+		t.Fatalf("expected info line, got: %q", out)
+	}
+	if strings.Contains(out, "WARN:") {
+		t.Fatalf("must not emit WARN when unreachable: %q", out)
+	}
+}


### PR DESCRIPTION
Closes #110

## Summary
Before `aegisctl inject guided --apply` submits, list existing PodChaos CRs in target ns; if any have a non-empty `trace_id` label, emit WARN to stderr with the list (truncated at 10). Non-blocking; cluster unreachable → single `info:` line and proceed. Gated by `--skip-stale-check`.

## Test plan
- [x] `go build -o /tmp/aegisctl ./cmd/aegisctl`
- [x] 6 unit tests (none/silent, empty-ns, traces→WARN, dedupe+filter, >10 truncation, unreachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)