### PR TITLE
feat(restart-pedestal): configurable timeout + skip-install hint + auto-install wait-for-ready + DSB 0.1.1 pin

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -133,11 +133,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.0
+      - name: 0.1.1
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
-          version: 0.1.0
+          version: 0.1.1
           chart_name: hotel-reservation
           repo_name: lgu-dsb
           repo_url: https://lgu-se-internal.github.io/DeathStarBench
@@ -166,11 +166,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.0
+      - name: 0.1.1
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
-          version: 0.1.0
+          version: 0.1.1
           chart_name: social-network
           repo_name: lgu-dsb
           repo_url: https://lgu-se-internal.github.io/DeathStarBench
@@ -199,11 +199,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.0
+      - name: 0.1.1
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
-          version: 0.1.0
+          version: 0.1.1
           chart_name: media-microservices
           repo_name: lgu-dsb
           repo_url: https://lgu-se-internal.github.io/DeathStarBench

--- a/AegisLab/regression/hotelreservation-guided.yaml
+++ b/AegisLab/regression/hotelreservation-guided.yaml
@@ -4,7 +4,7 @@ project_name: pair_diagnosis
 submit:
   pedestal:
     name: hs
-    version: "0.1.0"
+    version: "0.1.1"
   benchmark:
     name: clickhouse
     version: "1.0.0"

--- a/AegisLab/regression/mediamicroservices-guided.yaml
+++ b/AegisLab/regression/mediamicroservices-guided.yaml
@@ -4,7 +4,7 @@ project_name: pair_diagnosis
 submit:
   pedestal:
     name: mm
-    version: "0.1.0"
+    version: "0.1.1"
   benchmark:
     name: clickhouse
     version: "1.0.0"

--- a/AegisLab/regression/socialnetwork-guided.yaml
+++ b/AegisLab/regression/socialnetwork-guided.yaml
@@ -4,7 +4,7 @@ project_name: pair_diagnosis
 submit:
   pedestal:
     name: sn
-    version: "0.1.0"
+    version: "0.1.1"
   benchmark:
     name: clickhouse
     version: "1.0.0"

--- a/AegisLab/src/cmd/aegisctl/cmd/regression.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/regression.go
@@ -55,14 +55,16 @@ type regressionSummary struct {
 }
 
 var (
-	regressionCasesDir       string
-	regressionCaseFile       string
-	regressionSkipPreflight  bool
-	regressionAutoInstall    bool
-	regressionAppLabelKey    string
-	regressionPodListerHook  PodLister // test injection seam; nil => real k8s client
-	regressionInstallerHook  chartInstaller
-	regressionSystemsHook    SystemsFetcher // test injection seam; nil => real HTTP client
+	regressionCasesDir          string
+	regressionCaseFile          string
+	regressionSkipPreflight     bool
+	regressionAutoInstall       bool
+	regressionSkipRestartPedestal bool
+	regressionReadyTimeoutSeconds int
+	regressionAppLabelKey       string
+	regressionPodListerHook     PodLister // test injection seam; nil => real k8s client
+	regressionInstallerHook     chartInstaller
+	regressionSystemsHook       SystemsFetcher // test injection seam; nil => real HTTP client
 )
 
 // SystemsFetcher is the minimal /api/v2/systems surface
@@ -76,6 +78,10 @@ type SystemsFetcher interface {
 // can inject a fake; production uses a client-go backed implementation.
 type PodLister interface {
 	ListPods(ctx context.Context, namespace, labelSelector string) (count int, err error)
+	// CountReadyPods returns (total, ready) where `ready` is the number of
+	// matching pods whose containers all have Ready=true. Used by
+	// --auto-install to wait for chart rollout before submitting.
+	CountReadyPods(ctx context.Context, namespace, labelSelector string) (total int, ready int, err error)
 }
 
 type chartInstaller func(ctx context.Context, system, namespace string) error
@@ -293,6 +299,16 @@ func runRegressionCase(parentCtx context.Context, casePath string, rc regression
 
 	c := newClient()
 	path := fmt.Sprintf("/api/v2/projects/%d/injections/inject", pid)
+	// When --skip-restart-pedestal is set, hint the backend to no-op the
+	// helm install inside RestartPedestal (preflight already installed +
+	// waited for readiness). Backend falls back to a real install if the
+	// release is missing or unhealthy, so this is safe either way.
+	if regressionSkipRestartPedestal {
+		if rc.Submit == nil {
+			rc.Submit = map[string]any{}
+		}
+		rc.Submit["skip_restart_pedestal"] = true
+	}
 	var submitResp client.APIResponse[injectSubmitResponse]
 	if err := c.Post(path, rc.Submit, &submitResp); err != nil {
 		return regressionSummary{}, fmt.Errorf("submit regression case %q: %w", rc.Name, err)
@@ -736,6 +752,38 @@ func preflightRegressionCase(ctx context.Context, rc regressionCase, lister PodL
 				return fmt.Errorf("preflight: auto-install failed for system=%s namespace=%s: %w", sys, m.Namespace, err)
 			}
 		}
+		// Wait for the newly-installed charts to reach Ready before returning.
+		// Without this the caller submits immediately and the backend's
+		// RestartPedestal step re-uninstalls/reinstalls before pods stabilize,
+		// erasing the install work done here. Poll each missed target for
+		// --ready-timeout seconds (default 600) and fail fast with context.
+		timeoutSec := regressionReadyTimeoutSeconds
+		if timeoutSec <= 0 {
+			timeoutSec = 600
+		}
+		deadline := time.Now().Add(time.Duration(timeoutSec) * time.Second)
+		for _, m := range misses {
+			selector := labelKey + "=" + m.App
+			for {
+				total, ready, err := lister.CountReadyPods(ctx, m.Namespace, selector)
+				if err != nil {
+					return fmt.Errorf("preflight: wait-for-ready ns=%s selector=%s: %w", m.Namespace, selector, err)
+				}
+				if total > 0 && ready == total {
+					fmt.Fprintf(os.Stderr, "preflight: ready ns=%s %s (%d/%d)\n", m.Namespace, selector, ready, total)
+					break
+				}
+				if time.Now().After(deadline) {
+					return fmt.Errorf("preflight: timed out after %ds waiting for pods ns=%s selector=%s (ready %d/%d); bump --ready-timeout or inspect with `kubectl -n %s get pods -l %s`",
+						timeoutSec, m.Namespace, selector, ready, total, m.Namespace, selector)
+				}
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(5 * time.Second):
+				}
+			}
+		}
 		return nil
 	}
 
@@ -785,11 +833,35 @@ func (l *livePodLister) ListPods(ctx context.Context, namespace, labelSelector s
 	return len(pods.Items), nil
 }
 
+func (l *livePodLister) CountReadyPods(ctx context.Context, namespace, labelSelector string) (int, int, error) {
+	pods, err := l.cs.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return 0, 0, err
+	}
+	ready := 0
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		allReady := len(p.Status.ContainerStatuses) > 0
+		for _, cs := range p.Status.ContainerStatuses {
+			if !cs.Ready {
+				allReady = false
+				break
+			}
+		}
+		if allReady {
+			ready++
+		}
+	}
+	return len(pods.Items), ready, nil
+}
+
 func init() {
 	regressionRunCmd.Flags().StringVar(&regressionCasesDir, "cases-dir", "regression", "Directory containing repo-tracked regression case YAML files")
 	regressionRunCmd.Flags().StringVar(&regressionCaseFile, "file", "", "Path to a regression case YAML file")
 	regressionRunCmd.Flags().BoolVar(&regressionSkipPreflight, "skip-preflight", false, "Skip the pod/chart-installed preflight check (use when the CLI host cannot reach the target k8s cluster)")
 	regressionRunCmd.Flags().BoolVar(&regressionAutoInstall, "auto-install", false, "If preflight finds missing charts, shell out to `aegisctl pedestal chart install <system> --namespace <ns>` to fix them before submit")
+	regressionRunCmd.Flags().BoolVar(&regressionSkipRestartPedestal, "skip-restart-pedestal", false, "Hint the backend to skip the RestartPedestal helm install when the chart is already deployed (useful after --auto-install + wait-for-ready)")
+	regressionRunCmd.Flags().IntVar(&regressionReadyTimeoutSeconds, "ready-timeout", 600, "Seconds --auto-install waits for all preflight targets to become Ready before submit")
 	regressionRunCmd.Flags().StringVar(&regressionAppLabelKey, "app-label-key", "app", "Label key used to match pods against each spec's `app` value during preflight")
 
 	regressionCmd.AddCommand(regressionRunCmd)

--- a/AegisLab/src/cmd/aegisctl/cmd/regression_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/regression_test.go
@@ -29,6 +29,14 @@ func (f *fakePodLister) ListPods(_ context.Context, namespace, selector string) 
 	return f.byNSApp[key], nil
 }
 
+func (f *fakePodLister) CountReadyPods(_ context.Context, namespace, selector string) (int, int, error) {
+	if f.err != nil {
+		return 0, 0, f.err
+	}
+	n := f.byNSApp[namespace+"|"+selector]
+	return n, n, nil
+}
+
 func makePreflightCase() regressionCase {
 	return regressionCase{
 		Name:        "preflight-sample",
@@ -275,6 +283,9 @@ func TestRegressionPreflight_AutoInstallInvokesInstaller(t *testing.T) {
 	var installed []string
 	installer := func(_ context.Context, system, namespace string) error {
 		installed = append(installed, system+"/"+namespace)
+		// Simulate the chart coming up Ready so wait-for-ready terminates.
+		lister.byNSApp["mm0|app=user-service"] = 1
+		lister.byNSApp["mm0|app=compose-post-service"] = 1
 		return nil
 	}
 	oldAuto := regressionAutoInstall

--- a/AegisLab/src/consts/consts.go
+++ b/AegisLab/src/consts/consts.go
@@ -321,6 +321,7 @@ const (
 	RestartIntarval      = "interval"
 	RestartFaultDuration = "fault_duration"
 	RestartInjectPayload = "inject_payload"
+	RestartSkipInstall   = "skip_install"
 
 	InjectBenchmark     = "benchmark_version"
 	InjectPreDuration   = "pre_duration"

--- a/AegisLab/src/infra/helm/gateway.go
+++ b/AegisLab/src/infra/helm/gateway.go
@@ -187,6 +187,30 @@ func (g *Gateway) isReleaseInstalled(actionConfig *action.Configuration, release
 	return true, nil
 }
 
+// IsReleaseDeployed returns true when <releaseName> exists in <namespace> and
+// is in the `deployed` status. Used by callers (e.g. RestartPedestal with
+// SkipRestartPedestal=true) to short-circuit a reinstall when the chart is
+// already in place. Unreachable/failed releases return false so the caller
+// falls through to a real install.
+func (g *Gateway) IsReleaseDeployed(namespace, releaseName string) (bool, error) {
+	_, actionConfig, err := newRuntime(namespace)
+	if err != nil {
+		return false, err
+	}
+	statusAction := action.NewStatus(actionConfig)
+	rel, err := statusAction.Run(releaseName)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get release status: %w", err)
+	}
+	if rel == nil || rel.Info == nil {
+		return false, nil
+	}
+	return rel.Info.Status.String() == "deployed", nil
+}
+
 func (g *Gateway) uninstallRelease(actionConfig *action.Configuration, releaseName string, timeout time.Duration) error {
 	uninstallAction := action.NewUninstall(actionConfig)
 	uninstallAction.Wait = true

--- a/AegisLab/src/module/injection/api_types.go
+++ b/AegisLab/src/module/injection/api_types.go
@@ -388,6 +388,12 @@ type SubmitInjectionReq struct {
 	Specs       [][]GuidedSpec      `json:"specs" binding:"required"`              // GuidedConfig batches for fault injection
 	Algorithms  []dto.ContainerSpec `json:"algorithms" binding:"omitempty"`        // RCA algorithms to execute (optional)
 	Labels      []dto.LabelItem     `json:"labels" binding:"omitempty"`            // Labels to attach to the injection
+	// SkipRestartPedestal hints the RestartPedestal step to skip the helm
+	// install when the target release is already deployed and healthy. Namespace
+	// locking, index extraction, and the FaultInjection handoff still run as
+	// normal. Use when the caller has already installed the chart out-of-band
+	// (e.g. `aegisctl pedestal chart install` + preflight readiness wait).
+	SkipRestartPedestal bool `json:"skip_restart_pedestal" binding:"omitempty"`
 }
 
 func (req *SubmitInjectionReq) GuidedSpecs() [][]guidedcli.GuidedConfig {

--- a/AegisLab/src/module/injection/service.go
+++ b/AegisLab/src/module/injection/service.go
@@ -316,6 +316,7 @@ func (s *Service) SubmitFaultInjection(ctx context.Context, req *SubmitInjection
 			consts.RestartIntarval:      req.Interval,
 			consts.RestartFaultDuration: item.faultDuration,
 			consts.RestartInjectPayload: injectPayload,
+			consts.RestartSkipInstall:   req.SkipRestartPedestal,
 		}
 
 		task := &dto.UnifiedTask{

--- a/AegisLab/src/service/consumer/restart_pedestal.go
+++ b/AegisLab/src/service/consumer/restart_pedestal.go
@@ -38,11 +38,32 @@ func defaultHelmRepoURL(name string) string {
 	return config.GetString(fmt.Sprintf("helm.repo.%s.url", name))
 }
 
+// helmInstallTimeouts resolves the (overall, k8s-wait) timeouts used when
+// helm-installing a pedestal chart. Defaults are 1800s overall / 600s wait,
+// overridable via dynamic config keys so ops can retune without a rebuild:
+//
+//	helm.restart_pedestal.timeout_seconds       (overall install timeout)
+//	helm.restart_pedestal.wait_timeout_seconds  (k8s readiness wait timeout)
+//
+// Non-positive values fall back to the defaults.
+func helmInstallTimeouts() (time.Duration, time.Duration) {
+	overall := 1800 * time.Second
+	wait := 600 * time.Second
+	if v := config.GetInt("helm.restart_pedestal.timeout_seconds"); v > 0 {
+		overall = time.Duration(v) * time.Second
+	}
+	if v := config.GetInt("helm.restart_pedestal.wait_timeout_seconds"); v > 0 {
+		wait = time.Duration(v) * time.Second
+	}
+	return overall, wait
+}
+
 type restartPayload struct {
 	pedestal      dto.ContainerVersionItem
 	interval      int
 	faultDuration int
 	injectPayload map[string]any
+	skipInstall   bool
 }
 
 // executeRestartPedestal handles the execution of a restart pedestal task
@@ -176,16 +197,37 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 			return handleExecutionError(span, logEntry, "missing extra info in pedestal item", fmt.Errorf("missing extra info in pedestal item"))
 		}
 
-		if err := installPedestal(childCtx, helmGateway, namespace, index, payload.pedestal.Extra); err != nil {
-			toReleased = true
-			publishEvent(redisGateway, childCtx, fmt.Sprintf(consts.StreamTraceLogKey, task.TraceID), dto.TraceStreamEvent{
-				TaskID:    task.TaskID,
-				TaskType:  consts.TaskTypeRestartPedestal,
-				EventName: consts.EventRestartPedestalFailed,
-				Payload:   err.Error(),
-			})
+		// Skip the helm install when the caller has pre-installed the chart
+		// out-of-band (e.g. `aegisctl pedestal chart install` +
+		// wait-for-ready) and the release is already deployed. Namespace
+		// lock, index extraction, and the FaultInjection handoff below still
+		// run unchanged. Falls through to a real install if the release is
+		// missing, in a non-deployed state, or the status check errors out.
+		skippedInstall := false
+		if payload.skipInstall {
+			deployed, checkErr := helmGateway.IsReleaseDeployed(namespace, namespace)
+			if checkErr != nil {
+				logEntry.Warnf("skip_install requested but status check failed (%v); falling back to install", checkErr)
+			} else if deployed {
+				logEntry.Infof("skip_install: release %s/%s already deployed; skipping helm install", namespace, namespace)
+				skippedInstall = true
+			} else {
+				logEntry.Infof("skip_install requested but release %s/%s not deployed; installing", namespace, namespace)
+			}
+		}
 
-			return handleExecutionError(span, logEntry, fmt.Sprintf("failed to install pedestal of system %s", system), err)
+		if !skippedInstall {
+			if err := installPedestal(childCtx, helmGateway, namespace, index, payload.pedestal.Extra); err != nil {
+				toReleased = true
+				publishEvent(redisGateway, childCtx, fmt.Sprintf(consts.StreamTraceLogKey, task.TraceID), dto.TraceStreamEvent{
+					TaskID:    task.TaskID,
+					TaskType:  consts.TaskTypeRestartPedestal,
+					EventName: consts.EventRestartPedestalFailed,
+					Payload:   err.Error(),
+				})
+
+				return handleExecutionError(span, logEntry, fmt.Sprintf("failed to install pedestal of system %s", system), err)
+			}
 		}
 
 		message := fmt.Sprintf("Injection start at %s, duration %dm", injectTime.Local().String(), payload.faultDuration)
@@ -280,11 +322,16 @@ func parseRestartPayload(payload map[string]any) (*restartPayload, error) {
 		return nil, fmt.Errorf(message, consts.RestartInjectPayload)
 	}
 
+	// skipInstall is optional — absent or non-bool payloads fall through to
+	// "run the helm install normally".
+	skipInstall, _ := payload[consts.RestartSkipInstall].(bool)
+
 	return &restartPayload{
 		pedestal:      pedestal,
 		interval:      interval,
 		faultDuration: faultDuration,
 		injectPayload: injectPayload,
+		skipInstall:   skipInstall,
 	}, nil
 }
 
@@ -364,14 +411,15 @@ func installPedestal(ctx context.Context, gateway *helm.Gateway, releaseName str
 					"namespace":    releaseName,
 				}).Infof("Installing Helm chart from remote with parameters: %+v", helmValues)
 
+				overallTO, waitTO := helmInstallTimeouts()
 				if err := gateway.Install(ctx,
 					releaseName,
 					releaseName,
 					fullChart,
 					item.Version,
 					helmValues,
-					600*time.Second,
-					300*time.Second,
+					overallTO,
+					waitTO,
 				); err != nil {
 					logEntry.Warnf("Failed to install chart from remote: %v", err)
 					installErr = err
@@ -396,14 +444,15 @@ func installPedestal(ctx context.Context, gateway *helm.Gateway, releaseName str
 				"namespace":    releaseName,
 			}).Infof("Installing Helm chart from local path with parameters: %+v", helmValues)
 
+			overallTO, waitTO := helmInstallTimeouts()
 			if err := gateway.Install(ctx,
 				releaseName,
 				releaseName,
 				item.LocalPath,
 				item.Version,
 				helmValues,
-				600*time.Second,
-				360*time.Second,
+				overallTO,
+				waitTO,
 			); err != nil {
 				return fmt.Errorf("failed to install chart from local path %s: %w", item.LocalPath, err)
 			}


### PR DESCRIPTION
## Summary
Two focused commits landed together since they co-evolved with DSB PR LGU-SE-Internal/DeathStarBench#49.

### 1. RestartPedestal controls (P10)
- **`helm.restart_pedestal.timeout_seconds` / `wait_timeout_seconds` dynamic config** — default bumped **600s → 1800s** (overall) / 300-360s → 600s (k8s wait). Both Install() call sites in `service/consumer/restart_pedestal.go` now use the new resolver; ops can retune via etcd without a rebuild.
- **`SubmitInjectionReq.SkipRestartPedestal` bool** threaded through the task payload (`consts.RestartSkipInstall`). When set and the helm release is already `deployed`, the RestartPedestal task skips the helm reinstall (namespace lock, index extraction, FaultInjection handoff still run). Falls back to a real install if the release is missing or in any non-deployed state — safe to always pass.
- **`helm.Gateway.IsReleaseDeployed(ns, release)`** new public probe used by the skip path.
- **`aegisctl regression run --auto-install`** now waits for every preflight-installed chart to be Ready before submitting, capped by `--ready-timeout` (default 600s). Without this the caller submitted immediately and RestartPedestal re-uninstalled/reinstalled before pods stabilized — erasing the preflight work. Extends `PodLister` with `CountReadyPods(ns, selector) -> (total, ready)`.
- **`aegisctl regression run --skip-restart-pedestal`** injects the above hint into the submit body.

### 2. DSB chart pin follow-up
- LGU-SE-Internal/DeathStarBench#49 merged; gh-pages republished `hotel-reservation`, `social-network`, `media-microservices` at 0.1.1 (verified via `index.yaml`).
- `manifests/byte-cluster/initial-data/data.yaml` — `hs` / `sn` / `media` seed rows bump both `versions[].name` and `helm_config.version` 0.1.0 → 0.1.1. Old version replaced, not kept in parallel.
- `regression/{hotelreservation,socialnetwork,mediamicroservices}-guided.yaml` — `pedestal.version` 0.1.0 → 0.1.1 so smoke cases track the current chart.

## Why
- RestartPedestal helm installs on fresh clusters routinely exceed 600s (BuildKit image pulls, missing OCI secret, flaky egress). The old hard-coded 600s forced operators to re-run the regression pipeline from scratch on every timeout. 1800s matches what `aegisctl regression run --auto-install` actually observes in practice.
- `--skip-restart-pedestal` closes the `preflight → submit` redundancy: once preflight has installed the chart + waited for readiness, the backend reinstalling on top is pure churn (and occasionally races pod-readiness gates). Making it opt-in + idempotent means existing flows are unaffected.
- Wait-for-ready is the missing half of `--auto-install`. Without it the shorter race window between preflight install and RestartPedestal would occasionally tear the chart down mid-startup.
- DSB 0.1.1 already has `#47` (flatten infra image paths) + `#46` + `#45` + `#42` on it; pinning aegis to 0.1.0 means RestartPedestal keeps pulling the stale artifact even though the fixes are shipped.

## Test plan
- [x] `go build -tags duckdb_arrow -o /dev/null ./main.go` — backend builds
- [x] `go build -o /tmp/aegisctl ./cmd/aegisctl` — CLI builds
- [x] `go test ./cmd/aegisctl/cmd/... -run Regression -count=1` — passes (fakePodLister extended with `CountReadyPods`; auto-install test simulates Ready transition)
- [ ] `aegisctl regression run hotelreservation-guided --auto-install --skip-restart-pedestal` end-to-end on aegis-kind (needs DSB 0.1.1 tgz — available at https://lgu-se-internal.github.io/DeathStarBench/index.yaml)
- [ ] Timeout override: `etcdctl put helm.restart_pedestal.timeout_seconds 1200` then trigger inject; confirm helm context honors 1200s

## Follow-ups (not in this PR)
- aegisctl CLI spec + `docs/troubleshooting/benchmark-integration-playbook.md` mention of the new flags
- Possible: auto-imply `--skip-restart-pedestal` when `--auto-install` successfully waited (cuts one manual flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)