### PR TITLE
fix(chaossystem): preserve metadata providers on etcd re-register (#129)

### DIFF
--- a/AegisLab/src/service/consumer/config_handlers.go
+++ b/AegisLab/src/service/consumer/config_handlers.go
@@ -95,6 +95,7 @@ var registrySyncer chaosRegistrySyncer = defaultChaosRegistrySyncer{}
 type chaosRegistrySyncer interface {
 	IsRegistered(name string) bool
 	Register(cfg chaos.SystemConfig) error
+	Update(cfg chaos.SystemConfig) error
 	Unregister(name string) error
 }
 
@@ -106,6 +107,10 @@ func (defaultChaosRegistrySyncer) IsRegistered(name string) bool {
 
 func (defaultChaosRegistrySyncer) Register(cfg chaos.SystemConfig) error {
 	return chaos.RegisterSystem(cfg)
+}
+
+func (defaultChaosRegistrySyncer) Update(cfg chaos.SystemConfig) error {
+	return chaos.UpdateSystem(cfg)
 }
 
 func (defaultChaosRegistrySyncer) Unregister(name string) error {
@@ -197,23 +202,29 @@ func (h *chaosSystemHandler) syncRegistry(name string) error {
 		return nil
 	}
 
-	// Always re-register so NsPattern / AppLabelKey / DisplayName edits take
-	// effect. RegisterSystem is cheap and idempotent after an unregister.
-	if registrySyncer.IsRegistered(name) {
-		if err := registrySyncer.Unregister(name); err != nil {
-			return fmt.Errorf("unregister %s before re-register: %w", name, err)
-		}
-	}
 	appLabelKey := cfg.AppLabelKey
 	if appLabelKey == "" {
 		appLabelKey = "app"
 	}
-	if err := registrySyncer.Register(chaos.SystemConfig{
+	sysCfg := chaos.SystemConfig{
 		Name:        name,
 		NsPattern:   cfg.NsPattern,
 		DisplayName: cfg.DisplayName,
 		AppLabelKey: appLabelKey,
-	}); err != nil {
+	}
+	// Update in place when the system is already registered; this preserves
+	// the compile-time static metadata providers that Unregister+Register
+	// would drop (see issue #129). Falls back to Register for brand-new
+	// systems that were added at runtime via etcd.
+	if registrySyncer.IsRegistered(name) {
+		if err := registrySyncer.Update(sysCfg); err != nil {
+			return fmt.Errorf("update %s: %w", name, err)
+		}
+		logrus.Infof("Updated system %s (ns_pattern=%q, app_label=%q)",
+			name, cfg.NsPattern, appLabelKey)
+		return nil
+	}
+	if err := registrySyncer.Register(sysCfg); err != nil {
 		return fmt.Errorf("register %s: %w", name, err)
 	}
 	logrus.Infof("Registered system %s (ns_pattern=%q, app_label=%q)",

--- a/AegisLab/src/service/consumer/config_handlers_test.go
+++ b/AegisLab/src/service/consumer/config_handlers_test.go
@@ -39,6 +39,14 @@ func (f *fakeSyncer) Register(cfg chaos.SystemConfig) error {
 	return nil
 }
 
+func (f *fakeSyncer) Update(cfg chaos.SystemConfig) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.registered[cfg.Name] = cfg
+	f.events = append(f.events, "update:"+cfg.Name+":"+cfg.NsPattern+":"+cfg.AppLabelKey)
+	return nil
+}
+
 func (f *fakeSyncer) Unregister(name string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -175,8 +183,16 @@ func TestChaosSystemHandlerReRegistersOnNsPatternChange(t *testing.T) {
 		t.Fatalf("ns_pattern reconcile: %v", err)
 	}
 	last := fs.lastEvent()
-	if !strings.HasPrefix(last, "register:ts:^trainticket") {
-		t.Fatalf("last event = %q, want register:ts:^trainticket...", last)
+	// Re-registration must happen as an in-place Update so attached metadata
+	// providers survive (issue #129). A plain register: event would mean we
+	// regressed to Unregister+Register and wiped the providers.
+	if !strings.HasPrefix(last, "update:ts:^trainticket") {
+		t.Fatalf("last event = %q, want update:ts:^trainticket...", last)
+	}
+	for _, ev := range fs.events {
+		if strings.HasPrefix(ev, "unregister:ts") {
+			t.Fatalf("unexpected unregister during pattern update: events=%v", fs.events)
+		}
 	}
 }
 

--- a/AegisLab/src/service/initialization/systems.go
+++ b/AegisLab/src/service/initialization/systems.go
@@ -24,21 +24,30 @@ func InitializeSystems(db *gorm.DB) error {
 		}
 		enabled[name] = struct{}{}
 
-		if chaos.IsSystemRegistered(name) {
-			if err := chaos.UnregisterSystem(name); err != nil {
-				logrus.WithError(err).Warnf("Failed to replace registered system %s", name)
-			}
-		}
-		if err := chaos.RegisterSystem(chaos.SystemConfig{
+		sysCfg := chaos.SystemConfig{
 			Name:        name,
 			NsPattern:   cfg.NsPattern,
 			DisplayName: cfg.DisplayName,
 			AppLabelKey: normalizeAppLabelKey(cfg.AppLabelKey),
-		}); err != nil {
-			logrus.WithError(err).Warnf("Failed to register system %s", name)
-			continue
 		}
-		logrus.Infof("Registered system: %s (%s)", name, cfg.DisplayName)
+		// Update in place when already registered so the compile-time
+		// static metadata providers (service endpoints, DB ops, JVM methods)
+		// survive the etcd refresh. Unregister+Register would wipe them,
+		// which breaks guided resolve when system_metadata is empty
+		// (see issue #129).
+		if chaos.IsSystemRegistered(name) {
+			if err := chaos.UpdateSystem(sysCfg); err != nil {
+				logrus.WithError(err).Warnf("Failed to update registered system %s", name)
+				continue
+			}
+			logrus.Infof("Updated system registration: %s (%s)", name, cfg.DisplayName)
+		} else {
+			if err := chaos.RegisterSystem(sysCfg); err != nil {
+				logrus.WithError(err).Warnf("Failed to register system %s", name)
+				continue
+			}
+			logrus.Infof("Registered system: %s (%s)", name, cfg.DisplayName)
+		}
 	}
 
 	// Drop any runtime-only registrations that are no longer enabled in etcd.

--- a/chaos-experiment/handler/registration.go
+++ b/chaos-experiment/handler/registration.go
@@ -49,6 +49,19 @@ func RegisterSystem(cfg SystemConfig) error {
 	})
 }
 
+// UpdateSystem updates the registration fields of an already-registered system
+// in place. It is intended for callers that want to refresh NsPattern / DisplayName
+// / AppLabelKey from a dynamic source (e.g. etcd) without discarding the
+// compile-time static metadata providers that Unregister+Register would wipe.
+func UpdateSystem(cfg SystemConfig) error {
+	return systemconfig.UpdateSystem(systemconfig.SystemRegistration{
+		Name:        systemconfig.SystemType(cfg.Name),
+		NsPattern:   cfg.NsPattern,
+		DisplayName: cfg.DisplayName,
+		AppLabelKey: cfg.AppLabelKey,
+	})
+}
+
 // RegisterSystemData registers a system-data bundle and wires it into both the
 // injectionv2 registry layer and the dynamic metadata provider layer.
 func RegisterSystemData(name string, data *SystemData) error {

--- a/chaos-experiment/handler/registration_test.go
+++ b/chaos-experiment/handler/registration_test.go
@@ -150,6 +150,76 @@ func TestUnregisterSystemRemovesRuntimeData(t *testing.T) {
 	}
 }
 
+// TestUpdateSystemPreservesProviders is a regression guard for issue #129.
+// UpdateSystem must refresh the registration fields (NsPattern / DisplayName /
+// AppLabelKey) without evicting any metadata providers that were attached
+// after the initial Register. Unregister+Register would wipe them; Update
+// must not.
+func TestUpdateSystemPreservesProviders(t *testing.T) {
+	const systemName = "dynamic-system-update"
+
+	t.Cleanup(func() {
+		_ = systemconfig.SetCurrentSystem(systemconfig.SystemTrainTicket)
+		if IsSystemRegistered(systemName) {
+			_ = UnregisterSystem(systemName)
+		}
+	})
+
+	if err := RegisterSystem(SystemConfig{
+		Name:        systemName,
+		NsPattern:   "^dynamic-system-update\\d+$",
+		DisplayName: "Original",
+		AppLabelKey: "app",
+	}); err != nil {
+		t.Fatalf("RegisterSystem() error = %v", err)
+	}
+	if err := RegisterServiceEndpointProvider(systemName, &testServiceEndpointProvider{
+		services: []string{"api"},
+		endpoints: map[string][]ServiceEndpointData{
+			"api": {{ServiceName: "api", Route: "/health"}},
+		},
+	}); err != nil {
+		t.Fatalf("RegisterServiceEndpointProvider() error = %v", err)
+	}
+
+	if err := UpdateSystem(SystemConfig{
+		Name:        systemName,
+		NsPattern:   "^renamed\\d+$",
+		DisplayName: "Renamed",
+		AppLabelKey: "app.kubernetes.io/name",
+	}); err != nil {
+		t.Fatalf("UpdateSystem() error = %v", err)
+	}
+
+	reg := systemconfig.GetRegistration(systemconfig.SystemType(systemName))
+	if reg == nil {
+		t.Fatal("GetRegistration() returned nil after UpdateSystem()")
+	}
+	if reg.NsPattern != "^renamed\\d+$" || reg.DisplayName != "Renamed" || reg.AppLabelKey != "app.kubernetes.io/name" {
+		t.Fatalf("GetRegistration() = %+v, want renamed fields", reg)
+	}
+
+	// Provider must still be reachable post-update.
+	if err := systemconfig.SetCurrentSystem(systemconfig.SystemType(systemName)); err != nil {
+		t.Fatalf("SetCurrentSystem() error = %v", err)
+	}
+	store := systemconfig.GetMetadataStore()
+	names, err := store.GetAllServiceNames(systemName)
+	if err != nil {
+		t.Fatalf("GetAllServiceNames() error = %v", err)
+	}
+	if len(names) != 1 || names[0] != "api" {
+		t.Fatalf("GetAllServiceNames() = %v, want [api] — provider was dropped by UpdateSystem", names)
+	}
+	endpoints, err := store.GetServiceEndpoints(systemName, "api")
+	if err != nil {
+		t.Fatalf("GetServiceEndpoints() error = %v", err)
+	}
+	if len(endpoints) != 1 || endpoints[0].Route != "/health" {
+		t.Fatalf("GetServiceEndpoints() = %#v, want one endpoint with /health", endpoints)
+	}
+}
+
 type testServiceEndpointProvider struct {
 	services  []string
 	endpoints map[string][]ServiceEndpointData

--- a/chaos-experiment/internal/systemconfig/systemconfig.go
+++ b/chaos-experiment/internal/systemconfig/systemconfig.go
@@ -102,6 +102,27 @@ func RegisterSystem(reg SystemRegistration) error {
 	return nil
 }
 
+// UpdateSystem updates the registration fields (NsPattern/DisplayName/AppLabelKey)
+// of an already-registered system in place. Unlike UnregisterSystem + RegisterSystem,
+// this does NOT touch any metadata providers attached to the system, so the
+// compile-time static service-endpoint / database / JVM-method providers stay
+// wired up for callers that rely on internal-data fallback.
+func UpdateSystem(reg SystemRegistration) error {
+	if reg.Name == "" {
+		return fmt.Errorf("system name must not be empty")
+	}
+
+	registeredSystemsMu.Lock()
+	defer registeredSystemsMu.Unlock()
+
+	if _, exists := registeredSystems[reg.Name]; !exists {
+		return fmt.Errorf("system %s is not registered", reg.Name)
+	}
+
+	registeredSystems[reg.Name] = reg
+	return nil
+}
+
 // UnregisterSystem removes a previously registered system.
 func UnregisterSystem(name SystemType) error {
 	registeredSystemsMu.Lock()

--- a/chaos-experiment/internal/systemconfig/systemconfig_test.go
+++ b/chaos-experiment/internal/systemconfig/systemconfig_test.go
@@ -467,3 +467,49 @@ func TestRegisterSystemLifecycle(t *testing.T) {
 		t.Fatalf("GetCurrentSystem() = %q after unregister, want %q", GetCurrentSystem(), SystemTrainTicket)
 	}
 }
+
+func TestUpdateSystem(t *testing.T) {
+	const testSystem = SystemType("update-test-system")
+
+	t.Cleanup(func() {
+		_ = UnregisterSystem(testSystem)
+	})
+
+	// UpdateSystem on an unregistered system must error.
+	if err := UpdateSystem(SystemRegistration{Name: testSystem, NsPattern: "x", DisplayName: "X"}); err == nil {
+		t.Fatal("UpdateSystem() on unregistered system should return an error")
+	}
+
+	orig := SystemRegistration{
+		Name:        testSystem,
+		NsPattern:   "^update-test-system\\d+$",
+		DisplayName: "Original",
+		AppLabelKey: "app",
+	}
+	if err := RegisterSystem(orig); err != nil {
+		t.Fatalf("RegisterSystem() error = %v", err)
+	}
+
+	updated := SystemRegistration{
+		Name:        testSystem,
+		NsPattern:   "^uts\\d+$",
+		DisplayName: "Renamed",
+		AppLabelKey: "app.kubernetes.io/name",
+	}
+	if err := UpdateSystem(updated); err != nil {
+		t.Fatalf("UpdateSystem() error = %v", err)
+	}
+
+	got := GetRegistration(testSystem)
+	if got == nil {
+		t.Fatal("GetRegistration() returned nil after update")
+	}
+	if got.NsPattern != updated.NsPattern || got.DisplayName != updated.DisplayName || got.AppLabelKey != updated.AppLabelKey {
+		t.Fatalf("GetRegistration() = %+v, want %+v", got, updated)
+	}
+
+	// Empty name must be rejected.
+	if err := UpdateSystem(SystemRegistration{}); err == nil {
+		t.Fatal("UpdateSystem() with empty name should return an error")
+	}
+}


### PR DESCRIPTION
## Summary

Minimum 止血 for #129 — guided preview offered HTTP/DNS choices that backend submit rejected with 500.

Root cause (full write-up in #129): `InitializeSystems` and the etcd watcher both did `chaos.UnregisterSystem` → `RegisterSystem` to refresh a system's `NsPattern / DisplayName / AppLabelKey`. `UnregisterSystem` also wipes the attached metadata providers (service endpoints, DB ops, JVM methods, runtime mutators). The compile-time static fallback in chaos-experiment therefore went away at boot, leaving backend guided resolve with only the `DBMetadataStore` — which on clean deployments is empty, because the only write path to `system_metadata` is an admin-only HTTP endpoint that **no code in this repo calls**. CLI preview still had the static providers (aegisctl never calls `InitializeSystems`), so it offered options the backend couldn't validate.

## Fix

- Add `UpdateSystem` to chaos-experiment (`systemconfig` + `handler` wrappers) that updates the registration fields **in place** without touching providers.
- Have AegisLab's `InitializeSystems` and the etcd watcher (`chaosSystemHandler.syncRegistry`) call `UpdateSystem` when the system is already registered, falling back to `RegisterSystem` only for brand-new (runtime-added) systems.
- Regression tests: chaos-experiment asserts that providers survive `UpdateSystem`; AegisLab asserts the etcd watcher emits an `update:` event (not a `register:` preceded by `unregister:`) on NsPattern change.

This is the minimum stop-the-bleeding. The architectural fix — moving guided resolve to a server-side RPC so CLI and backend share one metadata view — is tracked separately.

## Test plan

- [ ] `cd chaos-experiment && go test ./...` (pre-existing unrelated flakes on `TestGenerateRandomAction` / `TestGetLabel` / `TestCRDClient1` reproduce on main, not caused here)
- [ ] `cd AegisLab/src && go build -tags duckdb_arrow -o /dev/null ./main.go`
- [ ] `cd AegisLab/src && go test ./service/consumer/... ./service/initialization/...`
- [ ] Manual repro on ByteDance cluster — `aegisctl inject guided --system ts2 ... --chaos-type DNSError --domain ts-auth-service --apply` should now succeed (or fail with a real reason, not "not found under app")

Fixes #129 (partially — see architectural follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)