### PR TITLE
chore(sockshop): seed OTel overrides + kind regression runbook

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -145,6 +145,25 @@ containers:
           chart_name: sockshop
           repo_name: sockshop-lgu
           repo_url: https://lgu-se-internal.github.io/coherence-helidon-sockshop-sample
+          # Chart hardcodes aegis-compatible defaults pointing at
+          # `monitoring/opentelemetry-kube-stack`. This cluster layout puts
+          # the Instrumentation CR and collector in the `otel` namespace,
+          # so override both before install — otherwise the OTel operator
+          # webhook silently skips auto-inject and BuildDatapack fails with
+          # an empty `abnormal_traces.parquet`.
+          values:
+            - key: otel.instrumentation
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: otel/otel-kube-stack
+              overridable: true
+            - key: otel.collectorEndpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-kube-stack-deployment-collector.otel:4317
+              overridable: true
           status: 1
     # issue #115: sockshop's coherence-helidon variant requires the
     # Coherence operator installed cluster-wide before the chart can be

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -119,6 +119,25 @@ containers:
           chart_name: sockshop
           repo_name: sockshop-lgu
           repo_url: https://lgu-se-internal.github.io/coherence-helidon-sockshop-sample
+          # Chart hardcodes aegis-compatible defaults pointing at
+          # `monitoring/opentelemetry-kube-stack`. This cluster layout puts
+          # the Instrumentation CR and collector in the `otel` namespace,
+          # so override both before install — otherwise the OTel operator
+          # webhook silently skips auto-inject and BuildDatapack fails with
+          # an empty `abnormal_traces.parquet`.
+          values:
+            - key: otel.instrumentation
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: otel/otel-kube-stack
+              overridable: true
+            - key: otel.collectorEndpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://otel-kube-stack-deployment-collector.otel:4317
+              overridable: true
           status: 1
     # issue #115: sockshop's coherence-helidon variant requires the
     # Coherence operator installed cluster-wide before the chart can be

--- a/AegisLab/regression/sockshop-guided.yaml
+++ b/AegisLab/regression/sockshop-guided.yaml
@@ -24,7 +24,7 @@ submit:
         namespace: sockshop0
         app: carts
         chaos_type: PodKill
-        duration: 1
+        duration: 5
 validation:
   timeout_seconds: 3000
   min_events: 6

--- a/docs/deployment/cold-start-kind.md
+++ b/docs/deployment/cold-start-kind.md
@@ -226,6 +226,63 @@ done
 Expected: `Completed` in roughly 4 minutes (pre=1min + duration=2min +
 build+run).
 
+### 7b. Regression tests per benchmark
+
+Once the smoke submit above completes, the tracked regression cases in
+`AegisLab/regression/*.yaml` are the canonical way to re-verify each
+benchmark. `--auto-install` makes aegisctl install the chart into the
+pedestal namespace if it isn't there yet.
+
+```bash
+# Run all shipped cases (one at a time — they share the aegis runner).
+for case in otel-demo-guided hotelreservation-guided socialnetwork-guided \
+            mediamicroservices-guided teastore-guided ob-guided \
+            sockshop-guided; do
+  /tmp/aegisctl regression run "$case" \
+    --cases-dir AegisLab/regression --auto-install --output json || break
+done
+```
+
+Benchmark-specific prereqs the runner does NOT auto-handle:
+
+| Benchmark | Extra step before first run | Why |
+|---|---|---|
+| `sockshop` | `helm repo add coherence https://oracle.github.io/coherence-operator/charts && helm upgrade -i coherence-operator coherence/coherence-operator -n coherence --create-namespace --wait` | Coherence CRs don't render without the operator. |
+| `teastore` | none | Jaeger-client-java bridge is inside the chart. |
+| `hs`/`sn`/`mm` | none | `dsb-wrk2` loader + Jaeger bridge are inside each chart. |
+
+The sockshop case additionally needs two chart-value overrides in the
+aegis seed because the upstream chart hardcodes
+`monitoring/opentelemetry-kube-stack` for the OTel injector — the kind
+profile puts both the Instrumentation CR and the collector in the
+`otel` namespace instead. These are now shipped in
+`AegisLab/data/initial_data/prod/data.yaml` under sockshop's
+`helm_config.values`:
+
+- `otel.instrumentation=otel/otel-kube-stack`
+- `otel.collectorEndpoint=http://otel-kube-stack-deployment-collector.otel:4317`
+
+Without these, BuildDatapack fails with
+`Parquet file has no data rows: abnormal_traces.parquet` because the
+OTel operator webhook silently skips injection when the Instrumentation
+CR's namespace/name doesn't resolve.
+
+If the chart was installed with stale values (e.g. the run raced the
+`aegisctl system reseed` that propagates data.yaml drift), uninstall
+and let `--auto-install` retry:
+
+```bash
+helm uninstall sockshop0 -n sockshop0
+/tmp/aegisctl regression run sockshop-guided \
+  --cases-dir AegisLab/regression --auto-install
+```
+
+`RunAlgorithm` uses `docker.io/opspai/detector` (public) by default;
+the `random` and `traceback` algos in the aegis seed point at a
+private Volces CN registry (`pair-diag-cn-guangzhou.cr.volces.com`)
+and will hang on `Pulling` from overseas until configured. Swap to
+`detector` in the regression YAML if that registry isn't reachable.
+
 ## 8. If a previous trace failed, clear the namespace lock
 
 rcabench holds a per-namespace lock in redis; a failed trace does not


### PR DESCRIPTION
## Summary

Follow-up to #136. Two runtime unblockers surfaced while validating `aegisctl regression run sockshop-guided` on kind, plus a runbook section that codifies the happy path for all shipped regression cases.

### 1. Seed OTel chart-value overrides for sockshop

The upstream chart's OTel auto-inject annotation hardcodes `monitoring/opentelemetry-kube-stack`, but the kind profile installs the `opentelemetry-kube-stack` Instrumentation CR and collector in the `otel` namespace. Without overriding, the OTel operator webhook silently skips injection, Coherence pods emit zero traces, and `BuildDatapack` fails with `Parquet file has no data rows: abnormal_traces.parquet`.

Shipping both overrides in sockshop's `helm_config.values` so first install works out of the box:

- `otel.instrumentation = otel/otel-kube-stack`
- `otel.collectorEndpoint = http://otel-kube-stack-deployment-collector.otel:4317`

### 2. Bump `sockshop-guided` duration 1 → 5

Duration `1` hit the regression deduplicator (`duplicate submission suppressed (batches [0])`); bumped to `5` to match the fix already applied to `hs-guided` in 224c034.

### 3. `docs/deployment/cold-start-kind.md` §7b

New "Regression tests per benchmark" section covering:
- the `aegisctl regression run` loop for all shipped cases
- sockshop's coherence-operator prerequisite (not auto-installed)
- the `random` / `traceback` algo images living on a Volces CN private registry (`pair-diag-cn-guangzhou.cr.volces.com`) and the swap-to-`detector` workaround if that registry isn't reachable

## Test plan

- [x] `aegisctl system reseed --name sockshop --apply` with the updated data.yaml inserts the two `helm_config.values` rows (validated equivalently via direct DB patch for the live cluster).
- [x] After the OTel overrides take effect, `carts-0` gets the `opentelemetry-auto-instrumentation-java` init container and traces flow end-to-end (BuildDatapack passes — the empty-traces-parquet failure no longer reproduces).
- [ ] Full `aegisctl regression run sockshop-guided` reaches `datapack.no_anomaly` — blocked in my environment by the Volces CN registry hang on `rca-algo-random`; unrelated to sockshop and documented in §7b.