### PR TITLE
fix(aegisctl): stop guided --apply from running local BatchCreate (#132)

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/inject_guided.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_guided.go
@@ -142,8 +142,14 @@ current stage's selection, and --apply to submit the finalized config.`,
 			MemType:        guidedMemType,
 			BodyType:       guidedBodyType,
 			ReplaceMethod:  guidedReplaceMethod,
-			Apply:          guidedApply,
-			SaveConfig:     effectiveSave,
+			// Apply is intentionally left false for the local guidedcli.Resolve
+			// call below: the aegisctl CLI submits via the backend /inject
+			// endpoint (see submitGuidedApply), and we do not want the local
+			// resolver to run handler.BatchCreate against the caller's
+			// kubeconfig. Doing so would emit misleading "namespaces not found"
+			// errors while the real execution happens server-side (issue #132).
+			Apply:      false,
+			SaveConfig: effectiveSave,
 			ResetConfig:    guidedResetConfig,
 		}
 
@@ -175,6 +181,10 @@ current stage's selection, and --apply to submit the finalized config.`,
 		setInt(&cliCfg.StatusCode, guidedStatusCode, false)
 
 		merged := guidedcli.MergeConfig(fileCfg, cliCfg)
+		// Suppress any Apply=true inherited from the persisted session — see
+		// the Apply comment above; apply happens exclusively via the backend
+		// submit path.
+		merged.Apply = false
 		if guidedNext != "" {
 			current, err := guidedcli.Resolve(ctx, merged)
 			if err != nil {
@@ -186,7 +196,7 @@ current stage's selection, and --apply to submit the finalized config.`,
 			}
 			merged.SaveConfig = effectiveSave
 			merged.ResetConfig = guidedResetConfig
-			merged.Apply = guidedApply
+			merged.Apply = false
 		}
 
 		response, err := guidedcli.Resolve(ctx, merged)


### PR DESCRIPTION
## Summary

Fixes #132. `aegisctl inject guided --apply` was forwarding `Apply=true` into the client-side `guidedcli.Resolve`, which then calls `handler.BatchCreate` against the caller's kubeconfig. On fresh hosts where the target namespace doesn't exist locally that surfaced:

```
level=warning msg="Auto-initializing Kubernetes client..."
level=error msg="Failed to create chaos: namespaces \"ts1\" not found"
```

…even though the backend submit (the real apply path) had already returned a valid `trace_id`.

## Fix

In `AegisLab/src/cmd/aegisctl/cmd/inject_guided.go`, keep `guidedApply` as the local flag that gates `submitGuidedApply`, but force `Apply=false` on the `GuidedConfig` we hand to `guidedcli.Resolve` (both the direct call and the `--next` pre-resolve). This preserves the `guidedcli` in-process SDK contract — callers that want local `BatchCreate` can still opt in — while the CLI funnels apply exclusively through the backend `/inject` envelope.

## Test plan

- [x] `go build -o /tmp/aegisctl ./cmd/aegisctl`
- [x] `go test ./cmd/aegisctl/cmd/ -run Guided -v` — 3 guided tests pass
- [ ] Re-run the repro from the issue against a namespace that doesn't exist locally; expect clean stdout with only the backend `trace_id` and no `Auto-initializing Kubernetes client` / `Failed to create chaos` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)