### PR TITLE
fix: rbac reconcile resource union + aegisctl page size cap (live E2E fixes)

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/pedestal_chart.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/pedestal_chart.go
@@ -350,7 +350,7 @@ func deriveNamespaceFromSystem(systemCode string) (string, error) {
 		NsPattern string `json:"ns_pattern"`
 	}
 	var resp client.APIResponse[client.PaginatedData[systemItem]]
-	if err := c.Get("/api/v2/systems?page=1&size=200", &resp); err != nil {
+	if err := c.Get("/api/v2/systems?page=1&size=100", &resp); err != nil {
 		return "", fmt.Errorf("list systems: %w", err)
 	}
 	for _, s := range resp.Data.Items {

--- a/AegisLab/src/cmd/aegisctl/cmd/regression.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/regression.go
@@ -594,7 +594,7 @@ func (l *liveSystemsFetcher) FetchSystem(_ context.Context, name string) (string
 		Count     int    `json:"count"`
 	}
 	var resp client.APIResponse[client.PaginatedData[systemItem]]
-	if err := l.c.Get("/api/v2/systems?page=1&size=500", &resp); err != nil {
+	if err := l.c.Get("/api/v2/systems?page=1&size=100", &resp); err != nil {
 		return "", 0, err
 	}
 	for _, s := range resp.Data.Items {

--- a/AegisLab/src/cmd/aegisctl/cmd/system.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/system.go
@@ -230,7 +230,7 @@ var systemListCmd = &cobra.Command{
 		c := newClient()
 
 		var resp client.APIResponse[client.PaginatedData[chaosSystemResp]]
-		if err := c.Get("/api/v2/systems?page=1&size=200", &resp); err != nil {
+		if err := c.Get("/api/v2/systems?page=1&size=100", &resp); err != nil {
 			return err
 		}
 
@@ -336,7 +336,7 @@ func setSystemStatus(c *client.Client, name string, status int) (*chaosSystemRes
 // in error messages. Never fatal: callers fall back to a generic message.
 func listSystemNames(c *client.Client) ([]string, error) {
 	var resp client.APIResponse[client.PaginatedData[chaosSystemResp]]
-	if err := c.Get("/api/v2/systems?page=1&size=500", &resp); err != nil {
+	if err := c.Get("/api/v2/systems?page=1&size=100", &resp); err != nil {
 		return nil, err
 	}
 	names := make([]string, 0, len(resp.Data.Items))
@@ -592,7 +592,7 @@ func validateSystemSeed(seed *systemSeed) error {
 // registered (distinguished from lookup errors).
 func findSystemByName(c *client.Client, name string) (*chaosSystemResp, error) {
 	var resp client.APIResponse[client.PaginatedData[chaosSystemResp]]
-	if err := c.Get("/api/v2/systems?page=1&size=500", &resp); err != nil {
+	if err := c.Get("/api/v2/systems?page=1&size=100", &resp); err != nil {
 		var apiErr *client.APIError
 		if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
 			return nil, nil

--- a/AegisLab/src/service/initialization/permissions.go
+++ b/AegisLab/src/service/initialization/permissions.go
@@ -49,6 +49,13 @@ func ReconcileSystemPermissions(db *gorm.DB) error {
 // systemResources is the canonical list of RBAC resources. It mirrors the
 // list used by initializeProducer (first-boot seed) so both paths produce
 // identical rows.
+//
+// The hardcoded list covers the core platform resources. Module-contributed
+// resources (registered via fx-group RoleGrantsRegistrar and merged into
+// consts.SystemRolePermissions by rbac.AggregatePermissions) are unioned in
+// by extendWithReferencedResources. This prevents the "resource X referenced
+// by permission rule not found" boot-time crash when a new module adds a
+// permission on a resource that the canonical list doesn't know about yet.
 func systemResources() []model.Resource {
 	resources := []model.Resource{
 		{Name: consts.ResourceSystem, Type: consts.ResourceTypeSystem, Category: consts.ResourceCategorySystem},
@@ -69,10 +76,42 @@ func systemResources() []model.Resource {
 		{Name: consts.ResourceInjection, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryChaos},
 		{Name: consts.ResourceExecution, Type: consts.ResourceTypeTable, Category: consts.ResourceCategoryChaos},
 	}
+	resources = extendWithReferencedResources(resources)
 	for i := range resources {
 		resources[i].DisplayName = consts.GetResourceDisplayName(resources[i].Name)
 	}
 	return resources
+}
+
+// extendWithReferencedResources ensures every resource referenced by a
+// permission rule in consts.SystemRolePermissions has a corresponding
+// Resource row. Module-contributed rules (via fx-group PermissionRegistrar /
+// RoleGrantsRegistrar) may reference resources that the hardcoded base list
+// doesn't know about — widget is a concrete example (#104 follow-up).
+// Unknown resources get safe defaults: Type=Table, Category=Asset.
+func extendWithReferencedResources(base []model.Resource) []model.Resource {
+	known := make(map[consts.ResourceName]struct{}, len(base))
+	for _, r := range base {
+		known[r.Name] = struct{}{}
+	}
+	seen := make(map[consts.ResourceName]struct{})
+	for _, rules := range consts.SystemRolePermissions {
+		for _, rule := range rules {
+			if _, ok := known[rule.Resource]; ok {
+				continue
+			}
+			if _, ok := seen[rule.Resource]; ok {
+				continue
+			}
+			seen[rule.Resource] = struct{}{}
+			base = append(base, model.Resource{
+				Name:     rule.Resource,
+				Type:     consts.ResourceTypeTable,
+				Category: consts.ResourceCategoryAsset,
+			})
+		}
+	}
+	return base
 }
 
 // systemRoles is the set of system roles derived from


### PR DESCRIPTION
Two fixes caught by a live redeploy of #112/#117/#118 against aegis-local on 2026-04-22. Followed by an ob-guided E2E that reached `datapack.no_anomaly` (trace `725159ae-…`, 18 events, validation passed).

## Commits

### 1. `fix(rbac)`: union module-contributed resources in reconcile
PR #112 (#104) introduced `ReconcileSystemPermissions` that now runs on every startup. `systemResources()` was a hardcoded 17-entry list and didn't include `widget`, which the widget module contributes via the fx-group `RoleGrantsRegistrar` and `rbac.AggregatePermissions` merges into `consts.SystemRolePermissions`.

Symptom on live redeploy:
```
failed to reconcile system permissions: resource widget referenced by permission rule not found
```

Fix: `extendWithReferencedResources` unions every `rule.Resource` from `consts.SystemRolePermissions` into the base list with safe defaults (Type=Table, Category=Asset). Keeps first-boot and every-boot paths emitting identical rows.

### 2. `fix(aegisctl)`: cap /systems page size at 100
Backend rejects size > `PageSizeXLarge=100` (`dto/common.go:34`). Four call sites hardcoded 200/500 — `system list`, `pedestal_chart` ns resolution, and the `regression run` ns_pattern fetcher from PR #111. All silently fell through to the verbatim fallback, disabling #111's auto-resolve in practice.

## Test plan
- [x] `go build -tags duckdb_arrow ./main.go` + `go build ./cmd/aegisctl`
- [x] `go test ./service/initialization/... ./module/rbac/... ./module/widget/... ./cmd/aegisctl/cmd/... -count=1`
- [x] Live redeploy to aegis-local → producer starts (was CrashLoopBackOff pre-fix)
- [x] `aegisctl regression run --file ob-bust.yaml --skip-preflight` → trace `725159ae-…` Completed, `datapack.no_anomaly`, 18 events

🤖 Generated with [Claude Code](https://claude.com/claude-code)