### PR TITLE
fix(regression/sockshop): expect algorithm.result.collection

### DIFF
--- a/AegisLab/regression/sockshop-guided.yaml
+++ b/AegisLab/regression/sockshop-guided.yaml
@@ -28,13 +28,18 @@ submit:
 validation:
   timeout_seconds: 3000
   min_events: 6
-  expected_final_event: datapack.no_anomaly
+  # The sockshop chart enables loadgen by default, so there is always
+  # live traffic against `carts` during the PodKill window. The algo
+  # therefore finds real anomaly signal and the chain terminates at
+  # `algorithm.result.collection` rather than the shortcut
+  # `datapack.no_anomaly` used by the quieter pedestals.
+  expected_final_event: algorithm.result.collection
   required_events:
     - restart.pedestal.started
     - fault.injection.started
     - datapack.build.started
     - algorithm.run.started
-    - datapack.no_anomaly
+    - algorithm.result.collection
   required_task_chain:
     - RestartPedestal
     - FaultInjection


### PR DESCRIPTION
## Summary

The sockshop chart ships loadgen enabled by default, so there is always continuous traffic against `carts` during the PodKill window. End-to-end validation on kind shows the trace terminates at `algorithm.result.collection` — the algo actually finds anomaly signal and produces a result — not at the shortcut `datapack.no_anomaly` used by the quieter pedestals.

Observed trace: `RestartPedestal → FaultInjection → BuildDatapack → RunAlgorithm → CollectResult`, all `Completed`, final event `algorithm.result.collection`, overall state `Completed`.

## Test plan

- [x] Full `aegisctl regression run sockshop-guided` completes with `state=Completed` and last event `algorithm.result.collection` on kind (trace `c1564ad9-ba61-4217-b019-d0177f5a26cd`).
- [x] No other regression YAML affected; other pedestals keep their `datapack.no_anomaly` contract.