### PR TITLE
fix(chaossystem): chart-by-name returns seed helm values + update regression labels for LGU forks

### DIFF
--- a/AegisLab/regression/hotelreservation-guided.yaml
+++ b/AegisLab/regression/hotelreservation-guided.yaml
@@ -24,7 +24,7 @@ submit:
     - - system: hs
         system_type: hs
         namespace: hs0
-        app: frontend-hs0-hotelres
+        app: user
         chaos_type: PodKill
         duration: 1
 validation:

--- a/AegisLab/regression/teastore-guided.yaml
+++ b/AegisLab/regression/teastore-guided.yaml
@@ -24,7 +24,7 @@ submit:
     - - system: tea
         system_type: tea
         namespace: tea0
-        app: auth
+        app: teastore
         chaos_type: PodKill
         duration: 5
 validation:

--- a/AegisLab/src/dto/container.go
+++ b/AegisLab/src/dto/container.go
@@ -31,7 +31,7 @@ type HelmConfigItem struct {
 }
 
 func NewHelmConfigItem(cfg *model.HelmConfig) *HelmConfigItem {
-	return &HelmConfigItem{
+	item := &HelmConfigItem{
 		Version:   cfg.Version,
 		RepoURL:   cfg.RepoURL,
 		RepoName:  cfg.RepoName,
@@ -39,6 +39,17 @@ func NewHelmConfigItem(cfg *model.HelmConfig) *HelmConfigItem {
 		LocalPath: cfg.LocalPath,
 		ValueFile: cfg.ValueFile,
 	}
+	if len(cfg.DynamicValues) > 0 {
+		item.DynamicValues = make([]ParameterItem, 0, len(cfg.DynamicValues))
+		for _, p := range cfg.DynamicValues {
+			val := ""
+			if p.DefaultValue != nil {
+				val = *p.DefaultValue
+			}
+			item.DynamicValues = append(item.DynamicValues, ParameterItem{Key: p.Key, Value: val})
+		}
+	}
+	return item
 }
 
 // GetValuesMap constructs a nested map of Helm values by merging file and dynamic values.

--- a/AegisLab/src/module/chaossystem/chart_values_test.go
+++ b/AegisLab/src/module/chaossystem/chart_values_test.go
@@ -1,0 +1,123 @@
+package chaossystem
+
+import (
+	"context"
+	"testing"
+
+	"aegis/consts"
+	"aegis/model"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestGetSystemChart_ReturnsSeededDynamicValues pins the backend-side bug fix
+// for PR #126 follow-up: the chart-by-name response must include the seed
+// helm_config.values entries so aegisctl pedestal chart install can apply
+// per-aegis overrides (registry, image tag, OTLP endpoint). Before the fix,
+// DynamicValues was never preloaded from the many2many join and the DTO
+// factory did not copy it, so the response silently omitted values.
+func TestGetSystemChart_ReturnsSeededDynamicValues(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{TranslateError: true})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&model.Container{},
+		&model.ContainerVersion{},
+		&model.HelmConfig{},
+		&model.ParameterConfig{},
+		&model.HelmConfigValue{},
+	); err != nil {
+		t.Skipf("sqlite AutoMigrate unsupported for model set: %v", err)
+	}
+
+	// Seed a pedestal container + active version + helm config whose
+	// chart_name matches what seed YAML produces for hs.
+	container := &model.Container{
+		Name:     "hs",
+		Type:     consts.ContainerTypePedestal,
+		Status:   consts.CommonEnabled,
+		IsPublic: true,
+	}
+	if err := db.Omit("active_name", "Versions").Create(container).Error; err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	version := &model.ContainerVersion{
+		Name:        "0.1.0",
+		ContainerID: container.ID,
+		Status:      consts.CommonEnabled,
+		UserID:      1,
+		Registry:    "docker.io",
+		Repository:  "hs",
+		Tag:         "0.1.0",
+	}
+	if err := db.Omit("active_version_key", "HelmConfig", "EnvVars").Create(version).Error; err != nil {
+		t.Fatalf("create version: %v", err)
+	}
+	helm := &model.HelmConfig{
+		ChartName:          "hotel-reservation",
+		Version:            "0.1.0",
+		ContainerVersionID: version.ID,
+		RepoURL:            "https://lgu-se-internal.github.io/DeathStarBench",
+		RepoName:           "lgu-dsb",
+	}
+	if err := db.Create(helm).Error; err != nil {
+		t.Fatalf("create helm config: %v", err)
+	}
+
+	// Two distinct helm values, mirroring the shape of the seed data.
+	registryDefault := "docker.io/opspai"
+	imageTagDefault := "20260423-61074ea"
+	params := []*model.ParameterConfig{
+		{
+			Key:          "global.dockerRegistry",
+			Type:         consts.ParameterTypeFixed,
+			Category:     consts.ParameterCategoryHelmValues,
+			ValueType:    consts.ValueDataTypeString,
+			DefaultValue: &registryDefault,
+			Overridable:  true,
+		},
+		{
+			Key:          "global.defaultImageVersion",
+			Type:         consts.ParameterTypeFixed,
+			Category:     consts.ParameterCategoryHelmValues,
+			ValueType:    consts.ValueDataTypeString,
+			DefaultValue: &imageTagDefault,
+			Overridable:  true,
+		},
+	}
+	for _, p := range params {
+		if err := db.Create(p).Error; err != nil {
+			t.Fatalf("create parameter %s: %v", p.Key, err)
+		}
+		if err := db.Create(&model.HelmConfigValue{HelmConfigID: helm.ID, ParameterConfigID: p.ID}).Error; err != nil {
+			t.Fatalf("link %s: %v", p.Key, err)
+		}
+	}
+
+	svc := &Service{repo: NewRepository(db)}
+	resp, err := svc.GetSystemChart(context.Background(), "hs")
+	if err != nil {
+		t.Fatalf("GetSystemChart: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("GetSystemChart: nil response")
+	}
+
+	// Shape assertions: values map should be nested per ParseHelmKey
+	// semantics ("global.dockerRegistry" -> {global: {dockerRegistry: ...}}).
+	if resp.Values == nil {
+		t.Fatalf("expected Values to be populated; got nil (DynamicValues likely not preloaded or not copied in DTO)")
+	}
+	globalMap, ok := resp.Values["global"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected Values.global to be a map, got %T: %v", resp.Values["global"], resp.Values)
+	}
+	if got := globalMap["dockerRegistry"]; got != registryDefault {
+		t.Errorf("Values.global.dockerRegistry = %v, want %q", got, registryDefault)
+	}
+	if got := globalMap["defaultImageVersion"]; got != imageTagDefault {
+		t.Errorf("Values.global.defaultImageVersion = %v, want %q", got, imageTagDefault)
+	}
+}

--- a/AegisLab/src/module/chaossystem/repository.go
+++ b/AegisLab/src/module/chaossystem/repository.go
@@ -142,7 +142,7 @@ func (r *Repository) GetPedestalHelmConfigByName(name string) (*model.HelmConfig
 	}
 
 	var helm model.HelmConfig
-	if err := r.db.Where("container_version_id = ?", version.ID).First(&helm).Error; err != nil {
+	if err := r.db.Preload("DynamicValues").Where("container_version_id = ?", version.ID).First(&helm).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil, nil
 		}


### PR DESCRIPTION
## Summary

Follow-up to #126. Two small backend fixes plus a regression-yaml touch-up that together unblock end-to-end install of LGU-fork charts (hs / sn / media / tea) straight from gh-pages.

### Backend bug — \`GET /api/v2/systems/by-name/<code>/chart\` dropped seed \`values:\`

After #126 moved 4 systems to upstream charts and stashed aegis-specific overrides in \`helm_config.values\`, the endpoint that aegisctl consumes silently returned no \`values\` field. Two missed wiring spots:

1. \`module/chaossystem/repository.go\`: the HelmConfig load forgot \`Preload(\"DynamicValues\")\`, so the many2many relation was empty in-memory even though rows exist in \`helm_config_values\`.
2. \`dto/container.go\`: \`NewHelmConfigItem\` set scalar fields but didn't copy \`cfg.DynamicValues\` → \`hci.DynamicValues\`, so \`GetValuesMap\` looped over an empty slice.

Response body before:
\`\`\`json
{\"system_name\":\"hs\",\"chart_name\":\"hotel-reservation\",\"version\":\"0.1.0\",\"repo_url\":\"https://lgu-se-internal.github.io/DeathStarBench\",\"repo_name\":\"lgu-dsb\",\"pedestal_tag\":\"0.1.0\"}
\`\`\`

After:
\`\`\`json
{...,\"values\":{\"global\":{\"dockerRegistry\":\"docker.io/opspai\",\"defaultImageVersion\":\"20260423-61074ea\",\"services\":{\"environments\":{\"OTEL_EXPORTER_OTLP_ENDPOINT\":\"http://otel-collector.otel.svc.cluster.local:4318\"}}}}}
\`\`\`

aegisctl \`pedestal chart install\` already honored the \`values\` field (writes temp values.yaml, passes \`-f\` to helm); the data just wasn't reaching it.

### Regression YAML labels — align to fork-native pod labels

After wrappers were removed, app labels on pedestal pods are now upstream-native (e.g. \`frontend\` not \`frontend-hs0-hotelres\`). Updated 2 of 4 regression yaml files:

- \`hotelreservation-guided.yaml\`: \`frontend-hs0-hotelres\` → \`user\` (mid-tier business service, avoids entry-tier).
- \`teastore-guided.yaml\`: \`auth\` → \`teastore\` (umbrella — see caveat).
- \`socialnetwork-guided.yaml\` / \`mediamicroservices-guided.yaml\`: kept \`user-service\` as-is (fork charts still emit this label).

## Test plan

- [x] New unit test \`TestGetSystemChart_ReturnsSeededDynamicValues\` in \`module/chaossystem/chart_values_test.go\` round-trips a seeded parameter through the full service → repo → DTO → GetValuesMap path; passes.
- [x] \`go build -tags duckdb_arrow\` clean; \`go build ./cmd/aegisctl\` clean.
- [x] Reverted-preload dry-run confirmed the test fails with \"expected Values to be populated; got nil\" — proves the test actually guards against the regression.
- [ ] End-to-end: run all 4 guided regressions against kind cluster after backend image rebuild.

## Known follow-up (not blocking this PR)

The teastore chart emits \`app: teastore\` uniformly across pods (per-service identity is only in \`app.kubernetes.io/name\`). PodKill on \`app: teastore\` will hit an arbitrary pod rather than the intended mid-tier \`auth\`. Either upstream the chart to emit \`app: <service>\` or extend the guided-spec schema to carry an optional \`label_key\` per target. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)