### PR TITLE
aegisctl: trace next-task / trace expedite (#109)

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/trace_next_task.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/trace_next_task.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"aegis/cmd/aegisctl/client"
+	"aegis/cmd/aegisctl/output"
+
+	"github.com/spf13/cobra"
+)
+
+// traceNextTaskStdout / traceNextTaskStderr are hooks for tests so they can
+// redirect the scriptable stdout stream (task-id) vs. the human-readable
+// stderr stream (info messages) independently.
+var (
+	traceNextTaskStdout io.Writer = os.Stdout
+	traceNextTaskStderr io.Writer = os.Stderr
+)
+
+// traceTask is the minimum shape we need from a task entry in the
+// `GET /api/v2/traces/{id}` response to pick the next pending one. Decoded via
+// encoding/json from the generic map[string]any payload the aegisctl client
+// uses for trace-get.
+type traceTask struct {
+	ID          string  `json:"id"`
+	Type        string  `json:"type"`
+	State       string  `json:"state"`
+	ExecuteTime float64 `json:"execute_time"`
+	CreatedAt   string  `json:"created_at"`
+}
+
+// resolveNextPendingTask fetches a trace by ID and returns the next task with
+// state == "Pending". "Next" is ordered by execute_time (ascending) with
+// created_at as a stable tiebreaker — matches how the scheduler picks tasks
+// off the delayed/ready queues. Returns a notFoundErrorf-wrapped error (exit
+// code 7) when no pending task exists so scripts can branch on it.
+func resolveNextPendingTask(traceID string) (*traceTask, error) {
+	c := newClient()
+	path := fmt.Sprintf("/api/v2/traces/%s", traceID)
+
+	var resp client.APIResponse[map[string]any]
+	if err := c.Get(path, &resp); err != nil {
+		return nil, err
+	}
+
+	tasksRaw, ok := resp.Data["tasks"]
+	if !ok || tasksRaw == nil {
+		return nil, notFoundErrorf("trace %s has no tasks", traceID)
+	}
+
+	// Re-marshal through JSON to get a typed slice.
+	data, err := json.Marshal(tasksRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parse tasks field: %w", err)
+	}
+	var tasks []traceTask
+	if err := json.Unmarshal(data, &tasks); err != nil {
+		return nil, fmt.Errorf("decode tasks field: %w", err)
+	}
+
+	pending := make([]traceTask, 0, len(tasks))
+	for _, t := range tasks {
+		if t.State == "Pending" {
+			pending = append(pending, t)
+		}
+	}
+	if len(pending) == 0 {
+		return nil, notFoundErrorf("trace %s has no pending task", traceID)
+	}
+
+	sort.SliceStable(pending, func(i, j int) bool {
+		if pending[i].ExecuteTime != pending[j].ExecuteTime {
+			return pending[i].ExecuteTime < pending[j].ExecuteTime
+		}
+		return pending[i].CreatedAt < pending[j].CreatedAt
+	})
+
+	t := pending[0]
+	return &t, nil
+}
+
+// --- trace next-task ---
+
+var traceNextTaskCmd = &cobra.Command{
+	Use:   "next-task <trace-id>",
+	Short: "Print the next pending task id for a trace",
+	Long: `Resolve the next pending child task for a trace and print its ID.
+
+The task ID is written to stdout (scriptable). Any human-readable messages
+(including JSON payloads when -o json is passed) are written to stderr-only
+when they would interfere with scripts — with -o json the JSON goes to stdout
+because that is the only output the caller asked for.
+
+Exits with ExitCodeNotFound (7) when the trace has no pending task.`,
+	Args: exactArgs(1, "trace next-task <trace-id>"),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAPIContext(true); err != nil {
+			return err
+		}
+
+		task, err := resolveNextPendingTask(args[0])
+		if err != nil {
+			return err
+		}
+
+		if output.OutputFormat(flagOutput) == output.FormatJSON {
+			// For --output json, emit the whole task struct on stdout so
+			// callers get id/type/state in one shot.
+			enc := json.NewEncoder(traceNextTaskStdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(task)
+		}
+
+		// Scriptable path: task id alone on stdout, info to stderr.
+		fmt.Fprintln(traceNextTaskStdout, task.ID)
+		fmt.Fprintf(traceNextTaskStderr, "next pending task: id=%s type=%s\n", task.ID, task.Type)
+		return nil
+	},
+}
+
+// --- trace expedite ---
+
+var traceExpediteCmd = &cobra.Command{
+	Use:   "expedite <trace-id>",
+	Short: "Expedite the next pending task of a trace",
+	Long: `Compose trace next-task + task expedite.
+
+Resolves the next pending child task of the trace, then POSTs to
+/api/v2/tasks/{id}/expedite (same endpoint as 'aegisctl task expedite').
+Exits with ExitCodeNotFound (7) without posting if the trace has no pending
+task.`,
+	Args: exactArgs(1, "trace expedite <trace-id>"),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAPIContext(true); err != nil {
+			return err
+		}
+
+		task, err := resolveNextPendingTask(args[0])
+		if err != nil {
+			return err
+		}
+
+		c := newClient()
+		path := fmt.Sprintf("/api/v2/tasks/%s/expedite", task.ID)
+
+		var resp client.APIResponse[map[string]any]
+		if err := c.Post(path, nil, &resp); err != nil {
+			return err
+		}
+
+		if output.OutputFormat(flagOutput) == output.FormatJSON {
+			output.PrintJSON(map[string]any{
+				"trace_id": args[0],
+				"task_id":  task.ID,
+				"type":     task.Type,
+				"response": resp.Data,
+			})
+			return nil
+		}
+
+		output.PrintInfo(fmt.Sprintf("Trace %s: expedited task %s (type=%s)", args[0], task.ID, task.Type))
+		return nil
+	},
+}
+
+func init() {
+	traceCmd.AddCommand(traceNextTaskCmd)
+	traceCmd.AddCommand(traceExpediteCmd)
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/trace_next_task_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/trace_next_task_test.go
@@ -1,0 +1,193 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// traceDetailFixture builds the minimum `GET /api/v2/traces/{id}` response
+// shape the next-task resolver cares about: a `tasks` array with id/state and
+// optional execute_time for ordering. Matches module/trace/api_types.go
+// TraceDetailResp.Tasks = []task.TaskResp.
+func traceDetailFixture(tasks []map[string]any) map[string]any {
+	return map[string]any{
+		"code":    200,
+		"message": "success",
+		"data": map[string]any{
+			"id":    "trace-xyz",
+			"state": "Running",
+			"tasks": tasks,
+		},
+	}
+}
+
+func withServer(t *testing.T, handler http.HandlerFunc) (restore func()) {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+
+	oldServer, oldToken, oldOutput := flagServer, flagToken, flagOutput
+	flagServer = ts.URL
+	flagToken = "test-token"
+	flagOutput = ""
+
+	return func() {
+		ts.Close()
+		flagServer, flagToken, flagOutput = oldServer, oldToken, oldOutput
+	}
+}
+
+func TestResolveNextPendingTask_PicksEarliestPending(t *testing.T) {
+	restore := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/traces/trace-xyz" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(traceDetailFixture([]map[string]any{
+			{"id": "task-done", "type": "FaultInjection", "state": "Completed", "execute_time": 100},
+			{"id": "task-late", "type": "BuildDatapack", "state": "Pending", "execute_time": 300},
+			{"id": "task-early", "type": "BuildDatapack", "state": "Pending", "execute_time": 200},
+		}))
+	})
+	defer restore()
+
+	task, err := resolveNextPendingTask("trace-xyz")
+	if err != nil {
+		t.Fatalf("resolveNextPendingTask: %v", err)
+	}
+	if task.ID != "task-early" {
+		t.Fatalf("expected earliest pending task-early, got %q", task.ID)
+	}
+}
+
+func TestResolveNextPendingTask_NoPendingReturnsNotFoundExit(t *testing.T) {
+	restore := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(traceDetailFixture([]map[string]any{
+			{"id": "task-a", "state": "Completed"},
+			{"id": "task-b", "state": "Running"},
+		}))
+	})
+	defer restore()
+
+	_, err := resolveNextPendingTask("trace-xyz")
+	if err == nil {
+		t.Fatal("expected error when no pending task")
+	}
+	var ee *exitError
+	if !errors.As(err, &ee) || ee.Code != ExitCodeNotFound {
+		t.Fatalf("expected ExitCodeNotFound, got err=%v", err)
+	}
+}
+
+func TestTraceNextTaskCmd_StdoutScriptable(t *testing.T) {
+	restore := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(traceDetailFixture([]map[string]any{
+			{"id": "task-run", "type": "BuildDatapack", "state": "Running"},
+			{"id": "task-next", "type": "RunAlgorithm", "state": "Pending", "execute_time": 500},
+		}))
+	})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	oldOut, oldErr := traceNextTaskStdout, traceNextTaskStderr
+	traceNextTaskStdout = &stdout
+	traceNextTaskStderr = &stderr
+	defer func() { traceNextTaskStdout = oldOut; traceNextTaskStderr = oldErr }()
+
+	if err := traceNextTaskCmd.RunE(traceNextTaskCmd, []string{"trace-xyz"}); err != nil {
+		t.Fatalf("traceNextTaskCmd: %v", err)
+	}
+
+	// stdout MUST contain just the bare task id followed by a newline —
+	// anything else breaks `ID=$(aegisctl trace next-task ...)` scripting.
+	if got := stdout.String(); got != "task-next\n" {
+		t.Fatalf("stdout = %q, want %q", got, "task-next\n")
+	}
+	if !strings.Contains(stderr.String(), "task-next") {
+		t.Fatalf("stderr should carry info message, got %q", stderr.String())
+	}
+}
+
+func TestTraceNextTaskCmd_NoPendingExitCode(t *testing.T) {
+	restore := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(traceDetailFixture([]map[string]any{
+			{"id": "task-a", "state": "Completed"},
+		}))
+	})
+	defer restore()
+
+	err := traceNextTaskCmd.RunE(traceNextTaskCmd, []string{"trace-xyz"})
+	if err == nil {
+		t.Fatal("expected error when no pending task")
+	}
+	var ee *exitError
+	if !errors.As(err, &ee) || ee.Code != ExitCodeNotFound {
+		t.Fatalf("expected ExitCodeNotFound, got err=%v", err)
+	}
+}
+
+func TestTraceExpediteCmd_ResolvesThenPostsExpedite(t *testing.T) {
+	var gotMethod, gotPath string
+	restore := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v2/traces/trace-xyz":
+			_ = json.NewEncoder(w).Encode(traceDetailFixture([]map[string]any{
+				{"id": "task-pend", "type": "RunAlgorithm", "state": "Pending", "execute_time": 123},
+			}))
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/api/v2/tasks/"):
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"code":    200,
+				"message": "success",
+				"data":    map[string]any{"task_id": "task-pend"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer restore()
+
+	if err := traceExpediteCmd.RunE(traceExpediteCmd, []string{"trace-xyz"}); err != nil {
+		t.Fatalf("traceExpediteCmd: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("expected POST to task expedite, got method=%q", gotMethod)
+	}
+	if gotPath != "/api/v2/tasks/task-pend/expedite" {
+		t.Fatalf("unexpected expedite URL: %s", gotPath)
+	}
+}
+
+func TestTraceExpediteCmd_NoPendingDoesNotPost(t *testing.T) {
+	posted := false
+	restore := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			posted = true
+		}
+		if r.URL.Path == "/api/v2/traces/trace-xyz" {
+			_ = json.NewEncoder(w).Encode(traceDetailFixture([]map[string]any{
+				{"id": "task-a", "state": "Completed"},
+			}))
+			return
+		}
+		http.NotFound(w, r)
+	})
+	defer restore()
+
+	err := traceExpediteCmd.RunE(traceExpediteCmd, []string{"trace-xyz"})
+	if err == nil {
+		t.Fatal("expected error when no pending task")
+	}
+	if posted {
+		t.Fatal("expedite MUST NOT POST when there is no pending task")
+	}
+	var ee *exitError
+	if !errors.As(err, &ee) || ee.Code != ExitCodeNotFound {
+		t.Fatalf("expected ExitCodeNotFound, got err=%v", err)
+	}
+}


### PR DESCRIPTION
Closes #109

## Summary
- `aegisctl trace next-task <trace-id>` — prints the trace's next pending task id (earliest execute_time, tie-broken by created_at). Exit 7 if no pending.
- `aegisctl trace expedite <trace-id>` — composes next-task + existing `POST /tasks/{id}/expedite`. Refuses cleanly if no pending.
- No backend changes needed: `TraceDetailResp` already embeds `[]TaskResp` with id+state+execute_time.

## Test plan
- [x] `go build -tags duckdb_arrow -o /dev/null ./main.go`
- [x] `go build -o /tmp/aegisctl ./cmd/aegisctl`
- [x] `go test ./cmd/aegisctl/cmd/... ./module/trace/... -count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)