### PR TITLE
fix: gate restart-pedestal inject on readiness and warmup

### DIFF
--- a/AegisLab/src/infra/k8s/gateway.go
+++ b/AegisLab/src/infra/k8s/gateway.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"aegis/consts"
 
@@ -128,6 +129,80 @@ func (g *Gateway) CheckHealth(ctx context.Context) error {
 		return fmt.Errorf("kubernetes API request failed: %w", err)
 	}
 	return nil
+}
+
+// WaitForNamespacePodsReady blocks until every active pod in the namespace is
+// Ready. "Active" means phase Pending/Running/Unknown (Succeeded/Failed pods
+// are ignored). The check requires at least one active pod to avoid a false
+// positive immediately after a helm release returns.
+func (g *Gateway) WaitForNamespacePodsReady(ctx context.Context, namespace string, timeout time.Duration) error {
+	client := getK8sClient()
+	if client == nil {
+		return fmt.Errorf("kubernetes client not available")
+	}
+	if timeout <= 0 {
+		timeout = 10 * time.Minute
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	var lastSummary string
+	for {
+		podList, err := client.CoreV1().Pods(namespace).List(waitCtx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("list pods in namespace %q: %w", namespace, err)
+		}
+
+		ready, summary := evaluateNamespacePodReadiness(podList.Items)
+		lastSummary = summary
+		if ready {
+			return nil
+		}
+
+		select {
+		case <-waitCtx.Done():
+			return fmt.Errorf("wait for pods ready in namespace %q timed out (%s): %w", namespace, lastSummary, waitCtx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func evaluateNamespacePodReadiness(pods []corev1.Pod) (bool, string) {
+	activeNames := make([]string, 0, len(pods))
+	notReadyNames := make([]string, 0)
+
+	for _, pod := range pods {
+		switch pod.Status.Phase {
+		case corev1.PodSucceeded, corev1.PodFailed:
+			continue
+		}
+
+		activeNames = append(activeNames, pod.Name)
+		if !isPodReady(pod.Status.Conditions) {
+			notReadyNames = append(notReadyNames, pod.Name)
+		}
+	}
+
+	if len(activeNames) == 0 {
+		return false, "no active pods found yet"
+	}
+	if len(notReadyNames) > 0 {
+		return false, fmt.Sprintf("%d/%d active pods not ready: %v", len(notReadyNames), len(activeNames), notReadyNames)
+	}
+	return true, fmt.Sprintf("all %d active pods are ready", len(activeNames))
+}
+
+func isPodReady(conditions []corev1.PodCondition) bool {
+	for _, cond := range conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 func getK8sClient() *kubernetes.Clientset {

--- a/AegisLab/src/infra/k8s/gateway_ready_test.go
+++ b/AegisLab/src/infra/k8s/gateway_ready_test.go
@@ -1,0 +1,66 @@
+package k8s
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEvaluateNamespacePodReadiness_NoActivePods(t *testing.T) {
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1ObjectMeta("done-1"),
+			Status:     corev1.PodStatus{Phase: corev1.PodSucceeded},
+		},
+	}
+	ready, _ := evaluateNamespacePodReadiness(pods)
+	if ready {
+		t.Fatalf("expected no-active-pods readiness=false")
+	}
+}
+
+func TestEvaluateNamespacePodReadiness_AllActiveReady(t *testing.T) {
+	pods := []corev1.Pod{
+		newPodWithReady("app-1", corev1.PodRunning, true),
+		newPodWithReady("app-2", corev1.PodRunning, true),
+	}
+	ready, _ := evaluateNamespacePodReadiness(pods)
+	if !ready {
+		t.Fatalf("expected all-active-ready readiness=true")
+	}
+}
+
+func TestEvaluateNamespacePodReadiness_ActiveNotReady(t *testing.T) {
+	pods := []corev1.Pod{
+		newPodWithReady("app-1", corev1.PodRunning, true),
+		newPodWithReady("app-2", corev1.PodPending, false),
+	}
+	ready, _ := evaluateNamespacePodReadiness(pods)
+	if ready {
+		t.Fatalf("expected active-not-ready readiness=false")
+	}
+}
+
+func newPodWithReady(name string, phase corev1.PodPhase, ready bool) corev1.Pod {
+	status := corev1.ConditionFalse
+	if ready {
+		status = corev1.ConditionTrue
+	}
+	return corev1.Pod{
+		ObjectMeta: metav1ObjectMeta(name),
+		Status: corev1.PodStatus{
+			Phase: phase,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: status,
+				},
+			},
+		},
+	}
+}
+
+func metav1ObjectMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{Name: name}
+}

--- a/AegisLab/src/service/consumer/restart_pedestal.go
+++ b/AegisLab/src/service/consumer/restart_pedestal.go
@@ -5,6 +5,7 @@ import (
 	"aegis/consts"
 	"aegis/dto"
 	helm "aegis/infra/helm"
+	k8s "aegis/infra/k8s"
 	redis "aegis/infra/redis"
 	"aegis/service/common"
 	"aegis/tracing"
@@ -56,6 +57,87 @@ func helmInstallTimeouts() (time.Duration, time.Duration) {
 		wait = time.Duration(v) * time.Second
 	}
 	return overall, wait
+}
+
+func restartWorkloadReadyTimeout() time.Duration {
+	timeout := 600 * time.Second
+	if v := config.GetInt("restart_pedestal.workload_ready_timeout_seconds"); v > 0 {
+		timeout = time.Duration(v) * time.Second
+	}
+	return timeout
+}
+
+func restartPostReadySoakDuration() time.Duration {
+	soak := 20 * time.Second
+	if v := config.GetInt("restart_pedestal.post_ready_soak_seconds"); v >= 0 {
+		soak = time.Duration(v) * time.Second
+	}
+	return soak
+}
+
+func extractPreDuration(injectPayload map[string]any) time.Duration {
+	if injectPayload == nil {
+		return 0
+	}
+	raw, ok := injectPayload[consts.InjectPreDuration]
+	if !ok || raw == nil {
+		return 0
+	}
+
+	switch v := raw.(type) {
+	case float64:
+		if v > 0 {
+			return time.Duration(v) * time.Minute
+		}
+	case float32:
+		if v > 0 {
+			return time.Duration(v) * time.Minute
+		}
+	case int:
+		if v > 0 {
+			return time.Duration(v) * time.Minute
+		}
+	case int64:
+		if v > 0 {
+			return time.Duration(v) * time.Minute
+		}
+	}
+	return 0
+}
+
+func waitForPedestalWorkloadReady(ctx context.Context, gateway *k8s.Gateway, namespace string) (time.Time, error) {
+	if gateway == nil {
+		logrus.Warnf("k8s gateway is nil; skipping workload-ready wait for namespace %q", namespace)
+		return time.Now(), nil
+	}
+
+	timeout := restartWorkloadReadyTimeout()
+	if err := gateway.WaitForNamespacePodsReady(ctx, namespace, timeout); err != nil {
+		return time.Time{}, err
+	}
+
+	soak := restartPostReadySoakDuration()
+	if soak <= 0 {
+		return time.Now(), nil
+	}
+
+	timer := time.NewTimer(soak)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return time.Time{}, ctx.Err()
+	case <-timer.C:
+		return time.Now(), nil
+	}
+}
+
+func adjustInjectTimeAfterWarmup(injectTime, warmupReadyAt time.Time, injectPayload map[string]any) time.Time {
+	minInjectTime := warmupReadyAt.Add(extractPreDuration(injectPayload))
+	if injectTime.Before(minInjectTime) {
+		return minInjectTime
+	}
+	return injectTime
 }
 
 type restartPayload struct {
@@ -228,6 +310,21 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 
 				return handleExecutionError(span, logEntry, fmt.Sprintf("failed to install pedestal of system %s", system), err)
 			}
+		}
+
+		warmupReadyAt, err := waitForPedestalWorkloadReady(childCtx, deps.K8sGateway, namespace)
+		if err != nil {
+			toReleased = true
+			return handleExecutionError(span, logEntry, "workload readiness/warmup wait failed", err)
+		}
+		adjustedInjectTime := adjustInjectTimeAfterWarmup(injectTime, warmupReadyAt, payload.injectPayload)
+		if !adjustedInjectTime.Equal(injectTime) {
+			logEntry.WithFields(logrus.Fields{
+				"old_inject_time": injectTime.String(),
+				"new_inject_time": adjustedInjectTime.String(),
+				"pre_duration":    extractPreDuration(payload.injectPayload).String(),
+			}).Warn("inject time adjusted to guarantee warm-up and normal-window coverage")
+			injectTime = adjustedInjectTime
 		}
 
 		message := fmt.Sprintf("Injection start at %s, duration %dm", injectTime.Local().String(), payload.faultDuration)

--- a/AegisLab/src/service/consumer/restart_pedestal_test.go
+++ b/AegisLab/src/service/consumer/restart_pedestal_test.go
@@ -1,0 +1,77 @@
+package consumer
+
+import (
+	"aegis/consts"
+	"testing"
+	"time"
+)
+
+func TestExtractPreDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]any
+		want    time.Duration
+	}{
+		{
+			name:    "missing pre_duration",
+			payload: map[string]any{},
+			want:    0,
+		},
+		{
+			name: "float64 pre_duration",
+			payload: map[string]any{
+				consts.InjectPreDuration: float64(2),
+			},
+			want: 2 * time.Minute,
+		},
+		{
+			name: "int pre_duration",
+			payload: map[string]any{
+				consts.InjectPreDuration: int(3),
+			},
+			want: 3 * time.Minute,
+		},
+		{
+			name: "non-positive pre_duration",
+			payload: map[string]any{
+				consts.InjectPreDuration: float64(0),
+			},
+			want: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractPreDuration(tc.payload)
+			if got != tc.want {
+				t.Fatalf("extractPreDuration() = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAdjustInjectTimeAfterWarmup(t *testing.T) {
+	base := time.Date(2026, 4, 24, 11, 13, 35, 0, time.UTC)
+	ready := time.Date(2026, 4, 24, 11, 14, 0, 0, time.UTC)
+
+	t.Run("keep inject time when already late enough", func(t *testing.T) {
+		inject := time.Date(2026, 4, 24, 11, 16, 0, 0, time.UTC)
+		got := adjustInjectTimeAfterWarmup(inject, ready, map[string]any{
+			consts.InjectPreDuration: float64(1),
+		})
+		if !got.Equal(inject) {
+			t.Fatalf("expected inject time unchanged, got %s", got)
+		}
+	})
+
+	t.Run("push inject time to ready plus pre_duration", func(t *testing.T) {
+		inject := base
+		got := adjustInjectTimeAfterWarmup(inject, ready, map[string]any{
+			consts.InjectPreDuration: float64(1),
+		})
+		want := ready.Add(1 * time.Minute)
+		if !got.Equal(want) {
+			t.Fatalf("adjusted inject time = %s, want %s", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## What
- wait for active namespace pods to become Ready after pedestal install/skip-install
- add a small post-ready soak before scheduling the inject handoff
- clamp inject time so it cannot start before `warmup_complete + pre_duration`
- add focused tests for namespace readiness evaluation and inject-time adjustment

## Why
Sockshop and other freshly restarted pedestals can report Helm success before workloads are actually ready and emitting traces. That lets the normal window fall into bootstrap time, which causes empty or invalid baseline datapacks.

## Validation
- `go test ./infra/k8s -run 'TestEvaluateNamespacePodReadiness|TestGetImagePullPolicy'`
- `go test ./service/consumer -run 'Test(ExtractPreDuration|AdjustInjectTimeAfterWarmup)'`
