### PR TITLE
chore(sockshop): point seed at self-hosted chart (fork gh-pages)

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -135,14 +135,16 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.1
+      - name: 1.1.1
         github_link: LGU-SE-Internal/coherence-helidon-sockshop-sample
         status: 1
+        # Chart is now self-hosted in the fork's gh-pages site (same pattern
+        # as hs/sn/media/teastore). Images live at docker.io/opspai/ss-*.
         helm_config:
-          version: 0.1.1
-          chart_name: sockshop-aegis
-          repo_name: opspai
-          repo_url: oci://registry-1.docker.io/opspai
+          version: 1.1.1
+          chart_name: sockshop
+          repo_name: sockshop-lgu
+          repo_url: https://lgu-se-internal.github.io/coherence-helidon-sockshop-sample
           status: 1
     # issue #115: sockshop's coherence-helidon variant requires the
     # Coherence operator installed cluster-wide before the chart can be

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -109,14 +109,16 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.1
+      - name: 1.1.1
         github_link: LGU-SE-Internal/coherence-helidon-sockshop-sample
         status: 1
+        # Chart is now self-hosted in the fork's gh-pages site (same pattern
+        # as hs/sn/media/teastore). Images live at docker.io/opspai/ss-*.
         helm_config:
-          version: 0.1.1
-          chart_name: sockshop-aegis
-          repo_name: opspai
-          repo_url: oci://registry-1.docker.io/opspai
+          version: 1.1.1
+          chart_name: sockshop
+          repo_name: sockshop-lgu
+          repo_url: https://lgu-se-internal.github.io/coherence-helidon-sockshop-sample
           status: 1
     # issue #115: sockshop's coherence-helidon variant requires the
     # Coherence operator installed cluster-wide before the chart can be

--- a/AegisLab/regression/sockshop-guided.yaml
+++ b/AegisLab/regression/sockshop-guided.yaml
@@ -4,7 +4,7 @@ project_name: pair_diagnosis
 submit:
   pedestal:
     name: sockshop
-    version: "0.1.1"
+    version: "1.1.1"
   benchmark:
     name: clickhouse
     version: "1.0.0"

--- a/docs/troubleshooting/benchmark-integration-playbook.md
+++ b/docs/troubleshooting/benchmark-integration-playbook.md
@@ -250,17 +250,29 @@ items are covered above.
 
 ### `ss` — SockShop (Coherence/Helidon Java)
 
+- **Chart + images are now self-hosted in the fork** (same pattern as
+  hs/sn/media/teastore): chart at
+  `https://lgu-se-internal.github.io/coherence-helidon-sockshop-sample/`
+  (repo `sockshop-lgu`, chart `sockshop`, ≥ `1.1.1`); images at
+  `docker.io/opspai/ss-{carts,catalog,orders,payment,shipping,users,frontend,loadgen}`
+  tagged `YYYYMMDD-<sha>` + `latest`. The previous
+  `opspai/sockshop-aegis` wrapper is retired.
 - **Coherence pods don't inherit `app` label.** Coherence Operator reads
-  `spec.labels` from the CR, not `metadata.labels`. Fix: patch each
-  `Coherence` CR template in the wrapper to also include `spec.labels`
-  with `{app: <name>}`. Bumped wrapper 0.1.0 → 0.1.1.
-- **Prerequisite: `coherence-operator`.** `helm repo add coherence …`
-  + `helm install operator coherence/coherence-operator` by hand before
-  installing sockshop-aegis.
+  `spec.labels` from the CR, not `metadata.labels`. Fix baked into the
+  chart since `1.1.1`: each `Coherence` CR template emits `spec.labels`
+  with `{app: <name>}`. Without this, aegisctl preflight fails with
+  `namespace sockshop0 has no pods matching app=carts`.
+- **Prerequisite: `coherence-operator`.** `helm repo add coherence
+  https://oracle.github.io/coherence-operator/charts` +
+  `helm install coherence-operator coherence/coherence-operator` by
+  hand before the first chart install. (Seed has this wired as a
+  `prerequisites` entry for the system, reconciled via
+  `aegisctl system reconcile-prereqs --name sockshop`.)
 - **No tracing bridge** — Coherence MP emits Prometheus metrics only.
   Needs `RCABENCH_OPTIONAL_EMPTY_PARQUETS` on the bench container.
-- Per-service Jib builds: `opspai/ss-{carts,catalog,orders,payment,
-  shipping,users}:2.12.3` + `opspai/ss-frontend:propagator`.
+- **Frontend is Node.js**, vendored into the fork at `frontend/` from
+  `YifanYang6/front-end@64dff7d` so the fork builds a single `ss-frontend`
+  image in its own CI. Provenance + re-sync in `frontend/PROVENANCE.md`.
 
 ### `tea` — TeaStore (Descartes Java)
 


### PR DESCRIPTION
## Summary

`LGU-SE-Internal/coherence-helidon-sockshop-sample` PR #22 merged: the fork now publishes both the Helm chart (gh-pages) and the container images (`docker.io/opspai/ss-*`), mirroring the `hs/sn/media/teastore` pattern. The `opspai/sockshop-aegis` wrapper chart is retired.

- `data.yaml` (prod + staging): sockshop version `0.1.1` → `1.1.1`; chart `repo_url` switched from `oci://registry-1.docker.io/opspai` (chart `sockshop-aegis`) to `https://lgu-se-internal.github.io/coherence-helidon-sockshop-sample` (chart `sockshop`, repo alias `sockshop-lgu`).
- `regression/sockshop-guided.yaml`: `pedestal.version` `0.1.1` → `1.1.1`.
- `docs/troubleshooting/benchmark-integration-playbook.md` §`ss`: rewritten to reflect self-hosted layout + `spec.labels` fix now baked into the chart.

## Test plan

- [ ] `aegisctl system reseed --name sockshop --apply` inserts the `1.1.1` helm_config cleanly (history preserved).
- [ ] `aegisctl regression run sockshop-guided --cases-dir AegisLab/regression` passes end-to-end on kind.
- [ ] `kubectl get pods -n sockshop0` shows `docker.io/opspai/ss-*:<YYYYMMDD-sha>` images, all Ready.