### PR TITLE
seed: consume LGU fork charts directly from gh-pages (hs/sn/media/teastore)

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -160,13 +160,32 @@ containers:
     status: 1
     versions:
       - name: 0.1.0
-        github_link: delimitrou/DeathStarBench
+        github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
           version: 0.1.0
-          chart_name: hotelreservation-aegis
-          repo_name: opspai
-          repo_url: oci://registry-1.docker.io/opspai
+          chart_name: hotel-reservation
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: docker.io/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-61074ea
+              overridable: true
+            - key: global.services.environments.OTEL_EXPORTER_OTLP_ENDPOINT
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              overridable: true
           status: 1
   - type: 2
     name: sn
@@ -174,13 +193,32 @@ containers:
     status: 1
     versions:
       - name: 0.1.0
-        github_link: delimitrou/DeathStarBench
+        github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
           version: 0.1.0
-          chart_name: socialnetwork-aegis
-          repo_name: opspai
-          repo_url: oci://registry-1.docker.io/opspai
+          chart_name: social-network
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: docker.io/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-61074ea
+              overridable: true
+            - key: global.otel.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              overridable: true
           status: 1
   - type: 2
     name: media
@@ -188,13 +226,32 @@ containers:
     status: 1
     versions:
       - name: 0.1.0
-        github_link: delimitrou/DeathStarBench
+        github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
           version: 0.1.0
-          chart_name: mediamicroservices-aegis
-          repo_name: opspai
-          repo_url: oci://registry-1.docker.io/opspai
+          chart_name: media-microservices
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: docker.io/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-61074ea
+              overridable: true
+            - key: global.otel.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              overridable: true
           status: 1
   - type: 2
     name: teastore
@@ -202,13 +259,32 @@ containers:
     status: 1
     versions:
       - name: 0.1.0
-        github_link: DescartesResearch/TeaStore
+        github_link: LGU-SE-Internal/TeaStore
         status: 1
         helm_config:
           version: 0.1.0
-          chart_name: teastore-aegis
-          repo_name: opspai
-          repo_url: oci://registry-1.docker.io/opspai
+          chart_name: teastore
+          repo_name: lgu-tea
+          repo_url: https://lgu-se-internal.github.io/TeaStore
+          values:
+            - key: global.image.registry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: docker.io/opspai
+              overridable: true
+            - key: global.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-2b3fd43
+              overridable: true
+            - key: opentelemetry.otlpEndpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-collector.otel.svc.cluster.local:4317
+              overridable: true
           status: 1
 datasets:
   - name: rca_pair_diagnosis_dataset

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -134,13 +134,32 @@ containers:
     status: 1
     versions:
       - name: 0.1.0
-        github_link: delimitrou/DeathStarBench
+        github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
           version: 0.1.0
-          chart_name: hotelreservation-aegis
-          repo_name: opspai
-          repo_url: oci://registry-1.docker.io/opspai
+          chart_name: hotel-reservation
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: docker.io/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-61074ea
+              overridable: true
+            - key: global.services.environments.OTEL_EXPORTER_OTLP_ENDPOINT
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              overridable: true
           status: 1
   - type: 2
     name: sn
@@ -148,13 +167,32 @@ containers:
     status: 1
     versions:
       - name: 0.1.0
-        github_link: delimitrou/DeathStarBench
+        github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
           version: 0.1.0
-          chart_name: socialnetwork-aegis
-          repo_name: opspai
-          repo_url: oci://registry-1.docker.io/opspai
+          chart_name: social-network
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: docker.io/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-61074ea
+              overridable: true
+            - key: global.otel.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              overridable: true
           status: 1
   - type: 2
     name: mm
@@ -162,13 +200,32 @@ containers:
     status: 1
     versions:
       - name: 0.1.0
-        github_link: delimitrou/DeathStarBench
+        github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
           version: 0.1.0
-          chart_name: mediamicroservices-aegis
-          repo_name: opspai
-          repo_url: oci://registry-1.docker.io/opspai
+          chart_name: media-microservices
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: docker.io/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-61074ea
+              overridable: true
+            - key: global.otel.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              overridable: true
           status: 1
   - type: 2
     name: tea
@@ -176,13 +233,32 @@ containers:
     status: 1
     versions:
       - name: 0.1.0
-        github_link: DescartesResearch/TeaStore
+        github_link: LGU-SE-Internal/TeaStore
         status: 1
         helm_config:
           version: 0.1.0
-          chart_name: teastore-aegis
-          repo_name: opspai
-          repo_url: oci://registry-1.docker.io/opspai
+          chart_name: teastore
+          repo_name: lgu-tea
+          repo_url: https://lgu-se-internal.github.io/TeaStore
+          values:
+            - key: global.image.registry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: docker.io/opspai
+              overridable: true
+            - key: global.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-2b3fd43
+              overridable: true
+            - key: opentelemetry.otlpEndpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-collector.otel.svc.cluster.local:4317
+              overridable: true
           status: 1
 datasets:
   - name: rca_pair_diagnosis_dataset

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -134,13 +134,32 @@ containers:
     status: 1
     versions:
       - name: 0.1.0
-        github_link: delimitrou/DeathStarBench
+        github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
           version: 0.1.0
-          chart_name: hotelreservation-aegis
-          repo_name: opspai
-          repo_url: oci://pair-cn-shanghai.cr.volces.com/opspai
+          chart_name: hotel-reservation
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: docker.io/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-61074ea
+              overridable: true
+            - key: global.services.environments.OTEL_EXPORTER_OTLP_ENDPOINT
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              overridable: true
           status: 1
   - type: 2
     name: sn
@@ -148,13 +167,32 @@ containers:
     status: 1
     versions:
       - name: 0.1.0
-        github_link: delimitrou/DeathStarBench
+        github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
           version: 0.1.0
-          chart_name: socialnetwork-aegis
-          repo_name: opspai
-          repo_url: oci://pair-cn-shanghai.cr.volces.com/opspai
+          chart_name: social-network
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: docker.io/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-61074ea
+              overridable: true
+            - key: global.otel.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              overridable: true
           status: 1
   - type: 2
     name: media
@@ -162,13 +200,32 @@ containers:
     status: 1
     versions:
       - name: 0.1.0
-        github_link: delimitrou/DeathStarBench
+        github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
           version: 0.1.0
-          chart_name: mediamicroservices-aegis
-          repo_name: opspai
-          repo_url: oci://pair-cn-shanghai.cr.volces.com/opspai
+          chart_name: media-microservices
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: docker.io/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-61074ea
+              overridable: true
+            - key: global.otel.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              overridable: true
           status: 1
   - type: 2
     name: teastore
@@ -176,13 +233,32 @@ containers:
     status: 1
     versions:
       - name: 0.1.0
-        github_link: DescartesResearch/TeaStore
+        github_link: LGU-SE-Internal/TeaStore
         status: 1
         helm_config:
           version: 0.1.0
-          chart_name: teastore-aegis
-          repo_name: opspai
-          repo_url: oci://pair-cn-shanghai.cr.volces.com/opspai
+          chart_name: teastore
+          repo_name: lgu-tea
+          repo_url: https://lgu-se-internal.github.io/TeaStore
+          values:
+            - key: global.image.registry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: docker.io/opspai
+              overridable: true
+            - key: global.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-2b3fd43
+              overridable: true
+            - key: opentelemetry.otlpEndpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-collector.otel.svc.cluster.local:4317
+              overridable: true
           status: 1
 datasets:
   - name: rca_pair_diagnosis_dataset


### PR DESCRIPTION
## Summary

Switch the 4 LGU-forked benchmark systems (`hs`, `sn`, `media`, `teastore`) from our OCI-hosted `-aegis` wrapper charts to direct consumption of upstream helm charts published on the fork's gh-pages (see [DSB PR #44](https://github.com/LGU-SE-Internal/DeathStarBench/pull/44) and [TeaStore PR #6](https://github.com/LGU-SE-Internal/TeaStore/pull/6)).

Per system (3 seed files each — prod / staging / byte-cluster):
- `helm_config.repo_url` → `https://lgu-se-internal.github.io/{DeathStarBench,TeaStore}`
- `helm_config.repo_name` → `lgu-dsb` / `lgu-tea`
- `helm_config.chart_name` → `hotel-reservation` / `social-network` / `media-microservices` / `teastore` (upstream's hyphenated names; dropped `-aegis` suffix)
- `helm_config.values:` block adds:
  - image registry override → `docker.io/opspai`
  - image tag → `20260423-61074ea` (hs/sn/media) or `20260423-2b3fd43` (teastore)
  - OTLP endpoint → `http://otel-collector.otel.svc.cluster.local:4318` (hs/sn/media) or `:4317` grpc (teastore)

Actual value keys match each chart's real schema (verified via `helm show values`): hs/sn/media use `global.dockerRegistry` + `global.defaultImageVersion`, hs's OTEL key is the nested env-var path `global.services.environments.OTEL_EXPORTER_OTLP_ENDPOINT`, sn/media use `global.otel.endpoint`, teastore uses `global.image.registry/tag` + `opentelemetry.otlpEndpoint`.

Sockshop is unchanged (different rework track — still on `sockshop-aegis` wrapper).

## Why

Removes the need for us to fork + re-publish charts for every small aegis override. Each value we were previously hardcoding in a wrapper is now a single seed line. Pairs with [benchmark-charts PR](https://github.com/OperationsPAI/benchmark-charts/pulls) that deletes the 4 now-unused wrappers.

## Test plan

- [x] YAML parses cleanly on all 3 seed files.
- [x] `https://lgu-se-internal.github.io/DeathStarBench/index.yaml` and `.../TeaStore/index.yaml` serve the referenced versions.
- [x] `docker.io/opspai/*:20260423-<sha>` tags exist (20 images, verified via `docker manifest inspect`).
- [ ] Run 4 guided regressions on kind (`hotelreservation-guided.yaml`, `socialnetwork-guided.yaml`, `mediamicroservices-guided.yaml`, `teastore-guided.yaml`) — goes in the follow-up PR that re-runs Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)