### PR TITLE
feat: pass helm set values via system prerequisites

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -175,6 +175,19 @@ containers:
         chart: coherence/coherence-operator
         namespace: coherence-test
         version: '>=3.4'
+        values:
+          - key: image.registry
+            value: pair-cn-shanghai.cr.volces.com/opspai
+          - key: image.name
+            value: coherence-operator
+          - key: image.tag
+            value: 3.5.11
+          - key: defaultCoherenceImage.registry
+            value: pair-cn-shanghai.cr.volces.com/opspai
+          - key: defaultCoherenceImage.name
+            value: coherence-ce
+          - key: defaultCoherenceImage.tag
+            value: 14.1.2-0-3
   - type: 2
     name: hs
     is_public: true

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -149,6 +149,19 @@ containers:
         chart: coherence/coherence-operator
         namespace: coherence-test
         version: '>=3.4'
+        values:
+          - key: image.registry
+            value: pair-cn-shanghai.cr.volces.com/opspai
+          - key: image.name
+            value: coherence-operator
+          - key: image.tag
+            value: 3.5.11
+          - key: defaultCoherenceImage.registry
+            value: pair-cn-shanghai.cr.volces.com/opspai
+          - key: defaultCoherenceImage.name
+            value: coherence-ce
+          - key: defaultCoherenceImage.tag
+            value: 14.1.2-0-3
   - type: 2
     name: hotelreservation
     is_public: true

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -128,6 +128,19 @@ containers:
         chart: coherence/coherence-operator
         namespace: coherence-test
         version: '>=3.4'
+        values:
+          - key: image.registry
+            value: pair-cn-shanghai.cr.volces.com/opspai
+          - key: image.name
+            value: coherence-operator
+          - key: image.tag
+            value: 3.5.11
+          - key: defaultCoherenceImage.registry
+            value: pair-cn-shanghai.cr.volces.com/opspai
+          - key: defaultCoherenceImage.name
+            value: coherence-ce
+          - key: defaultCoherenceImage.tag
+            value: 14.1.2-0-3
   - type: 2
     name: hs
     is_public: true

--- a/AegisLab/src/cmd/aegisctl/cmd/system_prereqs.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/system_prereqs.go
@@ -27,9 +27,15 @@ type systemPrereqResp struct {
 
 // helmPrereqSpec decodes the kind=helm payload inside SystemPrereqResp.Spec.
 type helmPrereqSpec struct {
-	Chart     string `json:"chart"`
-	Namespace string `json:"namespace"`
-	Version   string `json:"version"`
+	Chart     string               `json:"chart"`
+	Namespace string               `json:"namespace"`
+	Version   string               `json:"version"`
+	Values    []helmPrereqSetValue `json:"values"`
+}
+
+type helmPrereqSetValue struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // Prereq status values — mirror model.SystemPrerequisiteStatus*. Duplicated
@@ -64,8 +70,8 @@ var prereqRunner prereqReconcileRunner = realPrereqRunner{}
 
 // --- flags ---
 var (
-	systemReconcileName    string
-	systemReconcileDryRun  bool
+	systemReconcileName   string
+	systemReconcileDryRun bool
 )
 
 // systemReconcilePrereqsCmd implements `aegisctl system reconcile-prereqs`.
@@ -170,20 +176,14 @@ failed.`,
 			if systemReconcileDryRun {
 				r.Action = "dry-run"
 				results = append(results, r)
-				fmt.Fprintf(os.Stderr, "[plan] helm upgrade --install %s %s -n %s --create-namespace %s\n",
-					item.Prereq.Name, spec.Chart, spec.Namespace, versionFlag(spec.Version))
+				fmt.Fprintf(os.Stderr, "[plan] helm %s\n",
+					strings.Join(buildHelmUpgradeInstallArgs(item.Prereq.Name, spec), " "))
 				continue
 			}
 
 			fmt.Fprintf(os.Stderr, "[run]  helm upgrade --install %s %s -n %s (version=%s)\n",
 				item.Prereq.Name, spec.Chart, spec.Namespace, fallback(spec.Version, "<any>"))
-			helmArgs := []string{
-				"upgrade", "--install", item.Prereq.Name, spec.Chart,
-				"-n", spec.Namespace, "--create-namespace",
-			}
-			if strings.TrimSpace(spec.Version) != "" {
-				helmArgs = append(helmArgs, "--version", spec.Version)
-			}
+			helmArgs := buildHelmUpgradeInstallArgs(item.Prereq.Name, spec)
 			if _, err := prereqRunner.Run("helm", helmArgs...); err != nil {
 				r.Action = "failed"
 				r.Error = err.Error()
@@ -286,18 +286,28 @@ func writeReconcileReport(items interface{}) {
 	fmt.Fprintln(os.Stdout, string(b))
 }
 
-func versionFlag(v string) string {
-	if strings.TrimSpace(v) == "" {
-		return ""
-	}
-	return "--version " + v
-}
-
 func fallback(s, def string) string {
 	if strings.TrimSpace(s) == "" {
 		return def
 	}
 	return s
+}
+
+func buildHelmUpgradeInstallArgs(releaseName string, spec helmPrereqSpec) []string {
+	helmArgs := []string{
+		"upgrade", "--install", releaseName, spec.Chart,
+		"-n", spec.Namespace, "--create-namespace",
+	}
+	if strings.TrimSpace(spec.Version) != "" {
+		helmArgs = append(helmArgs, "--version", spec.Version)
+	}
+	for _, v := range spec.Values {
+		if strings.TrimSpace(v.Key) == "" {
+			continue
+		}
+		helmArgs = append(helmArgs, "--set", fmt.Sprintf("%s=%s", v.Key, v.Value))
+	}
+	return helmArgs
 }
 
 // prereqReconcileResult is one row in the machine-parseable stdout summary.

--- a/AegisLab/src/cmd/aegisctl/cmd/system_prereqs_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/system_prereqs_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildHelmUpgradeInstallArgs_WithVersionAndValues(t *testing.T) {
+	spec := helmPrereqSpec{
+		Chart:     "coherence/coherence-operator",
+		Namespace: "coherence-test",
+		Version:   ">=3.5",
+		Values: []helmPrereqSetValue{
+			{Key: "image.registry", Value: "pair-cn-shanghai.cr.volces.com/opspai"},
+			{Key: "image.name", Value: "coherence-operator"},
+			{Key: "", Value: "ignored-empty-key"},
+		},
+	}
+
+	got := buildHelmUpgradeInstallArgs("coherence-operator", spec)
+	want := []string{
+		"upgrade", "--install", "coherence-operator", "coherence/coherence-operator",
+		"-n", "coherence-test", "--create-namespace",
+		"--version", ">=3.5",
+		"--set", "image.registry=pair-cn-shanghai.cr.volces.com/opspai",
+		"--set", "image.name=coherence-operator",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("build args mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestBuildHelmUpgradeInstallArgs_CompatibleWithoutValues(t *testing.T) {
+	spec := helmPrereqSpec{
+		Chart:     "coherence/coherence-operator",
+		Namespace: "coherence-test",
+	}
+
+	got := buildHelmUpgradeInstallArgs("coherence-operator", spec)
+	want := []string{
+		"upgrade", "--install", "coherence-operator", "coherence/coherence-operator",
+		"-n", "coherence-test", "--create-namespace",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("build args mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}

--- a/AegisLab/src/model/system_prerequisite.go
+++ b/AegisLab/src/model/system_prerequisite.go
@@ -30,7 +30,8 @@ const (
 //
 //	{"chart": "coherence/coherence-operator",
 //	 "namespace": "coherence-test",
-//	 "version": ">=3.4"}
+//	 "version": ">=3.4",
+//	 "values": [{"key":"image.registry","value":"pair-cn-shanghai.cr.volces.com/opspai"}]}
 type SystemPrerequisite struct {
 	ID         int       `gorm:"primaryKey;autoIncrement" json:"id"`
 	SystemName string    `gorm:"not null;size:128;uniqueIndex:idx_sysprereq,priority:1" json:"system_name"`

--- a/AegisLab/src/service/initialization/consumer.go
+++ b/AegisLab/src/service/initialization/consumer.go
@@ -276,7 +276,7 @@ func buildPrerequisiteRow(systemName string, p InitialSystemPrerequisite) (*mode
 	if kind == "" {
 		kind = model.SystemPrerequisiteKindHelm
 	}
-	spec := map[string]string{}
+	spec := map[string]any{}
 	switch kind {
 	case model.SystemPrerequisiteKindHelm:
 		if strings.TrimSpace(p.Chart) == "" {
@@ -285,6 +285,21 @@ func buildPrerequisiteRow(systemName string, p InitialSystemPrerequisite) (*mode
 		spec["chart"] = p.Chart
 		spec["namespace"] = p.Namespace
 		spec["version"] = p.Version
+		if len(p.Values) > 0 {
+			values := make([]map[string]string, 0, len(p.Values))
+			for _, v := range p.Values {
+				if strings.TrimSpace(v.Key) == "" {
+					continue
+				}
+				values = append(values, map[string]string{
+					"key":   v.Key,
+					"value": v.Value,
+				})
+			}
+			if len(values) > 0 {
+				spec["values"] = values
+			}
+		}
 	default:
 		// Best-effort: preserve every non-Name/Kind field we know about so a
 		// new-kind reader can pick them up without a new seeder.
@@ -296,6 +311,21 @@ func buildPrerequisiteRow(systemName string, p InitialSystemPrerequisite) (*mode
 		}
 		if p.Version != "" {
 			spec["version"] = p.Version
+		}
+		if len(p.Values) > 0 {
+			values := make([]map[string]string, 0, len(p.Values))
+			for _, v := range p.Values {
+				if strings.TrimSpace(v.Key) == "" {
+					continue
+				}
+				values = append(values, map[string]string{
+					"key":   v.Key,
+					"value": v.Value,
+				})
+			}
+			if len(values) > 0 {
+				spec["values"] = values
+			}
 		}
 	}
 	raw, err := json.Marshal(spec)

--- a/AegisLab/src/service/initialization/system_prerequisites_test.go
+++ b/AegisLab/src/service/initialization/system_prerequisites_test.go
@@ -126,6 +126,31 @@ func TestBuildPrerequisiteRow_RejectsHelmWithoutChart(t *testing.T) {
 	}
 }
 
+func TestBuildPrerequisiteRow_StoresHelmValues(t *testing.T) {
+	row, err := buildPrerequisiteRow("sockshop", InitialSystemPrerequisite{
+		Name:      "coherence-operator",
+		Kind:      "helm",
+		Chart:     "coherence/coherence-operator",
+		Namespace: "coherence-test",
+		Values: []InitialHelmSetValue{
+			{Key: "image.registry", Value: "pair-cn-shanghai.cr.volces.com/opspai"},
+			{Key: "image.name", Value: "coherence-operator"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if !containsSubstr(row.SpecJSON, `"values":[`) {
+		t.Fatalf("spec_json missing values: %s", row.SpecJSON)
+	}
+	if !containsSubstr(row.SpecJSON, `"key":"image.registry"`) {
+		t.Fatalf("spec_json missing values key: %s", row.SpecJSON)
+	}
+	if !containsSubstr(row.SpecJSON, `"value":"pair-cn-shanghai.cr.volces.com/opspai"`) {
+		t.Fatalf("spec_json missing values value: %s", row.SpecJSON)
+	}
+}
+
 func containsSubstr(s, sub string) bool {
 	return len(s) >= len(sub) && (func() bool {
 		for i := 0; i+len(sub) <= len(s); i++ {

--- a/AegisLab/src/service/initialization/types.go
+++ b/AegisLab/src/service/initialization/types.go
@@ -57,11 +57,19 @@ type InitialDataContainer struct {
 // without a schema change because consumer.go serialises the whole struct
 // (minus Name/Kind) into the per-row spec_json column.
 type InitialSystemPrerequisite struct {
-	Name      string `yaml:"name"`
-	Kind      string `yaml:"kind"`
-	Chart     string `yaml:"chart"`
-	Namespace string `yaml:"namespace"`
-	Version   string `yaml:"version"`
+	Name      string                `yaml:"name"`
+	Kind      string                `yaml:"kind"`
+	Chart     string                `yaml:"chart"`
+	Namespace string                `yaml:"namespace"`
+	Version   string                `yaml:"version"`
+	Values    []InitialHelmSetValue `yaml:"values"`
+}
+
+// InitialHelmSetValue represents one `--set key=value` pair for a
+// kind=helm system prerequisite.
+type InitialHelmSetValue struct {
+	Key   string `yaml:"key"`
+	Value string `yaml:"value"`
 }
 
 func (c *InitialDataContainer) ConvertToDBContainer() *model.Container {

--- a/docs/deployment/cold-start-kind.md
+++ b/docs/deployment/cold-start-kind.md
@@ -247,7 +247,7 @@ Benchmark-specific prereqs the runner does NOT auto-handle:
 
 | Benchmark | Extra step before first run | Why |
 |---|---|---|
-| `sockshop` | `helm repo add coherence https://oracle.github.io/coherence-operator/charts && helm upgrade -i coherence-operator coherence/coherence-operator -n coherence --create-namespace --wait` | Coherence CRs don't render without the operator. |
+| `sockshop` | `helm repo add coherence https://oracle.github.io/coherence-operator/charts && helm repo update && helm upgrade -i coherence-operator coherence/coherence-operator -n coherence-test --create-namespace --wait --version 3.5.11 --set image.registry=pair-cn-shanghai.cr.volces.com/opspai --set image.name=coherence-operator --set image.tag=3.5.11 --set defaultCoherenceImage.registry=pair-cn-shanghai.cr.volces.com/opspai --set defaultCoherenceImage.name=coherence-ce --set defaultCoherenceImage.tag=14.1.2-0-3` | Coherence CRs don't render without the operator. |
 | `teastore` | none | Jaeger-client-java bridge is inside the chart. |
 | `hs`/`sn`/`mm` | none | `dsb-wrk2` loader + Jaeger bridge are inside each chart. |
 

--- a/docs/troubleshooting/benchmark-integration-playbook.md
+++ b/docs/troubleshooting/benchmark-integration-playbook.md
@@ -262,12 +262,12 @@ items are covered above.
   chart since `1.1.1`: each `Coherence` CR template emits `spec.labels`
   with `{app: <name>}`. Without this, aegisctl preflight fails with
   `namespace sockshop0 has no pods matching app=carts`.
-- **Prerequisite: `coherence-operator`.** `helm repo add coherence
-  https://oracle.github.io/coherence-operator/charts` +
-  `helm install coherence-operator coherence/coherence-operator` by
-  hand before the first chart install. (Seed has this wired as a
-  `prerequisites` entry for the system, reconciled via
-  `aegisctl system reconcile-prereqs --name sockshop`.)
+- **Prerequisite: `coherence-operator`.** Install with the Shanghai
+  mirror overrides:
+  `helm repo add coherence https://oracle.github.io/coherence-operator/charts && helm repo update && helm upgrade -i coherence-operator coherence/coherence-operator -n coherence-test --create-namespace --wait --version 3.5.11 --set image.registry=pair-cn-shanghai.cr.volces.com/opspai --set image.name=coherence-operator --set image.tag=3.5.11 --set defaultCoherenceImage.registry=pair-cn-shanghai.cr.volces.com/opspai --set defaultCoherenceImage.name=coherence-ce --set defaultCoherenceImage.tag=14.1.2-0-3`.
+  The same values are seeded in `prerequisites.values`, so
+  `aegisctl system reconcile-prereqs --name sockshop` applies them
+  automatically.
 - **No tracing bridge** — Coherence MP emits Prometheus metrics only.
   Needs `RCABENCH_OPTIONAL_EMPTY_PARQUETS` on the bench container.
 - **Frontend is Node.js**, vendored into the fork at `frontend/` from


### PR DESCRIPTION
## What
- add `values` support to system prerequisite spec serialization
- extend `aegisctl system reconcile-prereqs` to pass prerequisite values as Helm `--set key=value`
- seed sockshop's coherence prerequisite with the Shanghai mirror overrides
- update the cold-start and troubleshooting docs to use the same mirror-aware install flow

## Why
Byte/Shanghai environments can use the mirrored Coherence images, but the existing prerequisite flow only supported `chart/namespace/version`, so `reconcile-prereqs` could not express the required registry overrides.

## Validation
- `go test ./service/initialization -run 'Test(BuildPrerequisiteRow_StoresHelmValues|BuildPrerequisiteRow_DefaultsKindToHelm|InitializeSystemPrerequisites_SeedsAndIsIdempotent)$'`
- `go test ./cmd/aegisctl/cmd -run 'TestBuildHelmUpgradeInstallArgs_'`
