### PR TITLE
feat(aegisctl): warn on stale PodChaos before inject --apply (#103)

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/inject_guided_stale.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_guided_stale.go
@@ -90,7 +90,7 @@ func warnStalePodChaos(ctx context.Context, namespace string, lister StalePodCha
 	if extra > 0 {
 		listStr = fmt.Sprintf("%s, … and %d more", listStr, extra)
 	}
-	fmt.Fprintf(stderr, "WARN: %d PodChaos CR(s) in ns=%s from prior trace(s): %s\n", total, namespace, listStr)
+	fmt.Fprintf(stderr, "WARN: %d PodChaos CR(s) in ns=%s from unrelated trace(s): %s\n", total, namespace, listStr)
 	fmt.Fprintf(stderr, "      These will not block the new submit but may confuse kubectl get podchaos.\n")
 	fmt.Fprintf(stderr, "      Run `aegisctl trace cancel <id>` to clean up.\n")
 	return nil


### PR DESCRIPTION
Closes #103.

## Summary
Aligns the stale-PodChaos warning wording with the phrasing specified in issue #103:

```
WARN: N PodChaos CR(s) in ns=<ns> from unrelated trace(s): <ids>
      These will not block the new submit but may confuse kubectl get podchaos.
      Run `aegisctl trace cancel <id>` to clean up.
```

The underlying stale-CRD check (PodChaos listing via dynamic client, stderr-only output, non-blocking on cluster unreachable, `--skip-stale-check` escape hatch, gated to `--apply` path only — not dry-run / print) already landed in PR #113; issue #103 was left open because the WARN prefix said `from prior trace(s)` instead of `from unrelated trace(s)`. This PR is the one-line wording fix to close #103.

## Behavior recap (unchanged by this PR, for reviewer context)
- `--apply` only: `submitGuidedApply` calls `warnStalePodChaos` before submission; dry-run / print paths don't invoke it.
- Reuses the existing in-cluster-or-`~/.kube/config` resolution pattern (same as `newLivePodLister`); does not fork a new k8s init path.
- Non-blocking: cluster unreachable or list error -> single `info: skipped stale-CRD check ...` line on stderr and submit proceeds.
- Dedupes + filters empty `trace_id` labels; truncates at 10 with `... and N more`.
- All output goes to stderr so stdout remains machine-readable.

## Manual-test note
No live kind cluster was exercised from this worktree for this wording-only change. Verified locally:
- `cd AegisLab/src && go build ./cmd/aegisctl` — passes.
- `go test ./cmd/aegisctl/cmd/ -run 'StalePodChaos|InjectSubmit|SubmitGuidedApply' -v` — all 9 tests green (6 `warnStalePodChaos` cases + 3 guided-apply cases).

End-to-end against a real ns with orphan PodChaos CRs was **not** re-run as part of this PR since the live-cluster path landed and was validated in #113; this change only swaps one word in the format string.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>