### PR TITLE
feat(reasoning): migrate rca_label fault-propagation labeler into rcabench-platform

### DIFF
--- a/rcabench-platform/cli/reason.py
+++ b/rcabench-platform/cli/reason.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env -S uv run -s
+"""CLI wrapper mounting the reasoning sub-app alongside detector / eval / sample."""
+
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from rcabench_platform.v3.cli.main import app
+from rcabench_platform.v3.internal.reasoning.cli import app as reason_app
+
+load_dotenv(Path.cwd() / ".env")
+
+app.add_typer(reason_app, name="reason", help="Fault propagation reasoning / labeling")
+
+
+if __name__ == "__main__":
+    app()

--- a/rcabench-platform/docker/reason/Dockerfile
+++ b/rcabench-platform/docker/reason/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE=10.10.10.240/library/rcabench-platform:latest
+FROM ${BASE_IMAGE}
+
+ENV TZ=Asia/Shanghai
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+WORKDIR /app
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/rcabench-platform/docker/reason/entrypoint.sh
+++ b/rcabench-platform/docker/reason/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+cd /app
+echo "Running reason (fault propagation labeler)"
+LOGURU_COLORIZE=0 .venv/bin/python cli/reason.py reason "$@"

--- a/rcabench-platform/docs/reasoning-state-abstraction-proposal.md
+++ b/rcabench-platform/docs/reasoning-state-abstraction-proposal.md
@@ -1,0 +1,225 @@
+# Reasoning: cross-benchmark state abstraction
+
+Status: proposal / open for discussion
+Owner: reasoning pipeline
+Scope: `src/rcabench_platform/v3/internal/reasoning/` — state model, rule engine, observation layer
+
+## Motivation
+
+The reasoning pipeline was migrated from `rca_label/src/reason/` where it was
+originally built and tuned against **TrainTicket**. During sockshop integration
+testing (`sockshop0-users-pod-failure-wnhnql` datapack) the pipeline:
+
+- successfully built the topology graph (88 nodes / 108 edges) ✓
+- correctly detected the alarm span `front-end::GET /login` via
+  `identify_alarm_nodes_v2` (27155× latency blow-up vs baseline) ✓
+- correctly resolved injection nodes (pod `users-0`, container `coherence`) ✓
+- matched rules and reached the reachable subgraph (container → pod) ✓
+- ✗ terminated with `no_paths`: `detect_state_timeline` returned **0 state
+  windows on every node** — including the clearly-anomalous front-end span.
+
+Root cause on inspection: the propagator's rule engine keys off **state
+windows**, which in turn come from `detect_state_timeline` — a per-node
+metrics-based anomaly scorer. The state vocabulary it emits
+(`CRASH_LOOP_BACK_OFF`, `OOM_KILLED`, `FREQUENT_GC`, `SLOW_HTTP`, `SLOW_DB`, …)
+is effectively **TrainTicket's observability vocabulary**: these labels only
+materialize when Java-Spring auto-instrumentation + a specific K8s metric
+pipeline supply the underlying signals. Go (sockshop), C++ (DSB SocialNetwork /
+MediaMicroservices) and other stacks emit a different — and generally
+coarser — set of signals, so `detect_state_timeline` comes up empty, and the
+rule engine cannot propagate past the first hop.
+
+The original design intuition ("fault → deterministic features → state
+transitions → rules") is sound. The leak is that **the rules' state
+vocabulary is entangled with a single stack's observation vocabulary**, so
+rules that are logically universal cannot mechanically transfer.
+
+## Design goal
+
+Decouple the rule engine from per-stack observation. Introduce an **abstract
+canonical state layer** that the rules operate on, plus per-stack **observation
+adapters** that translate each benchmark's raw signals into canonical states.
+New benchmarks onboard by writing an adapter, not by editing the rules.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  RULE ENGINE  (canonical states + topology kinds, cross-stack)   │
+└─────────────────────────────▲────────────────────────────────────┘
+                              │  consumes: canonical state windows
+                              │
+  ┌───────────────────────────┴───────────────────────────────┐
+  │   CANONICAL STATE LAYER  (small, closed vocabulary)       │
+  │   e.g. HEALTHY / SLOW / ERRORING / UNAVAILABLE / MISSING  │
+  └──▲─────────────▲────────────────────▲─────────────────────┘
+     │             │                    │
+  [seed]       [trace adapter]     [metrics adapter]      [stack-specific
+     │             │                    │                  augmenter]
+fault_type     parent_span_id,      k8s.pod.cpu.usage,    JVM GC, DB client
+→ initial      duration,            memory.rss,           metrics, OOM events,
+ state on      http.status_code     restart_count         container reason codes
+ injection
+ node
+```
+
+## Proposal
+
+### 1. Canonical state lattice (small, closed, cross-stack)
+
+One small set of states applies to every `PlaceKind`. Candidate vocabulary
+(subject to refinement — see open questions):
+
+| Canonical state | Meaning |
+|---|---|
+| `HEALTHY` | Behaving like baseline |
+| `SLOW` | Latency materially above baseline (adaptive threshold) |
+| `ERRORING` | Elevated error rate (5xx / OTel ERROR / exceptions) |
+| `DEGRADED` | Resource pressure or restarts without outright failure |
+| `UNAVAILABLE` | Not serving (pod terminated, container crashed, endpoint absent) |
+| `MISSING` | Expected in baseline but absent in abnormal window |
+
+Every current fine-grained state (`SLOW_HTTP`, `SLOW_DB`, `CRASH_LOOP_BACK_OFF`,
+`OOM_KILLED`, `FREQUENT_GC`, `HIGH_CPU`, `HIGH_MEMORY`, …) becomes either:
+
+- **a specialization label** carried alongside the canonical state (multi-label:
+  `{SLOW, SLOW_DB}` implies `SLOW`), or
+- **derivable only when the augmenter adapter supplies the evidence**; absence
+  just means "we don't know the specialization", not "not slow".
+
+### 2. Fault type → deterministic initial state (no observation needed)
+
+`StateEnhancer` today applies injection-point enhancement only for the subset
+in `INJECTION_POINT_ENHANCEMENT_CATEGORIES`. Make it **universal** and
+**contract-driven**:
+
+| Fault type | Target node kind | Canonical seed state |
+|---|---|---|
+| `PodKill`, `PodFailure` | pod | `UNAVAILABLE` |
+| `ContainerKill` | container | `UNAVAILABLE` |
+| `CPUStress` | container | `DEGRADED` (+ optional `HIGH_CPU`) |
+| `MemoryStress` | container | `DEGRADED` (+ optional `HIGH_MEMORY`) |
+| `HTTPResponseDelay`, `HTTPRequestDelay` | span | `SLOW` |
+| `HTTPResponseAbort`, `HTTPRequestAbort` | span | `ERRORING` |
+| `NetworkDelay`, `NetworkLoss`, `NetworkCorrupt`, … | service / edge | `SLOW` or `ERRORING` |
+| `DNSError`, `DNSRandom` | service (caller) | `ERRORING` |
+| `TimeSkew` | pod | `DEGRADED` |
+| `JVMException`, `JVMReturn` | span | `ERRORING` |
+| `JVMLatency`, `JVMGarbageCollector` | span | `SLOW` |
+| `JVMMySQLException`, `JVMMySQLLatency` | db-span | `ERRORING` / `SLOW` |
+
+This table is **chaos-tool contract**, not inference. The injection node
+carries the seed state regardless of what the observation pipeline sees, so
+propagation always has something to start from.
+
+### 3. Observation layer: two adapters, clean separation
+
+#### a) Trace adapter (universal — every OTel stack)
+
+Drives state for **spans and services**. Inputs: trace parquets only.
+
+- `span.SLOW` ← adaptive threshold on duration (already implemented inside
+  `identify_alarm_nodes_v2`, extract as a shared primitive)
+- `span.ERRORING` ← rate of HTTP 5xx / OTel ERROR / span.status=ERROR
+- `span.MISSING` ← present in baseline, absent in abnormal window
+- `service.DEGRADED` / `UNAVAILABLE` ← derived: root span of service is
+  SLOW / ERRORING / MISSING
+- `edge.SLOW` / `edge.ERRORING` ← child-span anomaly attributable to a specific
+  call edge
+
+#### b) K8s-metrics adapter (universal — any OTel K8s receiver)
+
+Drives state for **pods and containers**. Restricted to the **common K8s
+metrics** every cluster with `k8s-cluster` receiver emits:
+
+- `k8s.pod.phase`, `k8s.container.restarts` → `UNAVAILABLE` / `DEGRADED`
+- `k8s.pod.cpu.usage`, `k8s.pod.memory.rss` (with baseline-adaptive thresholds) → `DEGRADED`
+- `k8s.pod.network.errors`, `k8s.pod.network.io` → `DEGRADED`
+
+No Java/JVM/DB-client metrics required. (They may be layered on — see next.)
+
+#### c) Stack-specific augmenters (optional, per benchmark)
+
+Additional adapters that contribute **specialization labels** on top of the
+canonical state. E.g.:
+
+- JVM augmenter (TrainTicket, TeaStore): adds `FREQUENT_GC` / `OOM_KILLED`
+- DB-client augmenter: adds `SLOW_DB` if span name matches a DB pattern and
+  duration anomalous
+- Python/Go runtime augmenters as needed
+
+Augmenters must **not** be required for any rule to fire. Their absence only
+degrades root-cause explanation quality, never correctness.
+
+### 4. Rule classification
+
+Audit `rules/builtin_rules.json` (13 rules today) and reclassify:
+
+- **Core rules**: operate on canonical states, required for cross-stack
+  operation. Expected ~10–15 rules covering `UNAVAILABLE → UNAVAILABLE`
+  (container → pod → service → span), `SLOW → SLOW` (callee → caller),
+  `ERRORING → ERRORING`, etc.
+- **Augmentation rules**: operate on specialization labels, fire only when
+  augmenter adapter produced them. These are the existing rules keyed on
+  `HIGH_CPU`, `OOM_KILLED`, `SLOW_DB`, etc. Keep as-is; just acknowledge
+  they're optional.
+
+### 5. Onboarding a new benchmark (target UX)
+
+```
+1. Deploy the benchmark with OTel traces + k8s-cluster metrics (already the
+   baseline requirement for any datapack).
+2. Run detector to produce normal/abnormal parquets (unchanged).
+3. Run reason. Works out of the box via trace adapter + k8s-metrics adapter.
+4. Optional: implement a stack-specific augmenter if you want richer
+   specialization labels in the output.
+```
+
+No rule edits. No state-enum edits.
+
+## Migration plan
+
+Phased — goal is zero regression on TrainTicket while unlocking the other
+benchmarks.
+
+| Phase | Work | Gate |
+|---|---|---|
+| 0 | Land this doc + issue-tracker ticket; collect corrections | design sign-off |
+| 1 | Extract the `identify_alarm_nodes_v2` span-state derivation into a named `TraceStateAdapter`; same code paths, just refactored | no behavior change |
+| 2 | Implement `CanonicalState` enum + per-PlaceKind canonical-state fields on graph nodes (alongside existing fine-grained fields) | green on TT |
+| 3 | Wire trace-adapter + k8s-metrics-adapter to populate canonical states; populate specialization labels too when fine-grained state_detector output is available | green on TT + sockshop `no_paths` case now produces paths |
+| 4 | Write JVM-augmenter as first example of specialization adapter. Prove TT's fine-grained rules still fire through the new pipeline | TT regression suite clean |
+| 5 | Audit 13 built-in rules: reclassify core vs augmentation, add any missing core rules (expected: a couple canonical-`SLOW`/`ERRORING` propagation rules) | — |
+| 6 | Enforce deterministic fault-type → seed-state table as a non-optional first step of `InjectionNodeResolver` / `StartingPointResolver` | sockshop green end-to-end |
+| 7 | Integration sweep: sockshop, HotelReservation, SocialNetwork, MediaMicroservices, TeaStore datapacks should all produce non-trivial causal graphs without stack-specific code changes | — |
+
+## Open questions
+
+1. **State lattice size** — is 6 states enough, or do we need an intermediate
+   level (e.g. split `DEGRADED` into `RESOURCE_PRESSURE` vs `RESTARTING`)? I'd
+   start minimal and grow by demand.
+2. **Multi-label representation** — currently node state is
+   `frozenset[str]`. Keep that, with canonical-state members coexisting with
+   specialization labels in the same set? Or split into two fields (more
+   explicit, more work)?
+3. **Backward compat of `causal_graph.json`** — downstream consumers read the
+   existing `state` field. If we keep it as a set of string labels but now the
+   set contains `{"slow", "slow_db"}` instead of just `{"slow_db"}`, is that
+   acceptable, or does the schema need versioning?
+4. **TrainTicket regression coverage** — do we have a stable TT datapack +
+   expected `causal_graph.json` that we can gate phase-2/3/4 against?
+5. **Rule authoring surface** — when core rules and augmentation rules
+   coexist, do we want a single `builtin_rules.json` with a `tier` field, or
+   separate files?
+6. **Alarm → state bridge as a transitional shortcut** — while phases 1–3 are
+   in flight, should we land the minimal "alarm-span → SLOW state window"
+   bridge (Plan A from earlier discussion) as a stopgap so sockshop / dsb
+   benchmarks aren't blocked for weeks? Lean yes if migration is slow.
+
+## Non-goals
+
+- Rewriting the rule engine itself (rule matcher / BFS / subgraph extraction).
+  The rules stay, their semantics stay; we only change the state vocabulary
+  they operate on and how that vocabulary is populated.
+- Abandoning the metrics-based state detector. It becomes the JVM / Java-stack
+  augmenter; it just stops being the mainline.
+- Changing the datapack contract (parquet layout, injection.json schema, file
+  locations).

--- a/rcabench-platform/scripts/docker.py
+++ b/rcabench-platform/scripts/docker.py
@@ -10,6 +10,7 @@ CONTEXTS: dict[str, Path] = {
     "rcabench-platform": Path.cwd(),
     "clickhouse_dataset": Path.cwd() / "docker/clickhouse_dataset",
     "detector": Path.cwd() / "docker/detector",
+    "reason": Path.cwd() / "docker/reason",
 }
 
 HARBOR_REPO = "10.10.10.240/library"

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/__init__.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/__init__.py
@@ -1,0 +1,5 @@
+"""Reason module - Fault propagation analysis for cloud-native environments."""
+
+from rcabench_platform.v3.internal.reasoning.algorithms.propagator import FaultPropagator, RuleUsageStats
+
+__all__ = ["FaultPropagator", "RuleUsageStats"]

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/_util.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/_util.py
@@ -1,0 +1,53 @@
+"""Logging helper ported from rca_label/src/common/logging.py.
+
+Reasoning uses stdlib ``logging`` internally (logger = logging.getLogger(__name__)).
+This helper lets CLI entrypoints configure a reasonable root-logger handler once.
+"""
+
+import logging
+from pathlib import Path
+
+try:
+    from rich.console import Console
+    from rich.logging import RichHandler
+
+    _HAS_RICH = True
+except ImportError:
+    _HAS_RICH = False
+
+
+_LINE_FMT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+_DATE_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+def setup_logging(verbose: bool = False, log_file: Path | None = None) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    root_logger.handlers.clear()
+
+    if _HAS_RICH:
+        console = Console(stderr=True, force_terminal=True)
+        console_handler: logging.Handler = RichHandler(
+            console=console,
+            show_time=True,
+            show_path=False,
+            markup=True,
+            rich_tracebacks=True,
+            tracebacks_show_locals=False,
+            log_time_format=f"[{_DATE_FMT}]",
+        )
+    else:
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(logging.Formatter(fmt=_LINE_FMT, datefmt=_DATE_FMT))
+    console_handler.setLevel(level)
+    root_logger.addHandler(console_handler)
+
+    if log_file:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
+        file_handler.setLevel(level)
+        file_handler.setFormatter(logging.Formatter(fmt=_LINE_FMT, datefmt=_DATE_FMT))
+        root_logger.addHandler(file_handler)
+        logging.getLogger(__name__).info(f"Logging to file: {log_file}")

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/_util.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/_util.py
@@ -13,6 +13,8 @@ try:
 
     _HAS_RICH = True
 except ImportError:
+    Console = None  # type: ignore[assignment,misc]
+    RichHandler = None  # type: ignore[assignment,misc]
     _HAS_RICH = False
 
 
@@ -27,7 +29,7 @@ def setup_logging(verbose: bool = False, log_file: Path | None = None) -> None:
     root_logger.setLevel(level)
     root_logger.handlers.clear()
 
-    if _HAS_RICH:
+    if _HAS_RICH and Console is not None and RichHandler is not None:
         console = Console(stderr=True, force_terminal=True)
         console_handler: logging.Handler = RichHandler(
             console=console,

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/baseline_detector.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/baseline_detector.py
@@ -1,0 +1,400 @@
+"""Baseline-aware state detection using Z-score and percentile thresholds.
+
+This module addresses Gap 2.1 from implementation_gaps.md by replacing
+static global thresholds with baseline-relative detection.
+
+Two detection methods are supported:
+1. Z-score based: For Gaussian-distributed metrics (CPU, memory utilization)
+   Z = (value - baseline_mean) / baseline_std
+
+2. Percentile based: For heavy-tailed metrics (latency, error counts)
+   Compares against baseline percentiles (P50, P90, P99, P99.9)
+   More robust for non-Gaussian distributions.
+"""
+
+from typing import Any
+
+import numpy as np
+
+
+class BaselineStatistics:
+    """Stores baseline statistics for a metric."""
+
+    def __init__(self, mean: float, std: float, count: int = 0):
+        """Initialize baseline statistics.
+
+        Args:
+            mean: Baseline mean value
+            std: Baseline standard deviation
+            count: Number of samples (for confidence)
+        """
+        self.mean = mean
+        self.std = std
+        self.count = count
+
+
+class PercentileStatistics:
+    """Stores percentile-based statistics for a metric.
+
+    More robust for heavy-tailed distributions like latency.
+    """
+
+    def __init__(
+        self,
+        p50: float,
+        p90: float,
+        p99: float,
+        p999: float,
+        count: int = 0,
+    ):
+        """Initialize percentile statistics.
+
+        Args:
+            p50: 50th percentile (median)
+            p90: 90th percentile
+            p99: 99th percentile
+            p999: 99.9th percentile
+            count: Number of samples (for confidence)
+        """
+        self.p50 = p50
+        self.p90 = p90
+        self.p99 = p99
+        self.p999 = p999
+        self.count = count
+
+
+class ZScoreThresholds:
+    """Z-score based thresholds for anomaly detection.
+
+    These are in units of standard deviations from the baseline mean.
+    """
+
+    # General anomaly thresholds (Z-scores)
+    CRITICAL_Z = 3.0  # 3 sigma (99.7% confidence)
+    WARNING_Z = 2.0  # 2 sigma (95% confidence)
+    MODERATE_Z = 1.5  # 1.5 sigma (86.6% confidence)
+
+    # Minimum std dev to avoid division by zero
+    MIN_STD = 1e-6
+
+
+class PercentileThresholds:
+    """Percentile-based thresholds for anomaly detection.
+
+    More robust for heavy-tailed distributions (latency, error counts).
+    """
+
+    # Multipliers for percentile-based detection
+    # Value > baseline_p99 * CRITICAL_MULTIPLIER = critical anomaly
+    CRITICAL_MULTIPLIER = 2.0  # 2x above P99
+    WARNING_MULTIPLIER = 1.5  # 1.5x above P99
+    MODERATE_MULTIPLIER = 1.2  # 1.2x above P99
+
+    # Absolute percentile thresholds
+    # Value > baseline_p999 = critical (exceeds 99.9th percentile)
+    CRITICAL_PERCENTILE = "p999"
+    WARNING_PERCENTILE = "p99"
+    MODERATE_PERCENTILE = "p90"
+
+
+class BaselineAwareDetector:
+    """Detector that uses baseline statistics for Z-score based anomaly detection.
+
+    Best for Gaussian-distributed metrics like CPU/memory utilization.
+    """
+
+    def __init__(self, baseline_stats: dict[str, BaselineStatistics] | None = None):
+        """Initialize baseline-aware detector.
+
+        Args:
+            baseline_stats: Dictionary mapping metric names to their baseline statistics
+                           Format: {"metric_name": BaselineStatistics(mean, std, count)}
+
+        Raises:
+            TypeError: If baseline_stats is not None and not a dict
+        """
+        if baseline_stats is not None and not isinstance(baseline_stats, dict):
+            raise TypeError(f"baseline_stats must be a dict or None, got {type(baseline_stats)}")
+        self.baseline_stats = baseline_stats if baseline_stats is not None else {}
+
+    def calculate_z_score(self, metric_name: str, value: float) -> float:
+        """Calculate Z-score for a metric value relative to baseline.
+
+        Z = (value - baseline_mean) / baseline_std
+
+        Args:
+            metric_name: Name of the metric
+            value: Current metric value
+
+        Returns:
+            Z-score (number of standard deviations from baseline mean)
+            Returns 0.0 if no baseline statistics available
+        """
+        if metric_name not in self.baseline_stats:
+            return 0.0
+
+        stats = self.baseline_stats[metric_name]
+
+        # Avoid division by zero
+        std = max(stats.std, ZScoreThresholds.MIN_STD)
+
+        z_score = (value - stats.mean) / std
+        return z_score
+
+    def is_critical_anomaly(self, metric_name: str, value: float) -> bool:
+        """Check if metric value is critically anomalous (Z > 3).
+
+        Args:
+            metric_name: Name of the metric
+            value: Current metric value
+
+        Returns:
+            True if Z-score > CRITICAL_Z (3 sigma)
+        """
+        z = self.calculate_z_score(metric_name, value)
+        return z > ZScoreThresholds.CRITICAL_Z
+
+    def is_warning_anomaly(self, metric_name: str, value: float) -> bool:
+        """Check if metric value is at warning level (Z > 2).
+
+        Args:
+            metric_name: Name of the metric
+            value: Current metric value
+
+        Returns:
+            True if Z-score > WARNING_Z (2 sigma)
+        """
+        z = self.calculate_z_score(metric_name, value)
+        return z > ZScoreThresholds.WARNING_Z
+
+    def is_moderate_anomaly(self, metric_name: str, value: float) -> bool:
+        """Check if metric value is moderately anomalous (Z > 1.5).
+
+        Args:
+            metric_name: Name of the metric
+            value: Current metric value
+
+        Returns:
+            True if Z-score > MODERATE_Z (1.5 sigma)
+        """
+        z = self.calculate_z_score(metric_name, value)
+        return z > ZScoreThresholds.MODERATE_Z
+
+
+class PercentileAwareDetector:
+    """Detector that uses percentile-based thresholds for anomaly detection.
+
+    Best for heavy-tailed distributions like latency, error counts.
+    More robust than Z-score for non-Gaussian metrics.
+    """
+
+    def __init__(self, percentile_stats: dict[str, PercentileStatistics] | None = None):
+        """Initialize percentile-aware detector.
+
+        Args:
+            percentile_stats: Dictionary mapping metric names to their percentile statistics
+                             Format: {"metric_name": PercentileStatistics(p50, p90, p99, p999, count)}
+
+        Raises:
+            TypeError: If percentile_stats is not None and not a dict
+        """
+        if percentile_stats is not None and not isinstance(percentile_stats, dict):
+            raise TypeError(f"percentile_stats must be a dict or None, got {type(percentile_stats)}")
+        self.percentile_stats = percentile_stats if percentile_stats is not None else {}
+
+    def is_critical_anomaly(self, metric_name: str, value: float) -> bool:
+        """Check if metric value is critically anomalous (exceeds P99.9 or 2x P99).
+
+        Args:
+            metric_name: Name of the metric
+            value: Current metric value
+
+        Returns:
+            True if value exceeds P99.9 or is 2x above P99
+        """
+        if metric_name not in self.percentile_stats:
+            return False
+
+        stats = self.percentile_stats[metric_name]
+
+        # Critical if exceeds P99.9 or 2x P99
+        return value > stats.p999 or value > stats.p99 * PercentileThresholds.CRITICAL_MULTIPLIER
+
+    def is_warning_anomaly(self, metric_name: str, value: float) -> bool:
+        """Check if metric value is at warning level (exceeds P99 or 1.5x P99).
+
+        Args:
+            metric_name: Name of the metric
+            value: Current metric value
+
+        Returns:
+            True if value exceeds P99 or is 1.5x above P99
+        """
+        if metric_name not in self.percentile_stats:
+            return False
+
+        stats = self.percentile_stats[metric_name]
+
+        # Warning if exceeds P99 or 1.5x P99
+        return value > stats.p99 or value > stats.p99 * PercentileThresholds.WARNING_MULTIPLIER
+
+    def is_moderate_anomaly(self, metric_name: str, value: float) -> bool:
+        """Check if metric value is moderately anomalous (exceeds P90 or 1.2x P99).
+
+        Args:
+            metric_name: Name of the metric
+            value: Current metric value
+
+        Returns:
+            True if value exceeds P90 or is 1.2x above P99
+        """
+        if metric_name not in self.percentile_stats:
+            return False
+
+        stats = self.percentile_stats[metric_name]
+
+        # Moderate if exceeds P90 or 1.2x P99
+        return value > stats.p90 or value > stats.p99 * PercentileThresholds.MODERATE_MULTIPLIER
+
+
+def compute_baseline_statistics(metric_values: np.ndarray) -> BaselineStatistics:
+    """Compute baseline statistics from historical metric values.
+
+    Args:
+        metric_values: Array of historical metric values
+
+    Returns:
+        BaselineStatistics with mean, std, and count
+    """
+    if len(metric_values) == 0:
+        return BaselineStatistics(mean=0.0, std=0.0, count=0)
+
+    # Remove NaN values
+    clean_values = metric_values[~np.isnan(metric_values)]
+
+    if len(clean_values) == 0:
+        return BaselineStatistics(mean=0.0, std=0.0, count=0)
+
+    mean = float(np.mean(clean_values))
+    std = float(np.std(clean_values))
+    count = len(clean_values)
+
+    return BaselineStatistics(mean=mean, std=std, count=count)
+
+
+def compute_percentile_statistics(metric_values: np.ndarray) -> PercentileStatistics:
+    """Compute percentile statistics from historical metric values.
+
+    More robust than mean/std for heavy-tailed distributions.
+
+    Args:
+        metric_values: Array of historical metric values
+
+    Returns:
+        PercentileStatistics with p50, p90, p99, p999, and count
+    """
+    if len(metric_values) == 0:
+        return PercentileStatistics(p50=0.0, p90=0.0, p99=0.0, p999=0.0, count=0)
+
+    # Remove NaN values
+    clean_values = metric_values[~np.isnan(metric_values)]
+
+    if len(clean_values) == 0:
+        return PercentileStatistics(p50=0.0, p90=0.0, p99=0.0, p999=0.0, count=0)
+
+    p50 = float(np.percentile(clean_values, 50))
+    p90 = float(np.percentile(clean_values, 90))
+    p99 = float(np.percentile(clean_values, 99))
+    p999 = float(np.percentile(clean_values, 99.9))
+    count = len(clean_values)
+
+    return PercentileStatistics(p50=p50, p90=p90, p99=p99, p999=p999, count=count)
+
+
+def extract_metric_value(metric: Any) -> float:
+    """Extract scalar value from metric (handle both arrays and scalars).
+
+    Args:
+        metric: Metric value (array or scalar)
+
+    Returns:
+        Aggregated scalar value (max value if array, else value itself)
+    """
+    if isinstance(metric, np.ndarray):
+        return float(np.max(metric)) if len(metric) > 0 else 0.0
+    return float(metric) if metric is not None else 0.0
+
+
+def calculate_series_stats(values: np.ndarray) -> tuple[float, float, float]:
+    """Calculate mean, std, and CV for a time series.
+
+    Args:
+        values: Time series values
+
+    Returns:
+        Tuple of (mean, std, cv) where cv is coefficient of variation (std/mean)
+    """
+    if len(values) == 0:
+        return 0.0, 0.0, 0.0
+
+    mean = float(np.mean(values))
+    std = float(np.std(values))
+
+    if mean > 1e-6:  # Avoid division by zero
+        cv = std / mean
+    else:
+        cv = 0.0
+
+    return mean, std, cv
+
+
+def get_adaptive_threshold(
+    baseline_mean: float,
+    cv: float,
+    cv_scale: float = 0.15,
+    cv_range: float = 3.0,
+    cv_base: float = 1.5,
+    latency_sensitivity: float = 0.6,
+    reference_latency: float = 0.2,
+) -> float:
+    """Calculate adaptive threshold for latency anomaly detection.
+
+    Core principle: smaller baseline → tolerate larger multiplier.
+    - 1ms → 100ms (100x): small absolute change, user barely notices
+    - 100ms → 1s (10x): large absolute change, severely impacts UX
+
+    Formula: threshold = (cv_base + cv_range * f(cv)) * (reference/baseline)^sensitivity
+    - Volatility component: f(cv) = 1 - exp(-cv/cv_scale)
+    - Latency-level component: (reference/baseline)^sensitivity
+
+    Args:
+        baseline_mean: Baseline latency mean (seconds)
+        cv: Baseline coefficient of variation (std/mean)
+        cv_base: Minimum threshold for stable data (default: 1.5)
+                 Smaller=stricter, larger=looser
+        cv_range: Maximum additional threshold from volatility (default: 3.0)
+                  Total range: [cv_base, cv_base + cv_range]
+        cv_scale: Volatility sensitivity (default: 0.15)
+                  Smaller=saturates faster, larger=saturates slower
+        latency_sensitivity: Latency-level adjustment strength (default: 0.5)
+                            Larger=baseline impact stronger
+        reference_latency: Neutral latency level in seconds (default: 0.3)
+                          Baseline below this gets higher threshold
+
+    Returns:
+        Threshold multiplier (typically 1.5-40.0)
+
+    Examples:
+        1ms baseline (CV=0.05):   threshold ≈ 40.0 (allows ~100x+)
+        300ms baseline (CV=0.2):  threshold ≈ 3.5 (allows ~5-10x)
+        5s baseline (CV=0.3):     threshold ≈ 1.8 (allows ~2-3x)
+    """
+    # Volatility component: cv_base + cv_range * (1 - e^(-cv/cv_scale))
+    cv_component = cv_base + cv_range * (1.0 - float(np.exp(-cv / cv_scale)))
+
+    # Latency-level component: (reference/baseline)^sensitivity
+    safe_baseline = max(baseline_mean, 1e-6)
+    latency_boost = float((reference_latency / safe_baseline) ** latency_sensitivity)
+
+    # Ensure threshold is at least 1.0 (otherwise normal values would be flagged)
+    return max(float(cv_component * latency_boost), 1.0)

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/propagator.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/propagator.py
@@ -1,0 +1,971 @@
+"""Slim FaultPropagator coordinator using extracted modules.
+
+This module provides the FaultPropagator class which coordinates:
+- StateEnhancer: Propagates container restart states to spans
+- RuleMatcher: Efficient rule lookup and matching
+- TopologyExplorer: BFS/DFS graph traversal
+- TemporalValidator: Temporal causality validation
+
+This is a refactored version of the original forward_propagator.py that
+uses extracted, testable components for better maintainability.
+"""
+
+import hashlib
+import json
+import logging
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+from rcabench_platform.v3.internal.reasoning.algorithms.rule_matcher import RuleMatcher
+from rcabench_platform.v3.internal.reasoning.algorithms.state_enhancer import (
+    CONTAINER_RESTART_TO_MISSING_SPAN,
+    INJECTION_POINT_TO_SPAN_AFFECTED,
+    POD_KILLED_TO_CONTAINER_RESTARTING,
+    InjectionPointEnhancement,
+    StateEnhancer,
+)
+from rcabench_platform.v3.internal.reasoning.algorithms.temporal_validator import TemporalValidator
+from rcabench_platform.v3.internal.reasoning.algorithms.topology_explorer import TopologyExplorer
+from rcabench_platform.v3.internal.reasoning.models.graph import Edge, HyperGraph, Node, PlaceKind
+from rcabench_platform.v3.internal.reasoning.models.propagation import PropagationPath, PropagationResult
+from rcabench_platform.v3.internal.reasoning.models.state import StateWindow
+from rcabench_platform.v3.internal.reasoning.rules.schema import PropagationDirection, PropagationRule
+
+logger = logging.getLogger(__name__)
+
+
+class RuleUsageStats:
+    """Track rule usage statistics during propagation."""
+
+    def __init__(self) -> None:
+        self.rule_counts: Counter[str] = Counter()
+
+    def record_rule_use(self, rule_id: str) -> None:
+        """Record that a rule was applied."""
+        self.rule_counts[rule_id] += 1
+
+    def save_to_file(self, filepath: Path | str) -> None:
+        """Save statistics to a JSON file."""
+        filepath = Path(filepath)
+        stats = {
+            "total_applications": sum(self.rule_counts.values()),
+            "unique_rules_used": len(self.rule_counts),
+            "rule_usage": dict(self.rule_counts.most_common()),
+        }
+        filepath.write_text(json.dumps(stats, indent=2))
+
+    def get_summary(self) -> str:
+        """Get a summary string of rule usage."""
+        lines = ["Rule Usage Statistics:"]
+        for rule_id, count in self.rule_counts.most_common():
+            lines.append(f"  {rule_id}: {count}")
+        return "\n".join(lines)
+
+
+class FaultPropagator:
+    """Bidirectional fault propagation analyzer using extracted components.
+
+    This coordinator class uses:
+    - StateEnhancer for state propagation (e.g., container restart -> MISSING_SPAN)
+    - RuleMatcher for efficient rule lookup and matching
+    - TopologyExplorer for BFS/DFS graph traversal
+    - TemporalValidator for temporal causality validation
+    """
+
+    def __init__(
+        self,
+        graph: HyperGraph,
+        rules: list[PropagationRule],
+        max_hops: int = 5,
+    ) -> None:
+        """Initialize the fault propagator.
+
+        Args:
+            graph: The hypergraph containing topology (with node states already populated)
+            rules: List of propagation rules
+            max_hops: Maximum propagation hops (default 5)
+        """
+        self.graph = graph
+        self.rules = rules
+        self.max_hops = max_hops
+
+        # Create and store state enhancer for later use
+        # Order matters: Pod KILLED -> Container RESTARTING -> Span MISSING_SPAN
+        self.state_enhancer = StateEnhancer(self.graph)
+        self.state_enhancer.register(POD_KILLED_TO_CONTAINER_RESTARTING)
+        self.state_enhancer.register(CONTAINER_RESTART_TO_MISSING_SPAN)
+        self.state_enhancer.apply_all()
+
+        # Build rule matcher with indices
+        self.rule_matcher = RuleMatcher(rules)
+        # Keep rule_index reference for backward compatibility
+        self.rule_index = self.rule_matcher.rule_index
+
+        # Create topology explorer
+        self.topology_explorer = TopologyExplorer(graph, max_hops)
+
+        # Create temporal validator
+        self.temporal_validator = TemporalValidator(self.graph)
+
+        # Initialize rule usage statistics
+        self.rule_stats = RuleUsageStats()
+
+    def propagate_from_injection(
+        self,
+        injection_node_ids: list[int],
+        alarm_nodes: set[int],
+        fault_category: str | None = None,
+        injection_service_id: int | None = None,
+        injection_point_enhancement: InjectionPointEnhancement | None = None,
+        source_service_id: int | None = None,
+        target_service_id: int | None = None,
+        fault_direction: str | None = None,
+    ) -> PropagationResult:
+        """Propagate fault from injection nodes to alarm nodes.
+
+        Args:
+            injection_node_ids: List of injection node IDs
+            alarm_nodes: Set of alarm node IDs to reach
+            fault_category: Optional fault category for injection point enhancement
+            injection_service_id: Optional service ID where fault was injected
+            injection_point_enhancement: Optional custom enhancement (defaults to builtin)
+            source_service_id: For network/DNS faults, the source service ID
+            target_service_id: For network/DNS faults, the target service ID
+            fault_direction: For network faults, the direction ("to", "from", "both")
+
+        Returns:
+            PropagationResult with valid paths
+        """
+        # Apply injection point enhancement if applicable
+        if fault_category and injection_service_id is not None:
+            enhancement = injection_point_enhancement or INJECTION_POINT_TO_SPAN_AFFECTED
+            self.state_enhancer.apply_injection_point_enhancement(
+                injection_service_id=injection_service_id,
+                fault_category=fault_category,
+                enhancement=enhancement,
+                source_service_id=source_service_id,
+                target_service_id=target_service_id,
+                fault_direction=fault_direction,
+            )
+
+        for injection_node_id in injection_node_ids:
+            injection_node = self.graph.get_node_by_id(injection_node_id)
+            if injection_node is None:
+                raise ValueError(f"Injection node {injection_node_id} not found in graph")
+
+        # Use edge filter based on rule matching
+        def edge_filter(src_id: int, dst_id: int, is_first_hop: bool) -> bool:
+            """Initial screening filter for BFS topology exploration.
+
+            Strategy: Recall-first for multi-hop rules - an edge passes if it matches
+            ANY hop of a multi-hop rule (not just the first hop). This prevents premature
+            pruning during BFS. Complete path validation happens later in extract_paths().
+            """
+            src_states = self._get_states_for_node(src_id)
+            dst_states = self._get_states_for_node(dst_id)
+            src_node = self.graph.get_node_by_id(src_id)
+            dst_node = self.graph.get_node_by_id(dst_id)
+
+            result = self.rule_matcher.edge_matches_any_rule(
+                src_id, dst_id, self.graph, src_states, dst_states, is_first_hop
+            )
+
+            # Debug: log span->span edges to diagnose propagation issues
+            if src_node and dst_node and src_node.kind == PlaceKind.span and dst_node.kind == PlaceKind.span:
+                if "injection_affected" in src_states or not result:
+                    logger.debug(
+                        f"    [EDGE_FILTER] span->span: {src_node.self_name} -> {dst_node.self_name}, "
+                        f"src_states={src_states}, dst_states={dst_states}, result={result}"
+                    )
+
+            if is_first_hop:
+                logger.debug(
+                    f"    [EDGE_FILTER] is_first_hop={is_first_hop}, "
+                    f"src={src_node.kind.value if src_node else 'None'}:{src_node.uniq_name if src_node else 'None'}, "
+                    f"dst={dst_node.kind.value if dst_node else 'None'}:{dst_node.uniq_name if dst_node else 'None'}, "
+                    f"src_states={src_states}, dst_states={dst_states}, result={result}"
+                )
+
+            return result
+
+        # Find reachable subgraph using TopologyExplorer
+        subgraph_edges = self.topology_explorer.find_reachable_subgraph(injection_node_ids, alarm_nodes, edge_filter)
+
+        warnings: list[str] = []
+
+        if len(subgraph_edges) == 0:
+            warning_msg = f"No reachable edges found from injection nodes {injection_node_ids}"
+            warnings.append(warning_msg)
+            logger.warning(f"  [WARNING] {warning_msg}")
+            # Return early with empty result
+            return PropagationResult(
+                injection_node_ids=injection_node_ids,
+                injection_states=["unknown"] * len(injection_node_ids),
+                paths=[],
+                visited_nodes=set(),
+                max_hops_reached=0,
+                subgraph_edges=[],
+                warnings=warnings,
+            )
+
+        logger.debug(f"  [DEBUG] Subgraph has {len(subgraph_edges)} edges")
+
+        # Extract paths from subgraph
+        all_topology_paths = self.topology_explorer.extract_paths(subgraph_edges, injection_node_ids, alarm_nodes)
+
+        if len(all_topology_paths) == 0:
+            warning_msg = f"No paths extracted from reachable subgraph ({len(subgraph_edges)} edges available)"
+            warnings.append(warning_msg)
+            logger.warning(f"  [WARNING] {warning_msg}")
+            # Return with subgraph but no paths
+            return PropagationResult(
+                injection_node_ids=injection_node_ids,
+                injection_states=["unknown"] * len(injection_node_ids),
+                paths=[],
+                visited_nodes=set(),
+                max_hops_reached=0,
+                subgraph_edges=subgraph_edges,
+                warnings=warnings,
+            )
+
+        logger.debug(f"  [DEBUG] Extracted {len(all_topology_paths)} paths")
+        for node_path in all_topology_paths:
+            logger.debug(f"    [DEBUG]   Path: {self._format_path_debug(node_path)}")
+
+        valid_paths: list[PropagationPath] = []
+        visited_nodes: set[int] = set()
+        max_hops = 0
+
+        for node_ids in all_topology_paths:
+            visited_nodes.update(node_ids)
+            max_hops = max(max_hops, len(node_ids) - 1)
+
+            path = self._verify_and_build_path(node_ids)
+            if path is not None:
+                valid_paths.append(path)
+
+        # Log and save rule usage statistics
+        if self.rule_stats.rule_counts:
+            logger.info(self.rule_stats.get_summary())
+
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            injection_hash = hashlib.md5(str(sorted(injection_node_ids)).encode()).hexdigest()[:8]
+            stat_dir = Path("output/stat") / f"{timestamp}-{injection_hash}"
+            stat_dir.mkdir(parents=True, exist_ok=True)
+            stat_file = stat_dir / "rule_stats.json"
+            self.rule_stats.save_to_file(stat_file)
+            logger.info(f"Saved rule statistics to {stat_file}")
+
+        return PropagationResult(
+            injection_node_ids=injection_node_ids,
+            injection_states=["unknown"] * len(injection_node_ids),
+            paths=valid_paths,
+            visited_nodes=visited_nodes,
+            max_hops_reached=max_hops,
+            subgraph_edges=subgraph_edges,
+            warnings=warnings,
+        )
+
+    def _get_states_for_node(self, node_id: int) -> set[str]:
+        """Get all states for a node from graph.node.state_timeline."""
+        node = self.graph.get_node_by_id(node_id)
+        if node and node.state_timeline:
+            states: set[str] = set()
+            for window in node.state_timeline:
+                states.update(window.states)
+            return states
+        return set()
+
+    def _get_node_states(self, node_id: int) -> list[StateWindow]:
+        """Get state timeline for a node from graph.node.state_timeline."""
+        node = self.graph.get_node_by_id(node_id)
+        if node and node.state_timeline:
+            return node.state_timeline
+        return []
+
+    def _format_path_debug(self, node_ids: list[int]) -> str:
+        """Format node IDs for debug output."""
+        parts = []
+        for nid in node_ids:
+            node = self.graph.get_node_by_id(nid)
+            if node:
+                parts.append(f"{node.kind.value}:{node.self_name}")
+            else:
+                parts.append(f"?:{nid}")
+        return " -> ".join(parts)
+
+    # ========================================================================
+    # Path verification methods
+    # These methods are imported from the original forward_propagator.py
+    # to maintain backward compatibility with tests
+    # ========================================================================
+
+    def _verify_and_build_path(self, node_ids: list[int]) -> PropagationPath | None:
+        """Verify and build a propagation path from node IDs.
+
+        This method coordinates:
+        1. Multi-hop rule matching via RuleMatcher
+        2. Temporal validation via TemporalValidator
+        3. Single-hop fallback verification
+
+        Args:
+            node_ids: List of node IDs forming the path
+
+        Returns:
+            PropagationPath if valid, None otherwise
+        """
+        if len(node_ids) < 2:
+            return None
+
+        # First, check if this path matches any multi-hop rules
+        multi_hop_rule = self._find_matching_multi_hop_rule(node_ids)
+        if multi_hop_rule is not None:
+            path = self._verify_multi_hop_path(node_ids, multi_hop_rule)
+            if path is not None:
+                return path
+
+        # Fall back to hop-by-hop verification
+        nodes: list[int] = []
+        states: list[list[str]] = []
+        edges: list[str] = []
+        rules: list[str] = []
+        state_start_times: list[int | None] = []
+        propagation_delays: list[float] = []
+
+        i = 0
+        while i < len(node_ids) - 1:
+            # Try to match a multi-hop rule starting at this position
+            multi_hop_matched = False
+            for rule in self.rules:
+                if not rule.is_multi_hop or not rule.path:
+                    continue
+
+                rule_node_count = len(rule.path) + 1
+                if i + rule_node_count > len(node_ids):
+                    continue
+
+                sub_path = node_ids[i : i + rule_node_count]
+                logger.debug(
+                    f"    [DEBUG] Trying multi-hop rule {rule.rule_id} at position {i}, "
+                    f"sub_path length={len(sub_path)}, path={self._format_path_debug(sub_path)}"
+                )
+                if self._matches_multi_hop_rule(rule, sub_path):
+                    prev_time = state_start_times[-1] if state_start_times else None
+                    verified = self._verify_multi_hop_subpath(
+                        sub_path, rule, prev_start_time=prev_time, is_first_hop=(i == 0)
+                    )
+                    if verified is not None:
+                        (
+                            sub_nodes,
+                            sub_states,
+                            sub_edges,
+                            sub_rules,
+                            sub_times,
+                            sub_delays,
+                        ) = verified
+
+                        if i == 0:
+                            nodes.extend(sub_nodes)
+                            states.extend(sub_states)
+                        else:
+                            nodes.extend(sub_nodes[1:])
+                            states.extend(sub_states[1:])
+
+                        edges.extend(sub_edges)
+                        rules.extend(sub_rules)
+
+                        if i == 0:
+                            state_start_times.extend(sub_times)
+                        else:
+                            state_start_times.extend(sub_times[1:])
+
+                        propagation_delays.extend(sub_delays)
+
+                        # After matching [i, i+1, ..., i+rule_node_count-1], next hop starts at i+rule_node_count-1
+                        # e.g., matched [A,B,C] (i=0, rule_node_count=3), next check C->D (i=2)
+                        i += rule_node_count - 1
+                        multi_hop_matched = True
+                        break
+
+            if multi_hop_matched:
+                continue
+
+            # Fall back to single-hop verification
+            hop_result = self._verify_single_hop(
+                hop_index=i,
+                src_id=node_ids[i],
+                dst_id=node_ids[i + 1],
+                prev_start_time=state_start_times[-1] if state_start_times else None,
+                is_first_hop=(i == 0),
+            )
+            if hop_result is None:
+                self._log_verification_failure(
+                    node_ids=node_ids,
+                    failed_hop_index=i,
+                    matched_nodes=nodes,
+                    matched_edges=edges,
+                    matched_rules=rules,
+                )
+                return None
+
+            (
+                hop_src_id,
+                hop_dst_id,
+                hop_src_states,
+                hop_dst_states,
+                hop_src_time,
+                hop_dst_time,
+                hop_edge_desc,
+                hop_rule_id,
+                hop_delay,
+            ) = hop_result
+
+            if i == 0:
+                nodes.append(hop_src_id)
+                states.append(hop_src_states)
+                state_start_times.append(hop_src_time)
+
+            nodes.append(hop_dst_id)
+            states.append(hop_dst_states)
+            state_start_times.append(hop_dst_time)
+            edges.append(hop_edge_desc)
+            rules.append(hop_rule_id)
+            propagation_delays.append(hop_delay)
+
+            i += 1
+
+        return PropagationPath(
+            nodes=nodes,
+            states=states,
+            edges=edges,
+            rules=rules,
+            confidence=1.0,
+            state_start_times=state_start_times,
+            propagation_delays=propagation_delays,
+        )
+
+    def _find_matching_multi_hop_rule(self, node_ids: list[int]) -> PropagationRule | None:
+        """Find a multi-hop rule matching the entire path."""
+        return self.rule_matcher.find_matching_multi_hop_rule(node_ids, self.graph)
+
+    def _matches_multi_hop_rule(self, rule: PropagationRule, node_ids: list[int]) -> bool:
+        """Check if node_ids matches a multi-hop rule structure."""
+        matches = self.rule_matcher.matches_multi_hop_rule(rule, node_ids, self.graph)
+        if not matches:
+            logger.debug(
+                f"      [DEBUG] Multi-hop rule {rule.rule_id} did NOT match path: {self._format_path_debug(node_ids)}"
+            )
+        else:
+            logger.debug(
+                f"      [DEBUG] Multi-hop rule {rule.rule_id} MATCHED path: {self._format_path_debug(node_ids)}"
+            )
+        return matches
+
+    def _verify_multi_hop_path(self, node_ids: list[int], rule: PropagationRule) -> PropagationPath | None:
+        """Verify a multi-hop path against a rule with temporal validation."""
+        if not rule.path or len(node_ids) != len(rule.path) + 1:
+            return None
+
+        src_id = node_ids[0]
+        src_timeline = self._get_node_states(src_id)
+        src_states_all: set[str] = set()
+        for window in src_timeline:
+            src_states_all.update(window.states)
+
+        src_node = self.graph.get_node_by_id(src_id)
+        if src_node is None:
+            return None
+
+        # Find first window with matching src_states
+        rule_src_states = set(rule.src_states)
+        src_matching_window = None
+        if rule_src_states and src_timeline:
+            for window in src_timeline:
+                if window.states.intersection(rule_src_states):
+                    src_matching_window = window
+                    break
+
+            if src_matching_window is None:
+                logger.debug(
+                    f"    [DEBUG] Multi-hop path rejected: source {src_node.self_name} "
+                    f"never has required states {rule_src_states}, actual: {src_states_all}"
+                )
+                return None
+
+        # Initialize tracking
+        nodes: list[int] = [src_id]
+        if src_matching_window:
+            states: list[list[str]] = [sorted(src_matching_window.states)]
+        else:
+            states = [sorted(src_states_all) if src_states_all else ["unknown"]]
+        edges_list: list[str] = []
+        rules_list: list[str] = []
+        state_start_times: list[int | None] = []
+        propagation_delays: list[float] = []
+
+        # Get start time for source
+        if src_matching_window:
+            src_start_time = src_matching_window.start_time
+        elif src_timeline:
+            src_start_time = src_timeline[0].start_time
+        else:
+            src_start_time = 0
+            # Find earliest state start time from all nodes in graph
+            all_starts = [
+                node.state_timeline[0].start_time for node in self.graph._node_id_map.values() if node.state_timeline
+            ]
+            if all_starts:
+                src_start_time = min(all_starts)
+
+        state_start_times.append(src_start_time)
+        current_start_time = src_start_time
+
+        # Validate each hop
+        for hop_idx, path_hop in enumerate(rule.path):
+            current_node_id = node_ids[hop_idx]
+            next_node_id = node_ids[hop_idx + 1]
+
+            edge_data, direction = self._get_edge_between(current_node_id, next_node_id)
+            if edge_data is None or direction is None:
+                return None
+
+            if edge_data.kind != path_hop.edge_kind or direction != path_hop.direction:
+                return None
+
+            edge_desc = f"{edge_data.kind.value}_{direction.value}"
+
+            next_node = self.graph.get_node_by_id(next_node_id)
+            if next_node is None:
+                return None
+
+            next_timeline = self._get_node_states(next_node_id)
+            next_states_all: set[str] = set()
+            for window in next_timeline:
+                next_states_all.update(window.states)
+
+            # Check intermediate_states constraint
+            is_last_hop = hop_idx == len(rule.path) - 1
+            if not is_last_hop:
+                if path_hop.intermediate_states is not None:
+                    check_states = next_states_all if next_states_all else {"unknown"}
+                    allowed_states = set(path_hop.intermediate_states)
+                    if not check_states.intersection(allowed_states):
+                        logger.debug(
+                            f"    [DEBUG] Multi-hop rejected: intermediate {next_node.self_name} "
+                            f"has {check_states}, allowed: {allowed_states}"
+                        )
+                        return None
+            else:
+                # Last hop: check possible_dst_states
+                dst_states_set = set(rule.possible_dst_states)
+                if dst_states_set and next_states_all:
+                    if not next_states_all.intersection(dst_states_set):
+                        logger.debug(
+                            f"    [DEBUG] Multi-hop rejected: dst {next_node.self_name} "
+                            f"has {next_states_all}, required: {dst_states_set}"
+                        )
+                        return None
+
+            # Temporal validation using TemporalValidator
+            causal_window = self.temporal_validator.find_causal_window(next_node_id, current_start_time)
+            if causal_window is not None:
+                delay = float(causal_window.start_time - current_start_time)
+                next_start_time = causal_window.start_time
+            else:
+                delay = 0.0
+                next_start_time = current_start_time
+
+            # Update tracking
+            nodes.append(next_node_id)
+            states.append(sorted(next_states_all) if next_states_all else ["unknown"])
+            edges_list.append(edge_desc)
+            rules_list.append(rule.rule_id)
+            state_start_times.append(next_start_time)
+            propagation_delays.append(delay)
+
+            current_start_time = next_start_time
+
+        # Record rule usage
+        self.rule_stats.record_rule_use(rule.rule_id)
+
+        return PropagationPath(
+            nodes=nodes,
+            states=states,
+            edges=edges_list,
+            rules=rules_list,
+            confidence=rule.confidence,
+            state_start_times=state_start_times,
+            propagation_delays=propagation_delays,
+        )
+
+    def _verify_multi_hop_subpath(
+        self,
+        node_ids: list[int],
+        rule: PropagationRule,
+        prev_start_time: int | None,
+        is_first_hop: bool,
+    ) -> (
+        tuple[
+            list[int],
+            list[list[str]],
+            list[str],
+            list[str],
+            list[int | None],
+            list[float],
+        ]
+        | None
+    ):
+        """Verify a multi-hop sub-path within a larger path."""
+        if not rule.path or len(node_ids) != len(rule.path) + 1:
+            return None
+
+        src_id = node_ids[0]
+        src_timeline = self._get_node_states(src_id)
+        src_states_all: set[str] = set()
+        for window in src_timeline:
+            src_states_all.update(window.states)
+
+        src_node = self.graph.get_node_by_id(src_id)
+        if src_node is None:
+            return None
+
+        rule_src_states = set(rule.src_states)
+        src_matching_window = None
+
+        if is_first_hop and rule_src_states and src_timeline:
+            for window in src_timeline:
+                if window.states.intersection(rule_src_states):
+                    src_matching_window = window
+                    break
+
+            if src_matching_window is None:
+                logger.debug(
+                    f"    [DEBUG] Multi-hop subpath rejected: source {src_node.self_name} "
+                    f"never has required states {rule_src_states}, actual: {src_states_all}"
+                )
+                return None
+        elif rule_src_states and src_states_all:
+            # Not first hop - still check src_states
+            if not src_states_all.intersection(rule_src_states):
+                logger.debug(
+                    f"    [DEBUG] Multi-hop subpath rejected: source {src_node.self_name} "
+                    f"lacks required states {rule_src_states}, actual: {src_states_all}"
+                )
+                return None
+
+        nodes: list[int] = [src_id]
+        if src_matching_window:
+            states: list[list[str]] = [sorted(src_matching_window.states)]
+        else:
+            states = [sorted(src_states_all) if src_states_all else ["unknown"]]
+        edges_list: list[str] = []
+        rules_list: list[str] = []
+        state_start_times: list[int | None] = []
+        propagation_delays: list[float] = []
+
+        # Get start time for source
+        if src_matching_window:
+            src_start_time = src_matching_window.start_time
+        elif prev_start_time is not None:
+            causal_window = self.temporal_validator.find_causal_window(src_id, prev_start_time)
+            src_start_time = causal_window.start_time if causal_window else prev_start_time
+        elif src_timeline:
+            src_start_time = src_timeline[0].start_time
+        else:
+            src_start_time = 0
+            # Find earliest state start time from all nodes in graph
+            all_starts = [
+                node.state_timeline[0].start_time for node in self.graph._node_id_map.values() if node.state_timeline
+            ]
+            if all_starts:
+                src_start_time = min(all_starts)
+
+        state_start_times.append(src_start_time)
+        current_start_time = src_start_time
+
+        for hop_idx, path_hop in enumerate(rule.path):
+            current_node_id = node_ids[hop_idx]
+            next_node_id = node_ids[hop_idx + 1]
+
+            edge_data, direction = self._get_edge_between(current_node_id, next_node_id)
+            if edge_data is None or direction is None:
+                return None
+
+            if edge_data.kind != path_hop.edge_kind or direction != path_hop.direction:
+                return None
+
+            edge_desc = f"{edge_data.kind.value}_{direction.value}"
+
+            next_node = self.graph.get_node_by_id(next_node_id)
+            if next_node is None:
+                return None
+
+            next_timeline = self._get_node_states(next_node_id)
+            next_states_all: set[str] = set()
+            for window in next_timeline:
+                next_states_all.update(window.states)
+
+            is_last_hop = hop_idx == len(rule.path) - 1
+            if not is_last_hop:
+                if path_hop.intermediate_states is not None:
+                    check_states = next_states_all if next_states_all else {"unknown"}
+                    allowed_states = set(path_hop.intermediate_states)
+                    if not check_states.intersection(allowed_states):
+                        return None
+
+            causal_window = self.temporal_validator.find_causal_window(next_node_id, current_start_time)
+            if causal_window is not None:
+                delay = float(causal_window.start_time - current_start_time)
+                next_start_time = causal_window.start_time
+            else:
+                delay = 0.0
+                next_start_time = current_start_time
+
+            nodes.append(next_node_id)
+            states.append(sorted(next_states_all) if next_states_all else ["unknown"])
+            edges_list.append(edge_desc)
+            rules_list.append(rule.rule_id)
+            state_start_times.append(next_start_time)
+            propagation_delays.append(delay)
+
+            current_start_time = next_start_time
+
+        self.rule_stats.record_rule_use(rule.rule_id)
+
+        return nodes, states, edges_list, rules_list, state_start_times, propagation_delays
+
+    def _verify_single_hop(
+        self,
+        hop_index: int,
+        src_id: int,
+        dst_id: int,
+        prev_start_time: int | None,
+        is_first_hop: bool,
+    ) -> tuple[int, int, list[str], list[str], int | None, int | None, str, str, float] | None:
+        """Verify a single hop in the propagation path."""
+        src_node = self.graph.get_node_by_id(src_id)
+        dst_node = self.graph.get_node_by_id(dst_id)
+
+        if src_node is None or dst_node is None:
+            return None
+
+        edge_data, direction = self._get_edge_between(src_id, dst_id)
+        if edge_data is None or direction is None:
+            return None
+
+        rule_key = (src_node.kind, edge_data.kind, direction)
+        matching_rules = self.rule_index.get(rule_key, [])
+
+        valid_rules: list[PropagationRule] = []
+        for r in matching_rules:
+            if r.is_multi_hop:
+                first_hop = r.path[0]  # type: ignore[index]
+                if first_hop.intermediate_kind == dst_node.kind:
+                    valid_rules.append(r)
+            else:
+                if r.dst_kind == dst_node.kind:
+                    valid_rules.append(r)
+
+        if not valid_rules:
+            return None
+
+        edge_desc = f"{edge_data.kind.value}_{direction.value}"
+
+        for rule in valid_rules:
+            if is_first_hop:
+                result = self._process_first_hop(hop_index, src_id, dst_id, edge_desc, rule)
+            else:
+                result = self._process_subsequent_hop(
+                    hop_index, src_id, dst_id, src_node, dst_node, edge_desc, rule, prev_start_time
+                )
+
+            if result is not None:
+                return result
+
+        return None
+
+    def _process_first_hop(
+        self,
+        hop_index: int,
+        src_id: int,
+        dst_id: int,
+        edge_desc: str,
+        rule: PropagationRule,
+    ) -> tuple[int, int, list[str], list[str], int | None, int | None, str, str, float] | None:
+        """Process the first hop from injection node."""
+        src_node = self.graph.get_node_by_id(src_id)
+        if src_node is None:
+            return None
+
+        src_timeline = self._get_node_states(src_id)
+        src_states_all: set[str] = set()
+        for window in src_timeline:
+            src_states_all.update(window.states)
+
+        dst_timeline = self._get_node_states(dst_id)
+        dst_states_all: set[str] = set()
+        for window in dst_timeline:
+            dst_states_all.update(window.states)
+
+        # Check source state requirement for span-direct starts
+        if src_node.kind == PlaceKind.span:
+            rule_src_states = set(rule.src_states)
+            if rule_src_states and not src_states_all.intersection(rule_src_states):
+                return None
+
+        # Destination must have some states
+        if not dst_states_all:
+            return None
+
+        # Get source time
+        if src_timeline:
+            src_time: int | None = src_timeline[0].start_time
+        else:
+            src_time = None
+
+        # Get destination time using temporal validator
+        if src_time is not None:
+            causal_window = self.temporal_validator.find_causal_window(dst_id, src_time)
+            if causal_window is not None:
+                dst_time: int | None = causal_window.start_time
+                delay = float(causal_window.start_time - src_time)
+            else:
+                dst_time = None
+                delay = 0.0
+        else:
+            if dst_timeline:
+                dst_time = dst_timeline[0].start_time
+            else:
+                dst_time = None
+            delay = 0.0
+
+        self.rule_stats.record_rule_use(rule.rule_id)
+
+        return (
+            src_id,
+            dst_id,
+            sorted(src_states_all) if src_states_all else ["unknown"],
+            sorted(dst_states_all),
+            src_time,
+            dst_time,
+            edge_desc,
+            rule.rule_id,
+            delay,
+        )
+
+    def _process_subsequent_hop(
+        self,
+        hop_index: int,
+        src_id: int,
+        dst_id: int,
+        src_node: Node,
+        dst_node: Node,
+        edge_desc: str,
+        rule: PropagationRule,
+        prev_start_time: int | None,
+    ) -> tuple[int, int, list[str], list[str], int | None, int | None, str, str, float] | None:
+        """Process a subsequent hop in the path."""
+        src_timeline = self._get_node_states(src_id)
+        src_states_all: set[str] = set()
+        for window in src_timeline:
+            src_states_all.update(window.states)
+
+        dst_timeline = self._get_node_states(dst_id)
+        dst_states_all: set[str] = set()
+        for window in dst_timeline:
+            dst_states_all.update(window.states)
+
+        # Check source states match rule
+        rule_src_states = set(rule.src_states)
+        if rule_src_states and not src_states_all.intersection(rule_src_states):
+            return None
+
+        # Check destination states match rule
+        rule_dst_states = set(rule.possible_dst_states)
+        if rule_dst_states and not dst_states_all.intersection(rule_dst_states):
+            return None
+
+        # Temporal validation
+        if prev_start_time is not None:
+            causal_window = self.temporal_validator.find_causal_window(dst_id, prev_start_time)
+            if causal_window is not None:
+                dst_time: int | None = causal_window.start_time
+                delay = float(causal_window.start_time - prev_start_time)
+            else:
+                # No causal window found
+                return None
+        else:
+            if dst_timeline:
+                dst_time = dst_timeline[0].start_time
+            else:
+                dst_time = None
+            delay = 0.0
+
+        src_time = prev_start_time
+
+        self.rule_stats.record_rule_use(rule.rule_id)
+
+        return (
+            src_id,
+            dst_id,
+            sorted(src_states_all) if src_states_all else ["unknown"],
+            sorted(dst_states_all) if dst_states_all else ["unknown"],
+            src_time,
+            dst_time,
+            edge_desc,
+            rule.rule_id,
+            delay,
+        )
+
+    def _get_edge_between(self, src_id: int, dst_id: int) -> tuple[Edge | None, PropagationDirection | None]:
+        """Get edge data and direction between two nodes."""
+        # Check FORWARD direction (src -> dst)
+        if self.graph._graph.has_edge(src_id, dst_id):
+            edge_attrs = self.graph._graph.get_edge_data(src_id, dst_id)
+            if edge_attrs:
+                edge_data = list(edge_attrs.values())[0].get("ref")
+                if edge_data:
+                    return edge_data, PropagationDirection.FORWARD
+
+        # Check BACKWARD direction (dst -> src)
+        if self.graph._graph.has_edge(dst_id, src_id):
+            edge_attrs = self.graph._graph.get_edge_data(dst_id, src_id)
+            if edge_attrs:
+                edge_data = list(edge_attrs.values())[0].get("ref")
+                if edge_data:
+                    return edge_data, PropagationDirection.BACKWARD
+
+        return None, None
+
+    def _log_verification_failure(
+        self,
+        node_ids: list[int],
+        failed_hop_index: int,
+        matched_nodes: list[int],
+        matched_edges: list[str],
+        matched_rules: list[str],
+    ) -> None:
+        """Log detailed diagnostic information when path verification fails."""
+        logger.debug(f"    [DEBUG] Path verification failed at hop {failed_hop_index}")
+
+        full_path = self._format_path_debug(node_ids)
+        logger.debug(f"    [DEBUG]   Intended path: {full_path}")
+
+        if matched_nodes:
+            matched_path = self._format_path_debug(matched_nodes)
+            logger.debug(f"    [DEBUG]   Matched ({len(matched_nodes)} nodes): {matched_path}")
+            if matched_edges:
+                logger.debug(f"    [DEBUG]   Edges: {' -> '.join(matched_edges)}")
+            if matched_rules:
+                logger.debug(f"    [DEBUG]   Rules: {' -> '.join(matched_rules)}")
+        else:
+            logger.debug("    [DEBUG]   No hops matched yet (failed at first hop)")
+
+        src_node = self.graph.get_node_by_id(node_ids[failed_hop_index])
+        dst_node = self.graph.get_node_by_id(node_ids[failed_hop_index + 1])
+        if src_node and dst_node:
+            logger.debug(
+                f"    [DEBUG]   Failed hop: {src_node.kind.value}:{src_node.self_name} -> "
+                f"{dst_node.kind.value}:{dst_node.self_name}"
+            )

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/rule_matcher.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/rule_matcher.py
@@ -1,0 +1,588 @@
+"""Rule matching module for fault propagation.
+
+This module provides the RuleMatcher class which handles matching propagation rules
+against graph edges and paths. It supports both single-hop and multi-hop rules with
+efficient indexing for O(1) lookup.
+
+Extracted from FaultPropagator to provide a unified rule matching interface.
+"""
+
+import logging
+
+from rcabench_platform.v3.internal.reasoning.models.graph import DepKind, Edge, HyperGraph, PlaceKind
+from rcabench_platform.v3.internal.reasoning.rules.schema import FirstHopConfig, PropagationDirection, PropagationRule
+
+logger = logging.getLogger(__name__)
+
+# Default FirstHopConfig per PlaceKind
+# Different source types have different first-hop semantics:
+# - Span: Must validate anomalous states at source (direct HTTP fault injection)
+# - Service: Dummy aggregation node, lenient matching
+# - Container/Pod: May not have exact rule states at injection point
+#
+# NOTE: All first hops are lenient with dst_states (lenient_dst_state_match=True)
+# because we only require destination to have SOME states, not necessarily matching
+# possible_dst_states. This is by design - the first hop from injection may
+# propagate to unexpected states due to fault semantics.
+DEFAULT_FIRST_HOP_CONFIGS: dict[PlaceKind, FirstHopConfig] = {
+    PlaceKind.span: FirstHopConfig(
+        require_src_states=True,  # Span injection must have anomalous states
+        require_dst_states=True,
+        lenient_dst_state_match=True,  # Accept any detected states at destination
+    ),
+    PlaceKind.service: FirstHopConfig(
+        require_src_states=False,  # Service is a dummy aggregation node
+        require_dst_states=True,
+        lenient_dst_state_match=True,  # Accept any span states for service->span
+    ),
+    PlaceKind.container: FirstHopConfig(
+        require_src_states=False,  # Container may not have exact rule states
+        require_dst_states=False,  # ✅ 改为 False：允许 Pod 没有状态
+        lenient_dst_state_match=True,  # Accept any detected states
+    ),
+    PlaceKind.pod: FirstHopConfig(
+        require_src_states=False,  # Pod may not have exact rule states
+        require_dst_states=False,  # ✅ 改为 False：允许下游节点没有状态
+        lenient_dst_state_match=True,  # Accept any detected states
+    ),
+}
+
+
+class RuleMatcher:
+    """Unified rule matcher for single-hop and multi-hop propagation rules.
+
+    Provides efficient rule lookup via indices and handles:
+    - Single-hop rule matching by (src_kind, edge_kind, direction)
+    - Multi-hop rule matching by path topology
+    - First-hop lenient matching for injection nodes
+    """
+
+    def __init__(self, rules: list[PropagationRule]):
+        """Initialize the rule matcher.
+
+        Args:
+            rules: List of propagation rules to match against
+        """
+        self.rules = rules
+        self._build_rule_indices()
+
+    def _build_rule_indices(self) -> None:
+        """Build indices for efficient rule lookup.
+
+        Index rules by (src_kind, edge_kind, direction) for O(1) lookup.
+        Multi-hop rules are indexed by their first hop.
+        """
+        self.rule_index: dict[
+            tuple[PlaceKind, DepKind | None, PropagationDirection | None],
+            list[PropagationRule],
+        ] = {}
+
+        for rule in self.rules:
+            if rule.path:
+                # Multi-hop rule: index by first hop
+                first_hop = rule.path[0]
+                key: tuple[PlaceKind, DepKind | None, PropagationDirection | None] = (
+                    rule.src_kind,
+                    first_hop.edge_kind,
+                    first_hop.direction,
+                )
+            else:
+                # Single-hop rule: index by edge_kind and direction
+                key = (rule.src_kind, rule.edge_kind, rule.direction)
+
+            if key not in self.rule_index:
+                self.rule_index[key] = []
+            self.rule_index[key].append(rule)
+
+    def get_rules_for_edge(
+        self,
+        src_kind: PlaceKind,
+        edge_kind: DepKind,
+        direction: PropagationDirection,
+    ) -> list[PropagationRule]:
+        """Get rules that could match an edge with given characteristics.
+
+        Args:
+            src_kind: Source node PlaceKind
+            edge_kind: Edge type
+            direction: Propagation direction
+
+        Returns:
+            List of potentially matching rules
+        """
+        key = (src_kind, edge_kind, direction)
+        return self.rule_index.get(key, [])
+
+    def matches_multi_hop_rule(
+        self,
+        rule: PropagationRule,
+        topology_path: list[int],
+        graph: HyperGraph,
+    ) -> bool:
+        """Check if a topology path matches a multi-hop rule structure.
+
+        Args:
+            rule: The multi-hop rule to check
+            topology_path: List of node IDs forming the path
+            graph: The graph containing the nodes
+
+        Returns:
+            True if the path structure matches the rule
+        """
+        if not rule.path:
+            return False
+
+        # Path should be: src + intermediate_nodes + dst
+        expected_len = len(rule.path) + 1
+        if len(topology_path) != expected_len:
+            return False
+
+        # Verify each hop in the path
+        for hop_idx, path_hop in enumerate(rule.path):
+            src_node_id = topology_path[hop_idx]
+            dst_node_id = topology_path[hop_idx + 1]
+
+            src_node = graph.get_node_by_id(src_node_id)
+            dst_node = graph.get_node_by_id(dst_node_id)
+
+            if src_node is None or dst_node is None:
+                return False
+
+            # Check intermediate node kind (if specified)
+            if hop_idx < len(rule.path) - 1:  # Not the last hop
+                if path_hop.intermediate_kind and dst_node.kind != path_hop.intermediate_kind:
+                    return False
+            else:  # Last hop
+                if dst_node.kind != rule.dst_kind:
+                    return False
+
+            # Find the edge between src and dst
+            edge_data = self._get_edge_data(graph, src_node_id, dst_node_id, path_hop.direction)
+            if edge_data is None:
+                return False
+
+            # Check edge kind
+            if edge_data.kind != path_hop.edge_kind:
+                return False
+
+            # Check edge condition if specified
+            if path_hop.edge_condition and not path_hop.edge_condition(edge_data):
+                return False
+
+        return True
+
+    def find_matching_multi_hop_rule(
+        self,
+        topology_path: list[int],
+        graph: HyperGraph,
+    ) -> PropagationRule | None:
+        """Find a multi-hop rule that matches the given topology path.
+
+        Args:
+            topology_path: List of node IDs forming the path
+            graph: The graph containing the nodes
+
+        Returns:
+            Matching PropagationRule or None if no match found
+        """
+        if len(topology_path) < 2:
+            return None
+
+        # Get source node to filter rules
+        src_node = graph.get_node_by_id(topology_path[0])
+        if src_node is None:
+            return None
+
+        # Check all multi-hop rules
+        for rule in self.rules:
+            if not rule.is_multi_hop:
+                continue
+
+            # Check source kind matches
+            if rule.src_kind != src_node.kind:
+                continue
+
+            # Check if topology matches multi-hop rule
+            if self.matches_multi_hop_rule(rule, topology_path, graph):
+                return rule
+
+        return None
+
+    def matches_edge(
+        self,
+        src_node_id: int,
+        dst_node_id: int,
+        graph: HyperGraph,
+        src_states: set[str],
+        dst_states: set[str],
+        is_first_hop: bool = False,
+    ) -> list[PropagationRule]:
+        """Find rules that match an edge with given node states.
+
+        This method unifies single-hop and any-hop-of-multi-hop matching.
+
+        Args:
+            src_node_id: Source node ID
+            dst_node_id: Destination node ID
+            graph: The graph containing the nodes
+            src_states: States observed at source node
+            dst_states: States observed at destination node
+            is_first_hop: Whether this is the first hop from injection node
+
+        Returns:
+            List of rules that match this edge
+        """
+        src_node = graph.get_node_by_id(src_node_id)
+        dst_node = graph.get_node_by_id(dst_node_id)
+        if src_node is None or dst_node is None:
+            return []
+
+        edge_data, direction = self._get_edge_between(graph, src_node_id, dst_node_id)
+        if edge_data is None or direction is None:
+            if is_first_hop:
+                logger.debug(
+                    f"      [RULE_MATCHER] No edge found between "
+                    f"{src_node.kind.value}:{src_node.uniq_name} -> {dst_node.kind.value}:{dst_node.uniq_name}"
+                )
+            return []
+
+        matching_rules: list[PropagationRule] = []
+
+        # Get rules indexed by (src_kind, edge_kind, direction)
+        rule_key = (src_node.kind, edge_data.kind, direction)
+        indexed_rules = self.rule_index.get(rule_key, [])
+
+        if is_first_hop:
+            logger.debug(
+                f"      [RULE_MATCHER] Edge: {src_node.kind.value} --{edge_data.kind.value}({direction.value})--> "
+                f"{dst_node.kind.value}, rule_key={rule_key}, indexed_rules={len(indexed_rules)}"
+            )
+
+        # Check indexed rules (first hop matches)
+        for rule in indexed_rules:
+            match_result = self._rule_matches_edge(
+                rule,
+                src_node.kind,
+                dst_node.kind,
+                src_states,
+                dst_states,
+                is_first_hop,
+                is_first_hop_of_rule=True,
+            )
+            if is_first_hop:
+                logger.debug(
+                    f"        [RULE_MATCHER] Checking rule {rule.rule_id}: "
+                    f"src_states={rule.src_states}, dst_kind={rule.dst_kind.value}, "
+                    f"match_result={match_result}"
+                )
+            if match_result:
+                matching_rules.append(rule)
+
+        # Also check subsequent hops of multi-hop rules
+        for rule in self.rules:
+            if not rule.is_multi_hop or not rule.path:
+                continue
+
+            # Debug: Check service -> pod edge matching
+            if src_node.kind == PlaceKind.service and dst_node.kind == PlaceKind.pod:
+                logger.debug(
+                    f"    [DEBUG] Checking rule {rule.rule_id} for service->pod edge, "
+                    f"edge_data.kind={edge_data.kind}, direction={direction}"
+                )
+
+            # Check each hop (except the first, which is already indexed)
+            for hop_idx, path_hop in enumerate(rule.path):
+                if hop_idx == 0:
+                    continue  # First hop already checked above
+
+                # Debug: Check each hop's matching
+                if src_node.kind == PlaceKind.service and dst_node.kind == PlaceKind.pod:
+                    logger.debug(
+                        f"      [DEBUG] hop_idx={hop_idx}, "
+                        f"path_hop.edge_kind={path_hop.edge_kind}, "
+                        f"path_hop.direction={path_hop.direction}, "
+                        f"edge_kind_match={path_hop.edge_kind == edge_data.kind}, "
+                        f"direction_match={path_hop.direction == direction}"
+                    )
+
+                # Check if edge matches this hop's edge_kind and direction
+                if path_hop.edge_kind != edge_data.kind or path_hop.direction != direction:
+                    continue
+
+                # For intermediate hops, check intermediate_kind
+                if hop_idx < len(rule.path) - 1:
+                    # Not the last hop - dst should match intermediate_kind
+                    if path_hop.intermediate_kind and path_hop.intermediate_kind != dst_node.kind:
+                        continue
+                else:
+                    # Last hop - dst should match rule.dst_kind
+                    if rule.dst_kind != dst_node.kind:
+                        continue
+
+                # Check src_node kind matches what would be expected from previous hop
+                prev_hop = rule.path[hop_idx - 1]
+                if prev_hop.intermediate_kind and prev_hop.intermediate_kind != src_node.kind:
+                    continue
+
+                # NOTE: Skip intermediate_states check during BFS exploration.
+                # State validation happens later in path verification phase.
+                # This prevents premature pruning of valid topology paths.
+
+                # For the last hop, check dst_states matches possible_dst_states
+                if hop_idx == len(rule.path) - 1:
+                    if dst_states and not dst_states.intersection(set(rule.possible_dst_states)):
+                        continue
+
+                # This edge matches a subsequent hop of a multi-hop rule
+                if rule not in matching_rules:
+                    matching_rules.append(rule)
+                break  # Don't add the same rule multiple times
+
+        return matching_rules
+
+    def edge_matches_any_rule(
+        self,
+        src_node_id: int,
+        dst_node_id: int,
+        graph: HyperGraph,
+        src_states: set[str],
+        dst_states: set[str],
+        is_first_hop: bool = False,
+    ) -> bool:
+        """Check if an edge matches any propagation rule.
+
+        Args:
+            src_node_id: Source node ID
+            dst_node_id: Destination node ID
+            graph: The graph containing the nodes
+            src_states: States observed at source node
+            dst_states: States observed at destination node
+            is_first_hop: Whether this is the first hop from injection node
+
+        Returns:
+            True if any rule matches
+        """
+        return (
+            len(
+                self.matches_edge(
+                    src_node_id,
+                    dst_node_id,
+                    graph,
+                    src_states,
+                    dst_states,
+                    is_first_hop,
+                )
+            )
+            > 0
+        )
+
+    def _get_first_hop_config(self, rule: PropagationRule, src_kind: PlaceKind) -> FirstHopConfig:
+        """Get the FirstHopConfig for a rule and source kind.
+
+        Uses rule.first_hop_config if specified, otherwise falls back to
+        DEFAULT_FIRST_HOP_CONFIGS based on src_kind.
+
+        Args:
+            rule: The rule to get config for
+            src_kind: Source node PlaceKind
+
+        Returns:
+            FirstHopConfig to use for first-hop validation
+        """
+        if rule.first_hop_config is not None:
+            return rule.first_hop_config
+
+        # Use default config for the source kind, or a sensible fallback
+        return DEFAULT_FIRST_HOP_CONFIGS.get(
+            src_kind,
+            FirstHopConfig(
+                require_src_states=False,
+                require_dst_states=True,
+                lenient_dst_state_match=False,
+            ),
+        )
+
+    def _rule_matches_edge(
+        self,
+        rule: PropagationRule,
+        src_kind: PlaceKind,
+        dst_kind: PlaceKind,
+        src_states: set[str],
+        dst_states: set[str],
+        is_first_hop: bool,
+        is_first_hop_of_rule: bool,
+    ) -> bool:
+        """Check if a specific rule matches an edge.
+
+        Uses FirstHopConfig (from rule or defaults) when is_first_hop=True.
+
+        Args:
+            rule: Rule to check
+            src_kind: Source node PlaceKind
+            dst_kind: Destination node PlaceKind
+            src_states: States observed at source
+            dst_states: States observed at destination
+            is_first_hop: Whether this is first hop from injection
+            is_first_hop_of_rule: Whether this is the first hop of the rule
+
+        Returns:
+            True if rule matches
+        """
+        # Check destination kind matches
+        if rule.is_multi_hop and rule.path and is_first_hop_of_rule:
+            # Multi-hop rule: check if first hop's intermediate_kind matches dst_node
+            first_hop = rule.path[0]
+            if first_hop.intermediate_kind != dst_kind:
+                return False
+        else:
+            # Single-hop rule: dst_kind must match
+            if rule.dst_kind != dst_kind:
+                return False
+
+        # Get FirstHopConfig for first-hop validation
+        first_hop_config = self._get_first_hop_config(rule, src_kind) if is_first_hop else None
+
+        # Check source states
+        if is_first_hop and first_hop_config:
+            # Use FirstHopConfig to determine source state validation
+            if first_hop_config.require_src_states:
+                # Strict: source must have states matching rule.src_states
+                rule_src_states = set(rule.src_states)
+                if rule_src_states:
+                    src_match = len(src_states.intersection(rule_src_states)) > 0
+                else:
+                    # Rule has no src_states constraint, accept any states
+                    src_match = len(src_states) > 0
+            else:
+                # Lenient: don't require source states to match - always accept
+                src_match = True
+        else:
+            # Non-first-hop: standard matching - accept if no states or states match
+            src_match = len(src_states) == 0 or len(src_states.intersection(set(rule.src_states))) > 0
+
+        if not src_match:
+            return False
+
+        # Check destination states
+        if is_first_hop and first_hop_config:
+            # Use FirstHopConfig to determine destination state validation
+            if first_hop_config.require_dst_states:
+                if first_hop_config.lenient_dst_state_match:
+                    # Lenient: accept any detected states at destination
+                    dst_match = len(dst_states) > 0
+                    if is_first_hop and not dst_match:
+                        logger.debug(
+                            f"          [RULE_MATCHER] Rule {rule.rule_id} REJECTED: "
+                            f"require_dst_states=True, lenient=True, but dst_states is empty! "
+                            f"dst_states={dst_states}"
+                        )
+                else:
+                    # Strict: destination must have states matching rule.possible_dst_states
+                    dst_match = len(dst_states) > 0 and len(dst_states.intersection(set(rule.possible_dst_states))) > 0
+                    if is_first_hop and not dst_match:
+                        logger.debug(
+                            f"          [RULE_MATCHER] Rule {rule.rule_id} REJECTED: "
+                            f"strict dst_states matching failed. dst_states={dst_states}, "
+                            f"rule.possible_dst_states={rule.possible_dst_states}"
+                        )
+            else:
+                # No destination states required
+                dst_match = True
+        elif rule.is_multi_hop and rule.path and is_first_hop_of_rule:
+            # For multi-hop rules (not first hop from injection), check intermediate_states
+            first_hop = rule.path[0]
+            if first_hop.intermediate_states is not None:
+                # If no states detected, treat as "unknown"
+                check_states = dst_states if dst_states else {"unknown"}
+                allowed_states = set(first_hop.intermediate_states)
+                dst_match = len(check_states.intersection(allowed_states)) > 0
+                if is_first_hop and not dst_match:
+                    logger.debug(
+                        f"          [RULE_MATCHER] Rule {rule.rule_id} REJECTED: "
+                        f"multi-hop intermediate_states check failed. dst_states={dst_states}, "
+                        f"allowed_states={allowed_states}"
+                    )
+            else:
+                # No intermediate_states constraint, accept any destination
+                dst_match = len(dst_states) > 0
+                if is_first_hop and not dst_match:
+                    logger.debug(
+                        f"          [RULE_MATCHER] Rule {rule.rule_id} REJECTED: "
+                        f"multi-hop rule requires dst to have states, but dst_states is empty!"
+                    )
+        else:
+            # Standard matching: accept if no states or states match
+            dst_match = len(dst_states) == 0 or len(dst_states.intersection(set(rule.possible_dst_states))) > 0
+
+        if is_first_hop and dst_match:
+            logger.debug(f"          [RULE_MATCHER] Rule {rule.rule_id} ACCEPTED: src_match=True, dst_match=True")
+
+        return dst_match
+
+    def _get_edge_between(
+        self,
+        graph: HyperGraph,
+        src_id: int,
+        dst_id: int,
+    ) -> tuple[Edge | None, PropagationDirection | None]:
+        """Get edge data and direction between two nodes.
+
+        Checks both forward (src -> dst) and backward (dst -> src) directions.
+
+        Args:
+            graph: The graph containing the nodes
+            src_id: Source node ID
+            dst_id: Destination node ID
+
+        Returns:
+            Tuple of (Edge, PropagationDirection) or (None, None) if no edge
+        """
+        # Check FORWARD direction (src -> dst)
+        if graph._graph.has_edge(src_id, dst_id):
+            edge_attrs = graph._graph.get_edge_data(src_id, dst_id)
+            if edge_attrs:
+                edge_data = list(edge_attrs.values())[0].get("ref")
+                if edge_data:
+                    return edge_data, PropagationDirection.FORWARD
+
+        # Check BACKWARD direction (dst -> src)
+        if graph._graph.has_edge(dst_id, src_id):
+            edge_attrs = graph._graph.get_edge_data(dst_id, src_id)
+            if edge_attrs:
+                edge_data = list(edge_attrs.values())[0].get("ref")
+                if edge_data:
+                    return edge_data, PropagationDirection.BACKWARD
+
+        return None, None
+
+    def _get_edge_data(
+        self,
+        graph: HyperGraph,
+        src_id: int,
+        dst_id: int,
+        direction: PropagationDirection,
+    ) -> Edge | None:
+        """Get edge data for a specific direction.
+
+        Args:
+            graph: The graph containing the nodes
+            src_id: Source node ID
+            dst_id: Destination node ID
+            direction: Expected direction
+
+        Returns:
+            Edge data or None if not found
+        """
+        if direction == PropagationDirection.FORWARD:
+            if graph._graph.has_edge(src_id, dst_id):
+                edge_attrs = graph._graph.get_edge_data(src_id, dst_id)
+                if edge_attrs:
+                    edge_data: Edge | None = list(edge_attrs.values())[0].get("ref")
+                    return edge_data
+        else:  # BACKWARD
+            if graph._graph.has_edge(dst_id, src_id):
+                edge_attrs = graph._graph.get_edge_data(dst_id, src_id)
+                if edge_attrs:
+                    edge_data = list(edge_attrs.values())[0].get("ref")
+                    return edge_data
+        return None

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/starting_point_resolver.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/starting_point_resolver.py
@@ -1,0 +1,232 @@
+"""Starting point resolver for fault propagation.
+
+This module resolves where propagation should start based on rule semantics.
+InjectionNodeResolver finds physical injection points; StartingPointResolver
+determines where propagation actually begins (caller, callee, or injection point).
+"""
+
+import logging
+
+from rcabench_platform.v3.internal.reasoning.models.graph import DepKind, HyperGraph, PlaceKind
+from rcabench_platform.v3.internal.reasoning.models.injection import ResolvedInjection
+from rcabench_platform.v3.internal.reasoning.rules.schema import PropagationRule
+
+logger = logging.getLogger(__name__)
+
+
+class StartingPointResolver:
+    """Resolve propagation starting points based on rule semantics.
+
+    After InjectionNodeResolver returns physical injection points, this resolver
+    determines actual propagation starting points based on the rule's propagation_source:
+    - 'injection_point': Use physical injection location directly
+    - 'caller': For response faults, find caller service (observes delay/error)
+    - 'callee': For request faults, use injection point (processes fault)
+    """
+
+    def __init__(self, graph: HyperGraph) -> None:
+        """Initialize the resolver.
+
+        Args:
+            graph: The HyperGraph to traverse for caller/callee resolution
+        """
+        self.graph = graph
+
+    def resolve(
+        self,
+        physical_node_ids: list[int],
+        resolved_injection: ResolvedInjection,
+        rules: list[PropagationRule],
+    ) -> list[int]:
+        """Resolve propagation starting points from physical injection nodes.
+
+        Args:
+            physical_node_ids: Node IDs from InjectionNodeResolver (physical injection points)
+            resolved_injection: Injection metadata including fault_category
+            rules: Propagation rules to check for propagation_source
+
+        Returns:
+            List of node IDs where propagation should start
+        """
+        fault_category = resolved_injection.fault_category
+
+        # Determine propagation_source from fault_category or rules
+        propagation_source = self._determine_propagation_source(fault_category, rules)
+
+        if propagation_source == "injection_point":
+            logger.debug(f"Using physical injection points directly: {physical_node_ids}")
+            return physical_node_ids
+
+        if propagation_source == "callee":
+            # Callee = physical injection point (callee processes the request fault)
+            logger.debug(f"Using callee (physical injection points): {physical_node_ids}")
+            return physical_node_ids
+
+        if propagation_source == "caller":
+            # Find caller service from graph topology
+            starting_points = self._resolve_to_caller(physical_node_ids)
+            if starting_points:
+                logger.info(
+                    f"Resolved caller starting points for {fault_category}: "
+                    f"{starting_points} (from physical: {physical_node_ids})"
+                )
+                return starting_points
+            # Fallback to physical nodes if no caller found
+            logger.warning(f"Could not find caller for {fault_category}, falling back to physical injection points")
+            return physical_node_ids
+
+        # Unknown propagation_source, use physical nodes
+        logger.warning(f"Unknown propagation_source '{propagation_source}', using physical injection points")
+        return physical_node_ids
+
+    def _determine_propagation_source(
+        self,
+        fault_category: str,
+        rules: list[PropagationRule],
+    ) -> str:
+        """Determine propagation_source from fault_category or rules.
+
+        Priority:
+        1. Find rules with explicit propagation_source matching this fault_category
+        2. Use fault_category semantics (http_response -> caller)
+        3. Default to 'injection_point'
+
+        Args:
+            fault_category: Granular fault category from ResolvedInjection
+            rules: Propagation rules to check
+
+        Returns:
+            Propagation source: 'injection_point', 'caller', or 'callee'
+        """
+        # Check rules for explicit propagation_source
+        for rule in rules:
+            if rule.propagation_source and rule.propagation_source != "injection_point":
+                # This rule has explicit non-default propagation_source
+                # For now, use fault_category-based logic as rules aren't yet populated
+                pass
+
+        # Use fault_category semantics
+        if fault_category == "http_response":
+            # HTTP Response faults (AbortResponse, DelayResponse, etc.)
+            # The fault effect (delay, error) is observed at the CALLER
+            return "caller"
+
+        if fault_category == "http_request":
+            # HTTP Request faults (AbortRequest, DelayRequest, etc.)
+            # The fault effect is at the CALLEE (processing the request)
+            return "callee"
+
+        # Other fault categories: container, jvm, pod, network, dns, etc.
+        # Use physical injection point directly
+        return "injection_point"
+
+    def _resolve_to_caller(
+        self,
+        physical_node_ids: list[int],
+    ) -> list[int]:
+        """Find caller service(s) for the given physical injection nodes.
+
+        For HTTP response faults, the physical injection is at the callee (server-side),
+        but propagation should start from the caller service that observes the fault.
+
+        Algorithm:
+        1. For each physical node (span or service):
+           a. If span: find caller spans via 'calls' edges, then their services
+           b. If service: find spans calling this service's spans
+
+        Args:
+            physical_node_ids: Physical injection node IDs
+            fault_category: Fault category for logging
+
+        Returns:
+            List of caller service node IDs
+        """
+        caller_node_ids: list[int] = []
+        seen_callers: set[int] = set()
+
+        for node_id in physical_node_ids:
+            node = self.graph.get_node_by_id(node_id)
+            if node.kind == PlaceKind.span:
+                # Find caller spans via 'calls' edges (caller -> callee)
+                callers = self._get_caller_spans(node_id)
+                for caller_span_id in callers:
+                    # Find service for caller span
+                    caller_service_id = self._get_service_for_span(caller_span_id)
+                    if caller_service_id and caller_service_id not in seen_callers:
+                        caller_node_ids.append(caller_service_id)
+                        seen_callers.add(caller_service_id)
+
+            elif node.kind == PlaceKind.service:
+                # Service injection: find spans included by this service,
+                # then find callers of those spans
+                service_spans = self._get_spans_for_service(node_id)
+                for span_id in service_spans:
+                    callers = self._get_caller_spans(span_id)
+                    for caller_span_id in callers:
+                        caller_service_id = self._get_service_for_span(caller_span_id)
+                        if caller_service_id and caller_service_id not in seen_callers:
+                            caller_node_ids.append(caller_service_id)
+                            seen_callers.add(caller_service_id)
+
+            else:
+                # Other node types (container, pod, etc.) - no caller resolution
+                logger.debug(f"Cannot resolve caller for node kind {node.kind}, using physical node")
+                if node_id not in seen_callers:
+                    caller_node_ids.append(node_id)
+                    seen_callers.add(node_id)
+
+        return caller_node_ids
+
+    def _get_caller_spans(self, span_node_id: int) -> list[int]:
+        """Find spans that call the given span (incoming 'calls' edges).
+
+        Args:
+            span_node_id: The callee span node ID
+
+        Returns:
+            List of caller span node IDs
+        """
+        callers: list[int] = []
+        # In the graph: caller_span --calls--> callee_span
+        # We need in_edges of type 'calls'
+        for src_id, _dst_id, edge_key in self.graph._graph.in_edges(span_node_id, keys=True):
+            if edge_key == DepKind.calls:
+                callers.append(src_id)
+        return callers
+
+    def _get_service_for_span(self, span_node_id: int) -> int | None:
+        """Find the service that includes the given span.
+
+        Args:
+            span_node_id: The span node ID
+
+        Returns:
+            Service node ID or None if not found
+        """
+        # In the graph: service --includes--> span
+        # We need in_edges of type 'includes'
+        for src_id, _dst_id, edge_key in self.graph._graph.in_edges(span_node_id, keys=True):
+            if edge_key == DepKind.includes:
+                src_node = self.graph.get_node_by_id(src_id)
+                if src_node.kind == PlaceKind.service:
+                    return int(src_id)
+        return None
+
+    def _get_spans_for_service(self, service_node_id: int) -> list[int]:
+        """Find all spans included by the given service.
+
+        Args:
+            service_node_id: The service node ID
+
+        Returns:
+            List of span node IDs
+        """
+        spans: list[int] = []
+        # In the graph: service --includes--> span
+        # We need out_edges of type 'includes'
+        for _src_id, dst_id, edge_key in self.graph._graph.out_edges(service_node_id, keys=True):
+            if edge_key == DepKind.includes:
+                dst_node = self.graph.get_node_by_id(dst_id)
+                if dst_node.kind == PlaceKind.span:
+                    spans.append(dst_id)
+        return spans

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/starting_point_resolver.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/starting_point_resolver.py
@@ -189,7 +189,7 @@ class StartingPointResolver:
         callers: list[int] = []
         # In the graph: caller_span --calls--> callee_span
         # We need in_edges of type 'calls'
-        for src_id, _dst_id, edge_key in self.graph._graph.in_edges(span_node_id, keys=True):
+        for src_id, _dst_id, edge_key in self.graph._graph.in_edges(span_node_id, keys=True):  # type: ignore[call-arg]
             if edge_key == DepKind.calls:
                 callers.append(src_id)
         return callers
@@ -205,7 +205,7 @@ class StartingPointResolver:
         """
         # In the graph: service --includes--> span
         # We need in_edges of type 'includes'
-        for src_id, _dst_id, edge_key in self.graph._graph.in_edges(span_node_id, keys=True):
+        for src_id, _dst_id, edge_key in self.graph._graph.in_edges(span_node_id, keys=True):  # type: ignore[call-arg]
             if edge_key == DepKind.includes:
                 src_node = self.graph.get_node_by_id(src_id)
                 if src_node.kind == PlaceKind.service:
@@ -224,7 +224,7 @@ class StartingPointResolver:
         spans: list[int] = []
         # In the graph: service --includes--> span
         # We need out_edges of type 'includes'
-        for _src_id, dst_id, edge_key in self.graph._graph.out_edges(service_node_id, keys=True):
+        for _src_id, dst_id, edge_key in self.graph._graph.out_edges(service_node_id, keys=True):  # type: ignore[call-arg]
             if edge_key == DepKind.includes:
                 dst_node = self.graph.get_node_by_id(dst_id)
                 if dst_node.kind == PlaceKind.span:

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/state_detector.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/state_detector.py
@@ -1,0 +1,1019 @@
+"""State detection for nodes based on metrics and attributes.
+
+All state detection is timeline-based, returning StateWindow objects.
+Each window represents a time range with a set of states (supports multi-state).
+"""
+
+import numpy as np
+
+from rcabench_platform.v3.internal.reasoning.algorithms.baseline_detector import (
+    BaselineAwareDetector,
+    BaselineStatistics,
+    calculate_series_stats,
+    compute_baseline_statistics,
+    get_adaptive_threshold,
+)
+from rcabench_platform.v3.internal.reasoning.models.graph import Node, PlaceKind
+from rcabench_platform.v3.internal.reasoning.models.state import (
+    ContainerState,
+    DaemonSetState,
+    DeploymentState,
+    MachineState,
+    NamespaceState,
+    PodState,
+    ReplicaSetState,
+    SpanState,
+    StatefulSetState,
+    StateWindow,
+)
+
+
+class WindowSizeConfig:
+    """Configurable window sizes per fault type.
+
+    Network faults may need finer granularity (1-2 seconds),
+    while resource faults can use coarser windows (5 seconds).
+    """
+
+    # Default window size in seconds
+    DEFAULT = 5
+
+    # Per-PlaceKind window sizes (in seconds)
+    # Network-related entities need finer granularity
+    SPAN = 3  # Spans may have short-lived latency spikes
+    SERVICE = 3  # Service metrics correlate with spans
+
+    # Resource-related entities can use coarser windows
+    POD = 5
+    CONTAINER = 5
+    MACHINE = 5
+
+    # Kubernetes control plane entities
+    DEPLOYMENT = 5
+    REPLICA_SET = 5
+    STATEFUL_SET = 5
+    DAEMON_SET = 5
+    NAMESPACE = 5
+
+    @classmethod
+    def get_window_size(cls, place_kind: PlaceKind) -> int:
+        """Get window size for a specific PlaceKind.
+
+        Args:
+            place_kind: The PlaceKind to get window size for
+
+        Returns:
+            Window size in seconds
+        """
+        kind_to_size = {
+            PlaceKind.span: cls.SPAN,
+            PlaceKind.service: cls.SERVICE,
+            PlaceKind.pod: cls.POD,
+            PlaceKind.container: cls.CONTAINER,
+            PlaceKind.machine: cls.MACHINE,
+            PlaceKind.deployment: cls.DEPLOYMENT,
+            PlaceKind.replica_set: cls.REPLICA_SET,
+            PlaceKind.stateful_set: cls.STATEFUL_SET,
+            PlaceKind.daemon_set: cls.DAEMON_SET,
+            PlaceKind.namespace: cls.NAMESPACE,
+        }
+        return kind_to_size.get(place_kind, cls.DEFAULT)
+
+
+class StateDetectionThresholds:
+    # Resource utilization thresholds
+    HIGH_CPU = 0.8
+    HIGH_MEMORY = 0.8
+
+    # Error rate thresholds
+    CRITICAL_ERROR_RATE = 0.3
+    UNAVAILABLE_ERROR_RATE = 0.8
+
+    # Latency thresholds (seconds)
+    HIGH_P99_LATENCY = 5.0
+    CRITICAL_P99_LATENCY = 10.0
+
+    # Relative change thresholds
+    LATENCY_MULTIPLIER_HIGH = 3.0
+    LATENCY_MULTIPLIER_CRITICAL = 10.0
+    ERROR_INCREASE_CRITICAL = 0.3
+
+
+def _compute_node_baseline_stats(node: Node) -> dict[str, BaselineStatistics]:
+    """Compute baseline statistics for all metrics in a node.
+
+    Args:
+        node: Node containing baseline metrics
+
+    Returns:
+        Dictionary mapping metric names to their baseline statistics
+    """
+    stats = {}
+    for metric_name, (_timestamps, values) in node.baseline_metrics.items():
+        if isinstance(values, np.ndarray) and len(values) > 0:
+            stats[metric_name] = compute_baseline_statistics(values)
+    return stats
+
+
+def _normalize_timestamp(ts: np.ndarray) -> np.ndarray:
+    """Convert timestamps to Unix seconds (int64).
+
+    Handles datetime64, Python datetime objects, and numeric timestamps.
+    """
+    if len(ts) == 0:
+        return np.array([], dtype=np.int64)
+
+    # Check if it's datetime64 type
+    if np.issubdtype(ts.dtype, np.datetime64):
+        # Convert to seconds since epoch
+        return ts.astype("datetime64[s]").astype(np.int64)
+
+    # Check if it's object dtype (might contain Python datetime objects)
+    if ts.dtype == object:
+        from datetime import datetime
+
+        first_elem = ts[0]
+        if isinstance(first_elem, datetime):
+            # Convert Python datetime objects to Unix seconds
+            return np.array([int(dt.timestamp()) for dt in ts], dtype=np.int64)
+
+    # Already numeric (assume seconds)
+    return ts.astype(np.int64)
+
+
+def _get_all_timestamps(node: Node) -> list[int]:
+    """Extract all unique timestamps from node metrics (abnormal period).
+
+    Returns timestamps as Unix seconds (int).
+    """
+    all_timestamps: set[int] = set()
+    for _metric_name, (timestamps, _values) in node.abnormal_metrics.items():
+        if isinstance(timestamps, np.ndarray) and len(timestamps) > 0:
+            normalized = _normalize_timestamp(timestamps)
+            all_timestamps.update(normalized.tolist())
+    return sorted(all_timestamps)
+
+
+def _get_all_baseline_timestamps(node: Node) -> list[int]:
+    """Extract all unique timestamps from node baseline metrics.
+
+    Returns timestamps as Unix seconds (int).
+    """
+    all_timestamps: set[int] = set()
+    for _metric_name, (timestamps, _values) in node.baseline_metrics.items():
+        if isinstance(timestamps, np.ndarray) and len(timestamps) > 0:
+            normalized = _normalize_timestamp(timestamps)
+            all_timestamps.update(normalized.tolist())
+    return sorted(all_timestamps)
+
+
+def _generate_fixed_windows(node: Node, window_size_sec: int | None = None) -> list[tuple[int, int]]:
+    """Generate fixed-size time windows from node metrics.
+
+    Args:
+        node: Node containing metrics with timestamps
+        window_size_sec: Window size in seconds (default: auto-determined by PlaceKind)
+
+    Returns:
+        List of (start_time, end_time) tuples in Unix seconds.
+        Returns empty list if no timestamps found.
+    """
+    # Use configurable window size based on node kind if not explicitly provided
+    if window_size_sec is None:
+        window_size_sec = WindowSizeConfig.get_window_size(node.kind)
+
+    all_timestamps = _get_all_timestamps(node)
+    if not all_timestamps:
+        return []
+
+    period_start = min(all_timestamps)
+    period_end = max(all_timestamps)
+
+    # Generate fixed windows
+    windows = []
+    current_time = period_start
+    while current_time < period_end:
+        window_end = current_time + window_size_sec
+        windows.append((current_time, window_end))
+        current_time = window_end
+
+    # Ensure we cover the last timestamp
+    if not windows or windows[-1][1] < period_end:
+        windows.append((current_time, current_time + window_size_sec))
+
+    return windows
+
+
+def _aggregate_metric_in_window(
+    node: Node,
+    metric_name: str,
+    start_time: int,
+    end_time: int,
+    agg_func: str = "mean",
+    use_baseline: bool = False,
+) -> float | None:
+    """Aggregate metric values within a time window.
+
+    Args:
+        node: Node containing metrics
+        metric_name: Name of the metric to aggregate
+        start_time: Window start (Unix seconds)
+        end_time: Window end (Unix seconds)
+        agg_func: Aggregation function ("mean", "max", "min", "sum")
+        use_baseline: If True, use baseline_metrics; otherwise use abnormal_metrics
+
+    Returns:
+        Aggregated value, or None if no data points in window
+    """
+    metrics_dict = node.baseline_metrics if use_baseline else node.abnormal_metrics
+
+    if metric_name not in metrics_dict:
+        return None
+
+    timestamps, values = metrics_dict[metric_name]
+    if not isinstance(timestamps, np.ndarray) or not isinstance(values, np.ndarray):
+        return None
+    if len(timestamps) == 0 or len(values) == 0:
+        return None
+
+    # Normalize timestamps to seconds
+    ts_seconds = _normalize_timestamp(timestamps)
+
+    # Filter values within window
+    mask = (ts_seconds >= start_time) & (ts_seconds < end_time)
+    window_values = values[mask]
+
+    if len(window_values) == 0:
+        return None
+
+    # Apply aggregation
+    if agg_func == "mean":
+        return float(np.mean(window_values))
+    elif agg_func == "max":
+        return float(np.max(window_values))
+    elif agg_func == "min":
+        return float(np.min(window_values))
+    elif agg_func == "sum":
+        return float(np.sum(window_values))
+    else:
+        return float(np.mean(window_values))
+
+
+def _filter_metrics_by_time_range(
+    metrics_dict: dict[str, tuple[np.ndarray, np.ndarray]],
+    start_time: int,
+    end_time: int,
+) -> dict[str, tuple[np.ndarray, np.ndarray]]:
+    """Filter metrics to only include data points within time range.
+
+    Args:
+        metrics_dict: Dictionary of metric_name -> (timestamps, values)
+        start_time: Window start (Unix seconds)
+        end_time: Window end (Unix seconds)
+
+    Returns:
+        Filtered metrics dictionary
+    """
+    filtered = {}
+    for metric_name, (timestamps, values) in metrics_dict.items():
+        if not isinstance(timestamps, np.ndarray) or not isinstance(values, np.ndarray):
+            continue
+        # Normalize timestamps to seconds
+        ts_seconds = _normalize_timestamp(timestamps)
+        mask = (ts_seconds >= start_time) & (ts_seconds < end_time)
+        filtered_ts = timestamps[mask]
+        filtered_vals = values[mask]
+        if len(filtered_ts) > 0:
+            filtered[metric_name] = (filtered_ts, filtered_vals)
+    return filtered
+
+
+def _merge_consecutive_windows(windows: list[StateWindow]) -> list[StateWindow]:
+    if not windows:
+        return []
+
+    merged = []
+    current = windows[0]
+
+    for next_window in windows[1:]:
+        # Merge if states are identical and windows are adjacent
+        if current.states == next_window.states and current.end_time >= next_window.start_time:
+            current = StateWindow(
+                start_time=current.start_time,
+                end_time=next_window.end_time,
+                states=current.states,
+            )
+        else:
+            merged.append(current)
+            current = next_window
+
+    merged.append(current)
+    return merged
+
+
+def detect_deployment_state_timeline(node: Node) -> list[StateWindow]:
+    """Detect Deployment state timeline using fixed 5-second windows."""
+    time_windows = _generate_fixed_windows(node)
+    if not time_windows:
+        return []
+
+    windows = []
+    for start_time, end_time in time_windows:
+        available = _aggregate_metric_in_window(node, "k8s.deployment.available", start_time, end_time, "mean")
+        desired = _aggregate_metric_in_window(node, "k8s.deployment.desired", start_time, end_time, "mean")
+
+        # No data in window -> UNKNOWN
+        if available is None or desired is None:
+            state = DeploymentState.UNKNOWN.value
+        elif desired == 0:
+            state = DeploymentState.UNKNOWN.value
+        elif available == 0:
+            state = DeploymentState.FAILED.value
+        elif available < desired:
+            state = DeploymentState.DEGRADED.value
+        else:
+            state = DeploymentState.AVAILABLE.value
+
+        windows.append(StateWindow(start_time=start_time, end_time=end_time, states={state}))
+
+    return _merge_consecutive_windows(windows)
+
+
+def detect_stateful_set_state_timeline(node: Node) -> list[StateWindow]:
+    """Detect StatefulSet state timeline using fixed 5-second windows."""
+    time_windows = _generate_fixed_windows(node)
+    if not time_windows:
+        return []
+
+    windows = []
+    for start_time, end_time in time_windows:
+        ready_pods = _aggregate_metric_in_window(node, "k8s.statefulset.ready_pods", start_time, end_time, "mean")
+        desired_pods = _aggregate_metric_in_window(node, "k8s.statefulset.desired_pods", start_time, end_time, "mean")
+
+        # No data in window -> UNKNOWN
+        if ready_pods is None or desired_pods is None:
+            state = StatefulSetState.UNKNOWN.value
+        elif desired_pods == 0:
+            state = StatefulSetState.UNKNOWN.value
+        elif ready_pods == 0:
+            state = StatefulSetState.FAILED.value
+        elif ready_pods < desired_pods:
+            state = StatefulSetState.DEGRADED.value
+        else:
+            state = StatefulSetState.READY.value
+
+        windows.append(StateWindow(start_time=start_time, end_time=end_time, states={state}))
+
+    return _merge_consecutive_windows(windows)
+
+
+def detect_replica_set_state_timeline(node: Node) -> list[StateWindow]:
+    """Detect ReplicaSet state timeline using fixed 5-second windows."""
+    time_windows = _generate_fixed_windows(node)
+    if not time_windows:
+        return []
+
+    windows = []
+    for start_time, end_time in time_windows:
+        available = _aggregate_metric_in_window(node, "k8s.replicaset.available", start_time, end_time, "mean")
+        desired = _aggregate_metric_in_window(node, "k8s.replicaset.desired", start_time, end_time, "mean")
+
+        # No data in window -> UNKNOWN
+        if available is None or desired is None:
+            state = ReplicaSetState.UNKNOWN.value
+        elif desired == 0:
+            state = ReplicaSetState.UNKNOWN.value
+        elif available == 0:
+            state = ReplicaSetState.FAILED.value
+        elif available < desired:
+            state = ReplicaSetState.DEGRADED.value
+        else:
+            state = ReplicaSetState.AVAILABLE.value
+
+        windows.append(StateWindow(start_time=start_time, end_time=end_time, states={state}))
+
+    return _merge_consecutive_windows(windows)
+
+
+def _detect_pod_killed(node: Node) -> tuple[bool, int | None, int | None]:
+    """Detect if a Pod was killed during the abnormal period.
+
+    Detection strategy: Compare the time coverage of metrics between baseline and abnormal periods.
+    If the abnormal period metrics end significantly earlier than baseline metrics coverage would
+    suggest, the Pod was likely killed.
+
+    For PodKill scenarios:
+    - Old Pod gets killed, metrics stop
+    - New Pod is created with different name, so this Pod node has no more data
+
+    Returns:
+        Tuple of (was_killed, kill_start_time, kill_end_time)
+        - was_killed: True if Pod appears to have been killed
+        - kill_start_time: Estimated time when Pod was killed (last metric timestamp)
+        - kill_end_time: End of abnormal period (for state window)
+    """
+    baseline_timestamps = _get_all_baseline_timestamps(node)
+    abnormal_timestamps = _get_all_timestamps(node)
+
+    if not baseline_timestamps or not abnormal_timestamps:
+        return False, None, None
+
+    # Calculate baseline duration and coverage
+    baseline_duration = max(baseline_timestamps) - min(baseline_timestamps)
+    if baseline_duration < 30:  # Need at least 30 seconds of baseline data
+        return False, None, None
+
+    # Calculate abnormal duration
+    abnormal_duration = max(abnormal_timestamps) - min(abnormal_timestamps)
+
+    # If abnormal period is significantly shorter than baseline (less than 50% coverage),
+    # the Pod was likely killed
+    coverage_ratio = abnormal_duration / baseline_duration if baseline_duration > 0 else 1.0
+
+    if coverage_ratio < 0.5:
+        # Pod was likely killed - metrics stopped early
+        kill_time = max(abnormal_timestamps)
+        # Estimate end of abnormal period based on baseline duration
+        estimated_abnormal_end = min(abnormal_timestamps) + baseline_duration
+        return True, kill_time, estimated_abnormal_end
+
+    return False, None, None
+
+
+def detect_pod_state_timeline(node: Node) -> list[StateWindow]:
+    """Detect Pod state timeline using fixed 5-second windows.
+
+    Supports multiple simultaneous states.
+    Detection strategy:
+    - Utilization metrics (0-1 range): Use BOTH fixed thresholds AND baseline comparison
+    - Absolute/counter metrics: Use baseline comparison with Z-score
+
+    The dual detection approach catches:
+    - Fixed threshold: Absolute resource exhaustion (>80% utilization)
+    - Baseline comparison: Significant relative increase (e.g., JVMCPUStress causing 20x CPU increase
+      even if absolute utilization is below 80%)
+    """
+    time_windows = _generate_fixed_windows(node)
+
+    # Check for Pod killed (metrics stopped early)
+    was_killed, kill_start, kill_end = _detect_pod_killed(node)
+
+    if not time_windows:
+        # If no time windows but Pod was killed, create a KILLED state window
+        if was_killed and kill_start is not None and kill_end is not None:
+            return [StateWindow(start_time=kill_start, end_time=kill_end, states={PodState.KILLED.value})]
+        return []
+
+    # Compute baseline statistics for anomaly detection
+    baseline_stats = _compute_node_baseline_stats(node)
+    detector = BaselineAwareDetector(baseline_stats) if baseline_stats else None
+
+    windows = []
+    for start_time, end_time in time_windows:
+        states: set[str] = set()
+
+        # === CPU Detection: Fixed threshold OR baseline comparison ===
+        cpu_util = _aggregate_metric_in_window(node, "k8s.pod.cpu_limit_utilization", start_time, end_time, "mean")
+
+        # Method 1: Fixed threshold for absolute high CPU (>80%)
+        if cpu_util is not None and cpu_util > StateDetectionThresholds.HIGH_CPU:
+            states.add(PodState.HIGH_CPU.value)
+
+        # Method 2: Baseline comparison for relative CPU increase
+        # This catches cases like JVMCPUStress where CPU increases 20x but stays below 80%
+        if detector and PodState.HIGH_CPU.value not in states:
+            # Check cpu_limit_utilization against baseline
+            if "k8s.pod.cpu_limit_utilization" in baseline_stats:
+                if cpu_util is not None and detector.is_critical_anomaly("k8s.pod.cpu_limit_utilization", cpu_util):
+                    states.add(PodState.HIGH_CPU.value)
+
+            # Also check absolute CPU usage (k8s.pod.cpu.usage) - useful for JVM stress faults
+            if "k8s.pod.cpu.usage" in baseline_stats and PodState.HIGH_CPU.value not in states:
+                cpu_usage = _aggregate_metric_in_window(node, "k8s.pod.cpu.usage", start_time, end_time, "mean")
+                if cpu_usage is not None and detector.is_critical_anomaly("k8s.pod.cpu.usage", cpu_usage):
+                    states.add(PodState.HIGH_CPU.value)
+
+            # Check JVM CPU utilization - catches JVMCPUStress specifically
+            if "jvm.cpu.recent_utilization" in baseline_stats and PodState.HIGH_CPU.value not in states:
+                jvm_cpu = _aggregate_metric_in_window(node, "jvm.cpu.recent_utilization", start_time, end_time, "mean")
+                if jvm_cpu is not None and detector.is_critical_anomaly("jvm.cpu.recent_utilization", jvm_cpu):
+                    states.add(PodState.HIGH_CPU.value)
+
+        # === Memory Detection: Fixed threshold OR baseline comparison ===
+        memory_util = _aggregate_metric_in_window(
+            node, "k8s.pod.memory_limit_utilization", start_time, end_time, "mean"
+        )
+
+        # Method 1: Fixed threshold for absolute high memory (>80%)
+        if memory_util is not None and memory_util > StateDetectionThresholds.HIGH_MEMORY:
+            states.add(PodState.HIGH_MEMORY.value)
+
+        # Method 2: Baseline comparison for relative memory increase
+        if detector and PodState.HIGH_MEMORY.value not in states:
+            if "k8s.pod.memory_limit_utilization" in baseline_stats:
+                if memory_util is not None and detector.is_critical_anomaly(
+                    "k8s.pod.memory_limit_utilization", memory_util
+                ):
+                    states.add(PodState.HIGH_MEMORY.value)
+
+            # Also check absolute memory usage
+            if "k8s.pod.memory.working_set" in baseline_stats and PodState.HIGH_MEMORY.value not in states:
+                mem_ws = _aggregate_metric_in_window(node, "k8s.pod.memory.working_set", start_time, end_time, "mean")
+                if mem_ws is not None and detector.is_critical_anomaly("k8s.pod.memory.working_set", mem_ws):
+                    states.add(PodState.HIGH_MEMORY.value)
+
+        # Filesystem usage - use fixed threshold for utilization (has natural 0-1 boundary)
+        fs_usage = _aggregate_metric_in_window(node, "k8s.pod.filesystem.usage", start_time, end_time, "mean")
+        fs_capacity = _aggregate_metric_in_window(node, "k8s.pod.filesystem.capacity", start_time, end_time, "mean")
+        if fs_usage is not None and fs_capacity is not None and fs_capacity > 0:
+            fs_utilization = fs_usage / fs_capacity
+            if fs_utilization > 0.95:  # Disk usage > 95%
+                states.add(PodState.HIGH_DISK_USAGE.value)
+
+        # === Absolute/counter metrics: Use BASELINE COMPARISON (no fixed upper bound) ===
+        if detector:
+            # Network errors - counter metric, compare increase against baseline
+            if "k8s.pod.network.errors" in baseline_stats:
+                net_errors = _aggregate_metric_in_window(node, "k8s.pod.network.errors", start_time, end_time, "mean")
+                if net_errors is not None and detector.is_critical_anomaly("k8s.pod.network.errors", net_errors):
+                    states.add(PodState.HIGH_NETWORK_ERRORS.value)
+
+            # HTTP latency - absolute duration varies by service type
+            if "http.server.request.duration.sum" in baseline_stats:
+                http_sum = _aggregate_metric_in_window(
+                    node, "http.server.request.duration.sum", start_time, end_time, "mean"
+                )
+                if http_sum is not None and detector.is_critical_anomaly("http.server.request.duration.sum", http_sum):
+                    states.add(PodState.HIGH_HTTP_LATENCY.value)
+
+            # JVM GC pressure - absolute duration varies by application
+            if "jvm.gc.duration.sum" in baseline_stats:
+                gc_sum = _aggregate_metric_in_window(node, "jvm.gc.duration.sum", start_time, end_time, "mean")
+                if gc_sum is not None and detector.is_critical_anomaly("jvm.gc.duration.sum", gc_sum):
+                    states.add(PodState.HIGH_GC_PRESSURE.value)
+
+        # No data or no anomalies -> check if we have any metrics at all
+        if not states:
+            # Check if any metric has data in this window
+            has_data = any(
+                _aggregate_metric_in_window(node, m, start_time, end_time, "mean") is not None
+                for m in node.abnormal_metrics
+            )
+            if has_data:
+                states.add(PodState.HEALTHY.value)
+            else:
+                states.add(PodState.UNKNOWN.value)
+
+        windows.append(StateWindow(start_time=start_time, end_time=end_time, states=states))
+
+    # If Pod was killed, add KILLED state to windows after the kill time
+    # Also extend the timeline to cover the period after metrics stopped
+    if was_killed and kill_start is not None and kill_end is not None:
+        updated_windows: list[StateWindow] = []
+        for window in windows:
+            if window.start_time >= kill_start:
+                # This window is after the kill - add KILLED state
+                new_states = window.states | {PodState.KILLED.value}
+                updated_windows.append(
+                    StateWindow(start_time=window.start_time, end_time=window.end_time, states=new_states)
+                )
+            else:
+                updated_windows.append(window)
+
+        # If there's a gap between last window and estimated end, add a KILLED window
+        if updated_windows and updated_windows[-1].end_time < kill_end:
+            updated_windows.append(
+                StateWindow(
+                    start_time=updated_windows[-1].end_time,
+                    end_time=kill_end,
+                    states={PodState.KILLED.value},
+                )
+            )
+        windows = updated_windows
+
+    return _merge_consecutive_windows(windows)
+
+
+def _detect_container_restart(node: Node) -> tuple[bool, int | None, int | None]:
+    """Detect if container has restarted during abnormal period.
+
+    Uses k8s.container.restarts counter metric. Detects the time window when
+    the restart count increases (from 0->1, 1->2, etc.).
+
+    Returns:
+        Tuple of (has_restarted, restart_start_time, restart_end_time)
+        - has_restarted: True if a restart was detected
+        - restart_start_time: Unix timestamp when restart counter increased (in seconds)
+        - restart_end_time: Unix timestamp of next data point after restart (in seconds)
+    """
+    restart_metric = "k8s.container.restarts"
+
+    # Get baseline max to compare against
+    baseline_max = 0.0
+    if restart_metric in node.baseline_metrics:
+        _, baseline_values = node.baseline_metrics[restart_metric]
+        if isinstance(baseline_values, np.ndarray) and len(baseline_values) > 0:
+            baseline_max = float(np.max(baseline_values))
+
+    # Check abnormal period for restart
+    if restart_metric not in node.abnormal_metrics:
+        return False, None, None
+
+    timestamps, values = node.abnormal_metrics[restart_metric]
+    if not isinstance(values, np.ndarray) or len(values) == 0:
+        return False, None, None
+
+    # Find the first point where value increases above baseline
+    restart_start_time = None
+    restart_end_time = None
+
+    for i in range(len(values)):
+        current_value = float(values[i])
+        if current_value > baseline_max:
+            # Found restart - the restart happened between previous and current timestamp
+            if i > 0:
+                # Restart window starts at previous timestamp (last known good state)
+                ts = timestamps[i - 1]
+                restart_start_time = int(ts.timestamp()) if hasattr(ts, "timestamp") else int(ts)
+            else:
+                # Restart at the very beginning
+                ts = timestamps[i]
+                restart_start_time = int(ts.timestamp()) if hasattr(ts, "timestamp") else int(ts)
+
+            # Restart window ends at current timestamp (container is back up)
+            ts = timestamps[i]
+            restart_end_time = int(ts.timestamp()) if hasattr(ts, "timestamp") else int(ts)
+            break
+
+    if restart_start_time is not None:
+        return True, restart_start_time, restart_end_time
+
+    return False, None, None
+
+
+def detect_container_state_timeline(node: Node) -> list[StateWindow]:
+    """Detect Container state timeline using fixed 5-second windows.
+
+    Supports multiple simultaneous states.
+    Uses baseline comparison with Z-score for absolute usage metrics.
+    Container metrics are absolute values (bytes, cores) that vary by container size.
+    """
+    time_windows = _generate_fixed_windows(node)
+    if not time_windows:
+        return []
+
+    # Compute baseline statistics for anomaly detection
+    baseline_stats = _compute_node_baseline_stats(node)
+    detector = BaselineAwareDetector(baseline_stats) if baseline_stats else None
+
+    # Detect container restart and get the precise restart time window
+    has_restarted, restart_start, restart_end = _detect_container_restart(node)
+
+    windows = []
+    for start_time, end_time in time_windows:
+        states: set[str] = set()
+
+        # Add RESTARTING state only if this window overlaps with the restart period
+        if has_restarted and restart_start is not None and restart_end is not None:
+            # Check if this window overlaps with restart period
+            if start_time <= restart_end and end_time >= restart_start:
+                states.add(ContainerState.RESTARTING.value)
+
+        # Container metrics are absolute usage values, use baseline comparison
+        if detector and "container.memory.working_set" in baseline_stats:
+            memory_usage = _aggregate_metric_in_window(
+                node, "container.memory.working_set", start_time, end_time, "mean"
+            )
+            if memory_usage is not None and detector.is_critical_anomaly("container.memory.working_set", memory_usage):
+                states.add(ContainerState.HIGH_MEMORY.value)
+
+        if detector and "container.cpu.usage" in baseline_stats:
+            cpu_usage = _aggregate_metric_in_window(node, "container.cpu.usage", start_time, end_time, "mean")
+            if cpu_usage is not None and detector.is_critical_anomaly("container.cpu.usage", cpu_usage):
+                states.add(ContainerState.HIGH_CPU.value)
+
+        # Filesystem usage - use fixed threshold for utilization
+        fs_usage = _aggregate_metric_in_window(node, "container.filesystem.usage", start_time, end_time, "mean")
+        fs_capacity = _aggregate_metric_in_window(node, "container.filesystem.capacity", start_time, end_time, "mean")
+        if fs_usage is not None and fs_capacity is not None and fs_capacity > 0:
+            fs_utilization = fs_usage / fs_capacity
+            if fs_utilization > 0.95:  # Disk usage > 95%
+                states.add(ContainerState.HIGH_DISK_USAGE.value)
+
+        # No anomalies -> check if we have any metrics at all
+        if not states:
+            has_data = any(
+                _aggregate_metric_in_window(node, m, start_time, end_time, "mean") is not None
+                for m in node.abnormal_metrics
+            )
+            if has_data:
+                states.add(ContainerState.HEALTHY.value)
+            else:
+                states.add(ContainerState.UNKNOWN.value)
+
+        windows.append(StateWindow(start_time=start_time, end_time=end_time, states=states))
+
+    return _merge_consecutive_windows(windows)
+
+
+def detect_service_state_timeline(node: Node) -> list[StateWindow]:
+    return []
+
+
+def detect_span_state_timeline(node: Node) -> list[StateWindow]:
+    time_windows = _generate_fixed_windows(node)
+
+    # If no abnormal data, check for MISSING_SPAN as fallback
+    if not time_windows:
+        if _detect_missing_span(node):
+            # For missing spans, we need to determine when the span became missing.
+            # Since there's no abnormal data, use a time range that covers the abnormal period.
+            # We use the baseline's time range as a reference, but shift it forward to represent
+            # that the span is missing during the abnormal period (which comes after baseline).
+            baseline_timestamps = _get_all_baseline_timestamps(node)
+            if baseline_timestamps:
+                # The abnormal period typically starts right after the baseline period ends.
+                # Use the baseline end time as the start of the missing span window.
+                # This represents: "span was present in baseline, but missing in abnormal period"
+                baseline_end = max(baseline_timestamps)
+                # Use a generous end time to cover the abnormal period
+                # Add a buffer to ensure it covers the injection time
+                start_time = baseline_end
+                end_time = baseline_end + 600  # 10 minutes should cover most abnormal periods
+            else:
+                # Fallback to 0 if no baseline data (shouldn't happen for missing spans)
+                start_time = 0
+                end_time = 0
+            return [StateWindow(start_time=start_time, end_time=end_time, states={SpanState.MISSING_SPAN.value})]
+        return []
+
+    # First pass: detect all states except MISSING_SPAN
+    windows = []
+    has_anomalous_state = False
+
+    for start_time, end_time in time_windows:
+        states = _detect_span_states(node, start_time, end_time)
+
+        # Check if any anomalous (non-HEALTHY, non-UNKNOWN) state was detected
+        anomalous_states = states - {SpanState.HEALTHY.value, SpanState.UNKNOWN.value}
+        if anomalous_states:
+            has_anomalous_state = True
+
+        if not states:
+            has_data = any(
+                _aggregate_metric_in_window(node, m, start_time, end_time, "mean") is not None
+                for m in node.abnormal_metrics
+            )
+            if has_data:
+                states = {SpanState.HEALTHY.value}
+            else:
+                states = {SpanState.UNKNOWN.value}
+
+        windows.append(StateWindow(start_time=start_time, end_time=end_time, states=states))
+
+    # Second pass: only check MISSING_SPAN if no other anomalous states detected
+    if not has_anomalous_state and _detect_missing_span(node):
+        windows = [
+            StateWindow(
+                start_time=w.start_time,
+                end_time=w.end_time,
+                states=w.states | {SpanState.MISSING_SPAN.value},
+            )
+            for w in windows
+        ]
+
+    return _merge_consecutive_windows(windows)
+
+
+def _detect_missing_span(node: Node) -> bool:
+    """Detect if span is missing during abnormal period.
+
+    Returns True if:
+    - Baseline has meaningful traffic (request_count >= 1.0 mean, or total requests >= 3)
+    - AND abnormal period has no data points OR significantly reduced traffic (<10% of baseline)
+    """
+
+    def get_series(metrics_dict: dict, key: str) -> np.ndarray:
+        if key not in metrics_dict:
+            return np.array([])
+        _ts, values = metrics_dict[key]
+        if isinstance(values, np.ndarray):
+            return values
+        return np.array([])
+
+    baseline_request_count_vals = get_series(node.baseline_metrics, "request_count")
+    abnormal_request_count_vals = get_series(node.abnormal_metrics, "request_count")
+
+    b_request_mean, _, _ = calculate_series_stats(baseline_request_count_vals)
+
+    # If baseline has no meaningful traffic, cannot detect missing span
+    # Use >= 1.0 to include spans with exactly 1 request per window
+    # Also check total requests (sum) to catch low-frequency but consistent traffic
+    b_total_requests = baseline_request_count_vals.sum() if len(baseline_request_count_vals) > 0 else 0
+    if b_request_mean < 1.0 and b_total_requests < 3:
+        return False
+
+    # Case 1: Abnormal period has no data points at all
+    if len(abnormal_request_count_vals) == 0:
+        return True
+
+    # Case 2: Abnormal period has data but traffic dropped significantly
+    a_request_mean, _, _ = calculate_series_stats(abnormal_request_count_vals)
+    missing_threshold = 0.1
+    return a_request_mean < b_request_mean * missing_threshold
+
+
+def _detect_span_states(
+    node: Node,
+    start_time: int,
+    end_time: int,
+) -> set[str]:
+    """Detect span states from trace metrics within time range.
+
+    Detection principle: An anomaly is only flagged if the abnormal value exceeds
+    the baseline's normal range (P95). If baseline itself has similar high values,
+    the abnormal window should be considered healthy.
+
+    Args:
+        node: Node with baseline and abnormal metrics
+        start_time: Window start (Unix seconds)
+        end_time: Window end (Unix seconds)
+
+    Returns:
+        Set of detected state strings
+    """
+    states: set[str] = set()
+
+    # Filter abnormal metrics by time range
+    abnormal_metrics = _filter_metrics_by_time_range(node.abnormal_metrics, start_time, end_time)
+
+    def get_series(metrics_dict: dict, key: str) -> np.ndarray:
+        if key not in metrics_dict:
+            return np.array([])
+        _ts, values = metrics_dict[key]
+        if isinstance(values, np.ndarray):
+            return values
+        return np.array([])
+
+    # Get baseline and abnormal values
+    baseline_error_rate_vals = get_series(node.baseline_metrics, "error_rate")
+    abnormal_error_rate_vals = get_series(abnormal_metrics, "error_rate")
+
+    baseline_p99_vals = get_series(node.baseline_metrics, "p99_duration")
+    abnormal_p99_vals = get_series(abnormal_metrics, "p99_duration")
+
+    baseline_avg_vals = get_series(node.baseline_metrics, "avg_duration")
+    abnormal_avg_vals = get_series(abnormal_metrics, "avg_duration")
+
+    # Calculate stats
+    b_err_mean, _, _ = calculate_series_stats(baseline_error_rate_vals)
+    a_err_mean, _, _ = calculate_series_stats(abnormal_error_rate_vals)
+
+    b_p99_mean, b_p99_std, b_p99_cv = calculate_series_stats(baseline_p99_vals)
+    a_p99_mean, a_p99_std, _ = calculate_series_stats(abnormal_p99_vals)
+    # For P99, use P75 of abnormal values to catch mixed distributions
+    a_p99_representative = float(np.percentile(abnormal_p99_vals, 75)) if len(abnormal_p99_vals) > 0 else 0.0
+    # Baseline upper bound: P95 of baseline values (normal fluctuation range)
+    b_p99_upper = float(np.percentile(baseline_p99_vals, 95)) if len(baseline_p99_vals) > 0 else 0.0
+
+    b_avg_mean, b_avg_std, b_avg_cv = calculate_series_stats(baseline_avg_vals)
+    a_avg_mean, a_avg_std, _ = calculate_series_stats(abnormal_avg_vals)
+    # For avg latency, use mean of abnormal values (window is short)
+    a_avg_representative = a_avg_mean
+    # Baseline upper bound: P95 of baseline values
+    b_avg_upper = float(np.percentile(baseline_avg_vals, 95)) if len(baseline_avg_vals) > 0 else 0.0
+
+    # Check if span name contains "error" (case-insensitive)
+    if "error" in node.self_name.lower():
+        states.add(SpanState.HIGH_ERROR_RATE.value)
+
+    # Detect HIGH_ERROR_RATE
+    # Only flag if abnormal error rate exceeds baseline's normal range
+    b_err_upper = float(np.percentile(baseline_error_rate_vals, 95)) if len(baseline_error_rate_vals) > 0 else 0.0
+    if a_err_mean > max(b_err_upper, b_err_mean * 1.5) and a_err_mean > 0.1:
+        states.add(SpanState.HIGH_ERROR_RATE.value)
+
+    # Detect HIGH_P99_LATENCY or TIMEOUT
+    # Must exceed BOTH: adaptive threshold AND baseline's normal upper bound (P95)
+    if b_p99_mean > 0 and len(abnormal_p99_vals) > 0:
+        p99_threshold = get_adaptive_threshold(b_p99_mean, b_p99_cv)
+        adaptive_limit = b_p99_mean * p99_threshold
+
+        # Only flag as anomaly if it exceeds baseline's P95 (normal fluctuation range)
+        # This prevents false positives when baseline itself has occasional high values
+        exceeds_baseline_range = a_p99_representative > b_p99_upper * 2
+
+        # Also check against adaptive threshold
+        exceeds_adaptive = a_p99_representative > adaptive_limit or a_p99_mean > adaptive_limit
+
+        if exceeds_baseline_range and exceeds_adaptive:
+            # If P99 latency exceeds 20 seconds, classify as TIMEOUT
+            if a_p99_representative > 20.0:
+                states.add(SpanState.TIMEOUT.value)
+            else:
+                states.add(SpanState.HIGH_P99_LATENCY.value)
+    elif a_p99_representative > 20.0:  # Direct timeout for zero baseline (>20s)
+        states.add(SpanState.TIMEOUT.value)
+    elif a_p99_representative > 8.0:  # Fallback for zero baseline
+        states.add(SpanState.HIGH_P99_LATENCY.value)
+
+    # Detect HIGH_AVG_LATENCY or TIMEOUT
+    # Must exceed BOTH: adaptive threshold AND baseline's normal upper bound (P95)
+    if b_avg_mean > 0 and len(abnormal_avg_vals) > 0:
+        avg_threshold = get_adaptive_threshold(b_avg_mean, b_avg_cv)
+        adaptive_limit = b_avg_mean * avg_threshold
+
+        # Only flag as anomaly if it exceeds baseline's P95
+        exceeds_baseline_range = a_avg_representative > b_avg_upper * 2
+
+        # Also check against adaptive threshold
+        exceeds_adaptive = a_avg_representative > adaptive_limit or a_avg_mean > adaptive_limit
+
+        if exceeds_baseline_range and exceeds_adaptive:
+            # If latency exceeds 20 seconds, classify as TIMEOUT instead of high latency
+            # This distinguishes actual timeouts from just slow responses
+            if a_avg_representative > 20.0:
+                states.add(SpanState.TIMEOUT.value)
+            else:
+                states.add(SpanState.HIGH_AVG_LATENCY.value)
+    elif a_avg_representative > 20.0:  # Direct timeout for zero baseline (>20s)
+        states.add(SpanState.TIMEOUT.value)
+    elif a_avg_representative > 5.0:  # Fallback for zero baseline
+        states.add(SpanState.HIGH_AVG_LATENCY.value)
+
+    return states
+
+
+def detect_machine_state_timeline(node: Node) -> list[StateWindow]:
+    """Detect Machine state timeline using fixed 5-second windows."""
+    time_windows = _generate_fixed_windows(node)
+    if not time_windows:
+        return []
+
+    windows = []
+    for start_time, end_time in time_windows:
+        windows.append(StateWindow(start_time=start_time, end_time=end_time, states={MachineState.UNKNOWN.value}))
+
+    return _merge_consecutive_windows(windows)
+
+
+def detect_namespace_state_timeline(node: Node) -> list[StateWindow]:
+    """Detect Namespace state timeline using fixed 5-second windows."""
+    time_windows = _generate_fixed_windows(node)
+    if not time_windows:
+        return []
+
+    windows = []
+    for start_time, end_time in time_windows:
+        windows.append(StateWindow(start_time=start_time, end_time=end_time, states={NamespaceState.ACTIVE.value}))
+
+    return _merge_consecutive_windows(windows)
+
+
+def detect_daemon_set_state_timeline(node: Node) -> list[StateWindow]:
+    """Detect DaemonSet state timeline using fixed 5-second windows."""
+    time_windows = _generate_fixed_windows(node)
+    if not time_windows:
+        return []
+
+    windows = []
+    for start_time, end_time in time_windows:
+        windows.append(StateWindow(start_time=start_time, end_time=end_time, states={DaemonSetState.UNKNOWN.value}))
+
+    return _merge_consecutive_windows(windows)
+
+
+def detect_state_timeline(node: Node) -> list[StateWindow]:
+    """Detect state timeline for any node based on its PlaceKind.
+
+    Returns time windows with states that can vary over time.
+    Nodes can have multiple simultaneous states.
+
+    Args:
+        node: Node to detect state timeline for
+
+    Returns:
+        List of StateWindow objects representing state changes over time
+    """
+    if node.kind == PlaceKind.machine:
+        return detect_machine_state_timeline(node)
+    elif node.kind == PlaceKind.namespace:
+        return detect_namespace_state_timeline(node)
+    elif node.kind == PlaceKind.deployment:
+        return detect_deployment_state_timeline(node)
+    elif node.kind == PlaceKind.stateful_set:
+        return detect_stateful_set_state_timeline(node)
+    elif node.kind == PlaceKind.replica_set:
+        return detect_replica_set_state_timeline(node)
+    elif node.kind == PlaceKind.daemon_set:
+        return detect_daemon_set_state_timeline(node)
+    elif node.kind == PlaceKind.pod:
+        return detect_pod_state_timeline(node)
+    elif node.kind == PlaceKind.container:
+        return detect_container_state_timeline(node)
+    elif node.kind == PlaceKind.service:
+        return detect_service_state_timeline(node)
+    elif node.kind == PlaceKind.span:
+        return detect_span_state_timeline(node)
+    else:
+        return []

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/state_enhancer.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/state_enhancer.py
@@ -1,0 +1,670 @@
+"""State enhancer framework for declarative state propagation.
+
+This module provides a declarative framework for enhancing node states based on
+graph topology traversal. Instead of hardcoding state propagation logic, rules
+can be defined as StateEnhancement dataclasses that specify:
+- Source node kind and states to match
+- Graph traversal path (edge kinds and directions)
+- Target node kind and states to apply
+
+Example: Container RESTARTING -> MISSING_SPAN on related Spans
+"""
+
+import logging
+from dataclasses import dataclass, field
+
+from rcabench_platform.v3.internal.reasoning.models.graph import DepKind, HyperGraph, PlaceKind
+from rcabench_platform.v3.internal.reasoning.models.state import ContainerState, PodState, SpanState, StateWindow
+from rcabench_platform.v3.internal.reasoning.rules.schema import PropagationDirection
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TraversalStep:
+    """A single step in the graph traversal path.
+
+    Defines how to traverse from one node to another via an edge.
+    """
+
+    edge_kind: DepKind
+    direction: PropagationDirection
+
+    def __post_init__(self) -> None:
+        """Validate the traversal step configuration."""
+        if not isinstance(self.edge_kind, DepKind):
+            raise ValueError(f"edge_kind must be a DepKind, got {type(self.edge_kind)}")
+        if not isinstance(self.direction, PropagationDirection):
+            raise ValueError(f"direction must be a PropagationDirection, got {type(self.direction)}")
+
+
+@dataclass
+class StateEnhancement:
+    """Declarative definition of state enhancement rules.
+
+    Specifies how to propagate states from source nodes to target nodes
+    via a graph traversal path.
+    """
+
+    source_kind: PlaceKind
+    source_states: set[str]
+    traversal_path: list[TraversalStep]
+    target_kind: PlaceKind
+    target_states: set[str]
+    description: str = ""
+    extend_to_first_activity: bool = field(default=False)
+    """If True, extend the source state window end time to when first target activity occurs."""
+
+    def __post_init__(self) -> None:
+        """Validate the enhancement configuration."""
+        if not self.source_states:
+            raise ValueError("source_states cannot be empty")
+        if not self.traversal_path:
+            raise ValueError("traversal_path cannot be empty")
+        if not self.target_states:
+            raise ValueError("target_states cannot be empty")
+
+
+@dataclass
+class InjectionPointEnhancement:
+    """Enhancement rule that marks all spans of injection service as affected.
+
+    For infrastructure faults (network, container, pod, dns, time), the injection point
+    service's spans may not show detectable anomalies in metrics. This enhancement
+    explicitly marks them so propagation rules can work correctly.
+    """
+
+    fault_categories: set[str]  # e.g., {"network", "container_resource", "pod_lifecycle", "dns", "time"}
+    target_states: set[str]  # States to add, e.g., {SpanState.INJECTION_AFFECTED}
+
+
+class StateEnhancer:
+    """Framework for applying declarative state enhancements to a graph.
+
+    StateEnhancer manages a collection of StateEnhancement rules and applies
+    them to modify node states based on graph topology traversal.
+    """
+
+    def __init__(
+        self,
+        graph: HyperGraph,
+    ):
+        """Initialize the state enhancer.
+
+        Args:
+            graph: The hypergraph containing topology (states stored in nodes)
+        """
+        self.graph = graph
+        self._enhancements: list[StateEnhancement] = []
+
+    def register(self, enhancement: StateEnhancement) -> None:
+        """Register a state enhancement rule.
+
+        Args:
+            enhancement: The enhancement rule to register
+        """
+        self._enhancements.append(enhancement)
+
+    def apply_all(self) -> None:
+        """Apply all registered state enhancements."""
+        for enhancement in self._enhancements:
+            self._apply_enhancement(enhancement)
+
+    def apply_injection_point_enhancement(
+        self,
+        injection_service_id: int,
+        fault_category: str,
+        enhancement: InjectionPointEnhancement,
+        abnormal_start_time: int | None = None,
+        abnormal_end_time: int | None = None,
+        source_service_id: int | None = None,
+        target_service_id: int | None = None,
+        fault_direction: str | None = None,
+    ) -> int:
+        """Mark spans with enhancement states based on fault type.
+
+        For network/DNS faults with source/target info, only mark cross-service call spans.
+        For other faults (container, pod, time), mark all spans of the injection service.
+
+        Args:
+            injection_service_id: The service where fault was injected
+            fault_category: The fault category (e.g., "network", "container_resource")
+            enhancement: The enhancement rule to apply
+            abnormal_start_time: Optional start time of abnormal period
+            abnormal_end_time: Optional end time of abnormal period
+            source_service_id: For network/DNS faults, the source service
+            target_service_id: For network/DNS faults, the target service
+            fault_direction: For network faults, the direction ("to", "from", "both")
+
+        Returns:
+            Number of spans marked with enhancement states
+        """
+        if fault_category not in enhancement.fault_categories:
+            logger.debug(
+                f"StateEnhancer: Skipping injection point enhancement for category "
+                f"'{fault_category}' (not in {enhancement.fault_categories})"
+            )
+            return 0
+
+        # Network fault with precise targeting
+        # NOTE: source_service/target_service refers to PACKET direction, not call direction.
+        #
+        # For direction="to": packets from source to target are blocked
+        #   - Affects: source calling target (request blocked)
+        #   - Affects: target calling source (response blocked)
+        #
+        # For direction="from": packets from target to source are blocked
+        #   - Affects: target calling source (request blocked)
+        #   - Affects: source calling target (response blocked)
+        #
+        # For direction="both": all packets between source and target are blocked
+        #   - Affects all calls between source and target
+        #
+        # In all cases, we need to find spans involved in calls BETWEEN the two services
+        # (regardless of which service is the caller), because both request and response
+        # travel through the network.
+        if fault_category == "network" and source_service_id is not None and target_service_id is not None:
+            # Find all spans involved in calls between the two services (both directions)
+            span_ids_src_to_tgt = self._get_spans_between_services(
+                source_service_id,
+                target_service_id,
+                "to",
+            )
+            span_ids_tgt_to_src = self._get_spans_between_services(
+                target_service_id,
+                source_service_id,
+                "to",
+            )
+            span_ids = list(set(span_ids_src_to_tgt) | set(span_ids_tgt_to_src))
+
+            if span_ids:
+                logger.debug(
+                    f"StateEnhancer: Network fault (direction={fault_direction}) - "
+                    f"found {len(span_ids)} spans between services "
+                    f"({len(span_ids_src_to_tgt)} src->tgt calls, {len(span_ids_tgt_to_src)} tgt->src calls)"
+                )
+            else:
+                # Fallback: no direct calls found between services, mark all source spans
+                span_ids = self._get_spans_for_service(source_service_id)
+                logger.debug(
+                    f"StateEnhancer: Network fault - no cross-service calls found, "
+                    f"falling back to all {len(span_ids)} spans of source service {source_service_id}"
+                )
+        # DNS fault: app_name (source) cannot resolve domain (target)
+        elif fault_category == "dns" and source_service_id is not None and target_service_id is not None:
+            span_ids = self._get_spans_between_services(
+                source_service_id,
+                target_service_id,
+                "to",  # DNS resolution only affects outgoing calls
+            )
+            if span_ids:
+                logger.debug(
+                    f"StateEnhancer: DNS fault - found {len(span_ids)} spans from "
+                    f"service {source_service_id} to {target_service_id}"
+                )
+            else:
+                # Fallback: no direct calls found, mark all source spans
+                span_ids = self._get_spans_for_service(source_service_id)
+                logger.debug(
+                    f"StateEnhancer: DNS fault - no cross-service calls found, "
+                    f"falling back to all {len(span_ids)} spans of source service {source_service_id}"
+                )
+        else:
+            # Fallback: mark all spans of injection service (for container/pod/time)
+            span_ids = self._get_spans_for_service(injection_service_id)
+
+        if not span_ids:
+            logger.debug(f"StateEnhancer: No spans found for service {injection_service_id}")
+            return 0
+
+        # Determine time window for enhancement
+        start_time, end_time = self._determine_abnormal_window(abnormal_start_time, abnormal_end_time)
+
+        marked_count = 0
+        for span_id in span_ids:
+            span_node = self.graph.get_node_by_id(span_id)
+            if span_node is None:
+                continue
+
+            self._add_enhancement_states_to_span(span_id, enhancement.target_states, start_time, end_time)
+            marked_count += 1
+
+        service_node = self.graph.get_node_by_id(injection_service_id)
+        service_name = service_node.self_name if service_node else str(injection_service_id)
+        logger.info(
+            f"StateEnhancer: Applied injection point enhancement: {marked_count} spans "
+            f"of service '{service_name}' marked with {enhancement.target_states}"
+        )
+
+        return marked_count
+
+    def _get_spans_for_service(self, service_id: int) -> list[int]:
+        """Get all span IDs included by a service.
+
+        Args:
+            service_id: The service node ID
+
+        Returns:
+            List of span node IDs
+        """
+        span_ids: list[int] = []
+
+        # Traverse 'includes' edges from service to spans
+        for src_id, dst_id, key in self.graph._graph.out_edges(service_id, keys=True):
+            edge_data = self.graph._graph.edges[src_id, dst_id, key].get("ref")
+            if edge_data and edge_data.kind == DepKind.includes:
+                dst_node = self.graph.get_node_by_id(dst_id)
+                if dst_node and dst_node.kind == PlaceKind.span:
+                    span_ids.append(dst_id)
+
+        return span_ids
+
+    def _get_spans_between_services(
+        self,
+        source_service_id: int,
+        target_service_id: int,
+        direction: str = "both",
+    ) -> list[int]:
+        """Get spans representing calls between two services.
+
+        For network and DNS faults, only spans that have direct calls edges crossing
+        the service boundary should be marked. This method finds those spans.
+
+        Args:
+            source_service_id: Service where traffic originates
+            target_service_id: Service receiving traffic
+            direction: "to" (source calls target), "from" (target calls source), "both"
+
+        Returns:
+            List of span IDs that have calls edges crossing service boundary
+        """
+        source_spans = set(self._get_spans_for_service(source_service_id))
+        target_spans = set(self._get_spans_for_service(target_service_id))
+
+        result: set[int] = set()
+
+        # direction="to" or "both": find source spans that call target spans
+        if direction in ("to", "both"):
+            for src_span_id in source_spans:
+                for _, dst_id, key in self.graph._graph.out_edges(src_span_id, keys=True):
+                    edge_data = self.graph._graph.edges[src_span_id, dst_id, key].get("ref")
+                    if edge_data and edge_data.kind == DepKind.calls and dst_id in target_spans:
+                        result.add(src_span_id)
+                        result.add(dst_id)  # Also mark the target span
+
+        # direction="from" or "both": find target spans that call source spans
+        if direction in ("from", "both"):
+            for tgt_span_id in target_spans:
+                for _, dst_id, key in self.graph._graph.out_edges(tgt_span_id, keys=True):
+                    edge_data = self.graph._graph.edges[tgt_span_id, dst_id, key].get("ref")
+                    if edge_data and edge_data.kind == DepKind.calls and dst_id in source_spans:
+                        result.add(tgt_span_id)
+                        result.add(dst_id)
+
+        return list(result)
+
+    def _determine_abnormal_window(
+        self,
+        abnormal_start_time: int | None,
+        abnormal_end_time: int | None,
+    ) -> tuple[int, int]:
+        """Determine the abnormal time window for enhancement.
+
+        If explicit times are not provided, derive from existing node timelines.
+
+        Args:
+            abnormal_start_time: Optional explicit start time
+            abnormal_end_time: Optional explicit end time
+
+        Returns:
+            Tuple of (start_time, end_time)
+        """
+        if abnormal_start_time is not None and abnormal_end_time is not None:
+            return abnormal_start_time, abnormal_end_time
+
+        # Derive from existing timelines in graph
+        all_starts: list[int] = []
+        all_ends: list[int] = []
+
+        for node in self.graph._node_id_map.values():
+            if node.state_timeline:
+                for window in node.state_timeline:
+                    all_starts.append(window.start_time)
+                    all_ends.append(window.end_time)
+
+        if all_starts and all_ends:
+            start = abnormal_start_time if abnormal_start_time is not None else min(all_starts)
+            end = abnormal_end_time if abnormal_end_time is not None else max(all_ends)
+            return start, end
+
+        # Fallback to epoch 0 and far future
+        return 0, 2**31 - 1
+
+    def _add_enhancement_states_to_span(
+        self,
+        span_id: int,
+        target_states: set[str],
+        start_time: int,
+        end_time: int,
+    ) -> None:
+        """Add enhancement states to a span's timeline.
+
+        Args:
+            span_id: The span node ID
+            target_states: States to add
+            start_time: Start time of enhancement window
+            end_time: End time of enhancement window
+        """
+        span_node = self.graph.get_node_by_id(span_id)
+        if span_node is None:
+            return
+
+        timeline = list(span_node.state_timeline) if span_node.state_timeline else []
+
+        if not timeline:
+            # Create a new timeline with enhancement states
+            new_timeline = [
+                StateWindow(
+                    start_time=start_time,
+                    end_time=end_time,
+                    states=target_states.copy(),
+                )
+            ]
+            self.graph.set_node_state_timeline(span_id, new_timeline)
+            return
+
+        # Add enhancement states to existing windows that overlap
+        updated_timeline: list[StateWindow] = []
+        for window in timeline:
+            if window.start_time <= end_time and window.end_time >= start_time:
+                # Overlapping window - add enhancement states
+                new_states = window.states | target_states
+                updated_timeline.append(
+                    StateWindow(
+                        start_time=window.start_time,
+                        end_time=window.end_time,
+                        states=new_states,
+                    )
+                )
+            else:
+                updated_timeline.append(window)
+
+        self.graph.set_node_state_timeline(span_id, updated_timeline)
+
+    def _apply_enhancement(self, enhancement: StateEnhancement) -> None:
+        """Apply a single state enhancement rule.
+
+        Args:
+            enhancement: The enhancement rule to apply
+        """
+        # Get all nodes of the source kind
+        source_nodes = self.graph.get_nodes_by_kind(enhancement.source_kind)
+
+        for source_node in source_nodes:
+            if source_node.id is None:
+                continue
+
+            # Get source node timeline and find matching state windows
+            source_timeline = self._get_timeline(source_node.id)
+            matching_windows = [w for w in source_timeline if enhancement.source_states & w.states]
+
+            if not matching_windows:
+                continue
+
+            # Calculate the source state window (earliest start, latest end)
+            source_start = min(w.start_time for w in matching_windows)
+            source_end = max(w.end_time for w in matching_windows)
+
+            # Traverse graph to find target nodes
+            target_node_ids = self._traverse_to_targets(
+                source_node.id,
+                enhancement.traversal_path,
+                enhancement.target_kind,
+            )
+
+            if not target_node_ids:
+                continue
+
+            # Optionally extend the window to first target activity
+            if enhancement.extend_to_first_activity:
+                first_activity = self._find_first_activity(target_node_ids, source_start)
+                if first_activity is not None:
+                    source_end = max(source_end, first_activity)
+
+            # Create the source window with extended time
+            source_window = StateWindow(
+                start_time=source_start,
+                end_time=source_end,
+                states=enhancement.source_states,
+            )
+
+            logger.debug(
+                f"StateEnhancer: Applying {enhancement.description} from "
+                f"node {source_node.id} to {len(target_node_ids)} targets "
+                f"(window: {source_start} - {source_end})"
+            )
+
+            # Apply target states to all target nodes
+            for target_id in target_node_ids:
+                self._add_states_to_node(
+                    target_id,
+                    source_window,
+                    enhancement.target_states,
+                )
+
+    def _get_timeline(self, node_id: int) -> list[StateWindow]:
+        """Get the state timeline for a node from graph.
+
+        Args:
+            node_id: The node ID
+
+        Returns:
+            List of StateWindow objects, sorted by start_time
+        """
+        node = self.graph.get_node_by_id(node_id)
+        if node and node.state_timeline:
+            return node.state_timeline
+        return []
+
+    def _traverse_to_targets(
+        self,
+        start_node_id: int,
+        traversal_path: list[TraversalStep],
+        target_kind: PlaceKind,
+    ) -> list[int]:
+        """Traverse the graph from a start node to find target nodes.
+
+        Args:
+            start_node_id: The starting node ID
+            traversal_path: List of traversal steps defining the path
+            target_kind: Expected PlaceKind of target nodes
+
+        Returns:
+            List of target node IDs
+        """
+        current_nodes = {start_node_id}
+
+        for step in traversal_path:
+            next_nodes: set[int] = set()
+
+            for node_id in current_nodes:
+                neighbors = self._get_neighbors_by_edge(
+                    node_id,
+                    step.edge_kind,
+                    step.direction,
+                )
+                next_nodes.update(neighbors)
+
+            current_nodes = next_nodes
+
+            if not current_nodes:
+                return []
+
+        # Filter to only nodes matching target_kind
+        result: list[int] = []
+        for node_id in current_nodes:
+            node = self.graph.get_node_by_id(node_id)
+            if node is not None and node.kind == target_kind:
+                result.append(node_id)
+
+        return result
+
+    def _get_neighbors_by_edge(
+        self,
+        node_id: int,
+        edge_kind: DepKind,
+        direction: PropagationDirection,
+    ) -> list[int]:
+        """Get neighboring nodes connected by a specific edge kind and direction.
+
+        Args:
+            node_id: The source node ID
+            edge_kind: The type of edge to traverse
+            direction: FORWARD (follow edge) or BACKWARD (against edge)
+
+        Returns:
+            List of neighbor node IDs
+        """
+        neighbors: list[int] = []
+
+        if direction == PropagationDirection.FORWARD:
+            # Follow edge direction: node -> neighbor
+            for src_id, dst_id, key in self.graph._graph.out_edges(node_id, keys=True):
+                edge_data = self.graph._graph.edges[src_id, dst_id, key].get("ref")
+                if edge_data and edge_data.kind == edge_kind:
+                    neighbors.append(dst_id)
+        else:
+            # Against edge direction: neighbor -> node
+            for src_id, dst_id, key in self.graph._graph.in_edges(node_id, keys=True):
+                edge_data = self.graph._graph.edges[src_id, dst_id, key].get("ref")
+                if edge_data and edge_data.kind == edge_kind:
+                    neighbors.append(src_id)
+
+        return neighbors
+
+    def _find_first_activity(self, node_ids: list[int], after_time: int) -> int | None:
+        """Find the earliest timestamp when any node has activity after a given time.
+
+        Args:
+            node_ids: List of node IDs to check
+            after_time: Look for activity after this timestamp
+
+        Returns:
+            The timestamp of the first activity, or None if no activity found
+        """
+        first_activity: int | None = None
+
+        for node_id in node_ids:
+            timeline = self._get_timeline(node_id)
+            for window in timeline:
+                if window.start_time >= after_time:
+                    if first_activity is None or window.start_time < first_activity:
+                        first_activity = window.start_time
+                    break
+
+        return first_activity
+
+    def _add_states_to_node(
+        self,
+        node_id: int,
+        source_window: StateWindow,
+        target_states: set[str],
+    ) -> None:
+        """Add target states to a node's timeline based on source window timing.
+
+        This creates/modifies StateWindows to add the target states during the
+        time period when the source state was active.
+
+        Args:
+            node_id: The target node ID
+            source_window: The source state window defining the time period
+            target_states: The states to add to the target node
+        """
+        timeline = list(self._get_timeline(node_id))
+
+        # If node has no timeline, create one with the target states
+        if not timeline:
+            new_timeline = [
+                StateWindow(
+                    start_time=source_window.start_time,
+                    end_time=source_window.end_time,
+                    states=target_states,
+                )
+            ]
+            self.graph.set_node_state_timeline(node_id, new_timeline)
+            return
+
+        # Check if there's a gap before the first window
+        first_window = timeline[0]
+        if first_window.start_time > source_window.start_time:
+            gap_end = min(first_window.start_time, source_window.end_time)
+            gap_window = StateWindow(
+                start_time=source_window.start_time,
+                end_time=gap_end,
+                states=target_states,
+            )
+            timeline = [gap_window] + timeline
+
+            logger.debug(f"StateEnhancer: Added gap window for node {node_id}: {source_window.start_time} - {gap_end}")
+
+        # Update existing windows that overlap with source window
+        updated_timeline: list[StateWindow] = []
+        for window in timeline:
+            # Check if this window overlaps with source window
+            if window.start_time <= source_window.end_time and window.end_time >= source_window.start_time:
+                # Add target states if not already present
+                if not target_states.issubset(window.states):
+                    new_states = window.states | target_states
+                    updated_timeline.append(
+                        StateWindow(
+                            start_time=window.start_time,
+                            end_time=window.end_time,
+                            states=new_states,
+                        )
+                    )
+                else:
+                    updated_timeline.append(window)
+            else:
+                updated_timeline.append(window)
+
+        self.graph.set_node_state_timeline(node_id, updated_timeline)
+
+
+# Builtin enhancement: Container RESTARTING -> MISSING_SPAN on related Spans
+# Traversal path: Container <- Pod <- Service -> Span
+# (BACKWARD via runs, BACKWARD via routes_to, FORWARD via includes)
+CONTAINER_RESTART_TO_MISSING_SPAN = StateEnhancement(
+    source_kind=PlaceKind.container,
+    source_states={ContainerState.RESTARTING.value},
+    traversal_path=[
+        TraversalStep(DepKind.runs, PropagationDirection.BACKWARD),
+        TraversalStep(DepKind.routes_to, PropagationDirection.BACKWARD),
+        TraversalStep(DepKind.includes, PropagationDirection.FORWARD),
+    ],
+    target_kind=PlaceKind.span,
+    target_states={SpanState.MISSING_SPAN.value},
+    description="Container restart propagates MISSING_SPAN to related spans",
+    extend_to_first_activity=True,
+)
+
+# Builtin enhancement: Pod KILLED -> Container RESTARTING
+# When a Pod is killed (e.g., PodKill fault), its containers are implicitly restarted.
+# Traversal path: Pod -> Container (FORWARD via runs)
+POD_KILLED_TO_CONTAINER_RESTARTING = StateEnhancement(
+    source_kind=PlaceKind.pod,
+    source_states={PodState.KILLED.value},
+    traversal_path=[
+        TraversalStep(DepKind.runs, PropagationDirection.FORWARD),
+    ],
+    target_kind=PlaceKind.container,
+    target_states={ContainerState.RESTARTING.value},
+    description="Pod killed propagates RESTARTING to its containers",
+    extend_to_first_activity=False,
+)
+
+# Builtin injection point enhancement: Mark all spans of injection service as INJECTION_AFFECTED
+# This is applied for infrastructure faults where metrics may not detect anomalies
+INJECTION_POINT_TO_SPAN_AFFECTED = InjectionPointEnhancement(
+    fault_categories={"container_resource", "pod_lifecycle", "network", "dns", "time", "jvm_method"},
+    target_states={SpanState.INJECTION_AFFECTED.value},
+)

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/state_enhancer.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/state_enhancer.py
@@ -250,7 +250,7 @@ class StateEnhancer:
         span_ids: list[int] = []
 
         # Traverse 'includes' edges from service to spans
-        for src_id, dst_id, key in self.graph._graph.out_edges(service_id, keys=True):
+        for src_id, dst_id, key in self.graph._graph.out_edges(service_id, keys=True):  # type: ignore[call-arg]
             edge_data = self.graph._graph.edges[src_id, dst_id, key].get("ref")
             if edge_data and edge_data.kind == DepKind.includes:
                 dst_node = self.graph.get_node_by_id(dst_id)
@@ -286,7 +286,7 @@ class StateEnhancer:
         # direction="to" or "both": find source spans that call target spans
         if direction in ("to", "both"):
             for src_span_id in source_spans:
-                for _, dst_id, key in self.graph._graph.out_edges(src_span_id, keys=True):
+                for _, dst_id, key in self.graph._graph.out_edges(src_span_id, keys=True):  # type: ignore[call-arg]
                     edge_data = self.graph._graph.edges[src_span_id, dst_id, key].get("ref")
                     if edge_data and edge_data.kind == DepKind.calls and dst_id in target_spans:
                         result.add(src_span_id)
@@ -295,7 +295,7 @@ class StateEnhancer:
         # direction="from" or "both": find target spans that call source spans
         if direction in ("from", "both"):
             for tgt_span_id in target_spans:
-                for _, dst_id, key in self.graph._graph.out_edges(tgt_span_id, keys=True):
+                for _, dst_id, key in self.graph._graph.out_edges(tgt_span_id, keys=True):  # type: ignore[call-arg]
                     edge_data = self.graph._graph.edges[tgt_span_id, dst_id, key].get("ref")
                     if edge_data and edge_data.kind == DepKind.calls and dst_id in source_spans:
                         result.add(tgt_span_id)
@@ -529,13 +529,13 @@ class StateEnhancer:
 
         if direction == PropagationDirection.FORWARD:
             # Follow edge direction: node -> neighbor
-            for src_id, dst_id, key in self.graph._graph.out_edges(node_id, keys=True):
+            for src_id, dst_id, key in self.graph._graph.out_edges(node_id, keys=True):  # type: ignore[call-arg]
                 edge_data = self.graph._graph.edges[src_id, dst_id, key].get("ref")
                 if edge_data and edge_data.kind == edge_kind:
                     neighbors.append(dst_id)
         else:
             # Against edge direction: neighbor -> node
-            for src_id, dst_id, key in self.graph._graph.in_edges(node_id, keys=True):
+            for src_id, dst_id, key in self.graph._graph.in_edges(node_id, keys=True):  # type: ignore[call-arg]
                 edge_data = self.graph._graph.edges[src_id, dst_id, key].get("ref")
                 if edge_data and edge_data.kind == edge_kind:
                     neighbors.append(src_id)

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/temporal_validator.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/temporal_validator.py
@@ -1,0 +1,202 @@
+"""Temporal causality validation for fault propagation.
+
+This module provides temporal validation for fault propagation paths,
+ensuring that effects occur after their causes with appropriate delays.
+Uses binary search for efficient state window lookup in sorted timelines.
+"""
+
+import bisect
+
+from rcabench_platform.v3.internal.reasoning.models.graph import HyperGraph
+from rcabench_platform.v3.internal.reasoning.models.state import StateWindow
+
+
+class TemporalValidator:
+    """Validates temporal causality constraints for fault propagation.
+
+    This class reads state timelines from graph nodes and provides methods
+    to find causally valid state windows - windows where a state is active
+    at or after a given timestamp, respecting the principle that effects
+    must occur after their causes.
+    """
+
+    def __init__(self, graph: HyperGraph) -> None:
+        """Initialize the temporal validator.
+
+        Args:
+            graph: The hypergraph containing nodes with state timelines.
+        """
+        self.graph = graph
+
+    def get_timeline(self, node_id: int) -> list[StateWindow]:
+        """Get the state timeline for a node from graph.
+
+        Args:
+            node_id: The node ID to get timeline for.
+
+        Returns:
+            List of StateWindows sorted by start_time, or empty list if not found.
+        """
+        node = self.graph.get_node_by_id(node_id)
+        if node and node.state_timeline:
+            return node.state_timeline
+        return []
+
+    def find_causal_window(
+        self,
+        node_id: int,
+        min_start_time: int,
+        required_states: set[str] | None = None,
+    ) -> StateWindow | None:
+        """Find a state window that is causally valid (at or after min_start_time).
+
+        If required_states is provided, returns the first window that matches
+        both temporal and state constraints. If not provided, returns the first
+        window at or after min_start_time regardless of states.
+
+        Args:
+            node_id: The node ID to find state window for.
+            min_start_time: Minimum start time for temporal causality.
+            required_states: Optional set of states the window must contain.
+
+        Returns:
+            First matching StateWindow or None if no valid window exists.
+        """
+        timeline = self.get_timeline(node_id)
+        if not timeline:
+            return None
+
+        if required_states is not None:
+            return self._find_matching_state_window(timeline, min_start_time, required_states)
+        else:
+            return self._find_causal_state_window(timeline, min_start_time)
+
+    def validate_hop(
+        self,
+        src_id: int,
+        dst_id: int,
+        src_time: int,
+        required_dst_states: set[str] | None = None,
+        min_delay: float | None = None,
+        max_delay: float | None = None,
+    ) -> tuple[StateWindow | None, float]:
+        """Validate a single propagation hop with temporal constraints.
+
+        Checks if the destination node has a valid state window after the source
+        time, optionally matching required states and delay constraints.
+
+        Args:
+            src_id: Source node ID (used for context, not currently used in logic).
+            dst_id: Destination node ID to find state window for.
+            src_time: Source state start time (causality reference point).
+            required_dst_states: Optional set of states the destination must have.
+            min_delay: Optional minimum delay in seconds.
+            max_delay: Optional maximum delay in seconds.
+
+        Returns:
+            Tuple of (StateWindow or None, delay in seconds).
+            If no valid window found or delay constraints violated, returns (None, 0.0).
+        """
+        # Find causally valid window at destination
+        causal_window = self.find_causal_window(dst_id, src_time, required_dst_states)
+
+        if causal_window is None:
+            return None, 0.0
+
+        # Calculate delay
+        delay = float(causal_window.start_time - src_time)
+
+        # Validate delay constraints
+        if min_delay is not None and delay < min_delay:
+            return None, 0.0
+
+        if max_delay is not None and delay > max_delay:
+            return None, 0.0
+
+        return causal_window, delay
+
+    def _find_causal_state_window(self, timeline: list[StateWindow], min_start_time: int) -> StateWindow | None:
+        """Find a state window that is causally valid (contains or starts at/after min_start_time).
+
+        A window is causally valid if:
+        1. It CONTAINS min_start_time (start <= min_start_time < end), OR
+        2. It STARTS at or after min_start_time
+
+        This handles persistent states (e.g., MISSING_SPAN) where the state is active
+        throughout a time range, not just at the start time.
+
+        Args:
+            timeline: Pre-sorted list of StateWindows by start_time.
+            min_start_time: Minimum start time for temporal causality.
+
+        Returns:
+            First causally valid StateWindow, or None if not found.
+        """
+        if not timeline:
+            return None
+
+        # First, check if any window CONTAINS min_start_time
+        # This handles persistent states that cover a time range
+        for window in timeline:
+            if window.start_time <= min_start_time < window.end_time:
+                return window
+
+        # Then look for windows that start at or after min_start_time
+        start_times = [w.start_time for w in timeline]
+        idx = bisect.bisect_left(start_times, min_start_time)
+
+        if idx < len(timeline):
+            return timeline[idx]
+        return None
+
+    def _find_matching_state_window(
+        self,
+        timeline: list[StateWindow],
+        min_start_time: int,
+        required_states: set[str],
+    ) -> StateWindow | None:
+        """Find a state window that is causally valid AND matches required states.
+
+        Causal validity means: the destination node must be in the required state
+        at time >= min_start_time. This is satisfied if:
+
+        1. A window STARTS at or after min_start_time (standard case for point-in-time states)
+        2. A window CONTAINS min_start_time (for persistent states like MISSING_SPAN)
+
+        Example for MISSING_SPAN:
+        - MISSING_SPAN window [1000, 1600) means "span is missing during entire abnormal period"
+        - If cause (e.g., container HIGH_CPU) starts at 1080
+        - Question: "Is span MISSING at time >= 1080?"
+        - Answer: Yes, because 1080 ∈ [1000, 1600) - the span is missing at that moment
+
+        Args:
+            timeline: Pre-sorted list of StateWindows by start_time.
+            min_start_time: The cause's start time - we check if effect exists at this time or later.
+            required_states: Set of states that the window must intersect with.
+
+        Returns:
+            First matching StateWindow or None if no valid window exists.
+        """
+        if not timeline or not required_states:
+            return None
+
+        # First, check if any window CONTAINS min_start_time
+        # This handles persistent states (e.g., MISSING_SPAN) that cover a time range
+        # where the state is continuously active
+        for window in timeline:
+            if window.start_time <= min_start_time < window.end_time:
+                if set(window.states).intersection(required_states):
+                    return window
+
+        # Find starting index using binary search for windows that start after min_start_time
+        start_times = [w.start_time for w in timeline]
+        idx = bisect.bisect_left(start_times, min_start_time)
+
+        # Search forward for a window with matching states
+        while idx < len(timeline):
+            window = timeline[idx]
+            if set(window.states).intersection(required_states):
+                return window
+            idx += 1
+
+        return None

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/topology_explorer.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/topology_explorer.py
@@ -1,0 +1,190 @@
+"""TopologyExplorer: BFS traversal and path extraction from heterogeneous graphs.
+
+This module handles topology exploration for fault propagation:
+- BFS to find reachable subgraph from injection nodes
+- DFS to extract all paths from injection to alarm nodes
+
+Supports "diamond-shaped" paths where a node can be visited multiple times,
+e.g., span -> service -> pod -> service -> span (service visited twice).
+This is controlled by max_node_visits parameter.
+"""
+
+import logging
+import time
+from collections import Counter, deque
+from collections.abc import Callable
+
+from rcabench_platform.v3.internal.reasoning.models.graph import HyperGraph
+
+logger = logging.getLogger(__name__)
+
+# Maximum times a single node can appear in a path.
+# Set to 2 to support diamond-shaped paths like:
+#   span -> service -> pod -> service -> span
+#   span -> service -> pod -> container -> pod -> service -> span
+DEFAULT_MAX_NODE_VISITS = 2
+
+
+class TopologyExplorer:
+    """Explores graph topology using BFS/DFS for fault propagation analysis.
+
+    This class handles pure topology exploration without rule semantics:
+    - Finding reachable edges from injection nodes via BFS
+    - Extracting all paths from injection to alarm nodes via DFS
+    """
+
+    def __init__(
+        self,
+        graph: HyperGraph,
+        max_hops: int = 5,
+        max_node_visits: int = DEFAULT_MAX_NODE_VISITS,
+    ):
+        """Initialize the topology explorer.
+
+        Args:
+            graph: The hypergraph containing topology
+            max_hops: Maximum propagation hops (default 5)
+            max_node_visits: Maximum times a node can appear in a path (default 2).
+                            Set to 2 to support diamond-shaped paths like
+                            span -> service -> pod -> service -> span.
+        """
+        self.graph = graph
+        self.max_hops = max_hops
+        self.max_node_visits = max_node_visits
+
+    def get_neighbors(self, node_id: int) -> list[int]:
+        """Get all neighbors (forward and backward) for a node.
+
+        Args:
+            node_id: The node to get neighbors for
+
+        Returns:
+            List of neighbor node IDs (both forward and backward edges)
+        """
+        neighbors: list[int] = []
+
+        # Forward neighbors (outgoing edges)
+        for _, dst_id, _ in self.graph._graph.out_edges(node_id, keys=True):
+            neighbors.append(dst_id)
+
+        # Backward neighbors (incoming edges)
+        for src_id, _, _ in self.graph._graph.in_edges(node_id, keys=True):
+            neighbors.append(src_id)
+
+        return neighbors
+
+    def find_reachable_subgraph(
+        self,
+        injection_node_ids: list[int],
+        alarm_nodes: set[int],
+        edge_filter: Callable[[int, int, bool], bool] | None = None,
+    ) -> list[tuple[int, int]]:
+        """Find all reachable edges from injection nodes using BFS.
+
+        Performs BFS from injection nodes, filtering edges that don't match
+        propagation rules. Returns the subgraph as a list of edges.
+
+        Args:
+            injection_node_ids: Starting node IDs for propagation
+            alarm_nodes: Target alarm node IDs (used for logging)
+            edge_filter: Optional function (src_id, dst_id, is_first_hop) -> bool
+                        to filter edges. If None, all edges are included.
+
+        Returns:
+            List of (src_id, dst_id) tuples representing reachable edges
+        """
+        start_time = time.time()
+        injection_set = set(injection_node_ids)
+        visited: set[int] = set(injection_set)
+        edges: set[tuple[int, int]] = set()
+
+        queue: deque[tuple[int, int]] = deque()  # (node_id, distance)
+        for nid in injection_node_ids:
+            queue.append((nid, 0))
+
+        while queue:
+            current_node_id, dist = queue.popleft()
+
+            if dist >= self.max_hops:
+                continue
+
+            for neighbor_id in self.get_neighbors(current_node_id):
+                # Apply edge filter if provided
+                is_first_hop = current_node_id in injection_set
+                if edge_filter is not None and not edge_filter(current_node_id, neighbor_id, is_first_hop):
+                    continue
+
+                edges.add((current_node_id, neighbor_id))
+                if neighbor_id not in visited:
+                    visited.add(neighbor_id)
+                    queue.append((neighbor_id, dist + 1))
+
+        reachable_alarms = alarm_nodes & visited - injection_set
+        elapsed_time = time.time() - start_time
+        logger.debug(
+            f"    [DEBUG] Reachable subgraph: {len(edges)} edges, "
+            f"{len(visited)} nodes, {len(reachable_alarms)} reachable alarms, "
+            f"time: {elapsed_time:.3f}s"
+        )
+        return list(edges)
+
+    def extract_paths(
+        self,
+        edges: list[tuple[int, int]],
+        injection_node_ids: list[int],
+        alarm_nodes: set[int],
+    ) -> list[list[int]]:
+        """Extract all paths from injection nodes to alarm nodes in the subgraph.
+
+        Uses DFS to find all paths from any injection node to any alarm node.
+        Allows a node to be visited up to max_node_visits times to support
+        diamond-shaped paths (e.g., span -> service -> pod -> service -> span).
+
+        Args:
+            edges: List of (src_id, dst_id) tuples from find_reachable_subgraph
+            injection_node_ids: Starting node IDs
+            alarm_nodes: Target alarm node IDs
+
+        Returns:
+            List of paths, where each path is a list of node IDs
+        """
+        if not edges:
+            return []
+
+        # Build adjacency list from edges
+        adj: dict[int, list[int]] = {}
+        all_nodes: set[int] = set()
+        for src, dst in edges:
+            adj.setdefault(src, []).append(dst)
+            all_nodes.add(src)
+            all_nodes.add(dst)
+
+        reachable_alarms = alarm_nodes & all_nodes
+        injection_set = set(injection_node_ids)
+        paths: list[list[int]] = []
+        max_visits = self.max_node_visits
+
+        # DFS from each injection node
+        def dfs(node_id: int, path: list[int], visit_counts: Counter[int]) -> None:
+            if node_id in reachable_alarms and node_id not in injection_set:
+                paths.append(path.copy())
+                # Continue to find longer paths through this alarm
+
+            if len(path) > self.max_hops + 1:
+                return
+
+            for neighbor_id in adj.get(node_id, []):
+                # Allow visiting a node up to max_node_visits times
+                if visit_counts[neighbor_id] < max_visits:
+                    path.append(neighbor_id)
+                    visit_counts[neighbor_id] += 1
+                    dfs(neighbor_id, path, visit_counts)
+                    path.pop()
+                    visit_counts[neighbor_id] -= 1
+
+        for injection_id in injection_node_ids:
+            if injection_id in all_nodes:
+                initial_counts: Counter[int] = Counter({injection_id: 1})
+                dfs(injection_id, [injection_id], initial_counts)
+
+        return paths

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/topology_explorer.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/topology_explorer.py
@@ -64,11 +64,11 @@ class TopologyExplorer:
         neighbors: list[int] = []
 
         # Forward neighbors (outgoing edges)
-        for _, dst_id, _ in self.graph._graph.out_edges(node_id, keys=True):
+        for _, dst_id, _ in self.graph._graph.out_edges(node_id, keys=True):  # type: ignore[call-arg]
             neighbors.append(dst_id)
 
         # Backward neighbors (incoming edges)
-        for src_id, _, _ in self.graph._graph.in_edges(node_id, keys=True):
+        for src_id, _, _ in self.graph._graph.in_edges(node_id, keys=True):  # type: ignore[call-arg]
             neighbors.append(src_id)
 
         return neighbors

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
@@ -155,10 +155,11 @@ def propagation_result_to_causal_graph(
                     alarm_nodes_dict[node_key] = causal_node
 
             # Collect service votes for this component
-            if path_services[i]:
+            svc = path_services[i]
+            if svc:
                 if component not in component_service_votes:
                     component_service_votes[component] = Counter()
-                component_service_votes[component][path_services[i]] += 1
+                component_service_votes[component][svc] += 1
 
             # Create component-level edge
             if i < len(path.nodes) - 1:
@@ -442,7 +443,7 @@ def run_single_case(
 
         logger.info(f"[{case_name}] Detecting states for {len(graph._node_id_map)} nodes...")
         for node in graph._node_id_map.values():
-            if node.state_timeline is None:  # Only detect if not already set
+            if node.state_timeline is None and node.id is not None:
                 timeline = detect_state_timeline(node)
                 graph.set_node_state_timeline(node.id, timeline)
         logger.info(f"[{case_name}] State detection complete")
@@ -538,7 +539,7 @@ def _resolve_injection_service_id(graph: HyperGraph, physical_node_ids: list[int
 
         # For span nodes, traverse via 'includes' edge (service -> span)
         if node.kind == PlaceKind.span:
-            for src_id, _dst_id, key in graph._graph.in_edges(node_id, keys=True):
+            for src_id, _dst_id, key in graph._graph.in_edges(node_id, keys=True):  # type: ignore[call-arg]
                 if key == DepKind.includes:
                     src_node = graph.get_node_by_id(src_id)
                     if src_node and src_node.kind == PlaceKind.service:
@@ -546,11 +547,11 @@ def _resolve_injection_service_id(graph: HyperGraph, physical_node_ids: list[int
 
         # For container nodes, traverse via runs (pod -> container) and routes_to (service -> pod)
         if node.kind == PlaceKind.container:
-            for pod_src_id, _dst_id, key in graph._graph.in_edges(node_id, keys=True):
+            for pod_src_id, _dst_id, key in graph._graph.in_edges(node_id, keys=True):  # type: ignore[call-arg]
                 if key == DepKind.runs:
                     pod_node = graph.get_node_by_id(pod_src_id)
                     if pod_node and pod_node.kind == PlaceKind.pod:
-                        for svc_src_id, _pod_dst_id, svc_key in graph._graph.in_edges(pod_src_id, keys=True):
+                        for svc_src_id, _pod_dst_id, svc_key in graph._graph.in_edges(pod_src_id, keys=True):  # type: ignore[call-arg]
                             if svc_key == DepKind.routes_to:
                                 svc_node = graph.get_node_by_id(svc_src_id)
                                 if svc_node and svc_node.kind == PlaceKind.service:
@@ -558,7 +559,7 @@ def _resolve_injection_service_id(graph: HyperGraph, physical_node_ids: list[int
 
         # For pod nodes, traverse via routes_to (service -> pod)
         if node.kind == PlaceKind.pod:
-            for src_id, _dst_id, key in graph._graph.in_edges(node_id, keys=True):
+            for src_id, _dst_id, key in graph._graph.in_edges(node_id, keys=True):  # type: ignore[call-arg]
                 if key == DepKind.routes_to:
                     src_node = graph.get_node_by_id(src_id)
                     if src_node and src_node.kind == PlaceKind.service:

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
@@ -1,0 +1,971 @@
+import json
+import logging
+import re
+import time
+from datetime import datetime
+from functools import partial
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import typer
+from tqdm import tqdm
+
+from rcabench_platform.v3.internal.reasoning._util import setup_logging
+from rcabench_platform.v3.internal.reasoning.algorithms.propagator import FaultPropagator
+from rcabench_platform.v3.internal.reasoning.algorithms.starting_point_resolver import StartingPointResolver
+from rcabench_platform.v3.internal.reasoning.loaders.parquet_loader import ParquetDataLoader
+from rcabench_platform.v3.internal.reasoning.loaders.utils import fmap_processpool
+from rcabench_platform.v3.internal.reasoning.models.graph import DepKind, HyperGraph, PlaceKind
+from rcabench_platform.v3.internal.reasoning.models.injection import InjectionNodeResolver
+from rcabench_platform.v3.internal.reasoning.models.propagation import PropagationResult
+from rcabench_platform.v3.internal.reasoning.rules.builtin_rules import get_builtin_rules
+from rcabench_platform.v3.sdk.evaluation.causal_graph import CausalEdge, CausalGraph, CausalNode
+from rcabench_platform.v3.sdk.utils.serde import save_json
+
+logger = logging.getLogger(__name__)
+app = typer.Typer(name="reason", help="Fault propagation reasoning engine CLI")
+
+
+# =============================================================================
+# Span to Service Mapping from Parquet
+# =============================================================================
+
+
+def load_span_to_service_mapping(data_dir: Path) -> dict[str, list[str]]:
+    """Load span_name -> service_name mapping directly from parquet files.
+
+    This provides the ground truth mapping of which services contain which spans,
+    avoiding ambiguity when the same span_name appears in multiple services.
+
+    Returns:
+        Dict mapping span_name to list of service_names that contain it.
+    """
+    mapping: dict[str, list[str]] = {}
+
+    abnormal_path = data_dir / "abnormal_traces.parquet"
+    normal_path = data_dir / "normal_traces.parquet"
+
+    dfs = []
+    if abnormal_path.exists():
+        dfs.append(pl.read_parquet(abnormal_path))
+    if normal_path.exists():
+        dfs.append(pl.read_parquet(normal_path))
+
+    if not dfs:
+        return mapping
+
+    all_traces = pl.concat(dfs)
+
+    # Group by span_name and collect unique service_names
+    span_services = all_traces.group_by("span_name").agg(pl.col("service_name").unique().alias("services"))
+
+    for row in span_services.iter_rows(named=True):
+        span_name = row["span_name"]
+        services = list(row["services"]) if row["services"] else []
+        mapping[span_name] = services
+
+    return mapping
+
+
+# =============================================================================
+# Conversion: PropagationResult -> CausalGraph
+# =============================================================================
+
+
+def propagation_result_to_causal_graph(
+    result: PropagationResult,
+    graph: HyperGraph,
+    injection_node_name: str,
+    alarm_node_ids: set[int],
+    span_to_service_mapping: dict[str, list[str]] | None = None,
+) -> CausalGraph:
+    """Convert PropagationResult to CausalGraph format.
+
+    This function generates both component-level and service-level edges.
+    For service-level edges, it uses the path context and parquet-based
+    span-to-service mapping to correctly assign spans to services when
+    the same span_name belongs to multiple services.
+
+    Args:
+        result: The propagation result
+        graph: The HyperGraph
+        injection_node_name: Name of the injection node
+        alarm_node_ids: Set of alarm node IDs
+        span_to_service_mapping: Optional mapping from span_name to list of services
+            (loaded from parquet files). If provided, this is used as ground truth.
+    """
+    from collections import Counter
+
+    nodes_dict: dict[str, CausalNode] = {}
+    edges_set: set[tuple[str, str]] = set()
+    alarm_nodes_dict: dict[str, CausalNode] = {}
+    # Track all service assignments for each component across all paths
+    component_service_votes: dict[str, Counter[str]] = {}
+
+    for path in result.paths:
+        # Track the current service context as we traverse the path
+        current_service_context: str | None = None
+        # Track service assignment for each node position in this path
+        path_services: list[str | None] = []
+
+        # First pass: determine service for each node in this path
+        for _i, node_id in enumerate(path.nodes):
+            node = graph.get_node_by_id(node_id)
+            if node is None:
+                path_services.append(None)
+                continue
+
+            node_service: str | None = None
+            if node.kind == PlaceKind.span:
+                node_service = _extract_service_from_span(
+                    graph, node_id, current_service_context, span_to_service_mapping
+                )
+                if node_service:
+                    current_service_context = node_service
+            elif node.kind == PlaceKind.service:
+                node_service = node.self_name
+                current_service_context = node_service
+            elif node.kind == PlaceKind.pod:
+                node_service = _extract_service_from_pod(node.self_name)
+                current_service_context = node_service
+
+            path_services.append(node_service)
+
+        # Second pass: create nodes and edges, collect service votes
+        for i, node_id in enumerate(path.nodes):
+            node = graph.get_node_by_id(node_id)
+            if node is None:
+                continue
+
+            component = node.uniq_name
+            states = frozenset(path.states[i]) if i < len(path.states) else frozenset()
+            timestamp = path.state_start_times[i] if i < len(path.state_start_times) else None
+
+            node_key = f"{component}|{','.join(sorted(states))}"
+            if node_key not in nodes_dict:
+                causal_node = CausalNode(
+                    timestamp=timestamp,
+                    component=component,
+                    state=states,
+                )
+                nodes_dict[node_key] = causal_node
+
+                if node_id in alarm_node_ids:
+                    alarm_nodes_dict[node_key] = causal_node
+
+            # Collect service votes for this component
+            if path_services[i]:
+                if component not in component_service_votes:
+                    component_service_votes[component] = Counter()
+                component_service_votes[component][path_services[i]] += 1
+
+            # Create component-level edge
+            if i < len(path.nodes) - 1:
+                next_node_id = path.nodes[i + 1]
+                next_node = graph.get_node_by_id(next_node_id)
+                if next_node:
+                    edges_set.add((component, next_node.uniq_name))
+
+    # Build component_to_service using majority vote
+    component_to_service: dict[str, str] = {}
+    for component, votes in component_service_votes.items():
+        # Use the most common service assignment
+        most_common = votes.most_common(1)
+        if most_common:
+            component_to_service[component] = most_common[0][0]
+
+    edges = [CausalEdge(source=src, target=tgt) for src, tgt in edges_set]
+
+    injection_node_obj = graph.get_node_by_name(injection_node_name)
+    root_causes = []
+    if injection_node_obj:
+        injection_states = frozenset(result.injection_states) if result.injection_states else frozenset()
+        root_causes.append(
+            CausalNode(
+                component=injection_node_name,
+                state=injection_states,
+            )
+        )
+
+    return CausalGraph(
+        nodes=list(nodes_dict.values()),
+        edges=edges,
+        root_causes=root_causes,
+        alarm_nodes=list(alarm_nodes_dict.values()),
+        component_to_service=component_to_service,
+    )
+
+
+def _extract_service_from_span(
+    graph: HyperGraph,
+    span_node_id: int,
+    service_context: str | None = None,
+    span_to_service_mapping: dict[str, list[str]] | None = None,
+) -> str | None:
+    """Extract service name from a span node.
+
+    Span nodes now use the format "{service_name}::{span_name}", so we can
+    directly extract the service name from the node's self_name.
+
+    Falls back to HyperGraph includes edges if the format doesn't match.
+
+    Args:
+        graph: The HyperGraph
+        span_node_id: The span node ID
+        service_context: The current service context (unused with new format)
+        span_to_service_mapping: Optional mapping (unused with new format)
+    """
+    node = graph.get_node_by_id(span_node_id)
+    if node is None:
+        return None
+
+    span_name = node.self_name
+
+    # New format: "{service_name}::{span_name}"
+    if "::" in span_name:
+        service_name = span_name.split("::", 1)[0]
+        return service_name
+
+    # Fallback for old format or HTTP client spans
+    # Try parquet-based mapping
+    if span_to_service_mapping and span_name in span_to_service_mapping:
+        candidate_services = span_to_service_mapping[span_name]
+        if candidate_services:
+            if len(candidate_services) == 1:
+                return candidate_services[0]
+            if service_context and service_context in candidate_services:
+                return service_context
+            return candidate_services[0]
+
+    # Fallback: use HyperGraph includes edges
+    candidate_services: list[str] = []
+    for edge in graph.get_edges_by_kind(DepKind.includes):
+        if edge.dst_id == span_node_id:
+            src_node = graph.get_node_by_id(edge.src_id)
+            if src_node and src_node.kind == PlaceKind.service:
+                candidate_services.append(src_node.self_name)
+
+    if candidate_services:
+        if len(candidate_services) == 1:
+            return candidate_services[0]
+        if service_context and service_context in candidate_services:
+            return service_context
+        return candidate_services[0]
+
+    # For HTTP client spans without includes edges
+    if span_name.startswith("HTTP "):
+        # Try to extract service from URL host (e.g., "HTTP POST http://ts-ui-dashboard:8080/...")
+        url_match = re.search(r"https?://([a-zA-Z0-9_-]+):", span_name)
+        if url_match:
+            return url_match.group(1)
+
+        # Fallback: find the called span and use its service
+        for edge in graph.get_edges_by_kind(DepKind.calls):
+            if edge.src_id == span_node_id:
+                called_service = _extract_service_from_span(
+                    graph, edge.dst_id, service_context, span_to_service_mapping
+                )
+                if called_service:
+                    return called_service
+
+    return None
+
+
+def _extract_service_from_pod(pod_name: str) -> str:
+    """Extract service name from pod name."""
+    parts = pod_name.rsplit("-", 2)
+    if len(parts) >= 3:
+        return "-".join(parts[:-2])
+    return pod_name
+
+
+def _build_visualization_paths(
+    result: PropagationResult,
+    graph: HyperGraph,
+    alarm_nodes: set[int],
+) -> list[dict[str, Any]]:
+    """Build path data with full node info for visualization."""
+    viz_paths = []
+    for path in result.paths:
+        path_nodes = []
+        for j, node_id in enumerate(path.nodes):
+            node = graph.get_node_by_id(node_id)
+
+            states_at_node = path.states[j] if j < len(path.states) else []
+            if isinstance(states_at_node, list):
+                state_str = ", ".join(states_at_node) if states_at_node else "UNKNOWN"
+            else:
+                state_str = str(states_at_node) if states_at_node else "UNKNOWN"
+
+            state_start_time = None
+            if path.state_start_times and j < len(path.state_start_times):
+                state_start_time = path.state_start_times[j]
+
+            # Edge, rule, and delay are for the hop FROM this node TO next node
+            # So they exist for nodes 0 to n-2 (not for the last node)
+            edge_kind = None
+            rule_id = None
+            propagation_delay = None
+            if j < len(path.nodes) - 1:
+                if path.edges and j < len(path.edges):
+                    edge_kind = path.edges[j]
+                if path.rules and j < len(path.rules):
+                    rule_id = path.rules[j]
+                if path.propagation_delays and j < len(path.propagation_delays):
+                    propagation_delay = path.propagation_delays[j]
+
+            path_nodes.append(
+                {
+                    "node_id": node_id,
+                    "kind": node.kind.value if node else "unknown",
+                    "name": node.self_name if node else f"Node_{node_id}",
+                    "uniq_name": node.uniq_name if node else f"unknown|Node_{node_id}",
+                    "state": state_str,
+                    "state_start_time": state_start_time,
+                    "is_alarm": node_id in alarm_nodes,
+                    "edge_kind": edge_kind,
+                    "rule_id": rule_id,
+                    "propagation_delay": propagation_delay,
+                }
+            )
+
+        viz_paths.append(
+            {
+                "confidence": path.confidence,
+                "nodes": path_nodes,
+            }
+        )
+    return viz_paths
+
+
+# =============================================================================
+# Single Case Processing
+# =============================================================================
+
+
+def run_single_case(
+    data_dir: Path,
+    max_hops: int,
+    return_graph: bool = False,
+    injection_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    case_name = data_dir.name
+    if case_name == "converted":
+        case_name = data_dir.parent.name
+
+    try:
+        loader = ParquetDataLoader(data_dir, 2)
+        graph = loader.build_graph_from_parquet()
+
+        alarm_node_names = loader.identify_alarm_nodes_v2()
+        alarm_nodes = _resolve_alarm_nodes(graph, list(alarm_node_names))
+
+        if not alarm_nodes:
+            _save_case_result(data_dir, case_name, "no_alarms")
+            return _build_result(case_name, "no_alarms", graph if return_graph else None)
+
+        actual_injection_nodes = []
+        resolution_info: dict[str, Any] = {}
+
+        assert injection_data is not None
+        resolver = InjectionNodeResolver(graph)
+        resolved = resolver.resolve(injection_data)
+        assert resolved.injection_nodes is not None
+        actual_injection_nodes = resolved.injection_nodes
+        resolution_info = {
+            "resolved_nodes": resolved.injection_nodes,
+            "start_kind": resolved.start_kind,
+            "category": resolved.category,
+            "fault_type": resolved.fault_type_name,
+            "resolution_method": resolved.resolution_method,
+        }
+        logger.info(
+            f"[{case_name}] Resolved injection: {resolved.fault_type_name} -> "
+            f"{resolved.start_kind} ({resolved.resolution_method}): {resolved.injection_nodes}"
+        )
+
+        physical_node_ids: list[int] = []
+        for injection_node in actual_injection_nodes:
+            injection_node_obj = graph.get_node_by_name(injection_node)
+            if injection_node_obj is None:
+                logger.warning(f"[{case_name}] Injection node not found: {injection_node}")
+                continue
+            assert injection_node_obj.id is not None
+            physical_node_ids.append(injection_node_obj.id)
+
+        assert physical_node_ids != []
+
+        # Resolve injection service ID for state enhancement
+        injection_service_id = _resolve_injection_service_id(graph, physical_node_ids)
+        if injection_service_id is not None:
+            resolution_info["injection_service_id"] = injection_service_id
+
+        # Extract service-pair info from injection_point (for network and DNS faults)
+        source_service_id: int | None = None
+        target_service_id: int | None = None
+        fault_direction: str | None = None
+
+        if resolved.injection_point:
+            ip = resolved.injection_point
+
+            # Network faults: source_service, target_service, direction
+            if resolved.category == "network":
+                if ip.source_service:
+                    src_node = graph.get_node_by_name(f"service|{ip.source_service}")
+                    source_service_id = src_node.id if src_node else None
+                if ip.target_service:
+                    tgt_node = graph.get_node_by_name(f"service|{ip.target_service}")
+                    target_service_id = tgt_node.id if tgt_node else None
+                fault_direction = ip.direction  # "to", "from", or "both"
+                if source_service_id or target_service_id:
+                    resolution_info["network_source"] = ip.source_service
+                    resolution_info["network_target"] = ip.target_service
+                    resolution_info["network_direction"] = fault_direction
+
+            # DNS faults: app_name (source) cannot resolve domain (target)
+            elif resolved.category == "dns":
+                if ip.app_name:
+                    src_node = graph.get_node_by_name(f"service|{ip.app_name}")
+                    source_service_id = src_node.id if src_node else None
+                if ip.domain:
+                    tgt_node = graph.get_node_by_name(f"service|{ip.domain}")
+                    target_service_id = tgt_node.id if tgt_node else None
+                fault_direction = "to"  # DNS affects outgoing direction only
+                if source_service_id or target_service_id:
+                    resolution_info["dns_app"] = ip.app_name
+                    resolution_info["dns_domain"] = ip.domain
+
+        rules = get_builtin_rules()
+
+        from rcabench_platform.v3.internal.reasoning.algorithms.state_detector import detect_state_timeline
+
+        logger.info(f"[{case_name}] Detecting states for {len(graph._node_id_map)} nodes...")
+        for node in graph._node_id_map.values():
+            if node.state_timeline is None:  # Only detect if not already set
+                timeline = detect_state_timeline(node)
+                graph.set_node_state_timeline(node.id, timeline)
+        logger.info(f"[{case_name}] State detection complete")
+
+        # Resolve propagation starting points based on rule semantics
+        # For HTTP response faults, propagation starts from caller service (not physical injection)
+        assert injection_data is not None
+
+        starting_resolver = StartingPointResolver(graph)
+        injection_node_ids = starting_resolver.resolve(
+            physical_node_ids=physical_node_ids,
+            resolved_injection=resolved,
+            rules=rules,
+        )
+        if injection_node_ids != physical_node_ids:
+            starting_node_names = [graph.get_node_by_id(nid).uniq_name for nid in injection_node_ids]
+            resolution_info["starting_points"] = starting_node_names
+            logger.info(
+                f"[{case_name}] StartingPointResolver: propagation starts from "
+                f"{starting_node_names} (physical: {actual_injection_nodes})"
+            )
+
+        propagator = FaultPropagator(
+            graph=graph,
+            rules=rules,
+            max_hops=max_hops,
+        )
+        result = propagator.propagate_from_injection(
+            injection_node_ids=injection_node_ids,
+            alarm_nodes=alarm_nodes,
+            fault_category=resolved.category,
+            injection_service_id=injection_service_id,
+            source_service_id=source_service_id,
+            target_service_id=target_service_id,
+            fault_direction=fault_direction,
+        )
+
+        if result.paths:
+            return _process_successful_propagation(
+                case_name=case_name,
+                result=result,
+                graph=propagator.graph,
+                injection_nodes=actual_injection_nodes,
+                alarm_nodes=alarm_nodes,
+                return_graph=return_graph,
+                data_dir=data_dir,
+                resolution_info=resolution_info,
+            )
+        else:
+            _save_case_result(data_dir, case_name, "no_paths")
+            return _build_result(case_name, "no_paths", graph if return_graph else None)
+
+    except Exception as e:
+        logger.exception(f"[{case_name}] Error during processing")
+        return {"case": case_name, "status": "error", "error": str(e), "paths": 0}
+
+
+def _resolve_alarm_nodes(graph: HyperGraph, alarm_node_names: list[str]) -> set[int]:
+    """Resolve alarm node names to node IDs."""
+    alarm_nodes: set[int] = set()
+    for node_name in alarm_node_names:
+        full_name = f"span|{node_name}"
+        node = graph.get_node_by_name(full_name)
+        if node and node.id is not None:
+            alarm_nodes.add(node.id)
+    return alarm_nodes
+
+
+def _resolve_injection_service_id(graph: HyperGraph, physical_node_ids: list[int]) -> int | None:
+    """Resolve the service ID associated with injection nodes.
+
+    For injection point state enhancement, we need to find the service that
+    contains the injection point. This function traverses from injection nodes
+    to find the associated service.
+
+    Args:
+        graph: The HyperGraph
+        physical_node_ids: List of physical injection node IDs
+
+    Returns:
+        Service node ID if found, None otherwise
+    """
+    from rcabench_platform.v3.internal.reasoning.models.graph import PlaceKind
+
+    for node_id in physical_node_ids:
+        node = graph.get_node_by_id(node_id)
+        if node is None:
+            continue
+
+        # If injection node is already a service, use it directly
+        if node.kind == PlaceKind.service:
+            return node_id
+
+        # For span nodes, traverse via 'includes' edge (service -> span)
+        if node.kind == PlaceKind.span:
+            for src_id, _dst_id, key in graph._graph.in_edges(node_id, keys=True):
+                if key == DepKind.includes:
+                    src_node = graph.get_node_by_id(src_id)
+                    if src_node and src_node.kind == PlaceKind.service:
+                        return int(src_id)
+
+        # For container nodes, traverse via runs (pod -> container) and routes_to (service -> pod)
+        if node.kind == PlaceKind.container:
+            for pod_src_id, _dst_id, key in graph._graph.in_edges(node_id, keys=True):
+                if key == DepKind.runs:
+                    pod_node = graph.get_node_by_id(pod_src_id)
+                    if pod_node and pod_node.kind == PlaceKind.pod:
+                        for svc_src_id, _pod_dst_id, svc_key in graph._graph.in_edges(pod_src_id, keys=True):
+                            if svc_key == DepKind.routes_to:
+                                svc_node = graph.get_node_by_id(svc_src_id)
+                                if svc_node and svc_node.kind == PlaceKind.service:
+                                    return int(svc_src_id)
+
+        # For pod nodes, traverse via routes_to (service -> pod)
+        if node.kind == PlaceKind.pod:
+            for src_id, _dst_id, key in graph._graph.in_edges(node_id, keys=True):
+                if key == DepKind.routes_to:
+                    src_node = graph.get_node_by_id(src_id)
+                    if src_node and src_node.kind == PlaceKind.service:
+                        return int(src_id)
+
+    return None
+
+
+def _build_result(
+    case_name: str,
+    status: str,
+    graph: HyperGraph | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Build a result dictionary."""
+    ret: dict[str, Any] = {"case": case_name, "status": status, "paths": 0}
+    ret.update(kwargs)
+    if graph is not None:
+        ret["graph"] = graph
+    return ret
+
+
+def _process_successful_propagation(
+    case_name: str,
+    result: PropagationResult,
+    graph: HyperGraph,
+    injection_nodes: list[str],
+    alarm_nodes: set[int],
+    return_graph: bool,
+    data_dir: Path,
+    resolution_info: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Process case with successful propagation paths."""
+    primary_injection_node = injection_nodes[0] if injection_nodes else ""
+
+    # Load span-to-service mapping from parquet files for accurate service assignment
+    span_to_service_mapping = load_span_to_service_mapping(data_dir)
+
+    causal_graph = propagation_result_to_causal_graph(
+        result=result,
+        graph=graph,
+        injection_node_name=primary_injection_node,
+        alarm_node_ids=alarm_nodes,
+        span_to_service_mapping=span_to_service_mapping,
+    )
+
+    viz_paths = _build_visualization_paths(result, graph, alarm_nodes)
+
+    _save_case_result(
+        data_dir=data_dir,
+        case_name=case_name,
+        status="success",
+        causal_graph=causal_graph,
+        injection_nodes=injection_nodes,
+        alarm_nodes=alarm_nodes,
+        result=result,
+        viz_paths=viz_paths,
+        resolution_info=resolution_info,
+    )
+
+    ret: dict[str, Any] = {
+        "case": case_name,
+        "status": "success",
+        "paths": len(result.paths),
+        "propagation_result": result,
+    }
+    if resolution_info:
+        ret["resolution_info"] = resolution_info
+    if return_graph:
+        ret["graph"] = graph
+    return ret
+
+
+def _clean_previous_results(data_dir: Path) -> None:
+    files_to_clean = [
+        data_dir / "result.json",
+        data_dir / "causal_graph.json",
+        data_dir / "no_alarms.marker",
+        data_dir / "no_paths.marker",
+    ]
+    for file in files_to_clean:
+        if file.exists():
+            file.unlink()
+
+
+def _save_case_result(
+    data_dir: Path,
+    case_name: str,
+    status: str,
+    causal_graph: CausalGraph | None = None,
+    injection_nodes: list[str] | None = None,
+    alarm_nodes: set[int] | None = None,
+    result: PropagationResult | None = None,
+    viz_paths: list[dict[str, Any]] | None = None,
+    resolution_info: dict[str, Any] | None = None,
+) -> None:
+    _clean_previous_results(data_dir)
+
+    if status == "success" and causal_graph and result and injection_nodes is not None and alarm_nodes is not None:
+        graph_data = causal_graph.model_dump()
+        save_json(graph_data, path=data_dir / "causal_graph.json")
+
+        result_data: dict[str, Any] = {
+            "case_name": case_name,
+            "injection_nodes": injection_nodes,
+            "alarm_nodes": list(alarm_nodes),
+            "propagation_result": result.to_dict(),
+            "visualization_paths": viz_paths or [],
+        }
+        if resolution_info:
+            result_data["resolution_info"] = resolution_info
+        save_json(result_data, path=data_dir / "result.json")
+        logger.info(f"[{case_name}] Saved causal_graph.json and result.json")
+
+    elif status == "no_alarms":
+        (data_dir / "no_alarms.marker").touch()
+        logger.info(f"[{case_name}] No alarm nodes found, created marker")
+
+    elif status == "no_paths":
+        (data_dir / "no_paths.marker").touch()
+        logger.info(f"[{case_name}] No propagation paths found, created marker")
+
+
+# =============================================================================
+# Batch Processing Helpers
+# =============================================================================
+
+
+def _log_batch_header(base_path: Path, output_path: Path, max_workers: int, max_cases: int) -> None:
+    """Log batch run header."""
+    logger.info("=" * 60)
+    logger.info("Batch RCA Label Runner")
+    logger.info("=" * 60)
+    logger.info(f"Data directory: {base_path}")
+    logger.info(f"Output directory: {output_path}")
+    logger.info(f"Max workers: {max_workers}")
+    logger.info(f"Max cases: {max_cases if max_cases > 0 else 'all'}")
+    logger.info("=" * 60)
+
+
+def _collect_batch_tasks(
+    base_path: Path,
+    max_cases: int,
+    skip_existing: bool = True,
+    retry_no_paths_only: bool = False,
+) -> tuple[list[tuple[Path, list[str], dict[str, Any]]], int]:
+    """Collect all tasks to run from case folders."""
+    tasks: list[tuple[Path, list[str], dict[str, Any]]] = []
+    skipped = 0
+
+    for case_folder in sorted(base_path.iterdir()):
+        if not case_folder.is_dir():
+            continue
+        if max_cases > 0 and len(tasks) >= max_cases:
+            break
+
+        data_dir = case_folder / "converted"
+        injection_file = data_dir / "injection.json"
+        if not injection_file.exists():
+            logger.debug(f"[{case_folder.name}] Skipping: injection.json not found")
+            continue
+
+        valid_marker = case_folder / ".valid"
+        if not valid_marker.exists():
+            logger.debug(f"[{case_folder.name}] Skipping: .valid marker not found")
+            continue
+
+        case_output_folder = data_dir
+
+        if retry_no_paths_only:
+            no_paths_marker = case_output_folder / "no_paths.marker"
+            if not no_paths_marker.exists():
+                skipped += 1
+                continue
+            no_paths_marker.unlink()
+
+        if skip_existing and not retry_no_paths_only:
+            if (case_output_folder / "result.json").exists():
+                skipped += 1
+                continue
+            if (case_output_folder / "no_alarms.marker").exists():
+                skipped += 1
+                continue
+
+        try:
+            with open(injection_file, encoding="utf-8") as f:
+                injection_data = json.load(f)
+
+            services = _extract_services_from_injection(injection_data)
+            if not services:
+                logger.debug(f"[{case_folder.name}] Skipping: No services in ground_truth")
+                continue
+
+            # Keep legacy injection_nodes as fallback
+            injection_nodes = [f"service|{service}" for service in services if service != "mysql"]
+
+            if injection_nodes:
+                # Pass both injection_nodes (fallback) and injection_data (for smart resolution)
+                tasks.append((data_dir, injection_nodes, injection_data))
+
+        except Exception as e:
+            logger.warning(f"[{case_folder.name}] Error reading injection.json: {e}")
+            continue
+
+    return tasks, skipped
+
+
+def _extract_services_from_injection(injection_data: dict[str, Any]) -> list[str]:
+    """Extract service names from injection.json ground_truth field."""
+    ground_truth = injection_data.get("ground_truth", {})
+
+    if isinstance(ground_truth, dict):
+        services: list[str] = ground_truth.get("service", [])
+        return services
+    elif isinstance(ground_truth, list):
+        services = []
+        for gt_item in ground_truth:
+            if isinstance(gt_item, dict):
+                services.extend(gt_item.get("service", []))
+        return services
+    return []
+
+
+def _run_batch_tasks(
+    tasks: list[tuple[Path, list[str], dict[str, Any]]],
+    max_hops: int,
+    output_path: Path,
+    max_workers: int,
+    log_path: Path,
+) -> dict[str, int]:
+    """Run batch tasks in parallel and collect statistics."""
+    stats = {
+        "total": len(tasks),
+        "success": 0,
+        "failed": 0,
+        "no_alarms": 0,
+        "no_paths": 0,
+    }
+    no_paths_records: list[dict[str, Any]] = []
+
+    task_callables = [
+        partial(
+            run_single_case,
+            data_dir,
+            max_hops,
+            False,
+            injection_data,  # Pass injection_data for smart resolution
+        )
+        for data_dir, injection_nodes, injection_data in tasks
+    ]
+
+    results = fmap_processpool(
+        task_callables,
+        parallel=max_workers,
+        ignore_exceptions=True,
+        cpu_limit_each=2,
+        log_level=logging.DEBUG,
+        log_file=str(log_path),
+    )
+
+    for i, result in enumerate(tqdm(results, desc="Processing", total=len(results))):
+        if result is None:
+            continue
+
+        _, injection_nodes, _ = tasks[i]
+        status = result["status"]
+
+        if status == "success":
+            stats["success"] += 1
+        elif status == "no_alarms":
+            stats["no_alarms"] += 1
+        elif status == "no_paths":
+            stats["no_paths"] += 1
+            no_paths_records.append({"case": result["case"], "injection_nodes": injection_nodes})
+        elif status == "injection_node_not_found":
+            stats["failed"] += 1
+        else:
+            stats["failed"] += 1
+
+    if no_paths_records:
+        no_paths_file = output_path / "no_paths_records.json"
+        save_json(no_paths_records, path=no_paths_file)
+        logger.info(f"Exported {len(no_paths_records)} no-paths records to: {no_paths_file}")
+
+    return stats
+
+
+def _log_batch_summary(stats: dict[str, int], total_time: float) -> None:
+    """Log batch run summary."""
+    logger.info("\n" + "=" * 60)
+    logger.info("Batch Run Complete")
+    logger.info("=" * 60)
+    logger.info(f"Total tasks: {stats['total']}")
+    logger.info(f"Success: {stats['success']}")
+    logger.info(f"Failed: {stats['failed']}")
+    logger.info(f"No alarms: {stats['no_alarms']}")
+    logger.info(f"No paths: {stats['no_paths']}")
+    logger.info(f"Total time: {total_time:.2f}s")
+    logger.info("=" * 60)
+
+
+# =============================================================================
+# CLI Commands
+# =============================================================================
+
+
+@app.command("run")
+def run(
+    data_dir: str = typer.Option(..., help="Directory containing parquet data files"),
+    max_hops: int = typer.Option(20, help="Maximum propagation hops"),
+) -> int:
+    """Run fault propagation analysis for a single case."""
+    setup_logging(verbose=True)
+    total_start = time.time()
+
+    data_path = Path(data_dir)
+    output_path = Path("output")
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    injection_file = data_path / "injection.json"
+    if not injection_file.exists():
+        logger.error(f"injection.json not found in {data_path}")
+        return 1
+
+    with open(injection_file, encoding="utf-8") as f:
+        injection_data = json.load(f)
+
+    services = _extract_services_from_injection(injection_data)
+    if not services:
+        logger.error("No services found in injection.json ground_truth")
+        return 1
+
+    result = run_single_case(
+        data_path,
+        max_hops,
+        return_graph=False,
+        injection_data=injection_data,
+    )
+
+    status = result["status"]
+    exit_code = 0
+
+    if status == "success":
+        resolution_info = result.get("resolution_info", {})
+        if resolution_info:
+            logger.info(f"\n[OK] Success: {result['paths']} paths")
+            logger.info(f"  Fault type: {resolution_info.get('fault_type', 'unknown')}")
+            logger.info(f"  Resolved to: {resolution_info.get('start_kind', 'service')}")
+            logger.info(f"  Method: {resolution_info.get('resolution_method', 'unknown')}")
+        else:
+            logger.info(f"\n[OK] Success: {result['paths']} paths")
+    elif status == "error":
+        logger.error(f"\n[ERR] Error: {result.get('error', 'Unknown error')}")
+        exit_code = 1
+    else:
+        logger.warning(f"\n[WARN] Status: {status}")
+
+    total_time = time.time() - total_start
+    logger.info(f"\n{'=' * 60}")
+    logger.info(f"Total execution time: {total_time:.2f}s")
+    logger.info(f"{'=' * 60}\n")
+
+    return exit_code
+
+
+@app.command()
+def batch(
+    data_base_dir: str = typer.Option(
+        "data/jfs/rcabench_dataset",
+        help="Base directory containing case folders",
+    ),
+    max_cases: int = typer.Option(0, help="Maximum number of cases to run (0 = all)"),
+    max_workers: int = typer.Option(12, help="Maximum number of parallel workers"),
+    max_hops: int = typer.Option(30, help="Maximum propagation hops"),
+    force: bool = typer.Option(False, "--force", help="Force reprocess all cases"),
+    retry_no_paths: bool = typer.Option(False, "--retry-no-paths", help="Only retry no_paths cases"),
+) -> int:
+    output_path = Path("output/batch_runs")
+    output_path.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_path = output_path / f"batch_{timestamp}.log"
+
+    setup_logging(verbose=True, log_file=log_path)
+    logging.getLogger("rcabench_platform.v3.internal.reasoning").setLevel(logging.WARNING)
+
+    total_start = time.time()
+    base_path = Path(data_base_dir)
+
+    _log_batch_header(base_path, output_path, max_workers, max_cases)
+
+    tasks, skipped = _collect_batch_tasks(
+        base_path,
+        max_cases,
+        skip_existing=not force,
+        retry_no_paths_only=retry_no_paths,
+    )
+    logger.info(f"Collected {len(tasks)} tasks to run")
+    if skipped > 0:
+        logger.info(f"Skipped {skipped} already processed cases\n")
+
+    stats = _run_batch_tasks(tasks, max_hops, output_path, max_workers, log_path)
+
+    total_time = time.time() - total_start
+    _log_batch_summary(stats, total_time)
+
+    return 0
+
+
+if __name__ == "__main__":
+    app()

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/exporters/__init__.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/exporters/__init__.py
@@ -1,0 +1,17 @@
+"""Exporters for RCA analysis results."""
+
+from rcabench_platform.v3.internal.reasoning.exporters.pattern_exporter import (
+    export_abnormal_edges,
+    export_abnormal_nodes,
+    export_all_patterns,
+    export_propagation_patterns,
+    is_abnormal_state,
+)
+
+__all__ = [
+    "export_abnormal_nodes",
+    "export_abnormal_edges",
+    "export_propagation_patterns",
+    "export_all_patterns",
+    "is_abnormal_state",
+]

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/exporters/pattern_exporter.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/exporters/pattern_exporter.py
@@ -1,0 +1,319 @@
+"""Export abnormal nodes and edges to Parquet files for LLM tools.
+
+This module exports:
+1. abnormal_nodes.parquet - All nodes with non-default states
+2. abnormal_edges.parquet - All edges connecting abnormal nodes
+3. propagation_patterns.parquet - (src_node, edge, dst_node, src_state, dst_state) tuples
+"""
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from rcabench_platform.v3.internal.reasoning.models.graph import CallsEdgeData, DepKind, HyperGraph, PlaceKind
+from rcabench_platform.v3.internal.reasoning.models.state import get_default_state
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    pass
+
+
+# Default states that are considered "normal" (not abnormal)
+DEFAULT_STATES = {
+    "HEALTHY",
+    "ACTIVE",
+    "AVAILABLE",
+    "READY",
+    "UNKNOWN",
+    "unknown",
+}
+
+
+def is_abnormal_state(state: str, node_kind: PlaceKind) -> bool:
+    """Check if a state is considered abnormal for the given node kind.
+
+    Args:
+        state: The detected state string
+        node_kind: The kind of node
+
+    Returns:
+        True if the state is abnormal, False otherwise
+    """
+    default = get_default_state(node_kind).value
+    return state.upper() != default.upper() and state.upper() not in DEFAULT_STATES
+
+
+def export_abnormal_nodes(
+    graph: HyperGraph,
+    node_states: dict[int, str],
+    output_path: Path,
+) -> pd.DataFrame:
+    """Export all abnormal nodes to a parquet file.
+
+    Args:
+        graph: The dependency graph
+        node_states: Mapping of node_id -> detected state
+        output_path: Path to save the parquet file
+
+    Returns:
+        DataFrame with abnormal nodes
+    """
+    records = []
+
+    for node_id, state in node_states.items():
+        node = graph.get_node_by_id(node_id)
+        if node is None:
+            continue
+
+        if is_abnormal_state(state, node.kind):
+            records.append(
+                {
+                    "node_id": node_id,
+                    "node_kind": node.kind.value,
+                    "node_name": node.self_name,
+                    "uniq_name": node.uniq_name,
+                    "state": state,
+                }
+            )
+
+    df = pd.DataFrame(records)
+    if not df.empty:
+        df.to_parquet(output_path / "abnormal_nodes.parquet", index=False)
+        logger.info(f"  ✓ Exported {len(df)} abnormal nodes to abnormal_nodes.parquet")
+    else:
+        logger.warning("  ⚠ No abnormal nodes found")
+
+    return df
+
+
+def export_abnormal_edges(
+    graph: HyperGraph,
+    node_states: dict[int, str],
+    output_path: Path,
+) -> pd.DataFrame:
+    """Export edges connecting abnormal nodes to a parquet file.
+
+    Args:
+        graph: The dependency graph
+        node_states: Mapping of node_id -> detected state
+        output_path: Path to save the parquet file
+
+    Returns:
+        DataFrame with abnormal edges
+    """
+    # Collect abnormal node IDs
+    abnormal_node_ids = set()
+    for node_id, state in node_states.items():
+        node = graph.get_node_by_id(node_id)
+        if node is not None and is_abnormal_state(state, node.kind):
+            abnormal_node_ids.add(node_id)
+
+    records = []
+
+    for edge in graph._edge_id_map.values():
+        # Include edge if either source or target is abnormal
+        if edge.src_id in abnormal_node_ids or edge.dst_id in abnormal_node_ids:
+            src_node = graph.get_node_by_id(edge.src_id)
+            dst_node = graph.get_node_by_id(edge.dst_id)
+
+            if src_node is None or dst_node is None:
+                continue
+
+            if edge.src_id not in node_states:
+                raise KeyError(f"node_states missing src_id={edge.src_id} for edge {edge.id}")
+            if edge.dst_id not in node_states:
+                raise KeyError(f"node_states missing dst_id={edge.dst_id} for edge {edge.id}")
+
+            record: dict[str, str | int | float | None] = {
+                "edge_id": edge.id,
+                "edge_kind": edge.kind.value,
+                "src_id": edge.src_id,
+                "src_kind": src_node.kind.value,
+                "src_name": src_node.self_name,
+                "src_state": node_states[edge.src_id],
+                "dst_id": edge.dst_id,
+                "dst_kind": dst_node.kind.value,
+                "dst_name": dst_node.self_name,
+                "dst_state": node_states[edge.dst_id],
+            }
+
+            # Add calls edge statistics if available
+            if edge.kind == DepKind.calls and isinstance(edge.data, CallsEdgeData):
+                data = edge.data
+                record.update(
+                    {
+                        "baseline_call_count": data.baseline_call_count,
+                        "baseline_error_count": data.baseline_error_count,
+                        "baseline_error_rate": data.baseline_error_rate,
+                        "baseline_avg_latency": data.baseline_avg_latency,
+                        "baseline_p99_latency": data.baseline_p99_latency,
+                        "abnormal_call_count": data.abnormal_call_count,
+                        "abnormal_error_count": data.abnormal_error_count,
+                        "abnormal_error_rate": data.abnormal_error_rate,
+                        "abnormal_avg_latency": data.abnormal_avg_latency,
+                        "abnormal_p99_latency": data.abnormal_p99_latency,
+                    }
+                )
+
+            records.append(record)
+
+    df = pd.DataFrame(records)
+    if not df.empty:
+        df.to_parquet(output_path / "abnormal_edges.parquet", index=False)
+        logger.info(f"  ✓ Exported {len(df)} edges connecting abnormal nodes to abnormal_edges.parquet")
+    else:
+        logger.warning("  ⚠ No edges connecting abnormal nodes found")
+
+    return df
+
+
+def export_propagation_patterns(
+    graph: HyperGraph,
+    node_states: dict[int, str],
+    output_path: Path,
+) -> pd.DataFrame:
+    """Export propagation patterns (abnormal src -> edge -> dst with states) to parquet.
+
+    This is the main file for LLM to read for rule generation.
+    Each row represents a potential fault propagation pattern:
+    (src_kind, src_state, edge_kind, dst_kind, dst_state, edge_statistics)
+
+    Args:
+        graph: The dependency graph
+        node_states: Mapping of node_id -> detected state
+        output_path: Path to save the parquet file
+
+    Returns:
+        DataFrame with propagation patterns
+    """
+    records = []
+
+    for edge in graph._edge_id_map.values():
+        src_node = graph.get_node_by_id(edge.src_id)
+        dst_node = graph.get_node_by_id(edge.dst_id)
+
+        if src_node is None or dst_node is None:
+            continue
+
+        if edge.src_id not in node_states:
+            raise KeyError(f"node_states missing src_id={edge.src_id} for edge {edge.id}")
+        if edge.dst_id not in node_states:
+            raise KeyError(f"node_states missing dst_id={edge.dst_id} for edge {edge.id}")
+
+        src_state = node_states[edge.src_id]
+        dst_state = node_states[edge.dst_id]
+
+        # Only include if at least one node is abnormal
+        src_abnormal = is_abnormal_state(src_state, src_node.kind)
+        dst_abnormal = is_abnormal_state(dst_state, dst_node.kind)
+
+        if not (src_abnormal or dst_abnormal):
+            continue
+
+        record = {
+            # Source node info
+            "src_kind": src_node.kind.value,
+            "src_name": src_node.self_name,
+            "src_state": src_state,
+            "src_is_abnormal": src_abnormal,
+            # Edge info
+            "edge_kind": edge.kind.value,
+            # Destination node info
+            "dst_kind": dst_node.kind.value,
+            "dst_name": dst_node.self_name,
+            "dst_state": dst_state,
+            "dst_is_abnormal": dst_abnormal,
+            # Pattern type
+            "pattern_type": _classify_pattern(src_abnormal, dst_abnormal),
+        }
+
+        # Add calls edge statistics if available
+        if edge.kind == DepKind.calls and isinstance(edge.data, CallsEdgeData):
+            data = edge.data
+            record.update(
+                {
+                    "baseline_call_count": data.baseline_call_count,
+                    "baseline_error_rate": data.baseline_error_rate,
+                    "baseline_avg_latency": data.baseline_avg_latency,
+                    "baseline_p99_latency": data.baseline_p99_latency,
+                    "abnormal_call_count": data.abnormal_call_count,
+                    "abnormal_error_rate": data.abnormal_error_rate,
+                    "abnormal_avg_latency": data.abnormal_avg_latency,
+                    "abnormal_p99_latency": data.abnormal_p99_latency,
+                    "latency_increase_ratio": (
+                        data.abnormal_avg_latency / data.baseline_avg_latency if data.baseline_avg_latency > 0 else 0.0
+                    ),
+                    "error_rate_delta": data.abnormal_error_rate - data.baseline_error_rate,
+                }
+            )
+
+        records.append(record)
+
+    df = pd.DataFrame(records)
+    if not df.empty:
+        # Sort by pattern_type to group forward/backward propagations
+        df = df.sort_values(["pattern_type", "src_kind", "edge_kind", "dst_kind"])
+        df.to_parquet(output_path / "propagation_patterns.parquet", index=False)
+        logger.info(f"  ✓ Exported {len(df)} propagation patterns to propagation_patterns.parquet")
+
+        # Log summary
+        pattern_summary = df.groupby("pattern_type").size()
+        for ptype, count in pattern_summary.items():
+            logger.info(f"    - {ptype}: {count} patterns")
+    else:
+        logger.warning("  ⚠ No propagation patterns found")
+
+    return df
+
+
+def _classify_pattern(src_abnormal: bool, dst_abnormal: bool) -> str:
+    """Classify the propagation pattern type.
+
+    Args:
+        src_abnormal: Whether source node is abnormal
+        dst_abnormal: Whether destination node is abnormal
+
+    Returns:
+        Pattern type string
+    """
+    if src_abnormal and dst_abnormal:
+        return "both_abnormal"  # Likely propagation chain
+    elif src_abnormal:
+        return "forward_propagation"  # Fault propagating from src to dst
+    else:
+        return "backward_propagation"  # Looking for root cause upstream
+
+
+def export_all_patterns(
+    graph: HyperGraph,
+    node_states: dict[int, str],
+    output_dir: Path,
+) -> dict[str, pd.DataFrame]:
+    """Export all abnormal patterns to parquet files.
+
+    Creates three files:
+    - abnormal_nodes.parquet
+    - abnormal_edges.parquet
+    - propagation_patterns.parquet
+
+    Args:
+        graph: The dependency graph
+        node_states: Mapping of node_id -> detected state
+        output_dir: Directory to save the parquet files
+
+    Returns:
+        Dictionary mapping filename to DataFrame
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info("\n[3.5/7] Exporting abnormal patterns for LLM analysis...")
+
+    results = {}
+    results["abnormal_nodes"] = export_abnormal_nodes(graph, node_states, output_dir)
+    results["abnormal_edges"] = export_abnormal_edges(graph, node_states, output_dir)
+    results["propagation_patterns"] = export_propagation_patterns(graph, node_states, output_dir)
+
+    return results

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/loaders/parquet_loader.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/loaders/parquet_loader.py
@@ -1,0 +1,2453 @@
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import polars as pl
+
+from ..algorithms.baseline_detector import get_adaptive_threshold
+from ..models.graph import CallsEdgeData, DepKind, Edge, HyperGraph, Node, PlaceKind
+from .utils import fmap_threadpool, timeit
+
+logger = logging.getLogger(__name__)
+
+
+PATTERN_REPLACEMENTS = [
+    # UUID patterns (must come before shorter hex patterns)
+    (
+        r"(.*?)/api/v1/contactservice/contacts/account/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        r"$1/api/v1/contactservice/contacts/account/{accountId}",
+    ),
+    (
+        r"(.*?)/api/v1/userservice/users/id/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        r"$1/api/v1/userservice/users/id/{userId}",
+    ),
+    (
+        r"(.*?)/api/v1/consignservice/consigns/order/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        r"$1/api/v1/consignservice/consigns/order/{id}",
+    ),
+    (
+        r"(.*?)/api/v1/consignservice/consigns/account/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        r"$1/api/v1/consignservice/consigns/account/{id}",
+    ),
+    # Date and multi-parameter patterns
+    (
+        r"(.*?)GET (.*?)/api/v1/foodservice/foods/[0-9]{4}-[0-9]{2}-[0-9]{2}/[a-z]+/[a-z]+/[A-Z0-9]+",
+        r"$1GET $2/api/v1/foodservice/foods/{date}/{startStation}/{endStation}/{tripId}",
+    ),
+    # Alphanumeric ID patterns
+    (
+        r"(.*?)GET (.*?)/api/v1/verifycode/verify/[0-9a-zA-Z]+",
+        r"$1GET $2/api/v1/verifycode/verify/{verifyCode}",
+    ),
+    # Fallback hex patterns for shorter IDs
+    (
+        r"(.*?)GET (.*?)/api/v1/contactservice/contacts/account/[0-9a-f]+",
+        r"$1GET $2/api/v1/contactservice/contacts/account/{accountId}",
+    ),
+    (
+        r"(.*?)GET (.*?)/api/v1/userservice/users/id/[0-9a-f]+",
+        r"$1GET $2/api/v1/userservice/users/id/{userId}",
+    ),
+    (
+        r"(.*?)GET (.*?)/api/v1/consignservice/consigns/order/[0-9a-f]+",
+        r"$1GET $2/api/v1/consignservice/consigns/order/{id}",
+    ),
+    (
+        r"(.*?)GET (.*?)/api/v1/consignservice/consigns/account/[0-9a-f]+",
+        r"$1GET $2/api/v1/consignservice/consigns/account/{id}",
+    ),
+    (
+        r"(.*?)GET (.*?)/api/v1/executeservice/execute/collected/[0-9a-f]+",
+        r"$1GET $2/api/v1/executeservice/execute/collected/{orderId}",
+    ),
+    # cancelservice with full UUID patterns (must come before shorter hex patterns)
+    (
+        r"(.*?)/api/v1/cancelservice/cancel/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        r"$1/api/v1/cancelservice/cancel/{orderId}/{loginId}",
+    ),
+    (
+        r"(.*?)/api/v1/cancelservice/cancel/refound/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        r"$1/api/v1/cancelservice/cancel/refound/{orderId}",
+    ),
+    (
+        r"(.*?)/api/v1/cancelservice/cancel/refound/[0-9a-f]+",
+        r"$1/api/v1/cancelservice/cancel/refound/{orderId}",
+    ),
+    (
+        r"(.*?)GET (.*?)/api/v1/executeservice/execute/execute/[0-9a-f]+",
+        r"$1GET $2/api/v1/executeservice/execute/execute/{orderId}",
+    ),
+    (
+        r"(.*?)DELETE (.*?)/api/v1/adminorderservice/adminorder/[0-9a-f]+/[A-Z0-9]+",
+        r"$1DELETE $2/api/v1/adminorderservice/adminorder/{orderId}/{trainNumber}",
+    ),
+    (
+        r"(.*?)DELETE (.*?)/api/v1/adminrouteservice/adminroute/[0-9a-f]+",
+        r"$1DELETE $2/api/v1/adminrouteservice/adminroute/{routeId}",
+    ),
+]
+
+# Compile regex patterns once at module load for performance
+COMPILED_PATTERNS = [(re.compile(pattern), replacement) for pattern, replacement in PATTERN_REPLACEMENTS]
+
+# Generic HTTP method span names without endpoints to filter out (exact match, case-insensitive)
+# These are spans that only contain the HTTP method without any path information
+GENERIC_HTTP_METHOD_SPANS = {
+    "GET",
+    "POST",
+    "PUT",
+    "DELETE",
+    "PATCH",
+    "HEAD",
+    "OPTIONS",
+    "CONNECT",
+    "TRACE",
+    "HTTP GET",
+    "HTTP POST",
+    "HTTP PUT",
+    "HTTP DELETE",
+    "HTTP PATCH",
+    "HTTP HEAD",
+    "HTTP OPTIONS",
+    "HTTP CONNECT",
+    "HTTP TRACE",
+}
+
+
+def is_generic_http_method_span(span_name: str) -> bool:
+    """
+    Check if a span name is a pure HTTP method without any endpoint path.
+
+    Only filters out spans like 'GET', 'POST', etc. that don't include
+    any path information. Spans like 'GET /api/v1/...' are NOT filtered.
+
+    Args:
+        span_name: The span name to check
+
+    Returns:
+        True if this is a generic HTTP method span that should be filtered out
+    """
+    if span_name is None:
+        return True
+
+    # Check exact match (case-insensitive)
+    return span_name.upper().strip() in GENERIC_HTTP_METHOD_SPANS
+
+
+# Purely synthetic traffic sources — excluded from root-span alarm detection because
+# their baselines don't reflect real user behavior. Kept separate from CALLER_LIKE_SERVICES
+# since frontend aggregators ARE the real user entry points and should participate in
+# alarm detection even though they're "callers" for span-service disambiguation.
+LOADGEN_LIKE_SERVICES: set[str] = {
+    "loadgenerator",
+    "load-generator",
+    "locust",
+    "wrk2",
+    "dsb-wrk2",
+    "k6",
+}
+
+# Frontend aggregators + loadgens. Used when multiple services share the same span_name
+# to prefer the backend service that owns the URL path rather than the caller.
+CALLER_LIKE_SERVICES: set[str] = LOADGEN_LIKE_SERVICES | {
+    "ts-ui-dashboard",  # TrainTicket frontend
+    "front-end",  # SockShop / otel-demo
+    "frontend",
+}
+
+
+def _is_caller_like(service_name: str) -> bool:
+    return service_name.lower() in CALLER_LIKE_SERVICES
+
+
+def _resolve_span_service(span_name: str, service_names: list[str]) -> str | None:
+    """Resolve the correct service for a span when multiple services have the same span_name.
+
+    For URL path spans (e.g., 'POST /api/v1/xxxservice/...'), the span should belong to
+    the backend service that matches the URL path, not a caller-like service (frontend /
+    loadgen — see ``CALLER_LIKE_SERVICES``).
+    """
+    if not service_names:
+        return None
+
+    if len(service_names) == 1:
+        return service_names[0]
+
+    url_match = re.match(r"^(?:GET|POST|PUT|DELETE|PATCH)\s+/api/v\d+/([a-zA-Z0-9_-]+)/", span_name, re.IGNORECASE)
+    if url_match:
+        service_path = url_match.group(1).lower()
+        for svc in service_names:
+            if _is_caller_like(svc):
+                continue
+            # e.g. URL segment "travel2service" matches "ts-travel2-service",
+            # "orderservice" matches "ts-order-service"
+            service_core = service_path.replace("service", "").replace("_", "").replace("-", "")
+            svc_core = svc.lower().replace("ts-", "").replace("-service", "").replace("-", "")
+            if service_core == svc_core:
+                return svc
+        non_caller = [s for s in service_names if not _is_caller_like(s)]
+        if non_caller:
+            return non_caller[0]
+
+    return service_names[0]
+
+
+class ParquetDataLoader:
+    def __init__(self, data_dir: Path | str = Path("data/converted"), polars_threads: int | None = None):
+        self.data_dir = Path(data_dir)
+
+        # Configure Polars thread pool to avoid CPU contention when running multiple processes
+        if polars_threads is not None:
+            pl.Config.set_streaming_chunk_size(polars_threads)
+            pl.Config.set_tbl_rows(polars_threads)
+
+        # Set environment variable for Polars thread pool (affects all operations)
+        import os
+
+        if polars_threads is not None:
+            os.environ["POLARS_MAX_THREADS"] = str(polars_threads)
+
+        # Cached DataFrames for metric extraction
+        self._baseline_metrics: pl.DataFrame | None = None
+        self._abnormal_metrics: pl.DataFrame | None = None
+        self._baseline_metrics_hist: pl.DataFrame | None = None
+        self._abnormal_metrics_hist: pl.DataFrame | None = None
+        self._baseline_metrics_sum: pl.DataFrame | None = None
+        self._abnormal_metrics_sum: pl.DataFrame | None = None
+        self._baseline_traces: pl.DataFrame | None = None
+        self._abnormal_traces: pl.DataFrame | None = None
+        self._baseline_logs: pl.DataFrame | None = None
+        self._abnormal_logs: pl.DataFrame | None = None
+
+    @staticmethod
+    def normalize_span_name(span_name: str) -> str:
+        """Apply pattern replacements to normalize span names with URL parameters."""
+        for compiled_pattern, replacement in COMPILED_PATTERNS:
+            span_name = compiled_pattern.sub(replacement, span_name)
+        return span_name
+
+    def load_metrics(self, period: str = "abnormal") -> pl.DataFrame:
+        """
+        Load metrics parquet into DataFrame.
+
+        Args:
+            period: Either 'normal' or 'abnormal'
+
+        Returns:
+            DataFrame with columns: time, metric, value, service_name, etc.
+        """
+        path = self.data_dir / f"{period}_metrics.parquet"
+        if not path.exists():
+            raise FileNotFoundError(f"Metrics file not found: {path}")
+        return pl.read_parquet(path)
+
+    def load_traces(self, period: str = "abnormal") -> pl.DataFrame:
+        """
+        Load traces parquet into DataFrame.
+
+        Args:
+            period: Either 'normal' or 'abnormal'
+
+        Returns:
+            DataFrame with columns: time, trace_id, span_id, parent_span_id,
+            span_name, attr.span_kind, service_name, duration, attr.status_code,
+            attr.http.response.status_code, attr.k8s.pod.name, etc.
+
+        Note:
+            Span names are automatically normalized to:
+            1. Convert URL parameters into template variables (e.g., /users/123 -> /users/{id})
+            2. Replace generic HTTP method spans with their first child's name for better semantics
+        """
+        path = self.data_dir / f"{period}_traces.parquet"
+        if not path.exists():
+            raise FileNotFoundError(f"Traces file not found: {path}")
+
+        df = pl.read_parquet(path)
+
+        # Normalize span names to reduce cardinality using vectorized string operations
+        if "span_name" in df.columns:
+            # Apply regex replacements in sequence using Polars native operations
+            span_col = pl.col("span_name")
+            for pattern, replacement in COMPILED_PATTERNS:
+                span_col = span_col.str.replace_all(pattern.pattern, replacement)
+            df = df.with_columns(span_col.alias("span_name"))
+
+        # NOTE: _enhance_generic_span_names is disabled because it causes issues:
+        # 1. It replaces Client span names with child span names, causing wrong service->span edges
+        # 2. It creates self-loop edges when parent and child end up with the same span_name
+        # df = self._enhance_generic_span_names(df)
+
+        return df
+
+    def load_logs(self, period: str = "abnormal") -> pl.DataFrame:
+        """
+        Load logs parquet into DataFrame.
+
+        Args:
+            period: Either 'normal' or 'abnormal'
+
+        Returns:
+            DataFrame with columns: time, trace_id, span_id, level,
+            service_name, message, attr.k8s.pod.name, etc.
+        """
+        path = self.data_dir / f"{period}_logs.parquet"
+        if not path.exists():
+            raise FileNotFoundError(f"Logs file not found: {path}")
+        return pl.read_parquet(path)
+
+    def _enhance_generic_span_names(self, df: pl.DataFrame) -> pl.DataFrame:
+        """
+        Replace generic HTTP method-only spans (GET, POST, etc.) with their first child's name.
+
+        This enhances semantic information by promoting meaningful child span names
+        to replace their generic parent spans that only contain HTTP methods.
+
+        Args:
+            df: DataFrame with trace data
+
+        Returns:
+            DataFrame with enhanced span names
+        """
+        generic_methods = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}
+
+        # Find spans that are just HTTP methods
+        generic_mask = df.filter(pl.col("span_name").is_in(generic_methods))
+        generic_count = len(generic_mask)
+
+        if generic_count == 0:
+            return df
+
+        logger.debug(f"Found {generic_count} generic HTTP method spans to enhance")
+
+        # Get all generic parent spans
+        generic_parents = generic_mask.select(["trace_id", "span_id", "span_name"]).rename(
+            {"span_id": "parent_span_id", "span_name": "parent_span_name"}
+        )
+
+        # Get all non-generic child spans
+        non_generic_children = df.filter(~pl.col("span_name").is_in(generic_methods)).select(
+            ["trace_id", "parent_span_id", "span_name"]
+        )
+
+        # Merge to find children of generic parents
+        merged = generic_parents.join(non_generic_children, on=["trace_id", "parent_span_id"], how="inner")
+
+        # Group by parent_span_id and take the first child's name
+        if len(merged) > 0:
+            # Sort to ensure consistent "first" child selection
+            merged = merged.sort(["trace_id", "parent_span_id"])
+            span_id_to_name = (
+                merged.group_by("parent_span_id").agg(pl.col("span_name").first()).to_dict(as_series=False)
+            )
+
+            # Create mapping dict
+            name_map = dict(zip(span_id_to_name["parent_span_id"], span_id_to_name["span_name"], strict=False))
+
+            # Apply replacements using vectorized when-then
+            df = df.with_columns(
+                pl.when(pl.col("span_name").is_in(generic_methods) & pl.col("span_id").is_in(name_map.keys()))
+                .then(pl.col("span_id").replace(name_map, default=pl.col("span_name")))
+                .otherwise(pl.col("span_name"))
+                .alias("span_name")
+            )
+
+            enhanced_count = len(name_map)
+            logger.info(f"Enhanced {enhanced_count}/{generic_count} generic HTTP method spans with child names")
+        else:
+            logger.info("No children found for generic HTTP method spans")
+
+        return df
+
+    def load_metrics_histogram(self, period: str = "abnormal") -> pl.DataFrame:
+        """
+        Load histogram metrics parquet into DataFrame.
+
+        Args:
+            period: Either 'normal' or 'abnormal'
+
+        Returns:
+            DataFrame with columns: time, metric, service_name, count, sum, min, max, etc.
+        """
+        path = self.data_dir / f"{period}_metrics_histogram.parquet"
+        if not path.exists():
+            raise FileNotFoundError(f"Histogram metrics file not found: {path}")
+        return pl.read_parquet(path)
+
+    def load_metrics_sum(self, period: str = "abnormal") -> pl.DataFrame:
+        """
+        Load sum metrics parquet into DataFrame.
+
+        Args:
+            period: Either 'normal' or 'abnormal'
+
+        Returns:
+            DataFrame with columns: time, metric, value, service_name, etc.
+        """
+        path = self.data_dir / f"{period}_metrics_sum.parquet"
+        if not path.exists():
+            raise FileNotFoundError(f"Sum metrics file not found: {path}")
+        return pl.read_parquet(path)
+
+    def load_conclusion(self) -> pl.DataFrame:
+        """
+        Load ground truth fault injection labels.
+
+        Returns:
+            DataFrame with columns: SpanName, AbnormalAvgDuration, NormalAvgDuration,
+            AbnormalSuccRate, NormalSuccRate, etc.
+        """
+        path = self.data_dir / "conclusion.parquet"
+        if not path.exists():
+            raise FileNotFoundError(f"Conclusion file not found: {path}")
+        return pl.read_parquet(path)
+
+    def identify_alarm_nodes(self) -> set[str]:
+        """Identify alarm nodes from conclusion.parquet based on Issues field.
+
+        Returns:
+            Set of span names that have non-empty Issues (indicating detected problems)
+        """
+        import json
+
+        conclusion_df = self.load_conclusion()
+
+        # Identify spans with non-empty Issues field
+        def has_issues(issues_str: str | None) -> bool:
+            """Check if Issues field contains actual issues (not just empty dict)."""
+            if not issues_str or issues_str == "{}":
+                return False
+            try:
+                issues = json.loads(issues_str)
+                return bool(issues)
+            except (json.JSONDecodeError, TypeError):
+                return False
+
+        alarm_spans = (
+            conclusion_df.filter(pl.col("Issues").map_elements(has_issues, return_dtype=pl.Boolean))
+            .select("SpanName")
+            .to_series()
+            .to_list()
+        )
+
+        return set(alarm_spans)
+
+    def identify_alarm_nodes_v2(
+        self,
+        error_rate_threshold: float = 0.1,
+        min_call_count: int = 1,
+    ) -> set[str]:
+        """Identify alarm nodes by comparing baseline vs abnormal root-span metrics.
+
+        Root spans are detected as ``parent_span_id == ""`` (server entry points). Spans
+        whose service is in ``LOADGEN_LIKE_SERVICES`` are excluded (synthetic traffic only);
+        real frontend aggregators like ``front-end`` / ``ts-ui-dashboard`` are kept since
+        they carry the actual user-facing anomalies.
+
+        Uses adaptive thresholds based on baseline statistics (matching state_detector logic).
+
+        Args:
+            error_rate_threshold: Minimum error rate in abnormal period to trigger alarm.
+            min_call_count: Minimum number of calls required in both periods for comparison.
+
+        Returns:
+            Set of full span names in format "{service_name}::{span_name}" that have
+            detected problems (latency increase, error rate increase, or disappearance).
+        """
+        baseline_traces = self.load_traces("normal")
+        abnormal_traces = self.load_traces("abnormal")
+
+        loadgens = list(LOADGEN_LIKE_SERVICES)
+
+        def filter_root_spans(df: pl.DataFrame) -> pl.DataFrame:
+            return df.filter(
+                (pl.col("parent_span_id") == "") & (~pl.col("service_name").str.to_lowercase().is_in(loadgens))
+            )
+
+        baseline_root = filter_root_spans(baseline_traces)
+        abnormal_root = filter_root_spans(abnormal_traces)
+
+        if len(baseline_root) == 0 or len(abnormal_root) == 0:
+            logger.warning("No backend root spans found in baseline or abnormal traces")
+            return set()
+
+        # Aggregate metrics by full_span_name (service_name::span_name) for baseline
+        baseline_agg = self._aggregate_root_span_metrics(baseline_root)
+        abnormal_agg = self._aggregate_root_span_metrics(abnormal_root)
+
+        # Join baseline and abnormal aggregations on full_span_name
+        comparison = baseline_agg.join(abnormal_agg, on="full_span_name", how="inner", suffix="_abn")
+
+        alarm_spans: set[str] = set()
+
+        for row in comparison.iter_rows(named=True):
+            full_span_name = row["full_span_name"]
+            b_count = row["call_count"]
+            a_count = row["call_count_abn"]
+
+            # Skip spans with insufficient data
+            if b_count < min_call_count or a_count < min_call_count:
+                continue
+
+            b_avg = row["avg_duration"]
+            b_std = row["std_duration"] or 0.0
+            a_avg = row["avg_duration_abn"]
+
+            b_p99 = row["p99_duration"]
+            a_p99 = row["p99_duration_abn"]
+
+            b_err = row["error_rate"]
+            a_err = row["error_rate_abn"]
+
+            # Calculate CV for adaptive threshold
+            b_avg_cv = b_std / b_avg if b_avg > 1e-6 else 0.0
+
+            # Latency detection (avg duration) with adaptive threshold
+            if b_avg > 0:
+                avg_threshold = get_adaptive_threshold(b_avg, b_avg_cv)
+                if a_avg > b_avg * avg_threshold:
+                    logger.debug(
+                        f"Alarm: {full_span_name} avg latency increased "
+                        f"({b_avg:.3f}s -> {a_avg:.3f}s, ratio={a_avg / b_avg:.2f}x, threshold={avg_threshold:.2f}x)"
+                    )
+                    alarm_spans.add(full_span_name)
+                    continue
+
+            # Latency detection (p99 duration) with adaptive threshold
+            # Approximate p99 std as 1.5x of avg std
+            b_p99_std = b_std * 1.5 if b_std else 0.0
+            b_p99_cv = b_p99_std / b_p99 if b_p99 > 1e-6 else 0.0
+            if b_p99 > 0:
+                p99_threshold = get_adaptive_threshold(b_p99, b_p99_cv)
+                if a_p99 > b_p99 * p99_threshold:
+                    logger.debug(
+                        f"Alarm: {full_span_name} p99 latency increased "
+                        f"({b_p99:.3f}s -> {a_p99:.3f}s, ratio={a_p99 / b_p99:.2f}x, threshold={p99_threshold:.2f}x)"
+                    )
+                    alarm_spans.add(full_span_name)
+                    continue
+
+            # Error rate detection
+            if a_err > b_err and a_err >= error_rate_threshold:
+                logger.debug(f"Alarm: {full_span_name} error rate increased ({b_err:.2%} -> {a_err:.2%})")
+                alarm_spans.add(full_span_name)
+
+        # Detect missing spans: spans that exist in baseline but not in abnormal period
+        # These are alarm candidates because they indicate complete failure
+        baseline_span_names = set(baseline_agg["full_span_name"].to_list())
+        abnormal_span_names = set(abnormal_agg["full_span_name"].to_list())
+        missing_spans = baseline_span_names - abnormal_span_names
+
+        for full_span_name in missing_spans:
+            # Only consider spans with meaningful baseline traffic
+            baseline_row = baseline_agg.filter(pl.col("full_span_name") == full_span_name)
+            if len(baseline_row) > 0:
+                b_count = baseline_row["call_count"][0]
+                if b_count >= min_call_count:
+                    logger.debug(f"Alarm: {full_span_name} missing in abnormal period (baseline had {b_count} calls)")
+                    alarm_spans.add(full_span_name)
+
+        logger.info(
+            f"identify_alarm_nodes_v2: detected {len(alarm_spans)} alarm spans "
+            f"(including {len(missing_spans & alarm_spans)} missing spans) "
+            f"from {len(comparison)} backend root span types"
+        )
+
+        return alarm_spans
+
+    def _aggregate_root_span_metrics(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Aggregate metrics for root spans grouped by service_name and span_name.
+
+        Args:
+            df: DataFrame with root span data (already filtered to exclude caller-like services).
+
+        Returns:
+            DataFrame with columns: full_span_name, call_count, error_count, avg_duration,
+            p99_duration, std_duration, error_rate.
+            full_span_name is in format "{service_name}::{span_name}".
+        """
+        # Prepare columns: duration in seconds, error flag, full span name
+        df_prepared = df.with_columns(
+            [
+                (pl.col("duration") / 1e9).alias("duration_sec"),
+                (
+                    (pl.col("attr.http.response.status_code").is_not_null())
+                    & (pl.col("attr.http.response.status_code") >= 500)
+                )
+                .cast(pl.Int32)
+                .alias("is_error"),
+                # Create full span name: service_name::span_name
+                (pl.col("service_name") + "::" + pl.col("span_name")).alias("full_span_name"),
+            ]
+        )
+
+        # Group by full_span_name (service_name::span_name) and aggregate
+        agg_df = df_prepared.group_by("full_span_name").agg(
+            [
+                pl.len().alias("call_count"),
+                pl.col("is_error").sum().alias("error_count"),
+                pl.col("duration_sec").mean().alias("avg_duration"),
+                pl.col("duration_sec").quantile(0.99).alias("p99_duration"),
+                pl.col("duration_sec").std().alias("std_duration"),
+            ]
+        )
+
+        # Calculate error rate
+        agg_df = agg_df.with_columns((pl.col("error_count") / pl.col("call_count")).alias("error_rate"))
+
+        return agg_df
+
+    def get_span_issues(self) -> dict[str, dict]:
+        """Get Issues information for all spans from conclusion.parquet.
+
+        Returns:
+            Dictionary mapping span names to their Issues dict
+        """
+        import json
+
+        conclusion_df = self.load_conclusion()
+        span_issues = {}
+
+        for row in conclusion_df.iter_rows(named=True):
+            span_name = row["SpanName"]
+            issues_str = row["Issues"]
+
+            if issues_str and issues_str != "{}":
+                try:
+                    issues = json.loads(issues_str)
+                    if issues:
+                        span_issues[span_name] = issues
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+        return span_issues
+
+    @timeit
+    def build_graph_from_parquet(
+        self,
+        baseline_period: str = "normal",
+        abnormal_period: str = "abnormal",
+        selected_metrics: list[str] | None = None,
+    ) -> HyperGraph:
+        """
+        Build HyperGraph from parquet files, including all K8s physical entities.
+
+        Args:
+            baseline_period: Which period to use as baseline ('normal')
+            abnormal_period: Which period contains faults ('abnormal')
+            endpoint_granularity: Use {service}::{endpoint} nodes if True, else service-level
+            selected_metrics: List of metric names to extract. If None, uses comprehensive defaults
+                covering CPU, memory, filesystem, HTTP, DB, JVM, and network metrics.
+
+        Returns:
+            HyperGraph with K8s entities (namespace, deployment, pod, container, service)
+            and their relationships (owns, schedules, runs, calls)
+        """
+        if selected_metrics is None:
+            selected_metrics = [
+                # CPU metrics (gauge)
+                "container.cpu.usage",
+                "container.cpu.time",
+                "k8s.pod.cpu.usage",
+                "k8s.pod.cpu.time",
+                "k8s.pod.cpu_limit_utilization",
+                "k8s.pod.cpu.node.utilization",
+                # Memory metrics (gauge)
+                "container.memory.working_set",
+                "container.memory.available",
+                "container.memory.usage",
+                "container.memory.rss",
+                "k8s.pod.memory.working_set",
+                "k8s.pod.memory.usage",
+                "k8s.pod.memory.rss",
+                "k8s.pod.memory_limit_utilization",
+                "k8s.pod.memory.node.utilization",
+                # Filesystem metrics (gauge)
+                "container.filesystem.usage",
+                "container.filesystem.available",
+                "k8s.pod.filesystem.usage",
+                "k8s.pod.filesystem.available",
+                # K8s state metrics (gauge)
+                "k8s.container.ready",
+                "k8s.container.restarts",
+                "k8s.pod.phase",
+                "k8s.deployment.available",
+                "k8s.deployment.desired",
+                "k8s.replicaset.available",
+                "k8s.replicaset.desired",
+                "k8s.statefulset.ready_pods",
+                "k8s.statefulset.current_pods",
+                # HTTP duration metrics (histogram)
+                "hubble_http_request_duration_seconds",
+                "http.server.request.duration",
+                "http.client.request.duration",
+                # HTTP count metrics (sum)
+                "hubble_http_requests_total",
+                # Database connection metrics (histogram)
+                "db.client.connections.use_time",
+                "db.client.connections.wait_time",
+                # Database connection state (gauge)
+                "db.client.connections.usage",
+                "db.client.connections.idle.min",
+                "db.client.connections.max",
+                "db.client.connections.pending_requests",
+                # JVM GC metrics (histogram)
+                "jvm.gc.duration",
+                # JVM memory metrics (gauge)
+                "jvm.memory.used",
+                "jvm.memory.committed",
+                "jvm.memory.limit",
+                "jvm.memory.init",
+                # JVM CPU and thread metrics (gauge)
+                "jvm.cpu.recent_utilization",
+                "jvm.cpu.time",
+                "jvm.thread.count",
+                "jvm.system.cpu.utilization",
+                # Network metrics (sum)
+                "k8s.pod.network.io",
+                "k8s.pod.network.errors",
+                "hubble_drop_total",
+            ]
+
+        graph = HyperGraph()
+
+        # Load all data sources and cache in instance variables
+        logger.info(f"Loading {baseline_period} data...")
+        self._baseline_metrics = self.load_metrics(baseline_period)
+        self._baseline_metrics_hist = self.load_metrics_histogram(baseline_period)
+        self._baseline_metrics_sum = self.load_metrics_sum(baseline_period)
+        self._baseline_traces = self.load_traces(baseline_period)
+        self._baseline_logs = self.load_logs(baseline_period)
+
+        logger.info(f"Loading {abnormal_period} data...")
+        self._abnormal_metrics = self.load_metrics(abnormal_period)
+        self._abnormal_metrics_hist = self.load_metrics_histogram(abnormal_period)
+        self._abnormal_metrics_sum = self.load_metrics_sum(abnormal_period)
+        self._abnormal_traces = self.load_traces(abnormal_period)
+        self._abnormal_logs = self.load_logs(abnormal_period)
+
+        # Use cached variables for resource extraction
+        baseline_metrics = self._baseline_metrics
+        baseline_metrics_hist = self._baseline_metrics_hist
+        baseline_metrics_sum = self._baseline_metrics_sum
+        baseline_traces = self._baseline_traces
+        baseline_logs = self._baseline_logs
+        abnormal_metrics = self._abnormal_metrics
+        abnormal_metrics_hist = self._abnormal_metrics_hist
+        abnormal_metrics_sum = self._abnormal_metrics_sum
+        abnormal_traces = self._abnormal_traces
+        abnormal_logs = self._abnormal_logs
+
+        # Extract K8s resource hierarchy from all data sources
+        logger.info("Extracting K8s resource hierarchy from all data sources...")
+        resources = self._extract_k8s_resources_from_all_sources(
+            baseline_metrics,
+            abnormal_metrics,
+            baseline_metrics_hist,
+            abnormal_metrics_hist,
+            baseline_metrics_sum,
+            abnormal_metrics_sum,
+            baseline_traces,
+            abnormal_traces,
+            baseline_logs,
+            abnormal_logs,
+        )
+
+        # Build all K8s entity nodes
+        logger.info("Building K8s entity nodes...")
+        self._build_k8s_nodes(graph, resources, selected_metrics)
+
+        # Build physical topology edges
+        logger.info("Building physical topology edges...")
+        self._build_physical_edges(graph, resources)
+
+        # Build service nodes and service->pod mappings from traces
+        logger.info("Building service nodes from traces...")
+        self._build_service_nodes_from_traces(graph, selected_metrics)
+
+        # Build span nodes with aggregated statistics
+        logger.info("Building span nodes from traces...")
+        self._build_span_nodes(graph, baseline_traces, abnormal_traces, baseline_logs, abnormal_logs)
+
+        # Build logical call edges at span level from traces
+        logger.info("Building span-to-span call edges from traces...")
+        edges = self._build_edges_from_traces(baseline_traces, abnormal_traces, graph)
+
+        for edge in edges:
+            graph.add_edge(edge, strict=False)
+
+        logger.info(f"Graph complete: {len(graph._node_id_map)} nodes, {len(graph._edge_id_map)} edges")
+
+        return graph
+
+    def _extract_k8s_resources_from_all_sources(
+        self,
+        baseline_metrics: pl.DataFrame,
+        abnormal_metrics: pl.DataFrame,
+        baseline_metrics_hist: pl.DataFrame,
+        abnormal_metrics_hist: pl.DataFrame,
+        baseline_metrics_sum: pl.DataFrame,
+        abnormal_metrics_sum: pl.DataFrame,
+        baseline_traces: pl.DataFrame,
+        abnormal_traces: pl.DataFrame,
+        baseline_logs: pl.DataFrame,
+        abnormal_logs: pl.DataFrame,
+    ) -> dict[str, dict[str, Any]]:
+        """
+        Extract K8s resource hierarchy from all data sources (metrics, traces, logs).
+
+        Returns:
+            Dictionary mapping resource types to {resource_name: metadata} structure.
+            Metadata includes parent relationships and timestamps (first_seen, last_seen).
+        """
+        resources: dict[str, dict[str, Any]] = {
+            "namespace": {},
+            "node": {},
+            "deployment": {},
+            "statefulset": {},
+            "replicaset": {},
+            "pod": {},
+            "container": {},
+        }
+
+        # Define K8s columns we need to extract
+        k8s_cols = [
+            "attr.k8s.namespace.name",
+            "attr.k8s.node.name",
+            "attr.k8s.deployment.name",
+            "attr.k8s.statefulset.name",
+            "attr.k8s.replicaset.name",
+            "attr.k8s.pod.name",
+            "attr.k8s.container.name",
+            "time",
+        ]
+
+        # Process each dataframe separately to extract K8s resources
+        all_dataframes = [
+            baseline_metrics,
+            abnormal_metrics,
+            baseline_metrics_hist,
+            abnormal_metrics_hist,
+            baseline_metrics_sum,
+            abnormal_metrics_sum,
+            baseline_traces,
+            abnormal_traces,
+            baseline_logs,
+            abnormal_logs,
+        ]
+
+        # Extract resources from each dataframe without concat
+        for df in all_dataframes:
+            # Select only K8s columns that exist in this dataframe
+            available_cols = [col for col in k8s_cols if col in df.columns]
+            if not available_cols:
+                continue
+
+            df_subset = df.select(available_cols)
+
+            # Extract unique namespaces
+            if "attr.k8s.namespace.name" in df_subset.columns:
+                namespaces = df_subset.select("attr.k8s.namespace.name").drop_nulls().unique().to_series().to_list()
+                for ns in namespaces:
+                    if ns not in resources["namespace"]:
+                        resources["namespace"][ns] = set()
+
+            # Extract unique nodes
+            if "attr.k8s.node.name" in df_subset.columns:
+                nodes = df_subset.select("attr.k8s.node.name").drop_nulls().unique().to_series().to_list()
+                for node in nodes:
+                    if node not in resources["node"]:
+                        resources["node"][node] = set()
+
+            # Extract deployments with their namespaces
+            if "attr.k8s.deployment.name" in df_subset.columns and "attr.k8s.namespace.name" in df_subset.columns:
+                deployment_df = (
+                    df_subset.select(["attr.k8s.deployment.name", "attr.k8s.namespace.name"])
+                    .drop_nulls(subset=["attr.k8s.deployment.name"])
+                    .unique()
+                )
+                deployments = dict(
+                    zip(
+                        deployment_df.select("attr.k8s.deployment.name").to_series().to_list(),
+                        deployment_df.select("attr.k8s.namespace.name").to_series().to_list(),
+                        strict=False,
+                    )
+                )
+                resources["deployment"].update(deployments)
+
+            # Extract statefulsets with their namespaces
+            if "attr.k8s.statefulset.name" in df_subset.columns and "attr.k8s.namespace.name" in df_subset.columns:
+                statefulset_df = (
+                    df_subset.select(["attr.k8s.statefulset.name", "attr.k8s.namespace.name"])
+                    .drop_nulls(subset=["attr.k8s.statefulset.name"])
+                    .unique()
+                )
+                statefulsets = dict(
+                    zip(
+                        statefulset_df.select("attr.k8s.statefulset.name").to_series().to_list(),
+                        statefulset_df.select("attr.k8s.namespace.name").to_series().to_list(),
+                        strict=False,
+                    )
+                )
+                resources["statefulset"].update(statefulsets)
+
+            # Extract replicasets with their parents
+            if "attr.k8s.replicaset.name" in df_subset.columns:
+                replicaset_cols = ["attr.k8s.replicaset.name"]
+                if "attr.k8s.deployment.name" in df_subset.columns:
+                    replicaset_cols.append("attr.k8s.deployment.name")
+                if "attr.k8s.statefulset.name" in df_subset.columns:
+                    replicaset_cols.append("attr.k8s.statefulset.name")
+
+                replicaset_df = (
+                    df_subset.select(replicaset_cols).drop_nulls(subset=["attr.k8s.replicaset.name"]).unique()
+                )
+
+                if "attr.k8s.deployment.name" in replicaset_df.columns:
+                    replicaset_df = replicaset_df.with_columns(
+                        pl.when(pl.col("attr.k8s.deployment.name").is_not_null())
+                        .then(pl.col("attr.k8s.deployment.name"))
+                        .otherwise(
+                            pl.col("attr.k8s.statefulset.name")
+                            if "attr.k8s.statefulset.name" in replicaset_df.columns
+                            else pl.lit(None)
+                        )
+                        .alias("parent")
+                    )
+                    replicasets = dict(
+                        zip(
+                            replicaset_df.select("attr.k8s.replicaset.name").to_series().to_list(),
+                            replicaset_df.select("parent").to_series().to_list(),
+                            strict=False,
+                        )
+                    )
+                    resources["replicaset"].update(replicasets)
+
+            # Extract pods with timestamps and parents
+            if "attr.k8s.pod.name" in df_subset.columns and "time" in df_subset.columns:
+                pod_cols = ["attr.k8s.pod.name", "time"]
+                if "attr.k8s.replicaset.name" in df_subset.columns:
+                    pod_cols.append("attr.k8s.replicaset.name")
+                if "attr.k8s.node.name" in df_subset.columns:
+                    pod_cols.append("attr.k8s.node.name")
+
+                pod_df = df_subset.select(pod_cols).drop_nulls(subset=["attr.k8s.pod.name"])
+
+                pod_agg = pod_df.group_by("attr.k8s.pod.name").agg(
+                    [
+                        pl.col("attr.k8s.replicaset.name").first().alias("replicaset")
+                        if "attr.k8s.replicaset.name" in pod_cols
+                        else pl.lit(None).alias("replicaset"),
+                        pl.col("attr.k8s.node.name").first().alias("node")
+                        if "attr.k8s.node.name" in pod_cols
+                        else pl.lit(None).alias("node"),
+                        pl.col("time").min().alias("first_seen"),
+                        pl.col("time").max().alias("last_seen"),
+                    ]
+                )
+
+                for row in pod_agg.iter_rows(named=True):
+                    pod_name = row["attr.k8s.pod.name"]
+                    if pod_name not in resources["pod"]:
+                        resources["pod"][pod_name] = {
+                            "replicaset": row["replicaset"],
+                            "node": row["node"],
+                            "first_seen": row["first_seen"],
+                            "last_seen": row["last_seen"],
+                        }
+                    else:
+                        # Update with non-null values
+                        if row["replicaset"] is not None:
+                            resources["pod"][pod_name]["replicaset"] = row["replicaset"]
+                        if row["node"] is not None:
+                            resources["pod"][pod_name]["node"] = row["node"]
+                        # Update timestamps
+                        if row["first_seen"] < resources["pod"][pod_name]["first_seen"]:
+                            resources["pod"][pod_name]["first_seen"] = row["first_seen"]
+                        if row["last_seen"] > resources["pod"][pod_name]["last_seen"]:
+                            resources["pod"][pod_name]["last_seen"] = row["last_seen"]
+
+            # Extract containers with timestamps and pods
+            if "attr.k8s.container.name" in df_subset.columns and "time" in df_subset.columns:
+                container_cols = ["attr.k8s.container.name", "time"]
+                if "attr.k8s.pod.name" in df_subset.columns:
+                    container_cols.append("attr.k8s.pod.name")
+
+                container_df = df_subset.select(container_cols).drop_nulls(subset=["attr.k8s.container.name"])
+
+                container_agg = container_df.group_by("attr.k8s.container.name").agg(
+                    [
+                        pl.col("attr.k8s.pod.name").first().alias("pod")
+                        if "attr.k8s.pod.name" in container_cols
+                        else pl.lit(None).alias("pod"),
+                        pl.col("time").min().alias("first_seen"),
+                        pl.col("time").max().alias("last_seen"),
+                    ]
+                )
+
+                for row in container_agg.iter_rows(named=True):
+                    container_name = row["attr.k8s.container.name"]
+                    if container_name not in resources["container"]:
+                        resources["container"][container_name] = {
+                            "pod": row["pod"],
+                            "first_seen": row["first_seen"],
+                            "last_seen": row["last_seen"],
+                        }
+                    else:
+                        # Update with non-null values
+                        if row["pod"] is not None:
+                            resources["container"][container_name]["pod"] = row["pod"]
+                        # Update timestamps
+                        if row["first_seen"] < resources["container"][container_name]["first_seen"]:
+                            resources["container"][container_name]["first_seen"] = row["first_seen"]
+                        if row["last_seen"] > resources["container"][container_name]["last_seen"]:
+                            resources["container"][container_name]["last_seen"] = row["last_seen"]
+
+        logger.info(
+            f"Extracted K8s resources: "
+            f"{len(resources['namespace'])} namespaces, "
+            f"{len(resources['node'])} nodes, "
+            f"{len(resources['deployment'])} deployments, "
+            f"{len(resources['statefulset'])} statefulsets, "
+            f"{len(resources['replicaset'])} replicasets, "
+            f"{len(resources['pod'])} pods, "
+            f"{len(resources['container'])} containers"
+        )
+
+        return resources
+
+    def _build_k8s_nodes(
+        self,
+        graph: HyperGraph,
+        resources: dict[str, dict[str, Any]],
+        selected_metrics: list[str],
+    ) -> None:
+        """Build nodes for all K8s entities with their metrics."""
+
+        # Build namespace nodes
+        for namespace_name in resources["namespace"]:
+            node = Node(
+                kind=PlaceKind.namespace,
+                self_name=namespace_name,
+            )
+            graph.add_node(node, strict=False)
+
+        # Build node (machine) nodes
+        for node_name in resources["node"]:
+            node = Node(
+                kind=PlaceKind.machine,
+                self_name=node_name,
+            )
+            graph.add_node(node, strict=False)
+
+        # Build deployment nodes
+        for deployment_name in resources["deployment"]:
+            node = Node(
+                kind=PlaceKind.deployment,
+                self_name=deployment_name,
+            )
+            graph.add_node(node, strict=False)
+
+        # Build statefulset nodes
+        for statefulset_name in resources["statefulset"]:
+            node = Node(
+                kind=PlaceKind.stateful_set,
+                self_name=statefulset_name,
+            )
+            graph.add_node(node, strict=False)
+
+        # Build replicaset nodes
+        for replicaset_name in resources["replicaset"]:
+            node = Node(
+                kind=PlaceKind.replica_set,
+                self_name=replicaset_name,
+            )
+            graph.add_node(node, strict=False)
+
+        # Build pod nodes with aggregated container metrics (parallel)
+        logger.info(f"Extracting metrics for {len(resources['pod'])} pods...")
+        pod_names = list(resources["pod"].keys())
+
+        def extract_pod_task(pod_name: str) -> tuple[str, dict, dict]:
+            baseline, abnormal = self._extract_pod_metrics(pod_name, selected_metrics)
+            return pod_name, baseline, abnormal
+
+        pod_tasks = [lambda pn=pn: extract_pod_task(pn) for pn in pod_names]
+        pod_results = fmap_threadpool(pod_tasks, parallel=8, ignore_exceptions=False, show_progress=False)
+
+        for pod_name, baseline_metrics, abnormal_metrics in pod_results:
+            node = Node(
+                kind=PlaceKind.pod,
+                self_name=pod_name,
+                baseline_metrics=baseline_metrics,
+                abnormal_metrics=abnormal_metrics,
+            )
+            graph.add_node(node, strict=False)
+
+        # Build container nodes with their metrics (parallel)
+        logger.info(f"Extracting metrics for {len(resources['container'])} containers...")
+        container_names = list(resources["container"].keys())
+
+        def extract_container_task(container_name: str) -> tuple[str, dict, dict]:
+            baseline, abnormal = self._extract_container_metrics(container_name, selected_metrics)
+            return container_name, baseline, abnormal
+
+        container_tasks = [lambda cn=cn: extract_container_task(cn) for cn in container_names]
+        container_results = fmap_threadpool(container_tasks, parallel=8, ignore_exceptions=False, show_progress=False)
+
+        for container_name, baseline_metrics, abnormal_metrics in container_results:
+            node = Node(
+                kind=PlaceKind.container,
+                self_name=container_name,
+                baseline_metrics=baseline_metrics,
+                abnormal_metrics=abnormal_metrics,
+            )
+            graph.add_node(node, strict=False)
+
+    def _build_physical_edges(self, graph: HyperGraph, resources: dict[str, dict[str, Any]]) -> None:
+        """Build physical topology edges between K8s entities."""
+
+        # Build node name lookup cache to avoid repeated string formatting and graph lookups
+        node_cache: dict[str, Node | None] = {}
+
+        def get_cached_node(kind: PlaceKind, name: str) -> Node | None:
+            key = f"{kind}|{name}"
+            if key not in node_cache:
+                node_cache[key] = graph.get_node_by_name(key)
+            return node_cache[key]
+
+        # namespace -> deployment (owns)
+        for deployment_name, namespace_name in resources["deployment"].items():
+            if namespace_name:
+                ns_node = get_cached_node(PlaceKind.namespace, namespace_name)
+                dep_node = get_cached_node(PlaceKind.deployment, deployment_name)
+
+                if ns_node and dep_node:
+                    assert dep_node.id is not None and ns_node.id is not None
+                    edge = Edge(
+                        src_id=ns_node.id,
+                        dst_id=dep_node.id,
+                        src_name=f"{PlaceKind.namespace}|{namespace_name}",
+                        dst_name=f"{PlaceKind.deployment}|{deployment_name}",
+                        kind=DepKind.owns,
+                        weight=1.0,
+                        data=None,
+                    )
+                    graph.add_edge(edge, strict=False)
+
+        # namespace -> statefulset (owns)
+        for statefulset_name, namespace_name in resources["statefulset"].items():
+            if namespace_name:
+                ns_node = get_cached_node(PlaceKind.namespace, namespace_name)
+                ss_node = get_cached_node(PlaceKind.stateful_set, statefulset_name)
+
+                if ns_node and ss_node:
+                    assert ss_node.id is not None and ns_node.id is not None
+                    edge = Edge(
+                        src_id=ns_node.id,
+                        dst_id=ss_node.id,
+                        src_name=f"{PlaceKind.namespace}|{namespace_name}",
+                        dst_name=f"{PlaceKind.stateful_set}|{statefulset_name}",
+                        kind=DepKind.owns,
+                        weight=1.0,
+                        data=None,
+                    )
+                    graph.add_edge(edge, strict=False)
+
+        # deployment -> replicaset (scales)
+        # statefulset -> replicaset (manages)
+        for replicaset_name, parent_name in resources["replicaset"].items():
+            if parent_name:
+                rs_node = get_cached_node(PlaceKind.replica_set, replicaset_name)
+                # Try deployment first
+                dep_node = get_cached_node(PlaceKind.deployment, parent_name)
+
+                if dep_node and rs_node:
+                    assert dep_node.id is not None and rs_node.id is not None
+                    edge = Edge(
+                        src_id=dep_node.id,
+                        dst_id=rs_node.id,
+                        src_name=f"{PlaceKind.deployment}|{parent_name}",
+                        dst_name=f"{PlaceKind.replica_set}|{replicaset_name}",
+                        kind=DepKind.scales,
+                        weight=1.0,
+                        data=None,
+                    )
+                    graph.add_edge(edge, strict=False)
+                else:
+                    # Try statefulset
+                    ss_node = get_cached_node(PlaceKind.stateful_set, parent_name)
+                    if ss_node and rs_node:
+                        assert ss_node.id is not None and rs_node.id is not None
+                        edge = Edge(
+                            src_id=ss_node.id,
+                            dst_id=rs_node.id,
+                            src_name=f"{PlaceKind.stateful_set}|{parent_name}",
+                            dst_name=f"{PlaceKind.replica_set}|{replicaset_name}",
+                            kind=DepKind.manages,
+                            weight=1.0,
+                            data=None,
+                        )
+                        graph.add_edge(edge, strict=False)
+
+        # replicaset -> pod (manages)
+        # node -> pod (schedules)
+        for pod_name, pod_info in resources["pod"].items():
+            pod_node = get_cached_node(PlaceKind.pod, pod_name)
+            if not pod_node:
+                continue
+
+            # replicaset -> pod
+            replicaset_name = pod_info.get("replicaset")
+            if replicaset_name:
+                rs_node = get_cached_node(PlaceKind.replica_set, replicaset_name)
+                if rs_node:
+                    assert rs_node.id is not None and pod_node.id is not None
+                    edge = Edge(
+                        src_id=rs_node.id,
+                        dst_id=pod_node.id,
+                        src_name=f"{PlaceKind.replica_set}|{replicaset_name}",
+                        dst_name=f"{PlaceKind.pod}|{pod_name}",
+                        kind=DepKind.manages,
+                        weight=1.0,
+                        data=None,
+                    )
+                    graph.add_edge(edge, strict=False)
+
+            # node -> pod
+            node_name = pod_info.get("node")
+            if node_name:
+                node = get_cached_node(PlaceKind.machine, node_name)
+                if node:
+                    assert node.id is not None and pod_node.id is not None
+                    edge = Edge(
+                        src_id=node.id,
+                        dst_id=pod_node.id,
+                        src_name=f"{PlaceKind.machine}|{node_name}",
+                        dst_name=f"{PlaceKind.pod}|{pod_name}",
+                        kind=DepKind.schedules,
+                        weight=1.0,
+                        data=None,
+                    )
+                    graph.add_edge(edge, strict=False)
+
+        # pod -> container (runs)
+        for container_name, container_info in resources["container"].items():
+            container_pod_name: str | None = (
+                container_info.get("pod") if isinstance(container_info, dict) else container_info
+            )
+            if container_pod_name:
+                pod_node = get_cached_node(PlaceKind.pod, container_pod_name)
+                container_node = get_cached_node(PlaceKind.container, container_name)
+                if pod_node and container_node:
+                    assert container_node.id is not None and pod_node.id is not None
+                    edge = Edge(
+                        src_id=pod_node.id,
+                        dst_id=container_node.id,
+                        src_name=f"{PlaceKind.pod}|{container_pod_name}",
+                        dst_name=f"{PlaceKind.container}|{container_name}",
+                        kind=DepKind.runs,
+                        weight=1.0,
+                        data=None,
+                    )
+                    graph.add_edge(edge, strict=False)
+
+    def _build_service_nodes_from_traces(
+        self,
+        graph: HyperGraph,
+        selected_metrics: list[str],
+    ) -> None:
+        """Build service nodes and connect them to pods based on trace data."""
+
+        assert self._abnormal_traces is not None, "Abnormal traces not loaded"
+
+        # Extract service names from both abnormal and baseline traces
+        abnormal_services = set(
+            self._abnormal_traces.select("service_name").unique().drop_nulls().to_series().to_list()
+        )
+        baseline_services: set[str] = set()
+        if self._baseline_traces is not None:
+            baseline_services = set(
+                self._baseline_traces.select("service_name").unique().drop_nulls().to_series().to_list()
+            )
+
+        # Union of all services from both periods
+        all_services = abnormal_services | baseline_services
+
+        logger.info(f"Extracting metrics for {len(all_services)} services...")
+
+        # Parallel extraction of service metrics
+        def extract_service_task(service_name: str) -> tuple[str, dict, dict, set[str]]:
+            baseline_metrics, abnormal_metrics = self._extract_service_metrics(service_name, selected_metrics)
+
+            # Collect pod names for this service from both periods
+            pod_names_set: set[str] = set()
+            assert self._abnormal_traces is not None
+            abnormal_service_traces = self._abnormal_traces.filter(pl.col("service_name") == service_name)
+            pod_names_set.update(
+                abnormal_service_traces.select("attr.k8s.pod.name").drop_nulls().unique().to_series().to_list()
+            )
+            if self._baseline_traces is not None:
+                baseline_service_traces = self._baseline_traces.filter(pl.col("service_name") == service_name)
+                pod_names_set.update(
+                    baseline_service_traces.select("attr.k8s.pod.name").drop_nulls().unique().to_series().to_list()
+                )
+
+            return service_name, baseline_metrics, abnormal_metrics, pod_names_set
+
+        service_tasks = [lambda sn=sn: extract_service_task(sn) for sn in all_services]
+        service_results = fmap_threadpool(service_tasks, parallel=8, ignore_exceptions=False, show_progress=False)
+
+        for service_name, baseline_metrics, abnormal_metrics, pod_names_set in service_results:
+            node = Node(
+                kind=PlaceKind.service,
+                self_name=service_name,
+                baseline_metrics=baseline_metrics,
+                abnormal_metrics=abnormal_metrics,
+            )
+            graph.add_node(node, strict=False)
+
+            # Use cached lookups for service-pod edges
+            service_node = graph.get_node_by_name(f"{PlaceKind.service}|{service_name}")
+            if service_node:
+                for pod_name in pod_names_set:
+                    pod_node = graph.get_node_by_name(f"{PlaceKind.pod}|{pod_name}")
+                    if pod_node:
+                        assert service_node.id is not None and pod_node.id is not None
+                        # service -> pod (routes_to)
+                        edge = Edge(
+                            src_id=service_node.id,
+                            dst_id=pod_node.id,
+                            src_name=f"{PlaceKind.service}|{service_name}",
+                            dst_name=f"{PlaceKind.pod}|{pod_name}",
+                            kind=DepKind.routes_to,
+                            weight=1.0,
+                            data=None,
+                        )
+                        graph.add_edge(edge, strict=False)
+                        graph.add_edge(edge, strict=False)
+
+    def _aggregate_service_trace_metrics(
+        self, service_name: str, baseline_traces_df: pl.DataFrame, abnormal_traces_df: pl.DataFrame
+    ) -> dict[str, np.ndarray]:
+        """Aggregate trace statistics for a service (error rate, latency, etc.).
+
+        Args:
+            service_name: Service to aggregate metrics for
+            baseline_traces_df: Baseline trace data
+            abnormal_traces_df: Abnormal trace data
+
+        Returns:
+            Dictionary with aggregated metrics:
+            - error_rate: Proportion of failed requests (5xx HTTP status)
+            - p99_duration: 99th percentile latency
+            - avg_duration: Average latency
+            - baseline_p99_duration: Baseline P99 latency for comparison
+            - baseline_error_rate: Baseline error rate
+        """
+        # Process baseline period
+        baseline_service = baseline_traces_df.filter(pl.col("service_name") == service_name)
+        baseline_stats = None
+        if len(baseline_service) > 0:
+            baseline_stats = (
+                baseline_service.with_columns(
+                    [
+                        (pl.col("duration") / 1e9).alias("duration_sec"),
+                        (
+                            pl.col("attr.http.response.status_code").is_not_null()
+                            & (pl.col("attr.http.response.status_code") >= 500)
+                        )
+                        .cast(pl.Int32)
+                        .alias("is_error"),
+                    ]
+                )
+                .select(
+                    [
+                        pl.len().alias("total_count"),
+                        pl.col("is_error").sum().alias("error_count"),
+                        pl.col("duration_sec").mean().alias("avg_duration"),
+                        pl.col("duration_sec").quantile(0.99).alias("p99_duration"),
+                    ]
+                )
+                .row(0, named=True)
+            )
+
+        # Process abnormal period
+        abnormal_service = abnormal_traces_df.filter(pl.col("service_name") == service_name)
+
+        if len(abnormal_service) == 0:
+            return {}
+
+        abnormal_stats = (
+            abnormal_service.with_columns(
+                [
+                    (pl.col("duration") / 1e9).alias("duration_sec"),
+                    (
+                        pl.col("attr.http.response.status_code").is_not_null()
+                        & (pl.col("attr.http.response.status_code") >= 500)
+                    )
+                    .cast(pl.Int32)
+                    .alias("is_error"),
+                ]
+            )
+            .select(
+                [
+                    pl.len().alias("total_count"),
+                    pl.col("is_error").sum().alias("error_count"),
+                    pl.col("duration_sec").mean().alias("avg_duration"),
+                    pl.col("duration_sec").quantile(0.99).alias("p99_duration"),
+                ]
+            )
+            .row(0, named=True)
+        )
+
+        total_count = abnormal_stats["total_count"]
+        error_count = abnormal_stats["error_count"]
+
+        metrics = {
+            "error_rate": np.array([error_count / total_count if total_count > 0 else 0.0]),
+            "p99_duration": np.array([abnormal_stats["p99_duration"] or 0.0]),
+            "avg_duration": np.array([abnormal_stats["avg_duration"] or 0.0]),
+        }
+
+        # Add baseline metrics if available
+        if baseline_stats:
+            baseline_total = baseline_stats["total_count"]
+            baseline_errors = baseline_stats["error_count"]
+            metrics["baseline_p99_duration"] = np.array([baseline_stats["p99_duration"] or 0.0])
+            metrics["baseline_error_rate"] = np.array([baseline_errors / baseline_total if baseline_total > 0 else 0.0])
+
+        return metrics
+
+    def _batch_extract_entity_metrics(
+        self,
+        entity_col: str,
+        entity_names: list[str],
+        selected_metrics: list[str],
+        filter_null_container: bool = False,
+    ) -> dict[str, tuple[dict[str, tuple[np.ndarray, np.ndarray]], dict[str, tuple[np.ndarray, np.ndarray]]]]:
+        """
+        Batch extract metrics for multiple entities (pods/containers/services).
+
+        Args:
+            entity_col: Column name to filter by (e.g., "attr.k8s.pod.name")
+            entity_names: List of entity names to extract metrics for
+            selected_metrics: List of metric names to extract
+            filter_null_container: If True, only get metrics where container.name is null
+
+        Returns:
+            Dict mapping entity_name -> (baseline_metrics, abnormal_metrics)
+        """
+        assert self._baseline_metrics is not None and self._abnormal_metrics is not None
+        assert self._baseline_metrics_hist is not None and self._abnormal_metrics_hist is not None
+        assert self._baseline_metrics_sum is not None and self._abnormal_metrics_sum is not None
+
+        # Categorize metrics by type
+        histogram_metrics = {
+            "hubble_http_request_duration_seconds",
+            "http.server.request.duration",
+            "http.client.request.duration",
+            "db.client.connections.use_time",
+            "db.client.connections.wait_time",
+            "jvm.gc.duration",
+        }
+        sum_metrics = {
+            "hubble_http_requests_total",
+            "k8s.pod.network.io",
+            "k8s.pod.network.errors",
+            "hubble_drop_total",
+        }
+        gauge_metrics = [m for m in selected_metrics if m not in histogram_metrics and m not in sum_metrics]
+        hist_metrics = [m for m in selected_metrics if m in histogram_metrics]
+        sum_metrics_list = [m for m in selected_metrics if m in sum_metrics]
+
+        result: dict[
+            str, tuple[dict[str, tuple[np.ndarray, np.ndarray]], dict[str, tuple[np.ndarray, np.ndarray]]]
+        ] = {}
+
+        # Pre-filter data by entities
+        entity_filter = pl.col(entity_col).is_in(entity_names)
+
+        # Process gauge metrics - optimized with group_by instead of nested loops
+        if gauge_metrics:
+            gauge_filter = entity_filter & pl.col("metric").is_in(gauge_metrics)
+            if filter_null_container:
+                gauge_filter = gauge_filter & pl.col("attr.k8s.container.name").is_null()
+
+            baseline_gauge = self._baseline_metrics.filter(gauge_filter).sort("time")
+            abnormal_gauge = self._abnormal_metrics.filter(gauge_filter).sort("time")
+
+            # Group by entity and metric in one pass
+            if len(abnormal_gauge) > 0:
+                abnormal_grouped = abnormal_gauge.group_by([entity_col, "metric"]).agg(
+                    [pl.col("time").alias("timestamps"), pl.col("value").alias("values")]
+                )
+
+                for row in abnormal_grouped.iter_rows(named=True):
+                    entity = row[entity_col]
+                    metric = row["metric"]
+
+                    if entity not in result:
+                        result[entity] = ({}, {})
+
+                    abnormal_metrics = result[entity][1]
+                    abnormal_metrics[metric] = (np.array(row["timestamps"]), np.array(row["values"]))
+
+            if len(baseline_gauge) > 0:
+                baseline_grouped = baseline_gauge.group_by([entity_col, "metric"]).agg(
+                    [pl.col("time").alias("timestamps"), pl.col("value").alias("values")]
+                )
+
+                for row in baseline_grouped.iter_rows(named=True):
+                    entity = row[entity_col]
+                    metric = row["metric"]
+
+                    if entity not in result:
+                        result[entity] = ({}, {})
+
+                    baseline_metrics = result[entity][0]
+                    baseline_metrics[metric] = (np.array(row["timestamps"]), np.array(row["values"]))
+
+        # Process histogram metrics - optimized with group_by
+        if hist_metrics:
+            hist_filter = entity_filter & pl.col("metric").is_in(hist_metrics)
+            baseline_hist = self._baseline_metrics_hist.filter(hist_filter).sort("time")
+            abnormal_hist = self._abnormal_metrics_hist.filter(hist_filter).sort("time")
+
+            # Process each stat column
+            for stat_col, suffix in [
+                ("p99", ".p99"),
+                ("p90", ".p90"),
+                ("p50", ".p50"),
+                ("sum", ".sum"),
+                ("count", ".count"),
+            ]:
+                # Abnormal period
+                if len(abnormal_hist) > 0 and stat_col in abnormal_hist.columns:
+                    abnormal_grouped = abnormal_hist.group_by([entity_col, "metric"]).agg(
+                        [pl.col("time").alias("timestamps"), pl.col(stat_col).alias("values")]
+                    )
+
+                    for row in abnormal_grouped.iter_rows(named=True):
+                        entity = row[entity_col]
+                        metric = row["metric"]
+
+                        if entity not in result:
+                            result[entity] = ({}, {})
+
+                        abnormal_metrics = result[entity][1]
+                        abnormal_metrics[f"{metric}{suffix}"] = (np.array(row["timestamps"]), np.array(row["values"]))
+
+                # Baseline period
+                if len(baseline_hist) > 0 and stat_col in baseline_hist.columns:
+                    baseline_grouped = baseline_hist.group_by([entity_col, "metric"]).agg(
+                        [pl.col("time").alias("timestamps"), pl.col(stat_col).alias("values")]
+                    )
+
+                    for row in baseline_grouped.iter_rows(named=True):
+                        entity = row[entity_col]
+                        metric = row["metric"]
+
+                        if entity not in result:
+                            result[entity] = ({}, {})
+
+                        baseline_metrics = result[entity][0]
+                        baseline_metrics[f"{metric}{suffix}"] = (np.array(row["timestamps"]), np.array(row["values"]))
+
+        # Process sum metrics - optimized with group_by
+        if sum_metrics_list:
+            sum_filter = entity_filter & pl.col("metric").is_in(sum_metrics_list)
+            baseline_sum = self._baseline_metrics_sum.filter(sum_filter).sort("time")
+            abnormal_sum = self._abnormal_metrics_sum.filter(sum_filter).sort("time")
+
+            # Abnormal period
+            if len(abnormal_sum) > 0:
+                abnormal_grouped = abnormal_sum.group_by([entity_col, "metric"]).agg(
+                    [pl.col("time").alias("timestamps"), pl.col("value").alias("values")]
+                )
+
+                for row in abnormal_grouped.iter_rows(named=True):
+                    entity = row[entity_col]
+                    metric = row["metric"]
+
+                    if entity not in result:
+                        result[entity] = ({}, {})
+
+                    abnormal_metrics = result[entity][1]
+                    abnormal_metrics[metric] = (np.array(row["timestamps"]), np.array(row["values"]))
+
+            # Baseline period
+            if len(baseline_sum) > 0:
+                baseline_grouped = baseline_sum.group_by([entity_col, "metric"]).agg(
+                    [pl.col("time").alias("timestamps"), pl.col("value").alias("values")]
+                )
+
+                for row in baseline_grouped.iter_rows(named=True):
+                    entity = row[entity_col]
+                    metric = row["metric"]
+
+                    if entity not in result:
+                        result[entity] = ({}, {})
+
+                    baseline_metrics = result[entity][0]
+                    baseline_metrics[metric] = (np.array(row["timestamps"]), np.array(row["values"]))
+
+        return result
+
+    def _extract_pod_metrics(
+        self, pod_name: str, selected_metrics: list[str]
+    ) -> tuple[dict[str, tuple[np.ndarray, np.ndarray]], dict[str, tuple[np.ndarray, np.ndarray]]]:
+        """Extract pod-level metrics including gauge, histogram, and sum types.
+
+        Pod nodes only contain metrics at the pod level (e.g., k8s.pod.*).
+        Container-level metrics (e.g., container.*) belong to container nodes.
+
+        Returns:
+            Tuple of (baseline_metrics, abnormal_metrics)
+            Each dict: metric_name -> (timestamps, values)
+            For histogram metrics, extracts p99, p90, p50, avg, count as separate series
+        """
+        # Use batch extraction for single pod
+        batch_result = self._batch_extract_entity_metrics(
+            entity_col="attr.k8s.pod.name",
+            entity_names=[pod_name],
+            selected_metrics=selected_metrics,
+            filter_null_container=True,
+        )
+        if pod_name not in batch_result:
+            logger.warning(f"No metrics found for pod {pod_name}, returning empty metrics")
+            return {}, {}
+        return batch_result[pod_name]
+
+    def _extract_container_metrics(
+        self, container_name: str, selected_metrics: list[str]
+    ) -> tuple[dict[str, tuple[np.ndarray, np.ndarray]], dict[str, tuple[np.ndarray, np.ndarray]]]:
+        """Extract metrics for a specific container including gauge, histogram, and sum types.
+
+        Returns:
+            Tuple of (baseline_metrics, abnormal_metrics)
+            Each dict: metric_name -> (timestamps, values)
+            For histogram metrics, extracts p99, p90, p50, avg, count as separate series
+        """
+        # Filter to only gauge metrics (containers don't have histogram/sum attribution)
+        histogram_metrics = {
+            "hubble_http_request_duration_seconds",
+            "http.server.request.duration",
+            "http.client.request.duration",
+            "db.client.connections.use_time",
+            "db.client.connections.wait_time",
+            "jvm.gc.duration",
+        }
+        sum_metrics = {
+            "hubble_http_requests_total",
+            "k8s.pod.network.io",
+            "k8s.pod.network.errors",
+            "hubble_drop_total",
+        }
+        gauge_only = [m for m in selected_metrics if m not in histogram_metrics and m not in sum_metrics]
+
+        if not gauge_only:
+            return {}, {}
+
+        # Use batch extraction for single container
+        batch_result = self._batch_extract_entity_metrics(
+            entity_col="attr.k8s.container.name",
+            entity_names=[container_name],
+            selected_metrics=gauge_only,
+            filter_null_container=False,
+        )
+        if container_name not in batch_result:
+            logger.warning(f"No metrics found for container {container_name}, returning empty metrics")
+            return {}, {}
+        return batch_result[container_name]
+
+    def _build_service_nodes(self, selected_metrics: list[str]) -> list[Node]:
+        """Build service-level nodes with aggregated metrics."""
+        assert self._abnormal_metrics is not None
+
+        nodes = []
+        services = self._abnormal_metrics.select("service_name").unique().drop_nulls().to_series().to_list()
+
+        for service in services:
+            # Extract metrics for this service
+            baseline_metrics, abnormal_metrics = self._extract_service_metrics(service, selected_metrics)
+
+            if not baseline_metrics and not abnormal_metrics:
+                logger.warning(f"No metrics found for service {service}, skipping")
+                continue
+
+            node = Node(
+                kind=PlaceKind.service,
+                self_name=service,
+                baseline_metrics=baseline_metrics,
+                abnormal_metrics=abnormal_metrics,
+            )
+            nodes.append(node)
+
+        return nodes
+
+    def _build_endpoint_nodes(self, selected_metrics: list[str]) -> list[Node]:
+        """Build endpoint-level nodes (service::endpoint)."""
+
+        # Get unique service-endpoint pairs from traces
+        # For now, use service-level since traces don't have endpoint info in the schema
+        # This can be extended when endpoint data is available
+        logger.warning("Endpoint granularity not fully supported with current schema, using service-level")
+        return self._build_service_nodes(selected_metrics)
+
+    def _extract_service_metrics(
+        self, service: str, selected_metrics: list[str]
+    ) -> tuple[dict[str, tuple[np.ndarray, np.ndarray]], dict[str, tuple[np.ndarray, np.ndarray]]]:
+        """
+        Extract and process metrics for a service including gauge, histogram, and sum types.
+
+        Returns:
+            Tuple of (baseline_metrics, abnormal_metrics)
+            Each dict: metric_name -> (timestamps, values)
+            For histogram metrics, extracts p99, p90, p50, avg, count as separate series
+        """
+        assert self._baseline_metrics is not None and self._abnormal_metrics is not None
+        assert self._baseline_metrics_hist is not None and self._abnormal_metrics_hist is not None
+        assert self._baseline_metrics_sum is not None and self._abnormal_metrics_sum is not None
+
+        baseline_metrics: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+        abnormal_metrics: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+
+        for metric_name in selected_metrics:
+            # Determine metric type based on name
+            is_histogram = metric_name in {
+                "hubble_http_request_duration_seconds",
+                "http.server.request.duration",
+                "http.client.request.duration",
+                "db.client.connections.use_time",
+                "db.client.connections.wait_time",
+                "jvm.gc.duration",
+            }
+            is_sum = metric_name in {
+                "hubble_http_requests_total",
+                "k8s.pod.network.io",
+                "k8s.pod.network.errors",
+                "hubble_drop_total",
+            }
+
+            if is_histogram:
+                # Extract histogram metrics for service
+                self._extract_histogram_metric_for_service(service, metric_name, baseline_metrics, abnormal_metrics)
+            elif is_sum:
+                # Extract sum metrics for service
+                self._extract_sum_metric_for_service(service, metric_name, baseline_metrics, abnormal_metrics)
+            else:
+                # Get baseline gauge data
+                baseline_data = (
+                    self._baseline_metrics.filter(
+                        (pl.col("service_name") == service) & (pl.col("metric") == metric_name)
+                    )
+                    .sort("time")
+                    .select(["time", "value"])
+                )
+                baseline_timestamps = baseline_data.select("time").to_series().to_numpy()
+                baseline_values = baseline_data.select("value").to_series().to_numpy()
+
+                # Get abnormal gauge data
+                abnormal_data = (
+                    self._abnormal_metrics.filter(
+                        (pl.col("service_name") == service) & (pl.col("metric") == metric_name)
+                    )
+                    .sort("time")
+                    .select(["time", "value"])
+                )
+                abnormal_timestamps = abnormal_data.select("time").to_series().to_numpy()
+                abnormal_values = abnormal_data.select("value").to_series().to_numpy()
+
+                if len(abnormal_values) == 0:
+                    continue
+
+                if len(baseline_values) > 0:
+                    baseline_metrics[metric_name] = (baseline_timestamps, baseline_values)
+                abnormal_metrics[metric_name] = (abnormal_timestamps, abnormal_values)
+
+        return baseline_metrics, abnormal_metrics
+
+    def _extract_histogram_metric_for_service(
+        self,
+        service_name: str,
+        metric_name: str,
+        baseline_metrics: dict[str, tuple[np.ndarray, np.ndarray]],
+        abnormal_metrics: dict[str, tuple[np.ndarray, np.ndarray]],
+    ) -> None:
+        """Extract histogram metric for service (p99, p90, p50, avg, count as separate time series)."""
+        assert self._baseline_metrics_hist is not None and self._abnormal_metrics_hist is not None
+
+        baseline_data = self._baseline_metrics_hist.filter(
+            (pl.col("service_name") == service_name) & (pl.col("metric") == metric_name)
+        ).sort("time")
+
+        abnormal_data = self._abnormal_metrics_hist.filter(
+            (pl.col("service_name") == service_name) & (pl.col("metric") == metric_name)
+        ).sort("time")
+
+        for stat_col, suffix in [
+            ("p99", ".p99"),
+            ("p90", ".p90"),
+            ("p50", ".p50"),
+            ("sum", ".sum"),
+            ("count", ".count"),
+        ]:
+            if stat_col in abnormal_data.columns:
+                abnormal_ts = abnormal_data.select("time").to_series().to_numpy()
+                abnormal_values = abnormal_data.select(stat_col).to_series().to_numpy()
+
+                if len(abnormal_values) > 0:
+                    abnormal_metrics[f"{metric_name}{suffix}"] = (abnormal_ts, abnormal_values)
+
+                    if stat_col in baseline_data.columns and len(baseline_data) > 0:
+                        baseline_ts = baseline_data.select("time").to_series().to_numpy()
+                        baseline_values = baseline_data.select(stat_col).to_series().to_numpy()
+                        baseline_metrics[f"{metric_name}{suffix}"] = (baseline_ts, baseline_values)
+
+    def _extract_sum_metric_for_service(
+        self,
+        service_name: str,
+        metric_name: str,
+        baseline_metrics: dict[str, tuple[np.ndarray, np.ndarray]],
+        abnormal_metrics: dict[str, tuple[np.ndarray, np.ndarray]],
+    ) -> None:
+        """Extract sum (counter) metric for service."""
+        assert self._baseline_metrics_sum is not None and self._abnormal_metrics_sum is not None
+
+        baseline_data = (
+            self._baseline_metrics_sum.filter(
+                (pl.col("service_name") == service_name) & (pl.col("metric") == metric_name)
+            )
+            .sort("time")
+            .select(["time", "value"])
+        )
+
+        abnormal_data = (
+            self._abnormal_metrics_sum.filter(
+                (pl.col("service_name") == service_name) & (pl.col("metric") == metric_name)
+            )
+            .sort("time")
+            .select(["time", "value"])
+        )
+
+        if len(abnormal_data) > 0:
+            abnormal_ts = abnormal_data.select("time").to_series().to_numpy()
+            abnormal_values = abnormal_data.select("value").to_series().to_numpy()
+            abnormal_metrics[metric_name] = (abnormal_ts, abnormal_values)
+
+            if len(baseline_data) > 0:
+                baseline_ts = baseline_data.select("time").to_series().to_numpy()
+                baseline_values = baseline_data.select("value").to_series().to_numpy()
+                baseline_metrics[metric_name] = (baseline_ts, baseline_values)
+
+    def _compute_residual(self, abnormal: np.ndarray, baseline: np.ndarray) -> np.ndarray:
+        """
+        Compute residual signal (abnormal - baseline).
+
+        Handles length mismatch by using the minimum length.
+        """
+        if len(baseline) == 0:
+            return abnormal.copy()
+
+        min_len = min(len(abnormal), len(baseline))
+        result: np.ndarray = abnormal[:min_len] - baseline[:min_len]
+        return result
+
+    def _normalize_residual(self, residual: np.ndarray) -> np.ndarray:
+        if len(residual) == 0:
+            return residual.copy()
+
+        # Handle all-zero case
+        if np.all(residual == 0):
+            return residual.copy()
+
+        # Handle NaN values
+        if np.all(np.isnan(residual)):
+            return np.zeros_like(residual)
+
+        # Filter out NaN for statistics calculation
+        valid_residual = residual[~np.isnan(residual)]
+        if len(valid_residual) == 0:
+            return np.zeros_like(residual)
+
+        # Robust z-score: use median and MAD instead of mean and std
+        median = np.median(valid_residual)
+        mad = np.median(np.abs(valid_residual - median))
+
+        z_scores: np.ndarray
+        if mad == 0:
+            # Fall back to standard normalization if MAD is zero
+            std = np.std(valid_residual)
+            if std == 0:
+                return np.zeros_like(residual)
+            z_scores = (residual - np.mean(valid_residual)) / std
+        else:
+            z_scores = (residual - median) / (1.4826 * mad)
+
+        # Replace NaN with 0
+        z_scores = np.nan_to_num(z_scores, nan=0.0)
+
+        # Clip to [-3, 3] std then map to [0, 1]
+        clipped = np.clip(z_scores, -3, 3)
+        normalized: np.ndarray = (clipped + 3) / 6
+
+        return normalized
+
+    def _build_span_nodes(
+        self,
+        graph: HyperGraph,
+        baseline_traces_df: pl.DataFrame,
+        abnormal_traces_df: pl.DataFrame,
+        baseline_logs_df: pl.DataFrame,
+        abnormal_logs_df: pl.DataFrame,
+    ) -> None:
+        """
+        Build span nodes from trace data using (service_name, span_name) as identifier.
+
+        Each span node is uniquely identified by its service and span_name combination,
+        which prevents ambiguity when the same span_name appears in multiple services
+        (e.g., TripRepository.findByTripId in both ts-travel-service and ts-travel2-service).
+
+        The span node's self_name format is: "{service_name}::{span_name}"
+        This ensures that spans with the same name but in different services are distinct nodes.
+        """
+        # Process baseline traces - group by (service_name, span_name)
+        baseline_valid = baseline_traces_df.drop_nulls(subset=["span_name", "service_name"]).with_columns(
+            [
+                (pl.col("duration") / 1e9).alias("duration_sec"),
+                (
+                    pl.col("attr.http.response.status_code").is_not_null()
+                    & (pl.col("attr.http.response.status_code") >= 500)
+                )
+                .cast(pl.Int32)
+                .alias("is_error"),
+            ]
+        )
+
+        # Add 5-second time bucketing for time-series metrics
+        baseline_with_time = baseline_valid.with_columns(pl.col("time").dt.truncate("5s").alias("time_window"))
+
+        # Group by (service_name, span_name) instead of just span_name
+        baseline_agg = (
+            baseline_with_time.group_by(["service_name", "span_name", "time_window"])
+            .agg(
+                [
+                    pl.len().alias("baseline_call_count"),
+                    pl.col("is_error").sum().alias("baseline_error_count"),
+                    pl.col("duration_sec").mean().alias("baseline_avg_duration"),
+                    pl.col("duration_sec").quantile(0.5).alias("baseline_p50_duration"),
+                    pl.col("duration_sec").quantile(0.99).alias("baseline_p99_duration"),
+                    pl.col("duration_sec").max().alias("baseline_max_duration"),
+                ]
+            )
+            .with_columns((pl.col("baseline_error_count") / pl.col("baseline_call_count")).alias("baseline_error_rate"))
+            .sort(["service_name", "span_name", "time_window"])
+        )
+
+        # Process abnormal traces
+        abnormal_valid = abnormal_traces_df.drop_nulls(subset=["span_name", "service_name"])
+
+        if len(abnormal_valid) == 0:
+            logger.warning("No valid abnormal traces found for building span nodes")
+            return
+
+        abnormal_valid = abnormal_valid.with_columns(
+            [
+                (pl.col("duration") / 1e9).alias("duration_sec"),
+                (
+                    pl.col("attr.http.response.status_code").is_not_null()
+                    & (pl.col("attr.http.response.status_code") >= 500)
+                )
+                .cast(pl.Int32)
+                .alias("is_error"),
+            ]
+        )
+
+        # Add 5-second time bucketing for time-series metrics
+        abnormal_with_time = abnormal_valid.with_columns(pl.col("time").dt.truncate("5s").alias("time_window"))
+
+        # Group by (service_name, span_name) instead of just span_name
+        abnormal_agg = (
+            abnormal_with_time.group_by(["service_name", "span_name", "time_window"])
+            .agg(
+                [
+                    pl.len().alias("call_count"),
+                    pl.col("is_error").sum().alias("error_count"),
+                    pl.col("duration_sec").mean().alias("avg_duration"),
+                    pl.col("duration_sec").quantile(0.5).alias("p50_duration"),
+                    pl.col("duration_sec").quantile(0.99).alias("p99_duration"),
+                    pl.col("duration_sec").max().alias("max_duration"),
+                ]
+            )
+            .with_columns((pl.col("error_count") / pl.col("call_count")).alias("error_rate"))
+            .sort(["service_name", "span_name", "time_window"])
+        )
+
+        # Get unique (service_name, span_name) pairs from both periods
+        all_service_span_pairs: set[tuple[str, str]] = set()
+        if len(baseline_agg) > 0:
+            for row in baseline_agg.select(["service_name", "span_name"]).unique().iter_rows():
+                all_service_span_pairs.add((row[0], row[1]))
+        if len(abnormal_agg) > 0:
+            for row in abnormal_agg.select(["service_name", "span_name"]).unique().iter_rows():
+                all_service_span_pairs.add((row[0], row[1]))
+
+        # Create span nodes with time-series metrics
+        filtered_count = 0
+        for service_name, span_name in sorted(all_service_span_pairs):
+            if span_name is None or service_name is None:
+                continue
+
+            # Filter out pure HTTP method spans without endpoint paths (e.g., 'GET', 'POST')
+            if is_generic_http_method_span(span_name):
+                filtered_count += 1
+                continue
+
+            # Create unique span identifier: service_name::span_name
+            span_full_name = f"{service_name}::{span_name}"
+
+            # Extract trace time-series metrics
+            baseline_trace_metrics: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+            abnormal_trace_metrics: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+
+            # Extract baseline trace time-series
+            baseline_span_data = baseline_agg.filter(
+                (pl.col("service_name") == service_name) & (pl.col("span_name") == span_name)
+            )
+            if len(baseline_span_data) > 0:
+                timestamps = baseline_span_data.select("time_window").to_series().to_numpy()
+                baseline_trace_metrics["request_count"] = (
+                    timestamps,
+                    baseline_span_data.select("baseline_call_count").to_series().to_numpy().astype(np.float64),
+                )
+                baseline_trace_metrics["error_rate"] = (
+                    timestamps,
+                    baseline_span_data.select("baseline_error_rate").to_series().to_numpy().astype(np.float64),
+                )
+                baseline_trace_metrics["avg_duration"] = (
+                    timestamps,
+                    baseline_span_data.select("baseline_avg_duration").to_series().to_numpy().astype(np.float64),
+                )
+                baseline_trace_metrics["p50_duration"] = (
+                    timestamps,
+                    baseline_span_data.select("baseline_p50_duration").to_series().to_numpy().astype(np.float64),
+                )
+                baseline_trace_metrics["p99_duration"] = (
+                    timestamps,
+                    baseline_span_data.select("baseline_p99_duration").to_series().to_numpy().astype(np.float64),
+                )
+                baseline_trace_metrics["max_duration"] = (
+                    timestamps,
+                    baseline_span_data.select("baseline_max_duration").to_series().to_numpy().astype(np.float64),
+                )
+
+            # Extract abnormal trace time-series
+            abnormal_span_data = abnormal_agg.filter(
+                (pl.col("service_name") == service_name) & (pl.col("span_name") == span_name)
+            )
+            if len(abnormal_span_data) > 0:
+                timestamps = abnormal_span_data.select("time_window").to_series().to_numpy()
+                abnormal_trace_metrics["request_count"] = (
+                    timestamps,
+                    abnormal_span_data.select("call_count").to_series().to_numpy().astype(np.float64),
+                )
+                abnormal_trace_metrics["error_rate"] = (
+                    timestamps,
+                    abnormal_span_data.select("error_rate").to_series().to_numpy().astype(np.float64),
+                )
+                abnormal_trace_metrics["avg_duration"] = (
+                    timestamps,
+                    abnormal_span_data.select("avg_duration").to_series().to_numpy().astype(np.float64),
+                )
+                abnormal_trace_metrics["p50_duration"] = (
+                    timestamps,
+                    abnormal_span_data.select("p50_duration").to_series().to_numpy().astype(np.float64),
+                )
+                abnormal_trace_metrics["p99_duration"] = (
+                    timestamps,
+                    abnormal_span_data.select("p99_duration").to_series().to_numpy().astype(np.float64),
+                )
+                abnormal_trace_metrics["max_duration"] = (
+                    timestamps,
+                    abnormal_span_data.select("max_duration").to_series().to_numpy().astype(np.float64),
+                )
+
+            # Note: Log metrics extraction is skipped for now as it requires span_id mapping
+            # which is more complex with the new (service, span) grouping
+            baseline_metrics = baseline_trace_metrics
+            abnormal_metrics = abnormal_trace_metrics
+
+            node = Node(
+                kind=PlaceKind.span,
+                self_name=span_full_name,
+                baseline_metrics=baseline_metrics,
+                abnormal_metrics=abnormal_metrics,
+            )
+            graph.add_node(node, strict=False)
+
+            # Create includes edge: service -> span
+            service_node = graph.get_node_by_name(f"{PlaceKind.service}|{service_name}")
+            span_node = graph.get_node_by_name(f"{PlaceKind.span}|{span_full_name}")
+
+            if service_node and span_node:
+                assert service_node.id is not None and span_node.id is not None
+                edge = Edge(
+                    src_id=service_node.id,
+                    dst_id=span_node.id,
+                    src_name=f"{PlaceKind.service}|{service_name}",
+                    dst_name=f"{PlaceKind.span}|{span_full_name}",
+                    kind=DepKind.includes,
+                    weight=1.0,
+                    data=None,
+                )
+                graph.add_edge(edge, strict=False)
+
+        logger.info(
+            f"Built {len(all_service_span_pairs) - filtered_count} span nodes "
+            f"(filtered out {filtered_count} generic HTTP method spans)"
+        )
+
+    def _batch_extract_span_log_metrics(
+        self,
+        span_names: list[str],
+        baseline_traces_df: pl.DataFrame,
+        abnormal_traces_df: pl.DataFrame,
+        baseline_logs_df: pl.DataFrame,
+        abnormal_logs_df: pl.DataFrame,
+    ) -> dict[str, tuple[dict[str, tuple[np.ndarray, np.ndarray]], dict[str, tuple[np.ndarray, np.ndarray]]]]:
+        """
+        Batch extract log metrics for multiple spans.
+
+        Returns:
+            Dict mapping span_name -> (baseline_metrics, abnormal_metrics)
+        """
+        result: dict[
+            str, tuple[dict[str, tuple[np.ndarray, np.ndarray]], dict[str, tuple[np.ndarray, np.ndarray]]]
+        ] = {}
+
+        # Build span_name -> span_ids mapping for baseline
+        if "level" in baseline_logs_df.columns and "span_id" in baseline_logs_df.columns:
+            baseline_span_mapping = (
+                baseline_traces_df.filter(pl.col("span_name").is_in(span_names))
+                .select(["span_name", "span_id"])
+                .unique()
+            )
+
+            # Join logs with span mapping and aggregate
+            baseline_logs_joined = baseline_logs_df.join(baseline_span_mapping, on="span_id", how="inner").with_columns(
+                [
+                    pl.col("time").dt.truncate("5s").alias("time_window"),
+                    (pl.col("level") == "ERROR").cast(pl.Int32).alias("is_error"),
+                    (pl.col("level") == "WARN").cast(pl.Int32).alias("is_warn"),
+                ]
+            )
+
+            baseline_agg = (
+                baseline_logs_joined.group_by(["span_name", "time_window"])
+                .agg(
+                    [
+                        pl.col("is_error").sum().alias("error_count"),
+                        pl.col("is_warn").sum().alias("warn_count"),
+                        pl.len().alias("total_count"),
+                    ]
+                )
+                .sort(["span_name", "time_window"])
+            )
+
+            # Extract per span
+            for span in span_names:
+                span_data = baseline_agg.filter(pl.col("span_name") == span)
+                baseline_metrics: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+
+                if len(span_data) > 0:
+                    timestamps = span_data.select("time_window").to_series().to_numpy()
+                    baseline_metrics["log.error_count"] = (
+                        timestamps,
+                        span_data.select("error_count").to_series().to_numpy().astype(np.float64),
+                    )
+                    baseline_metrics["log.warn_count"] = (
+                        timestamps,
+                        span_data.select("warn_count").to_series().to_numpy().astype(np.float64),
+                    )
+                    baseline_metrics["log.total_count"] = (
+                        timestamps,
+                        span_data.select("total_count").to_series().to_numpy().astype(np.float64),
+                    )
+
+                result[span] = (baseline_metrics, {})
+
+        # Build span_name -> span_ids mapping for abnormal
+        if "level" in abnormal_logs_df.columns and "span_id" in abnormal_logs_df.columns:
+            abnormal_span_mapping = (
+                abnormal_traces_df.filter(pl.col("span_name").is_in(span_names))
+                .select(["span_name", "span_id"])
+                .unique()
+            )
+
+            # Join logs with span mapping and aggregate
+            abnormal_logs_joined = abnormal_logs_df.join(abnormal_span_mapping, on="span_id", how="inner").with_columns(
+                [
+                    pl.col("time").dt.truncate("5s").alias("time_window"),
+                    (pl.col("level") == "ERROR").cast(pl.Int32).alias("is_error"),
+                    (pl.col("level") == "WARN").cast(pl.Int32).alias("is_warn"),
+                ]
+            )
+
+            abnormal_agg = (
+                abnormal_logs_joined.group_by(["span_name", "time_window"])
+                .agg(
+                    [
+                        pl.col("is_error").sum().alias("error_count"),
+                        pl.col("is_warn").sum().alias("warn_count"),
+                        pl.len().alias("total_count"),
+                    ]
+                )
+                .sort(["span_name", "time_window"])
+            )
+
+            # Extract per span
+            for span in span_names:
+                span_data = abnormal_agg.filter(pl.col("span_name") == span)
+                abnormal_metrics: dict[str, tuple[np.ndarray, np.ndarray]] = {}
+
+                if len(span_data) > 0:
+                    timestamps = span_data.select("time_window").to_series().to_numpy()
+                    abnormal_metrics["log.error_count"] = (
+                        timestamps,
+                        span_data.select("error_count").to_series().to_numpy().astype(np.float64),
+                    )
+                    abnormal_metrics["log.warn_count"] = (
+                        timestamps,
+                        span_data.select("warn_count").to_series().to_numpy().astype(np.float64),
+                    )
+                    abnormal_metrics["log.total_count"] = (
+                        timestamps,
+                        span_data.select("total_count").to_series().to_numpy().astype(np.float64),
+                    )
+
+                if span in result:
+                    baseline_metrics, _ = result[span]
+                    result[span] = (baseline_metrics, abnormal_metrics)
+                else:
+                    result[span] = ({}, abnormal_metrics)
+
+        # Fill in missing spans with empty metrics
+        for span in span_names:
+            if span not in result:
+                result[span] = ({}, {})
+
+        return result
+
+    def _build_edges_from_traces(
+        self,
+        baseline_traces_df: pl.DataFrame,
+        abnormal_traces_df: pl.DataFrame,
+        graph: HyperGraph,
+    ) -> list[Edge]:
+        """
+        Build logical edges from trace data at span level.
+
+        Creates span->span call edges based on parent_span_id relationships.
+        Aggregates both baseline and abnormal statistics for each edge.
+        Service-to-service edges are NOT created.
+
+        Span names use the format "{service_name}::{span_name}" to uniquely
+        identify spans across different services.
+        """
+        edges: list[Edge] = []
+
+        # Process baseline and abnormal traces separately
+        baseline_edge_stats = self._aggregate_trace_edges(baseline_traces_df)
+        abnormal_edge_stats = self._aggregate_trace_edges(abnormal_traces_df)
+
+        # Merge baseline and abnormal statistics
+        all_edge_pairs = set(baseline_edge_stats.keys()) | set(abnormal_edge_stats.keys())
+
+        # Create span->span call edges
+        for edge_key in all_edge_pairs:
+            parent_full_name, child_full_name = edge_key
+
+            # Edge may exist only in baseline or abnormal period - empty dict is valid default
+            baseline_stats = baseline_edge_stats.get(edge_key, {})
+            abnormal_stats = abnormal_edge_stats.get(edge_key, {})
+
+            parent_node = graph.get_node_by_name(f"{PlaceKind.span}|{parent_full_name}")
+            child_node = graph.get_node_by_name(f"{PlaceKind.span}|{child_full_name}")
+
+            if not parent_node or not child_node:
+                logger.debug(f"Skipping edge {parent_full_name} -> {child_full_name}: nodes not found")
+                continue
+
+            assert parent_node.id is not None and child_node.id is not None
+
+            # Helper to safely extract stat with explicit default for missing period
+            def get_stat(stats: dict, key: str, default: float = 0.0) -> float:
+                return float(stats[key]) if key in stats else default
+
+            # Create edge from parent to child with both baseline and abnormal stats
+            edge = Edge(
+                src_id=parent_node.id,
+                dst_id=child_node.id,
+                src_name=f"{PlaceKind.span}|{parent_full_name}",
+                dst_name=f"{PlaceKind.span}|{child_full_name}",
+                kind=DepKind.calls,
+                weight=get_stat(abnormal_stats, "call_count"),
+                data=CallsEdgeData(
+                    baseline_call_count=int(get_stat(baseline_stats, "call_count")),
+                    baseline_error_count=int(get_stat(baseline_stats, "error_count")),
+                    baseline_avg_latency=get_stat(baseline_stats, "avg_latency"),
+                    baseline_median_latency=get_stat(baseline_stats, "median_latency"),
+                    baseline_p90_latency=get_stat(baseline_stats, "p90_latency"),
+                    baseline_p99_latency=get_stat(baseline_stats, "p99_latency"),
+                    abnormal_call_count=int(get_stat(abnormal_stats, "call_count")),
+                    abnormal_error_count=int(get_stat(abnormal_stats, "error_count")),
+                    abnormal_avg_latency=get_stat(abnormal_stats, "avg_latency"),
+                    abnormal_median_latency=get_stat(abnormal_stats, "median_latency"),
+                    abnormal_p90_latency=get_stat(abnormal_stats, "p90_latency"),
+                    abnormal_p99_latency=get_stat(abnormal_stats, "p99_latency"),
+                ),
+            )
+            edges.append(edge)
+
+        return edges
+
+    def _aggregate_trace_edges(self, traces_df: pl.DataFrame) -> dict[tuple[str, str], dict[str, float]]:
+        """
+        Aggregate trace edges (parent->child span relationships) with statistics.
+
+        Generic HTTP method spans (GET, POST, etc.) are treated as bridges:
+        if parent -> GET -> child exists, it becomes parent -> child directly.
+
+        Span names are prefixed with service_name to create unique identifiers:
+        "{service_name}::{span_name}"
+
+        Args:
+            traces_df: Trace dataframe
+
+        Returns:
+            Dictionary mapping (parent_full_name, child_full_name) -> stats dict
+            where full_name = "{service_name}::{span_name}"
+            Stats include: call_count, error_count, avg_latency, median_latency, p90_latency, p99_latency
+        """
+        # Filter valid spans with span_name and service_name
+        valid_spans = traces_df.drop_nulls(subset=["span_name", "service_name"])
+
+        if len(valid_spans) == 0:
+            logger.warning("No valid spans found for aggregating edges")
+            return {}
+
+        # Build span_id -> (span_name, service_name, parent_span_id) mapping for bridge resolution
+        span_info = {}
+        for row in valid_spans.select(["trace_id", "span_id", "span_name", "service_name", "parent_span_id"]).iter_rows(
+            named=True
+        ):
+            key = (row["trace_id"], row["span_id"])
+            span_info[key] = {
+                "span_name": row["span_name"],
+                "service_name": row["service_name"],
+                "parent_span_id": row["parent_span_id"],
+            }
+
+        def resolve_real_parent(trace_id: str, parent_span_id: str | None, max_depth: int = 10) -> str | None:
+            """
+            Resolve the real parent by skipping generic HTTP method spans.
+            Returns the parent_span_id of the first non-generic ancestor.
+            """
+            current_parent_id = parent_span_id
+            depth = 0
+            while current_parent_id is not None and depth < max_depth:
+                parent_key = (trace_id, current_parent_id)
+                if parent_key not in span_info:
+                    # Parent span not found, return current
+                    return current_parent_id
+                parent_info = span_info[parent_key]
+                parent_name = parent_info["span_name"]
+                # If parent is a generic HTTP method span, skip to its parent
+                if is_generic_http_method_span(parent_name):
+                    current_parent_id = parent_info["parent_span_id"]
+                    depth += 1
+                else:
+                    # Found a non-generic parent
+                    return current_parent_id
+            return current_parent_id
+
+        # Create resolved parent_span_id for each span
+        resolved_parents = []
+        for row in valid_spans.select(["trace_id", "span_id", "parent_span_id"]).iter_rows(named=True):
+            resolved_parent_id = resolve_real_parent(row["trace_id"], row["parent_span_id"])
+            resolved_parents.append(
+                {
+                    "trace_id": row["trace_id"],
+                    "span_id": row["span_id"],
+                    "resolved_parent_span_id": resolved_parent_id,
+                }
+            )
+
+        resolved_df = pl.DataFrame(resolved_parents)
+
+        # Join resolved parents back to valid_spans
+        valid_spans = valid_spans.join(resolved_df, on=["trace_id", "span_id"], how="left")
+
+        # Convert duration to seconds and mark errors
+        valid_spans = valid_spans.with_columns(
+            [
+                (pl.col("duration") / 1e9).alias("duration_sec"),
+                (
+                    pl.col("attr.http.response.status_code").is_not_null()
+                    & (pl.col("attr.http.response.status_code") >= 500)
+                )
+                .cast(pl.Int32)
+                .alias("is_error"),
+                # Create full span name: service_name::span_name
+                (pl.col("service_name") + "::" + pl.col("span_name")).alias("child_full_name"),
+            ]
+        )
+
+        # Filter out generic HTTP method spans from being children (they are bridges, not endpoints)
+        valid_spans = valid_spans.filter(
+            ~pl.col("span_name").map_elements(is_generic_http_method_span, return_dtype=pl.Boolean)
+        )
+
+        # Build parent info with full name
+        parent_spans = valid_spans.select(
+            [
+                pl.col("trace_id"),
+                pl.col("span_id").alias("resolved_parent_span_id"),
+                (pl.col("service_name") + "::" + pl.col("span_name")).alias("parent_full_name"),
+            ]
+        )
+
+        # Merge child spans with their resolved parents
+        call_edges = valid_spans.join(parent_spans, on=["trace_id", "resolved_parent_span_id"], how="inner")
+
+        # Group by parent-child span pairs (using full names) and aggregate
+        agg_exprs = [
+            pl.len().alias("call_count"),
+            pl.col("is_error").sum().alias("error_count"),
+            pl.col("duration_sec").mean().alias("avg_latency"),
+            pl.col("duration_sec").quantile(0.5).alias("median_latency"),
+            pl.col("duration_sec").quantile(0.9).alias("p90_latency"),
+            pl.col("duration_sec").quantile(0.99).alias("p99_latency"),
+        ]
+
+        edge_agg = call_edges.group_by(["parent_full_name", "child_full_name"]).agg(agg_exprs)
+
+        # Filter out self-loops
+        edge_agg = edge_agg.filter(pl.col("parent_full_name") != pl.col("child_full_name"))
+
+        # Convert to dictionary
+        result = {}
+        for row in edge_agg.iter_rows(named=True):
+            key = (str(row["parent_full_name"]), str(row["child_full_name"]))
+            result[key] = {
+                "call_count": int(row["call_count"]),
+                "error_count": int(row["error_count"]),
+                "avg_latency": float(row["avg_latency"]),
+                "median_latency": float(row["median_latency"]),
+                "p90_latency": float(row["p90_latency"]),
+                "p99_latency": float(row["p99_latency"]),
+            }
+
+        return result

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/loaders/timing.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/loaders/timing.py
@@ -1,0 +1,28 @@
+import functools
+import os
+import time
+from pathlib import Path
+
+
+def timeit(func):
+    """Decorator to measure and log function execution time to .timeit.log
+
+    Only logs when ENABLE_TIMEIT environment variable is set.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if not os.getenv("ENABLE_TIMEIT"):
+            return func(*args, **kwargs)
+
+        start = time.perf_counter()
+        result = func(*args, **kwargs)
+        elapsed = time.perf_counter() - start
+
+        log_path = Path(".timeit.log")
+        with log_path.open("a") as f:
+            f.write(f"{func.__module__}.{func.__name__}: {elapsed:.6f}s\n")
+
+        return result
+
+    return wrapper

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/loaders/utils.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/loaders/utils.py
@@ -1,0 +1,264 @@
+import functools
+import logging
+import multiprocessing
+import multiprocessing.pool
+import os
+import time
+import traceback
+from collections.abc import Callable, Sequence
+from multiprocessing.pool import ThreadPool
+from pathlib import Path
+from typing import Any, Literal, TypeVar
+
+from tqdm.auto import tqdm
+
+logger = logging.getLogger(__name__)
+
+
+def timeit(func):
+    """Decorator to measure and log function execution time to .timeit.log
+
+    Only logs when ENABLE_TIMEIT environment variable is set.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if not os.getenv("ENABLE_TIMEIT"):
+            return func(*args, **kwargs)
+
+        start = time.perf_counter()
+        result = func(*args, **kwargs)
+        elapsed = time.perf_counter() - start
+
+        log_path = Path(".timeit.log")
+        with log_path.open("a") as f:
+            f.write(f"{func.__module__}.{func.__name__}: {elapsed:.6f}s\n")
+
+        return result
+
+    return wrapper
+
+
+def set_cpu_limit_outer(n: int | None) -> None:
+    if n is None:
+        return
+
+    os.environ["POLARS_MAX_THREADS"] = str(n)
+
+
+def set_cpu_limit_inner(n: int | None) -> None:
+    if n is None:
+        return
+
+    os.environ["POLARS_MAX_THREADS"] = str(n)
+
+    try:
+        import torch  # type: ignore
+
+        torch.set_num_threads(n)
+    except ImportError:
+        pass
+
+
+def call_initializers(init_list: list[tuple[Callable, Any]]) -> None:
+    for func, args in init_list:
+        func(*args)
+
+
+R = TypeVar("R")
+
+
+def _fmap(
+    mode: Literal["threadpool", "processpool"],
+    tasks: Sequence[Callable[[], R]],
+    *,
+    parallel: int,
+    ignore_exceptions: bool,
+    cpu_limit_each: int | None,
+    show_progress: bool = True,
+    log_level: int | None = None,
+    log_file: str | None = None,
+) -> list[R]:
+    if cpu_limit_each is not None:
+        assert mode == "processpool", "cpu_limit is only supported for processpool mode"
+        assert cpu_limit_each > 0, "cpu_limit must be greater than 0"
+
+    if not isinstance(tasks, list):
+        tasks = list(tasks)
+
+    if len(tasks) == 0:
+        return []
+
+    if parallel is None or parallel > 1:
+        num_workers = parallel or multiprocessing.cpu_count()
+        num_workers = min(num_workers, len(tasks))
+    else:
+        num_workers = 1
+
+    if num_workers > 1:
+        if mode == "threadpool":
+            pool: ThreadPool | multiprocessing.pool.Pool = ThreadPool(
+                processes=num_workers,
+            )
+        elif mode == "processpool":
+            set_cpu_limit_outer(cpu_limit_each)
+            pool = multiprocessing.get_context("spawn").Pool(
+                processes=num_workers,
+                initializer=call_initializers,
+                initargs=(initializers(cpu_limit=cpu_limit_each, log_level=log_level, log_file=log_file),),
+            )
+        else:
+            raise ValueError(f"Unknown mode: {mode}")
+
+        with pool:
+            # Use apply_async with direct function call
+            asyncs = [pool.apply_async(task) for task in tasks]
+            finished = [False] * len(asyncs)
+            index_results: list[tuple[int, R]] = []
+            exception_count = 0
+
+            with tqdm(total=len(asyncs), desc=f"fmap_{mode}", disable=not show_progress) as pbar:
+                while not all(finished):
+                    for i, async_ in enumerate(asyncs):
+                        if finished[i]:
+                            continue
+                        if not async_.ready():
+                            continue
+                        try:
+                            result = async_.get(timeout=0.1)
+                            finished[i] = True
+                            index_results.append((i, result))
+                            pbar.update(1)
+                        except multiprocessing.TimeoutError:
+                            continue
+                        except Exception as e:
+                            exception_count += 1
+                            finished[i] = True
+                            pbar.update(1)
+                            if ignore_exceptions:
+                                traceback.print_exc()
+                                logger.error(f"Exception in task {i}: {e}")
+                            else:
+                                raise e
+                    time.sleep(0.1)
+
+        index_results.sort(key=lambda x: x[0])
+        results = [result for _, result in index_results]
+    else:
+        results = []
+        exception_count = 0
+        for i, task in enumerate(tqdm(tasks, desc="fmap", disable=not show_progress)):
+            try:
+                result = task()
+                results.append(result)
+            except Exception as e:
+                exception_count += 1
+                if ignore_exceptions:
+                    traceback.print_exc()
+                    logger.error(f"Exception in task {i}: {e}")
+                else:
+                    raise e
+
+    if exception_count > 0:
+        logger.warning(f"fmap_{mode} completed with {exception_count} exceptions.")
+
+    logger.debug(f"fmap_{mode} completed with {len(results)} results in {len(tasks)} tasks.")
+
+    return results
+
+
+def fmap_threadpool(
+    tasks: Sequence[Callable[[], R]],
+    *,
+    parallel: int,
+    ignore_exceptions: bool = False,
+    show_progress: bool = True,
+) -> list[R]:
+    return _fmap(
+        "threadpool",
+        tasks,
+        parallel=parallel,
+        ignore_exceptions=ignore_exceptions,
+        cpu_limit_each=None,
+        show_progress=show_progress,
+    )
+
+
+def fmap_processpool(
+    tasks: Sequence[Callable[[], R]],
+    *,
+    parallel: int,
+    ignore_exceptions: bool = False,
+    cpu_limit_each: int | None = None,
+    show_progress: bool = True,
+    log_level: int | None = None,
+    log_file: str | None = None,
+) -> list[R]:
+    return _fmap(
+        "processpool",
+        tasks,
+        parallel=parallel,
+        ignore_exceptions=ignore_exceptions,
+        cpu_limit_each=cpu_limit_each,
+        show_progress=show_progress,
+        log_level=log_level,
+        log_file=log_file,
+    )
+
+
+def set_log_level(level: int | None) -> None:
+    """Set log level for src modules in child processes."""
+    if level is not None:
+        logging.getLogger("src").setLevel(level)
+
+
+def setup_subprocess_logging(log_file_path: str | None, log_level: int) -> None:
+    """Setup logging in subprocess to write to shared log file."""
+    formatter = logging.Formatter(
+        fmt="%(asctime)s - %(name)s - %(levelname)s - [PID:%(process)d] - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(log_level)
+    root_logger.handlers.clear()
+
+    # File handler (if specified)
+    if log_file_path:
+        file_handler = logging.FileHandler(log_file_path, mode="a", encoding="utf-8")
+        file_handler.setLevel(log_level)
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
+
+    # Console handler for critical errors
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.ERROR)  # Only show errors on console from subprocesses
+    console_handler.setFormatter(formatter)
+    root_logger.addHandler(console_handler)
+
+    # Suppress verbose logs from third-party libraries
+    logging.getLogger("openai").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("openai._base_client").setLevel(logging.WARNING)
+    logging.getLogger("httpcore.connection").setLevel(logging.WARNING)
+    logging.getLogger("anthropic").setLevel(logging.WARNING)
+    logging.getLogger("anthropic._base_client").setLevel(logging.WARNING)
+    logging.getLogger("openinference.instrumentation.langchain").setLevel(logging.INFO)
+
+
+def initializers(
+    *,
+    cpu_limit: int | None = None,
+    log_level: int | None = None,
+    log_file: str | None = None,
+) -> list[tuple[Callable, Any]]:
+    ans: list[tuple[Callable, Any]] = [
+        (set_cpu_limit_inner, (cpu_limit,)),
+    ]
+
+    # Setup logging in subprocess
+    if log_level is not None:
+        ans.append((setup_subprocess_logging, (log_file, log_level)))
+
+    return ans

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/graph.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/graph.py
@@ -484,7 +484,7 @@ class GraphEditSequence(BaseModel):
     def __getitem__(self, idx: int) -> GraphEdit:
         return self.edits[idx]
 
-    def __iter__(self):
+    def __iter__(self):  # type: ignore[override]
         return iter(self.edits)
 
 

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/graph.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/graph.py
@@ -1,0 +1,499 @@
+import itertools
+import logging
+from collections import defaultdict
+from datetime import datetime
+from enum import auto
+from typing import TYPE_CHECKING, Any
+
+import networkx as nx  # type: ignore[import-untyped]
+import numpy as np
+from pydantic import BaseModel, Field
+
+from rcabench_platform.compat import StrEnum
+
+if TYPE_CHECKING:
+    from .state import StateWindow
+
+logger = logging.getLogger(__name__)
+
+
+class PlaceKind(StrEnum):
+    machine = auto()
+    """k8s node"""
+
+    namespace = auto()
+    """k8s namespace"""
+
+    stateful_set = auto()
+    """k8s stateful set"""
+
+    deployment = auto()
+    """k8s deployment"""
+
+    replica_set = auto()
+    """k8s replica set"""
+
+    service = auto()
+    """k8s service"""
+
+    pod = auto()
+    """k8s pod"""
+
+    container = auto()
+    """k8s container"""
+
+    pvc = auto()
+    """k8s persistent volume claim"""
+
+    pv = auto()
+    """k8s persistent volume"""
+
+    configmap = auto()
+    """k8s config map"""
+
+    secret = auto()
+    """k8s secret"""
+
+    ingress = auto()
+    """k8s ingress"""
+
+    endpoints = auto()
+    """k8s endpoints"""
+
+    daemon_set = auto()
+    """k8s daemon set"""
+
+    function = auto()
+    """function"""
+
+    span = auto()
+    """distributed tracing span"""
+
+
+class DepKind(StrEnum):
+    owns = auto()
+    """namespace -> (service | stateful_set | deployment)"""
+
+    routes_to = auto()
+    """service -> pod"""
+
+    scales = auto()
+    """deployment -> replica_set"""
+
+    manages = auto()
+    """(stateful_set | replica_set) -> pod"""
+
+    schedules = auto()
+    """machine -> pod"""
+
+    runs = auto()
+    """pod -> container"""
+
+    claims = auto()
+    """pod -> pvc"""
+
+    binds_to = auto()
+    """pvc -> pv"""
+
+    calls = auto()
+    """(function | span) -> (function | span) - API call relationships in distributed tracing"""
+
+    includes = auto()
+    """service -> (function | span) - service contains API endpoints/spans"""
+
+    related_to = auto()
+    """service -> (stateful_set | deployment)"""
+
+    mounts = auto()
+    """container -> (pvc | configmap | secret)"""
+
+    exposes = auto()
+    """service -> endpoints"""
+
+    depends_on = auto()
+    """generic dependency relationship"""
+
+    affects = auto()
+    """resource interference/impact relationship"""
+
+
+class EdgeData(BaseModel):
+    pass
+
+
+class CallsEdgeData(EdgeData):
+    # Baseline (normal period) statistics
+    baseline_call_count: int = Field(default=0, ge=0, description="baseline total calls")
+    baseline_error_count: int = Field(default=0, ge=0, description="baseline errors (5xx status)")
+    baseline_avg_latency: float = Field(default=0.0, ge=0, description="baseline average latency in seconds")
+    baseline_median_latency: float = Field(default=0.0, ge=0, description="baseline median (p50) latency in seconds")
+    baseline_p90_latency: float = Field(default=0.0, ge=0, description="baseline p90 latency in seconds")
+    baseline_p99_latency: float = Field(default=0.0, ge=0, description="baseline p99 latency in seconds")
+
+    # Abnormal period statistics
+    abnormal_call_count: int = Field(default=0, ge=0, description="abnormal total calls")
+    abnormal_error_count: int = Field(default=0, ge=0, description="abnormal errors (5xx status)")
+    abnormal_avg_latency: float = Field(default=0.0, ge=0, description="abnormal average latency in seconds")
+    abnormal_median_latency: float = Field(default=0.0, ge=0, description="abnormal median (p50) latency in seconds")
+    abnormal_p90_latency: float = Field(default=0.0, ge=0, description="abnormal p90 latency in seconds")
+    abnormal_p99_latency: float = Field(default=0.0, ge=0, description="abnormal p99 latency in seconds")
+
+    @property
+    def baseline_qps(self) -> float:
+        return float(self.baseline_call_count)
+
+    @property
+    def baseline_error_rate(self) -> float:
+        return self.baseline_error_count / self.baseline_call_count if self.baseline_call_count > 0 else 0.0
+
+    @property
+    def abnormal_qps(self) -> float:
+        return float(self.abnormal_call_count)
+
+    @property
+    def abnormal_error_rate(self) -> float:
+        return self.abnormal_error_count / self.abnormal_call_count if self.abnormal_call_count > 0 else 0.0
+
+
+class Node(BaseModel):
+    model_config = {"arbitrary_types_allowed": True}
+
+    id: int | None = Field(default=None, description="node identifier")
+    kind: PlaceKind = Field(..., description="node type")
+    self_name: str = Field(..., description="node's own name")
+    uniq_name: str = Field(default="", description="unique identifier combining kind and name")
+    baseline_metrics: dict[str, tuple[np.ndarray, np.ndarray]] = Field(
+        default_factory=dict,
+        description="baseline (normal period) time-series metrics. "
+        "metric_name -> (timestamps, values). "
+        "timestamps: Unix seconds (shape: n); values: metric measurements (shape: n). ",
+    )
+    abnormal_metrics: dict[str, tuple[np.ndarray, np.ndarray]] = Field(
+        default_factory=dict,
+        description="abnormal period time-series metrics. "
+        "metric_name -> (timestamps, values). "
+        "timestamps: Unix seconds (shape: n); values: metric measurements (shape: n). ",
+    )
+    state_timeline: "list[StateWindow] | None" = Field(
+        default=None,
+        description="Time-windowed states. None = not computed; [] = computed but empty.",
+    )
+
+
+class Edge(BaseModel):
+    id: int | None = Field(default=None, description="edge identifier")
+    src_id: int = Field(..., description="source node ID")
+    dst_id: int = Field(..., description="target node ID")
+    src_name: str = Field(..., description="source node unique name")
+    dst_name: str = Field(..., description="target node unique name")
+    kind: DepKind = Field(..., description="edge type")
+    weight: float = Field(default=1.0, ge=0, description="edge weight")
+    data: CallsEdgeData | None = Field(..., description="type-specific metadata (CallsEdgeData, AffectsEdgeData, etc.)")
+
+
+class HyperGraph:
+    def __init__(self) -> None:
+        self._graph: nx.MultiDiGraph = nx.MultiDiGraph()
+
+        # node id generator
+        self._node_id_gen = itertools.count(1)
+
+        # edge id generator
+        self._edge_id_gen = itertools.count(1)
+
+        # node.id -> node
+        self._node_id_map: dict[int, Node] = {}
+
+        # edge.id -> edge
+        self._edge_id_map: dict[int, Edge] = {}
+
+        # node.uniq_name -> node
+        self._node_name_map: dict[str, Node] = {}
+
+        # node.kind -> set of node ids
+        self._node_kind_map: defaultdict[PlaceKind, set[int]] = defaultdict(set)
+
+        # edge.kind -> set of edge ids
+        self._edge_kind_map: defaultdict[DepKind, set[int]] = defaultdict(set)
+
+        # custom data
+        self.data: dict[str, Any] = {}
+
+    def add_node(self, node: Node, *, strict: bool = True) -> Node:
+        if not node.uniq_name:
+            node.uniq_name = f"{node.kind}|{node.self_name}"
+
+        if strict:
+            assert node.uniq_name not in self._node_name_map
+        else:
+            prev = self._node_name_map.get(node.uniq_name)
+            if prev:
+                return prev
+
+        if not node.id:
+            node.id = next(self._node_id_gen)
+        assert node.id not in self._node_id_map
+
+        self._graph.add_node(node.id, ref=node)
+        self._node_id_map[node.id] = node
+        self._node_name_map[node.uniq_name] = node
+        self._node_kind_map[node.kind].add(node.id)
+
+        return node
+
+    def add_edge(self, edge: Edge, *, strict: bool = True) -> Edge:
+        assert edge.src_id in self._node_id_map
+        assert edge.dst_id in self._node_id_map
+
+        edge_data = self._graph.edges.get((edge.src_id, edge.dst_id, edge.kind))
+        if strict:
+            assert edge_data is None
+        else:
+            if edge_data:
+                return edge_data["ref"]  # type: ignore[no-any-return]
+
+        if not edge.id:
+            edge.id = next(self._edge_id_gen)
+        assert edge.id not in self._edge_id_map
+
+        src_node = self.get_node_by_id(edge.src_id)
+        dst_node = self.get_node_by_id(edge.dst_id)
+        assert src_node is not None and dst_node is not None
+
+        self._graph.add_edge(edge.src_id, edge.dst_id, edge.kind, ref=edge)
+        self._edge_id_map[edge.id] = edge
+        self._edge_kind_map[edge.kind].add(edge.id)
+
+        return edge
+
+    def get_node_by_id(self, node_id: int) -> Node:
+        node = self._node_id_map.get(node_id)
+        assert node is not None and node.id is not None
+        return node
+
+    def get_node_by_name(self, uniq_name: str) -> Node | None:
+        node = self._node_name_map.get(uniq_name)
+        if node is not None:
+            assert node.id is not None
+        return node
+
+    def get_edge_by_id(self, edge_id: int) -> Edge | None:
+        return self._edge_id_map.get(edge_id)
+
+    def get_nodes_by_kind(self, kind: PlaceKind) -> list[Node]:
+        node_ids = self._node_kind_map.get(kind, set())
+        return [self._node_id_map[nid] for nid in node_ids]
+
+    def get_edges_by_kind(self, kind: DepKind) -> list[Edge]:
+        edge_ids = self._edge_kind_map.get(kind, set())
+        return [self._edge_id_map[eid] for eid in edge_ids]
+
+    def find_paths(self, source_id: int, target_id: int, max_depth: int = 5) -> list[list[int]]:
+        if source_id not in self._node_id_map or target_id not in self._node_id_map:
+            return []
+
+        try:
+            paths = nx.all_simple_paths(self._graph, source_id, target_id, cutoff=max_depth)
+            return [list(path) for path in paths]
+        except nx.NetworkXNoPath:
+            return []
+        except nx.NodeNotFound:
+            return []
+
+    def extract_subgraph(self, source_ids: list[int], target_ids: list[int], max_depth: int = 5) -> "HyperGraph":
+        forward_reachable = set()
+        for source_id in source_ids:
+            if source_id in self._node_id_map:
+                # BFS with depth limit
+                forward_reachable.add(source_id)
+                for target_id in self._node_id_map.keys():
+                    paths = self.find_paths(source_id, target_id, max_depth)
+                    if paths:
+                        for path in paths:
+                            forward_reachable.update(path)
+
+        # Compute backward reachable nodes from all targets
+        backward_reachable = set()
+        for target_id in target_ids:
+            if target_id in self._node_id_map:
+                # Reverse BFS with depth limit
+                backward_reachable.add(target_id)
+                for source_id in self._node_id_map.keys():
+                    paths = self.find_paths(source_id, target_id, max_depth)
+                    if paths:
+                        for path in paths:
+                            backward_reachable.update(path)
+
+        # Keep intersection: nodes reachable in both directions
+        relevant_nodes = forward_reachable & backward_reachable
+
+        # Build new subgraph
+        subgraph = HyperGraph()
+        subgraph.data = self.data.copy()
+
+        # Add relevant nodes
+        for node_id in relevant_nodes:
+            node = self._node_id_map[node_id]
+            subgraph.add_node(node.model_copy(deep=True), strict=False)
+
+        # Add edges where both endpoints are in relevant_nodes
+        for edge in self._edge_id_map.values():
+            if edge.src_id in relevant_nodes and edge.dst_id in relevant_nodes:
+                subgraph.add_edge(edge.model_copy(deep=True), strict=False)
+
+        return subgraph
+
+    def set_node_state_timeline(self, node_id: int, timeline: "list[StateWindow]") -> None:
+        """Set the state timeline for a node.
+
+        Args:
+            node_id: The node ID to set timeline for
+            timeline: List of StateWindow objects representing state changes over time
+        """
+        if node_id not in self._node_id_map:
+            raise KeyError(f"Node {node_id} not found in graph")
+        self._node_id_map[node_id].state_timeline = timeline
+
+    def get_node_state_timeline(self, node_id: int) -> "list[StateWindow] | None":
+        """Get the state timeline for a node.
+
+        Args:
+            node_id: The node ID to get timeline for
+
+        Returns:
+            List of StateWindow objects or None if not computed
+        """
+        if node_id not in self._node_id_map:
+            raise KeyError(f"Node {node_id} not found in graph")
+        return self._node_id_map[node_id].state_timeline
+
+
+class GraphEditType(StrEnum):
+    add_node = auto()
+    remove_node = auto()
+    add_edge = auto()
+    remove_edge = auto()
+
+
+class GraphEdit(BaseModel):
+    edit_type: GraphEditType = Field(..., description="type of edit operation")
+    timestamp: datetime | None = Field(default=None, description="when the edit occurred")
+    node: Node | None = Field(default=None, description="node for add_node")
+    edge: Edge | None = Field(default=None, description="edge for add_edge")
+    node_id: int | None = Field(default=None, description="node_id for remove_node")
+    edge_id: int | None = Field(default=None, description="edge_id for remove_edge")
+    _backup: dict[str, Any] = {}
+
+    def apply(self, graph: HyperGraph) -> bool:
+        try:
+            if self.edit_type == GraphEditType.add_node:
+                assert self.node is not None
+                graph.add_node(self.node, strict=False)
+            elif self.edit_type == GraphEditType.remove_node:
+                assert self.node_id is not None
+                node = graph.get_node_by_id(self.node_id)
+                if not node:
+                    return False
+                self._backup["node"] = node.model_dump()
+                del graph._node_id_map[self.node_id]
+                del graph._node_name_map[node.uniq_name]
+                graph._node_kind_map[node.kind].discard(self.node_id)
+                graph._graph.remove_node(self.node_id)
+            elif self.edit_type == GraphEditType.add_edge:
+                assert self.edge is not None
+                graph.add_edge(self.edge, strict=False)
+            elif self.edit_type == GraphEditType.remove_edge:
+                assert self.edge_id is not None
+                edge = graph.get_edge_by_id(self.edge_id)
+                if not edge:
+                    return False
+                self._backup["edge"] = edge.model_dump()
+                del graph._edge_id_map[self.edge_id]
+                graph._edge_kind_map[edge.kind].discard(self.edge_id)
+                if graph._graph.has_edge(edge.src_id, edge.dst_id, edge.kind):
+                    graph._graph.remove_edge(edge.src_id, edge.dst_id, edge.kind)
+            return True
+        except Exception as e:
+            logger.error(f"failed to apply {self.edit_type}: {e}")
+            return False
+
+    def inverse(self) -> "GraphEdit":
+        if self.edit_type == GraphEditType.add_node:
+            assert self.node is not None
+            return GraphEdit(
+                edit_type=GraphEditType.remove_node,
+                node_id=self.node.id,
+                timestamp=self.timestamp,
+            )
+        elif self.edit_type == GraphEditType.remove_node:
+            return GraphEdit(
+                edit_type=GraphEditType.add_node,
+                node=Node(**self._backup["node"]),
+                timestamp=self.timestamp,
+            )
+        elif self.edit_type == GraphEditType.add_edge:
+            assert self.edge is not None
+            return GraphEdit(
+                edit_type=GraphEditType.remove_edge,
+                edge_id=self.edge.id,
+                timestamp=self.timestamp,
+            )
+        elif self.edit_type == GraphEditType.remove_edge:
+            return GraphEdit(
+                edit_type=GraphEditType.add_edge,
+                edge=Edge(**self._backup["edge"]),
+                timestamp=self.timestamp,
+            )
+        raise ValueError(f"unknown edit type: {self.edit_type}")
+
+
+class GraphEditSequence(BaseModel):
+    edits: list[GraphEdit] = Field(default_factory=list, description="ordered edit operations")
+    start_timestamp: datetime | None = Field(default=None, description="sequence start time")
+    end_timestamp: datetime | None = Field(default=None, description="sequence end time")
+
+    def add(self, edit: GraphEdit) -> None:
+        self.edits.append(edit)
+        if edit.timestamp:
+            if not self.start_timestamp or edit.timestamp < self.start_timestamp:
+                self.start_timestamp = edit.timestamp
+            if not self.end_timestamp or edit.timestamp > self.end_timestamp:
+                self.end_timestamp = edit.timestamp
+
+    def apply(self, graph: HyperGraph) -> list[bool]:
+        return [edit.apply(graph) for edit in self.edits]
+
+    def apply_until(self, graph: HyperGraph, timestamp: datetime) -> list[bool]:
+        results = []
+        for edit in self.edits:
+            if edit.timestamp and edit.timestamp > timestamp:
+                break
+            results.append(edit.apply(graph))
+        return results
+
+    def inverse(self) -> "GraphEditSequence":
+        return GraphEditSequence(
+            edits=[edit.inverse() for edit in reversed(self.edits)],
+            start_timestamp=self.end_timestamp,
+            end_timestamp=self.start_timestamp,
+        )
+
+    def __len__(self) -> int:
+        return len(self.edits)
+
+    def __getitem__(self, idx: int) -> GraphEdit:
+        return self.edits[idx]
+
+    def __iter__(self):
+        return iter(self.edits)
+
+
+# Rebuild Node model to resolve forward reference to StateWindow
+# This is necessary because StateWindow is defined in state.py which imports from this module
+def _rebuild_models() -> None:
+    from rcabench_platform.v3.internal.reasoning.models.state import StateWindow  # noqa: F401
+
+    Node.model_rebuild()
+
+
+_rebuild_models()

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/injection.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/injection.py
@@ -1,0 +1,833 @@
+"""Injection metadata parsing and node resolution.
+
+This module provides tools to parse injection.json and resolve the true injection
+point based on fault type. Different fault types require different granularity:
+- HTTP faults: resolve to specific span by route matching
+- Container faults: resolve to container node
+- Network faults: resolve based on direction
+- JVM faults: resolve via mapping file (to be provided)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from rcabench_platform.v3.internal.reasoning.models.graph import HyperGraph, Node
+
+from rcabench_platform.v3.internal.reasoning.models.graph import PlaceKind
+
+logger = logging.getLogger(__name__)
+
+
+# Fault type names for reference
+FAULT_TYPES: list[str] = [
+    "PodKill",  # 0
+    "PodFailure",  # 1
+    "ContainerKill",  # 2
+    "MemoryStress",  # 3
+    "CPUStress",  # 4
+    "HTTPRequestAbort",  # 5
+    "HTTPResponseAbort",  # 6
+    "HTTPRequestDelay",  # 7
+    "HTTPResponseDelay",  # 8
+    "HTTPResponseReplaceBody",  # 9
+    "HTTPResponsePatchBody",  # 10
+    "HTTPRequestReplacePath",  # 11
+    "HTTPRequestReplaceMethod",  # 12
+    "HTTPResponseReplaceCode",  # 13
+    "DNSError",  # 14
+    "DNSRandom",  # 15
+    "TimeSkew",  # 16
+    "NetworkDelay",  # 17
+    "NetworkLoss",  # 18
+    "NetworkDuplicate",  # 19
+    "NetworkCorrupt",  # 20
+    "NetworkBandwidth",  # 21
+    "NetworkPartition",  # 22
+    "JVMLatency",  # 23
+    "JVMReturn",  # 24
+    "JVMException",  # 25
+    "JVMGarbageCollector",  # 26
+    "JVMCPUStress",  # 27
+    "JVMMemoryStress",  # 28
+    "JVMMySQLLatency",  # 29
+    "JVMMySQLException",  # 30
+]
+
+
+# Fault categories that require injection point state enhancement.
+# For these fault types, the injection point service's spans may not show detectable
+# anomalies in metrics. State enhancement explicitly marks them so propagation rules
+# can work correctly.
+INJECTION_POINT_ENHANCEMENT_CATEGORIES: set[str] = {
+    "container_resource",  # CPU/Memory stress - effects may not appear in spans
+    "pod_lifecycle",  # Pod lifecycle faults - may cause silent failures
+    "network",  # NetworkDelay, NetworkCorrupt, etc. - affects transport layer
+    "dns",  # DNS faults - resolution failures
+    "time",  # TimeSkew - clock issues
+}
+
+
+# Mapping fault_type index to category for resolution strategy
+FAULT_TYPE_CATEGORIES: dict[int, str] = {
+    # Pod/Container lifecycle -> container/pod node
+    0: "pod_lifecycle",  # PodKill
+    1: "pod_lifecycle",  # PodFailure
+    2: "pod_lifecycle",  # ContainerKill
+    # Container resource -> container node
+    3: "container_resource",  # MemoryStress
+    4: "container_resource",  # CPUStress
+    # HTTP request faults -> span node (matched by route)
+    5: "http_span",  # HTTPRequestAbort
+    6: "http_span",  # HTTPResponseAbort
+    7: "http_span",  # HTTPRequestDelay
+    8: "http_span",  # HTTPResponseDelay
+    9: "http_span",  # HTTPResponseReplaceBody
+    10: "http_span",  # HTTPResponsePatchBody
+    11: "http_span",  # HTTPRequestReplacePath
+    12: "http_span",  # HTTPRequestReplaceMethod
+    13: "http_span",  # HTTPResponseReplaceCode
+    # DNS faults -> service node
+    14: "dns",  # DNSError
+    15: "dns",  # DNSRandom
+    # Time -> pod node
+    16: "time",  # TimeSkew
+    # Network faults -> service based on direction
+    17: "network",  # NetworkDelay
+    18: "network",  # NetworkLoss
+    19: "network",  # NetworkDuplicate
+    20: "network",  # NetworkCorrupt
+    21: "network",  # NetworkBandwidth
+    22: "network",  # NetworkPartition
+    # JVM method faults -> span (via mapping) or container fallback
+    23: "jvm_method",  # JVMLatency
+    24: "jvm_method",  # JVMReturn
+    25: "jvm_method",  # JVMException
+    26: "jvm_method",  # JVMGarbageCollector
+    27: "jvm_method",  # JVMCPUStress
+    28: "jvm_method",  # JVMMemoryStress
+    # JVM database faults -> database span
+    29: "jvm_database",  # JVMMySQLLatency
+    30: "jvm_database",  # JVMMySQLException
+}
+
+# HTTP Response fault types - where propagation semantically starts from caller
+# These affect the response the caller receives, not the callee's processing
+HTTP_RESPONSE_FAULT_TYPES: set[int] = {
+    6,  # HTTPResponseAbort
+    8,  # HTTPResponseDelay
+    9,  # HTTPResponseReplaceBody
+    10,  # HTTPResponsePatchBody
+    13,  # HTTPResponseReplaceCode
+}
+
+
+def get_fault_category(fault_type: int, category: str) -> str:
+    """Get granular fault category for downstream StartingPointResolver.
+
+    Args:
+        fault_type: The numeric fault type
+        category: The coarse category from FAULT_TYPE_CATEGORIES
+
+    Returns:
+        Granular fault category: 'http_response', 'http_request', 'container',
+        'jvm', 'pod', 'network', 'dns', or 'service'
+    """
+    if category == "http_span":
+        if fault_type in HTTP_RESPONSE_FAULT_TYPES:
+            return "http_response"
+        return "http_request"
+    elif category == "container_resource":
+        return "container"
+    elif category == "pod_lifecycle":
+        return "pod"
+    elif category == "jvm_method":
+        return "jvm"
+    elif category == "jvm_database":
+        return "jvm_database"
+    # Keep network, dns, time as-is
+    return category
+
+
+class InjectionPoint(BaseModel):
+    """Parsed injection point from display_config.injection_point."""
+
+    # Common fields
+    app_name: str | None = None
+    namespace: str | None = None
+
+    # HTTP injection fields (fault_type 5-13)
+    method: str | None = None  # GET, POST, etc.
+    route: str | None = None  # /api/v1/trainservice/trains/byName/*
+    server_address: str | None = None
+    server_port: str | None = None
+
+    # Container injection fields (fault_type 3-4)
+    container_name: str | None = None
+    pod_name: str | None = None
+    app_label: str | None = None
+
+    # JVM injection fields (fault_type 23-28)
+    class_name: str | None = None
+    method_name: str | None = None
+
+    # Database injection fields (fault_type 29-30)
+    db_name: str | None = None
+    table_name: str | None = None
+    operation_type: str | None = None  # SELECT, INSERT, etc.
+
+    # Network injection fields (fault_type 17-22)
+    source_service: str | None = None
+    target_service: str | None = None
+    direction: str | None = None  # to, from, both
+
+    # DNS injection fields (fault_type 14-15)
+    domain: str | None = None  # Target domain that fails to resolve
+
+
+class InjectionMetadata(BaseModel):
+    """Full injection metadata parsed from injection.json."""
+
+    fault_type: int
+    injection_point: InjectionPoint
+    fault_type_name: str = ""
+
+    # Fault-specific parameters
+    delay_duration: int | None = None  # For delay faults (ms)
+    latency_ms: int | None = None  # For latency faults
+    latency_duration: int | None = None  # Alternative latency field
+    memory_size: int | None = None  # For memory faults (MB)
+
+    # Ground truth (for fallback)
+    ground_truth_services: list[str] = Field(default_factory=list)
+    ground_truth_containers: list[str] = Field(default_factory=list)
+    ground_truth_pods: list[str] = Field(default_factory=list)
+
+    @classmethod
+    def from_injection_json(cls, data: dict) -> InjectionMetadata:
+        """Parse injection.json dict into InjectionMetadata.
+
+        Accepts ``fault_type`` as either an int index into ``FAULT_TYPES`` (legacy
+        rca_label datapacks) or a string like ``"PodKill"`` (current AegisLab schema).
+        """
+        raw = data.get("fault_type", -1)
+        if isinstance(raw, str):
+            try:
+                fault_type = FAULT_TYPES.index(raw)
+            except ValueError:
+                fault_type = -1
+        else:
+            try:
+                fault_type = int(raw)
+            except (TypeError, ValueError):
+                fault_type = -1
+        fault_type_name = FAULT_TYPES[fault_type] if 0 <= fault_type < len(FAULT_TYPES) else "Unknown"
+
+        # Parse display_config which is a JSON string
+        display_config: dict = {}
+        display_config_str = data.get("display_config", "{}")
+        if isinstance(display_config_str, str):
+            try:
+                display_config = json.loads(display_config_str)
+            except json.JSONDecodeError:
+                logger.warning(f"Failed to parse display_config: {display_config_str[:100]}")
+
+        # Extract injection_point from display_config
+        injection_point_data = display_config.get("injection_point", {})
+        injection_point = InjectionPoint(
+            app_name=injection_point_data.get("app_name"),
+            namespace=display_config.get("namespace"),
+            method=injection_point_data.get("method"),
+            route=injection_point_data.get("route"),
+            server_address=injection_point_data.get("server_address"),
+            server_port=injection_point_data.get("server_port"),
+            container_name=injection_point_data.get("container_name"),
+            pod_name=injection_point_data.get("pod_name"),
+            app_label=injection_point_data.get("app_label"),
+            class_name=injection_point_data.get("class_name"),
+            method_name=injection_point_data.get("method_name"),
+            db_name=injection_point_data.get("db_name"),
+            table_name=injection_point_data.get("table_name"),
+            operation_type=injection_point_data.get("operation_type"),
+            source_service=injection_point_data.get("source_service"),
+            target_service=injection_point_data.get("target_service"),
+            direction=display_config.get("direction"),
+            domain=injection_point_data.get("domain"),
+        )
+
+        # Extract ground_truth for fallback. AegisLab emits a list[dict] (one entry per
+        # fault in a batch); rca_label legacy datapacks emit a single dict.
+        ground_truth = data.get("ground_truth", {})
+        gt_services: list[str] = []
+        gt_containers: list[str] = []
+        gt_pods: list[str] = []
+        gt_entries = ground_truth if isinstance(ground_truth, list) else [ground_truth]
+        for entry in gt_entries:
+            if not isinstance(entry, dict):
+                continue
+            gt_services.extend(entry.get("service", []) or [])
+            gt_containers.extend(entry.get("container", []) or [])
+            gt_pods.extend(entry.get("pod", []) or [])
+
+        return cls(
+            fault_type=fault_type,
+            fault_type_name=fault_type_name,
+            injection_point=injection_point,
+            delay_duration=display_config.get("delay_duration"),
+            latency_ms=display_config.get("latency_ms"),
+            latency_duration=display_config.get("latency_duration"),
+            memory_size=display_config.get("memory_size"),
+            ground_truth_services=gt_services,
+            ground_truth_containers=gt_containers,
+            ground_truth_pods=gt_pods,
+        )
+
+
+class ResolvedInjection(BaseModel):
+    """Result of injection node resolution."""
+
+    injection_nodes: list[str]  # List of node names (e.g., "span|GET /api/...")
+    start_kind: str  # "span", "container", "pod", or "service"
+    category: str  # Fault category from FAULT_TYPE_CATEGORIES
+    fault_category: str  # More granular category for downstream StartingPointResolver
+    # e.g., 'http_response', 'http_request', 'container', 'jvm', 'pod', 'network', 'dns'
+    fault_type_name: str  # Human-readable fault type name
+    resolution_method: str  # How the resolution was done (for debugging)
+    injection_point: InjectionPoint | None = None  # Original injection point config for downstream use
+
+
+class InjectionNodeResolver:
+    """Resolve injection.json to appropriate graph node(s).
+
+    This resolver uses the fault type and injection_point metadata to find
+    the true injection point at the appropriate granularity level.
+    """
+
+    def __init__(
+        self,
+        graph: HyperGraph,
+        jvm_method_mapping: dict[str, str] | None = None,
+    ):
+        """Initialize the resolver.
+
+        Args:
+            graph: The HyperGraph to resolve nodes against
+            jvm_method_mapping: Optional mapping from Java method (class.method)
+                               to span name. Will be loaded later if not provided.
+        """
+        self.graph = graph
+        self.jvm_method_mapping = jvm_method_mapping or {}
+
+    def resolve(self, injection_data: dict) -> ResolvedInjection:
+        """Resolve injection metadata to graph node names.
+
+        Args:
+            injection_data: Raw injection.json dict
+
+        Returns:
+            ResolvedInjection with injection nodes and metadata
+        """
+        metadata = InjectionMetadata.from_injection_json(injection_data)
+        fault_type = metadata.fault_type
+        category = FAULT_TYPE_CATEGORIES.get(fault_type, "service")
+        fault_category = get_fault_category(fault_type, category)
+        point = metadata.injection_point
+
+        logger.debug(f"Resolving fault type {fault_type} ({metadata.fault_type_name}), category: {category}")
+
+        if category == "http_span":
+            nodes, method = self._resolve_http_span(point, metadata)
+            return ResolvedInjection(
+                injection_nodes=nodes,
+                start_kind="span" if nodes and nodes[0].startswith("span|") else "service",
+                category=category,
+                fault_category=fault_category,
+                fault_type_name=metadata.fault_type_name,
+                resolution_method=method,
+                injection_point=point,
+            )
+
+        elif category == "container_resource":
+            nodes, method = self._resolve_container(point, metadata)
+            return ResolvedInjection(
+                injection_nodes=nodes,
+                start_kind="container" if nodes and nodes[0].startswith("container|") else "service",
+                category=category,
+                fault_category=fault_category,
+                fault_type_name=metadata.fault_type_name,
+                resolution_method=method,
+                injection_point=point,
+            )
+
+        elif category == "pod_lifecycle":
+            nodes, method = self._resolve_pod_lifecycle(point, metadata)
+            kind = "pod" if nodes and nodes[0].startswith("pod|") else "service"
+            if nodes and nodes[0].startswith("container|"):
+                kind = "container"
+            return ResolvedInjection(
+                injection_nodes=nodes,
+                start_kind=kind,
+                category=category,
+                fault_category=fault_category,
+                fault_type_name=metadata.fault_type_name,
+                resolution_method=method,
+                injection_point=point,
+            )
+
+        elif category == "jvm_method":
+            nodes, method = self._resolve_jvm_method(point, metadata)
+            kind = "span" if nodes and nodes[0].startswith("span|") else "service"
+            if nodes and nodes[0].startswith("container|"):
+                kind = "container"
+            return ResolvedInjection(
+                injection_nodes=nodes,
+                start_kind=kind,
+                category=category,
+                fault_category=fault_category,
+                fault_type_name=metadata.fault_type_name,
+                resolution_method=method,
+                injection_point=point,
+            )
+
+        elif category == "jvm_database":
+            nodes, method = self._resolve_database_span(point, metadata)
+            return ResolvedInjection(
+                injection_nodes=nodes,
+                start_kind="span" if nodes and nodes[0].startswith("span|") else "service",
+                category=category,
+                fault_category=fault_category,
+                fault_type_name=metadata.fault_type_name,
+                resolution_method=method,
+                injection_point=point,
+            )
+
+        elif category == "network":
+            nodes, method = self._resolve_network(point, metadata)
+            return ResolvedInjection(
+                injection_nodes=nodes,
+                start_kind="service",
+                category=category,
+                fault_category=fault_category,
+                fault_type_name=metadata.fault_type_name,
+                resolution_method=method,
+                injection_point=point,
+            )
+
+        elif category == "dns":
+            nodes, method = self._resolve_dns(point, metadata)
+            return ResolvedInjection(
+                injection_nodes=nodes,
+                start_kind="service",
+                category=category,
+                fault_category=fault_category,
+                fault_type_name=metadata.fault_type_name,
+                resolution_method=method,
+                injection_point=point,
+            )
+
+        elif category == "time":
+            nodes, method = self._resolve_time(point, metadata)
+            return ResolvedInjection(
+                injection_nodes=nodes,
+                start_kind="pod" if nodes and nodes[0].startswith("pod|") else "service",
+                category=category,
+                fault_category=fault_category,
+                fault_type_name=metadata.fault_type_name,
+                resolution_method=method,
+                injection_point=point,
+            )
+
+        else:
+            # Default fallback to service
+            nodes, method = self._resolve_service_fallback(metadata)
+            return ResolvedInjection(
+                injection_nodes=nodes,
+                start_kind="service",
+                category=category,
+                fault_category=fault_category,
+                fault_type_name=metadata.fault_type_name,
+                resolution_method=method,
+                injection_point=point,
+            )
+
+    def _resolve_http_span(
+        self,
+        point: InjectionPoint,
+        metadata: InjectionMetadata,
+    ) -> tuple[list[str], str]:
+        """Match HTTP route to span node belonging to app_name service.
+
+        This resolver finds spans that:
+        1. Match the route pattern
+        2. Belong to the app_name service (the caller that initiates the request)
+
+        For HTTP faults, app_name is the service where the fault is injected
+        (the caller making the request). We should match spans belonging to
+        this service, not the target service (server_address).
+
+        Span patterns to match:
+        - 'GET /api/v1/trainservice/trains/byName/{id}'
+        - 'HTTP GET http://ts-train-service:8080/api/v1/...'
+        """
+        route = point.route
+        method = point.method
+        server = point.server_address
+        caller = point.app_name
+
+        # Try to match spans by route if route info is available
+        if not route or not method:
+            # Fallback to service (prefer caller, then server)
+            fallback_service = caller or server
+            if not fallback_service and metadata.ground_truth_services:
+                fallback_service = metadata.ground_truth_services[0]
+            if fallback_service:
+                return [f"service|{fallback_service}"], "http_span_fallback_no_route"
+            return [], "http_span_no_route_no_service"
+
+        # Normalize route: replace wildcards with regex pattern
+        # /api/v1/trains/byName/* -> /api/v1/trains/byName/.*
+        route_pattern = re.escape(route).replace(r"\*", ".*")
+
+        # Try to match spans by route pattern, filtered by app_name service
+        matched_spans: list[str] = []
+        for node in self.graph.get_nodes_by_kind(PlaceKind.span):
+            span_name = node.self_name
+
+            # Check if span belongs to the caller service (app_name)
+            if caller and not self._span_belongs_to_service(node, caller):
+                continue
+
+            # Pattern 1: "{METHOD} /api/..."
+            if span_name.startswith(f"{method} "):
+                path_part = span_name[len(method) + 1 :]
+                if re.match(route_pattern, path_part):
+                    matched_spans.append(node.uniq_name)
+                    continue
+
+            # Pattern 2: "HTTP {METHOD} http://{server}:port/api/..."
+            if span_name.startswith(f"HTTP {method} http://"):
+                # Extract path from full URL
+                url_match = re.match(r"HTTP \w+ http://[^/]+(.+)", span_name)
+                if url_match:
+                    path_part = url_match.group(1)
+                    if re.match(route_pattern, path_part):
+                        matched_spans.append(node.uniq_name)
+                        continue
+
+        if matched_spans:
+            logger.debug(f"Matched {len(matched_spans)} spans for route {route} in service {caller}")
+            return matched_spans, "http_span_caller_service"
+
+        # Fallback: service of the caller (app_name)
+        fallback_service = caller or server
+        if not fallback_service and metadata.ground_truth_services:
+            fallback_service = metadata.ground_truth_services[0]
+
+        if fallback_service:
+            logger.debug(f"No span match for route {route}, falling back to service|{fallback_service}")
+            return [f"service|{fallback_service}"], "http_span_fallback_to_service"
+
+        return [], "http_span_no_match"
+
+    def _span_belongs_to_service(self, span_node: Node, service_name: str) -> bool:
+        """Check if a span belongs to the given service.
+
+        Uses the 'includes' edge: service --includes--> span
+
+        Args:
+            span_node: The span node to check
+            service_name: The service name to match (e.g., 'ts-preserve-service')
+
+        Returns:
+            True if the span belongs to the service
+        """
+        from rcabench_platform.v3.internal.reasoning.models.graph import DepKind
+
+        if span_node.id is None:
+            return False
+
+        # Find service that includes this span
+        for src_id, _dst_id, edge_key in self.graph._graph.in_edges(span_node.id, keys=True):
+            if edge_key == DepKind.includes:
+                src_node = self.graph.get_node_by_id(src_id)
+                if src_node and src_node.kind == PlaceKind.service:
+                    # Check if service name matches (with or without 'service|' prefix)
+                    if src_node.self_name == service_name or src_node.self_name == f"ts-{service_name}":
+                        return True
+                    # Also check partial match for cases like "ts-preserve-service" matching "preserve-service"
+                    if service_name in src_node.self_name or src_node.self_name in service_name:
+                        return True
+        return False
+
+    def _resolve_container(
+        self,
+        point: InjectionPoint,
+        metadata: InjectionMetadata,
+    ) -> tuple[list[str], str]:
+        """Resolve container fault to container node."""
+        container_name = point.container_name or point.app_label or point.app_name
+
+        if not container_name and metadata.ground_truth_containers:
+            # Filter out external services from container list
+            external_services = {"mysql", "redis", "postgres", "mongodb", "kafka", "rabbitmq"}
+            internal_containers = [c for c in metadata.ground_truth_containers if c not in external_services]
+            container_name = internal_containers[0] if internal_containers else metadata.ground_truth_containers[0]
+
+        if not container_name:
+            # Final fallback to service
+            return self._resolve_service_fallback(metadata)
+
+        # Try exact container match
+        container_node = self.graph.get_node_by_name(f"container|{container_name}")
+        if container_node:
+            return [container_node.uniq_name], "exact_container_match"
+
+        # Try partial match on container name
+        for node in self.graph.get_nodes_by_kind(PlaceKind.container):
+            if container_name in node.self_name:
+                return [node.uniq_name], "partial_container_match"
+
+        # Fallback to service
+        logger.debug(f"No container match for {container_name}, falling back to service")
+        return [f"service|{container_name}"], "fallback_to_service"
+
+    def _resolve_pod_lifecycle(
+        self,
+        point: InjectionPoint,
+        metadata: InjectionMetadata,
+    ) -> tuple[list[str], str]:
+        """Resolve pod lifecycle fault (PodKill, PodFailure, ContainerKill)."""
+        # For ContainerKill (fault_type 2), prefer container node
+        if metadata.fault_type == 2:
+            nodes, method = self._resolve_container(point, metadata)
+            if nodes:
+                return nodes, f"container_kill_{method}"
+
+        # For PodKill/PodFailure, try pod node
+        pod_name = point.pod_name
+        if not pod_name and metadata.ground_truth_pods:
+            pod_name = metadata.ground_truth_pods[0]
+
+        if pod_name:
+            pod_node = self.graph.get_node_by_name(f"pod|{pod_name}")
+            if pod_node:
+                return [pod_node.uniq_name], "exact_pod_match"
+
+            # Try partial match
+            for node in self.graph.get_nodes_by_kind(PlaceKind.pod):
+                if pod_name in node.self_name:
+                    return [node.uniq_name], "partial_pod_match"
+
+        # Fallback to container
+        nodes, method = self._resolve_container(point, metadata)
+        if nodes:
+            return nodes, f"fallback_{method}"
+
+        # Final fallback to service (prefer internal services)
+        return self._resolve_service_fallback(metadata)
+
+    def _resolve_jvm_method(
+        self,
+        point: InjectionPoint,
+        metadata: InjectionMetadata,
+    ) -> tuple[list[str], str]:
+        """Resolve JVM method fault to span via mapping.
+
+        JVM method: assurance.controller.AssuranceController.modifyAssurance
+        May map to span: "AssuranceController.modifyAssurance" or HTTP endpoint
+        """
+        if not point.class_name or not point.method_name:
+            # No method info, fall back to container
+            return self._resolve_container(point, metadata)
+
+        full_method = f"{point.class_name}.{point.method_name}"
+
+        # Use provided mapping if available
+        if full_method in self.jvm_method_mapping:
+            span_name = self.jvm_method_mapping[full_method]
+            span_node = self.graph.get_node_by_name(f"span|{span_name}")
+            if span_node:
+                return [span_node.uniq_name], "jvm_mapping"
+
+        # Try direct match - some spans are named like "Controller.method"
+        simple_class_name = point.class_name.split(".")[-1]  # Get just "AssuranceController"
+        direct_match_name = f"{simple_class_name}.{point.method_name}"
+
+        for node in self.graph.get_nodes_by_kind(PlaceKind.span):
+            if node.self_name == direct_match_name:
+                return [node.uniq_name], "direct_span_match"
+
+        # Fallback to container (JVM faults affect the whole container)
+        logger.debug(f"No span match for JVM method {full_method}, falling back to container")
+        nodes, method = self._resolve_container(point, metadata)
+        return nodes, f"jvm_fallback_{method}"
+
+    def _resolve_database_span(
+        self,
+        point: InjectionPoint,
+        metadata: InjectionMetadata,
+    ) -> tuple[list[str], str]:
+        """Resolve JVM database fault to database span.
+
+        Database spans are named like: "SELECT ts.trip2"
+        """
+        operation = point.operation_type  # SELECT, INSERT, etc.
+        db_name = point.db_name
+        table_name = point.table_name
+
+        if operation and db_name and table_name:
+            # Pattern: "SELECT ts.trip2"
+            span_name_pattern = f"{operation} {db_name}.{table_name}"
+
+            for node in self.graph.get_nodes_by_kind(PlaceKind.span):
+                if node.self_name == span_name_pattern:
+                    return [node.uniq_name], "exact_db_span_match"
+
+                # Partial match
+                if node.self_name.startswith(f"{operation} ") and table_name in node.self_name:
+                    return [node.uniq_name], "partial_db_span_match"
+
+        # Fallback to service (prefer app service over external mysql)
+        if metadata.ground_truth_services:
+            # Filter out external database services
+            external_services = {"mysql", "redis", "postgres", "mongodb"}
+            app_services = [s for s in metadata.ground_truth_services if s not in external_services]
+            if app_services:
+                return [f"service|{app_services[0]}"], "fallback_to_app_service"
+            return [f"service|{metadata.ground_truth_services[0]}"], "fallback_to_service"
+
+        return self._resolve_container(point, metadata)
+
+    def _resolve_network(
+        self,
+        point: InjectionPoint,
+        metadata: InjectionMetadata,
+    ) -> tuple[list[str], str]:
+        """Resolve network fault based on direction.
+
+        Network faults affect traffic between services.
+        User perceives fault at the caller side.
+
+        For external services (mysql, redis, etc.) that don't appear in traces,
+        we need to use the internal service that calls them.
+        """
+        source = point.source_service
+        target = point.target_service
+        direction = point.direction
+
+        # When A calls B and there's network issue, A perceives the problem
+        # For 'to' direction: fault on outgoing from source -> source perceives
+        # For 'from' direction: fault on incoming to source -> source perceives
+        # For 'both': both directions affected -> source perceives
+
+        # Check if source exists in graph
+        if source:
+            source_node = self.graph.get_node_by_name(f"service|{source}")
+            if source_node:
+                return [f"service|{source}"], f"network_source_{direction or 'unknown'}"
+
+            # Source not in graph (e.g., external mysql/redis)
+            # Use target instead since it's the internal service affected
+            logger.debug(f"Source service {source} not found in graph, using target service {target}")
+            if target:
+                target_node = self.graph.get_node_by_name(f"service|{target}")
+                if target_node:
+                    return [f"service|{target}"], f"network_target_{direction or 'unknown'}_source_external"
+
+        # Fallback to ground_truth services, excluding external services
+        if metadata.ground_truth_services:
+            # Filter out common external services
+            external_services = {"mysql", "redis", "postgres", "mongodb", "kafka", "rabbitmq"}
+            internal_services = [s for s in metadata.ground_truth_services if s not in external_services]
+
+            if internal_services:
+                return [f"service|{internal_services[0]}"], "fallback_to_internal_service"
+            # If only external services exist, use the first one anyway
+            return [f"service|{metadata.ground_truth_services[0]}"], "fallback_to_service"
+
+        return [], "no_network_source"
+
+    def _resolve_dns(
+        self,
+        point: InjectionPoint,
+        metadata: InjectionMetadata,
+    ) -> tuple[list[str], str]:
+        """Resolve DNS fault to service.
+
+        DNS faults affect service discovery, so we start from service level.
+        """
+        app_name = point.app_name
+        if app_name:
+            return [f"service|{app_name}"], "dns_app"
+
+        if metadata.ground_truth_services:
+            return [f"service|{metadata.ground_truth_services[0]}"], "dns_fallback_service"
+
+        return [], "no_dns_target"
+
+    def _resolve_time(
+        self,
+        point: InjectionPoint,
+        metadata: InjectionMetadata,
+    ) -> tuple[list[str], str]:
+        """Resolve time skew fault to pod.
+
+        Time skew affects system clock at pod level.
+        """
+        pod_name = point.pod_name
+        if pod_name:
+            pod_node = self.graph.get_node_by_name(f"pod|{pod_name}")
+            if pod_node:
+                return [pod_node.uniq_name], "time_pod"
+
+        # Fallback to service
+        if metadata.ground_truth_services:
+            return [f"service|{metadata.ground_truth_services[0]}"], "time_fallback_service"
+
+        return [], "no_time_target"
+
+    def _resolve_service_fallback(
+        self,
+        metadata: InjectionMetadata,
+    ) -> tuple[list[str], str]:
+        """Fallback resolution using ground_truth services.
+
+        Prioritizes internal services over external services (mysql, redis, etc.).
+        """
+        if metadata.ground_truth_services:
+            # Filter out common external services
+            external_services = {"mysql", "redis", "postgres", "mongodb", "kafka", "rabbitmq"}
+            internal_services = [s for s in metadata.ground_truth_services if s not in external_services]
+
+            if internal_services:
+                return [f"service|{internal_services[0]}"], "service_fallback_internal"
+            # If only external services exist, use the first one anyway
+            return [f"service|{metadata.ground_truth_services[0]}"], "service_fallback_all"
+
+        return [], "no_service_fallback"
+
+
+def resolve_injection_nodes(
+    injection_data: dict,
+    graph: HyperGraph,
+    jvm_method_mapping: dict[str, str] | None = None,
+) -> tuple[list[str], str]:
+    """Convenience function to resolve injection nodes.
+
+    Args:
+        injection_data: Raw injection.json dict
+        graph: The HyperGraph to resolve against
+        jvm_method_mapping: Optional JVM method to span mapping
+
+    Returns:
+        Tuple of (injection_node_names, start_kind)
+    """
+    resolver = InjectionNodeResolver(graph, jvm_method_mapping)
+    result = resolver.resolve(injection_data)
+    return result.injection_nodes, result.start_kind

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/injection.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/injection.py
@@ -553,7 +553,7 @@ class InjectionNodeResolver:
             return False
 
         # Find service that includes this span
-        for src_id, _dst_id, edge_key in self.graph._graph.in_edges(span_node.id, keys=True):
+        for src_id, _dst_id, edge_key in self.graph._graph.in_edges(span_node.id, keys=True):  # type: ignore[call-arg]
             if edge_key == DepKind.includes:
                 src_node = self.graph.get_node_by_id(src_id)
                 if src_node and src_node.kind == PlaceKind.service:

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/propagation.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/propagation.py
@@ -1,0 +1,52 @@
+"""Data models for fault propagation analysis."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PropagationPath:
+    """A single path in the fault propagation chain."""
+
+    nodes: list[int]  # Node IDs in order
+    states: list[list[str]]  # List of states at each node (each node can have multiple states)
+    edges: list[str]  # Edge descriptions (for visualization)
+    rules: list[str]  # Rule IDs applied at each hop
+    confidence: float  # Overall confidence (product of rule confidences)
+    state_start_times: list[int | None] = field(
+        default_factory=list
+    )  # Timestamp when each state started (Unix seconds, aligned to 10s)
+    propagation_delays: list[float] = field(default_factory=list)  # Time delay for each hop (seconds)
+
+
+@dataclass
+class PropagationResult:
+    injection_node_ids: list[int]
+    injection_states: list[str]
+    paths: list[PropagationPath]
+    visited_nodes: set[int]  # All nodes visited during propagation
+    max_hops_reached: int
+    subgraph_edges: list[tuple[int, int]] = field(default_factory=list)  # All edges in the reachable subgraph
+    warnings: list[str] = field(default_factory=list)  # Warnings about anomalies during propagation
+
+    def to_dict(self) -> dict:
+        """Convert PropagationResult to dictionary."""
+        return {
+            "injection_node_ids": self.injection_node_ids,
+            "injection_states": self.injection_states,
+            "paths": [
+                {
+                    "nodes": path.nodes,
+                    "states": path.states,
+                    "edges": path.edges,
+                    "rules": path.rules,
+                    "confidence": path.confidence,
+                    "state_start_times": path.state_start_times,
+                    "propagation_delays": path.propagation_delays,
+                }
+                for path in self.paths
+            ],
+            "visited_nodes": list(self.visited_nodes),
+            "max_hops_reached": self.max_hops_reached,
+            "subgraph_edges": [{"src": src, "dst": dst} for src, dst in self.subgraph_edges],
+            "warnings": self.warnings,
+        }

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/state.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/state.py
@@ -1,8 +1,8 @@
 from enum import auto
-from rcabench_platform.compat import StrEnum
 
 from pydantic import BaseModel
 
+from rcabench_platform.compat import StrEnum
 from rcabench_platform.v3.internal.reasoning.models.graph import PlaceKind
 
 

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/state.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/state.py
@@ -1,0 +1,206 @@
+from enum import auto
+from rcabench_platform.compat import StrEnum
+
+from pydantic import BaseModel
+
+from rcabench_platform.v3.internal.reasoning.models.graph import PlaceKind
+
+
+class StateWindow(BaseModel):
+    """Time window with associated states.
+
+    A node can have multiple states simultaneously (e.g., HIGH_CPU + HIGH_MEMORY).
+    """
+
+    start_time: int  # Unix timestamp (seconds)
+    end_time: int  # Unix timestamp (seconds)
+    states: set[str]  # Set of states active during this window
+
+    model_config = {"frozen": True}
+
+
+class MachineState(StrEnum):
+    UNKNOWN = auto()
+
+
+class NamespaceState(StrEnum):
+    ACTIVE = auto()
+    UNKNOWN = auto()
+
+
+class DeploymentState(StrEnum):
+    """States for K8s deployments.
+
+    Measurement:
+    - AVAILABLE: k8s.deployment.available == k8s.deployment.desired
+    - DEGRADED: k8s.deployment.available < k8s.deployment.desired
+    - FAILED: k8s.deployment.available == 0 AND k8s.deployment.desired > 0
+    - UNKNOWN: Metrics unavailable
+    """
+
+    AVAILABLE = auto()
+    DEGRADED = auto()
+    FAILED = auto()
+    UNKNOWN = auto()
+
+
+class StatefulSetState(StrEnum):
+    """States for K8s stateful sets.
+
+    Measurement:
+    - READY: k8s.statefulset.ready_pods == k8s.statefulset.desired_pods
+    - DEGRADED: k8s.statefulset.ready_pods < k8s.statefulset.desired_pods
+    - FAILED: k8s.statefulset.ready_pods == 0 AND k8s.statefulset.desired_pods > 0
+    - UNKNOWN: Metrics unavailable
+    """
+
+    READY = auto()
+    DEGRADED = auto()
+    FAILED = auto()
+    UNKNOWN = auto()
+
+
+class ReplicaSetState(StrEnum):
+    """States for K8s replica sets.
+
+    Measurement:
+    - AVAILABLE: k8s.replicaset.available == k8s.replicaset.desired
+    - DEGRADED: 0 < k8s.replicaset.available < k8s.replicaset.desired
+    - FAILED: k8s.replicaset.available == 0 AND k8s.replicaset.desired > 0
+    - UNKNOWN: Metrics unavailable
+    """
+
+    AVAILABLE = auto()
+    DEGRADED = auto()
+    FAILED = auto()
+    UNKNOWN = auto()
+
+
+class DaemonSetState(StrEnum):
+    UNKNOWN = auto()
+
+
+class PodState(StrEnum):
+    HEALTHY = auto()
+    UNKNOWN = auto()  # No data available in time window
+
+    KILLED = auto()
+    PROCESS_PAUSED = auto()  # e.g., chaos mesh pod-failure (pause container)
+
+    HIGH_CPU = auto()
+    HIGH_MEMORY = auto()
+    HIGH_DISK_USAGE = auto()  # Detected via k8s.pod.filesystem.usage anomaly
+    HIGH_NETWORK_ERRORS = auto()  # Detected via k8s.pod.network.errors anomaly
+    HIGH_HTTP_LATENCY = auto()  # Detected via http.server.request.duration anomaly
+    HIGH_GC_PRESSURE = auto()  # Detected via jvm.gc.duration anomaly (for Java apps)
+
+    DISK_SLOW = auto()
+    DISK_FAULT = auto()  # e.g., I/O errors
+    DISK_CORRUPTION = auto()  # e.g., data corruption detected
+    DISK_PERMISSION = auto()
+
+    NETWORK_DELAY = auto()
+    NETWORK_LOSS = auto()
+    NETWORK_DUPLICATION = auto()
+    NETWORK_CORRUPTION = auto()
+    NETWORK_REORDERING = auto()
+    NETWORK_BANDWIDTH_LIMIT = auto()
+    NETWORK_PARTITION = auto()
+    DNS_ERROR = auto()
+
+    CLOCK_SKEW = auto()
+
+    # === inferred state
+    NO_CPU_AVAILABLE = auto()
+    NO_MEMORY_AVAILABLE = auto()
+
+
+class ContainerState(StrEnum):
+    HEALTHY = auto()
+    UNKNOWN = auto()  # No data available in time window
+
+    KILLED = auto()
+    PROCESS_PAUSED = auto()
+    RESTARTING = auto()  # Container restart detected via k8s.container.restarts
+
+    HIGH_CPU = auto()
+    HIGH_MEMORY = auto()
+    HIGH_DISK_USAGE = auto()  # Detected via filesystem usage > 95%
+
+    DISK_SLOW = auto()
+    DISK_FAULT = auto()  # e.g., I/O errors
+    DISK_CORRUPTION = auto()  # e.g., data corruption detected
+    DISK_PERMISSION = auto()
+
+    CLOCK_SKEW = auto()
+
+    # === inferred state
+    NO_CPU_AVAILABLE = auto()
+    NO_MEMORY_AVAILABLE = auto()
+
+
+class ServiceState(StrEnum):
+    HEALTHY = auto()
+    HIGH_ERROR_RATE = auto()  # most of the spans have error status
+    HIGH_LATENCY = auto()  # most of the spans have high latency
+    UNAVAILABLE = auto()  # all spans are failing or timing out
+
+
+class SpanState(StrEnum):
+    HEALTHY = auto()  # No issues detected
+    UNKNOWN = auto()  # No data available in time window
+    HIGH_P99_LATENCY = auto()  # Span duration p99 significantly above baseline
+    HIGH_AVG_LATENCY = auto()  # Span duration average significantly above baseline
+    HIGH_ERROR_RATE = auto()  # Span error rate above baseline, e.g., HTTP 5xx
+    TIMEOUT = auto()  # Span duration exceeds timeout threshold
+    HIGH_LOG_ERROR = auto()  # High number of error logs within spans compared to baseline
+    MISSING_SPAN = auto()  # Request count dropped to 0 while baseline had significant traffic
+
+    CONNECTION_RESET = auto()  # e.g., TCP reset, HTTP abort
+    MALFORMED_RESPONSE = auto()  # e.g., body replacement/patching
+
+    # Infrastructure injection state - span affected by infrastructure fault (may not show in metrics)
+    INJECTION_AFFECTED = auto()
+
+
+STATE_ENUM_MAP: dict[PlaceKind, type[StrEnum]] = {
+    PlaceKind.machine: MachineState,
+    PlaceKind.namespace: NamespaceState,
+    PlaceKind.deployment: DeploymentState,
+    PlaceKind.stateful_set: StatefulSetState,
+    PlaceKind.replica_set: ReplicaSetState,
+    PlaceKind.daemon_set: DaemonSetState,
+    PlaceKind.pod: PodState,
+    PlaceKind.container: ContainerState,
+    PlaceKind.service: ServiceState,
+    PlaceKind.span: SpanState,
+}
+
+
+def get_state_enum(place_kind: PlaceKind) -> type[StrEnum]:
+    return STATE_ENUM_MAP[place_kind]
+
+
+def get_default_state(place_kind: PlaceKind) -> StrEnum:
+    """Get the default (normal) state for a given PlaceKind.
+
+    Args:
+        place_kind: The PlaceKind to get default state for
+
+    Returns:
+        The default state for the PlaceKind
+    """
+    get_state_enum(place_kind)
+    default_map = {
+        PlaceKind.machine: MachineState.UNKNOWN,
+        PlaceKind.namespace: NamespaceState.ACTIVE,
+        PlaceKind.deployment: DeploymentState.AVAILABLE,
+        PlaceKind.stateful_set: StatefulSetState.READY,
+        PlaceKind.replica_set: ReplicaSetState.AVAILABLE,
+        PlaceKind.daemon_set: DaemonSetState.UNKNOWN,
+        PlaceKind.pod: PodState.HEALTHY,
+        PlaceKind.container: ContainerState.HEALTHY,
+        PlaceKind.service: ServiceState.HEALTHY,
+        PlaceKind.span: SpanState.HEALTHY,
+    }
+    return default_map[place_kind]

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/builtin_rules.json
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/builtin_rules.json
@@ -1,0 +1,278 @@
+{
+    "$schema": "propagation_rules_schema.json",
+    "description": "Fault propagation rules with multi-granularity injection support",
+    "source": "Data-driven optimization + fault-type-aware injection support",
+    "version": "2.3-injection-point-enhancement",
+    "rules": [
+        {"_comment": "===== Container → Pod → Service → Span Multi-hop (for Container Resource Faults) ====="},
+        {
+            "name": "RULE_CONTAINER_RESOURCE_TO_SPANS",
+            "rule_id": "container_001",
+            "description": "Container HIGH_CPU/HIGH_MEMORY affects all spans of the service via multi-hop path. Resource stress can cause latency, errors, or even missing spans.",
+            "src_kind": "container",
+            "src_states": ["high_cpu", "high_memory"],
+            "path": [
+                {
+                    "edge_kind": "runs",
+                    "direction": "backward",
+                    "intermediate_kind": "pod",
+                    "intermediate_states": ["high_cpu", "high_memory", "healthy", "unknown"]
+                },
+                {"edge_kind": "routes_to", "direction": "backward", "intermediate_kind": "service"},
+                {"edge_kind": "includes", "direction": "forward"}
+            ],
+            "dst_kind": "span",
+            "possible_dst_states": ["HIGH_AVG_LATENCY", "HIGH_P99_LATENCY", "TIMEOUT", "MISSING_SPAN", "HIGH_ERROR_RATE"],
+            "confidence": 0.85
+        },
+        {
+            "name": "RULE_CONTAINER_RESTART_TO_SPANS",
+            "rule_id": "container_002",
+            "description": "Container RESTARTING causes missing spans via multi-hop path",
+            "src_kind": "container",
+            "src_states": ["RESTARTING"],
+            "path": [
+                {
+                    "edge_kind": "runs",
+                    "direction": "backward",
+                    "intermediate_kind": "pod",
+                    "intermediate_states": ["healthy", "unknown"]
+                },
+                {"edge_kind": "routes_to", "direction": "backward", "intermediate_kind": "service"},
+                {"edge_kind": "includes", "direction": "forward"}
+            ],
+            "dst_kind": "span",
+            "possible_dst_states": ["MISSING_SPAN", "HIGH_ERROR_RATE", "TIMEOUT"],
+            "confidence": 0.9
+        },
+        {"_comment": "===== Pod → Service → Span Multi-hop (for Pod Lifecycle Faults) ====="},
+        {
+            "name": "RULE_POD_RESOURCE_TO_SPANS",
+            "rule_id": "pod_001",
+            "description": "Pod HIGH_CPU/HIGH_MEMORY affects all spans of the service",
+            "src_kind": "pod",
+            "src_states": ["high_cpu", "high_memory"],
+            "path": [
+                {"edge_kind": "routes_to", "direction": "backward", "intermediate_kind": "service"},
+                {"edge_kind": "includes", "direction": "forward"}
+            ],
+            "dst_kind": "span",
+            "possible_dst_states": ["HIGH_AVG_LATENCY", "HIGH_P99_LATENCY", "TIMEOUT"],
+            "confidence": 0.85
+        },
+        {"_comment": "===== Service → Span First Hop ====="},
+        {
+            "name": "RULE_SERVICE_DELAY_TO_SPAN",
+            "rule_id": "service_001",
+            "description": "Service delay propagates to span latency (first hop). Usage: 81,043",
+            "src_kind": "service",
+            "src_states": [],
+            "edge_kind": "includes",
+            "direction": "forward",
+            "dst_kind": "span",
+            "possible_dst_states": ["HIGH_AVG_LATENCY", "HIGH_P99_LATENCY", "TIMEOUT"],
+            "confidence": 0.85,
+            "first_hop_config": {
+                "require_src_states": false,
+                "require_dst_states": true,
+                "lenient_dst_state_match": true
+            }
+        },
+        {
+            "name": "RULE_SERVICE_ERROR_TO_SPAN",
+            "rule_id": "service_002",
+            "description": "Service errors propagate to span errors (first hop). Included for completeness even with 0 usage.",
+            "src_kind": "service",
+            "src_states": ["ERROR", "UNAVAILABLE", "DOWN"],
+            "edge_kind": "includes",
+            "direction": "forward",
+            "dst_kind": "span",
+            "possible_dst_states": [
+                "HIGH_ERROR_RATE",
+                "TIMEOUT",
+                "CONNECTION_RESET",
+                "MISSING_SPAN",
+                "HIGH_LOG_ERROR",
+                "MALFORMED_RESPONSE"
+            ],
+            "confidence": 0.85,
+            "first_hop_config": {
+                "require_src_states": false,
+                "require_dst_states": true,
+                "lenient_dst_state_match": true
+            }
+        },
+        {"_comment": "===== Span-to-Span Propagation (Main Engine) ====="},
+        {
+            "name": "RULE_SPAN_HIGH_LATENCY_TO_CALLER",
+            "rule_id": "span_003",
+            "description": "Latency propagates through call chain. Usage: 191,012 (PRIMARY RULE)",
+            "src_kind": "span",
+            "src_states": ["HIGH_AVG_LATENCY", "HIGH_P99_LATENCY"],
+            "edge_kind": "calls",
+            "direction": "backward",
+            "dst_kind": "span",
+            "possible_dst_states": ["HIGH_AVG_LATENCY", "HIGH_P99_LATENCY", "TIMEOUT"],
+            "confidence": 0.8
+        },
+        {
+            "name": "RULE_SPAN_ERROR_TO_CALLER",
+            "rule_id": "span_004",
+            "description": "Errors propagate through call chain. Usage: 6,573",
+            "src_kind": "span",
+            "src_states": ["HIGH_ERROR_RATE", "TIMEOUT"],
+            "edge_kind": "calls",
+            "direction": "backward",
+            "dst_kind": "span",
+            "possible_dst_states": ["HIGH_ERROR_RATE", "TIMEOUT"],
+            "confidence": 0.8
+        },
+        {
+            "name": "RULE_SPAN_MISSING_TO_CALLER_ERROR",
+            "rule_id": "span_006",
+            "description": "Missing spans (e.g., from container restart) propagate as errors. Usage: 14,691",
+            "src_kind": "span",
+            "src_states": ["MISSING_SPAN"],
+            "edge_kind": "calls",
+            "direction": "backward",
+            "dst_kind": "span",
+            "possible_dst_states": ["HIGH_ERROR_RATE", "TIMEOUT", "MISSING_SPAN"],
+            "confidence": 0.85
+        },
+        {
+            "name": "RULE_SPAN_ERROR_BYPASS_HEALTHY_CONTROLLER",
+            "rule_id": "span_007",
+            "description": "Errors bypass healthy controller spans (Java OTel quirk). Usage: 32,311",
+            "src_kind": "span",
+            "src_states": ["HIGH_ERROR_RATE", "MISSING_SPAN"],
+            "path": [
+                {
+                    "edge_kind": "calls",
+                    "direction": "backward",
+                    "intermediate_kind": "span",
+                    "intermediate_states": ["healthy", "unknown"]
+                },
+                {"edge_kind": "calls", "direction": "backward"}
+            ],
+            "dst_kind": "span",
+            "possible_dst_states": ["HIGH_ERROR_RATE", "MISSING_SPAN"],
+            "confidence": 0.7
+        },
+        {
+            "name": "RULE_SPAN_ERROR_TO_CALLER_LATENCY",
+            "rule_id": "span_008",
+            "description": "Errors/timeouts cause upstream latency while waiting. Usage: 8 (new rule)",
+            "src_kind": "span",
+            "src_states": ["HIGH_ERROR_RATE", "TIMEOUT"],
+            "edge_kind": "calls",
+            "direction": "backward",
+            "dst_kind": "span",
+            "possible_dst_states": ["TIMEOUT"],
+            "confidence": 0.75
+        },
+        {
+            "name": "RULE_SPAN_INJECTION_AFFECTED_TO_CALLER",
+            "rule_id": "span_009",
+            "description": "Injection-affected spans propagate errors/latency to callers. For infrastructure faults (network, container, pod, dns) where injection point spans may not show detectable anomalies.",
+            "src_kind": "span",
+            "src_states": ["injection_affected"],
+            "edge_kind": "calls",
+            "direction": "backward",
+            "dst_kind": "span",
+            "possible_dst_states": ["HIGH_ERROR_RATE", "HIGH_AVG_LATENCY", "HIGH_P99_LATENCY", "TIMEOUT", "MISSING_SPAN"],
+            "confidence": 0.85
+        },
+        {
+            "name": "RULE_SPAN_HEALTHY_INJECTION_BYPASS_TO_ERROR",
+            "rule_id": "span_011",
+            "description": "For JVM method faults: injection span (controller, no error metrics) propagates through spans to reach caller HTTP spans with errors. Allows healthy/unknown src to bypass intermediate spans.",
+            "src_kind": "span",
+            "src_states": ["healthy", "unknown"],
+            "path": [
+                {
+                    "edge_kind": "calls",
+                    "direction": "backward",
+                    "intermediate_kind": "span",
+                    "intermediate_states": ["healthy", "unknown", "high_error_rate", "high_avg_latency", "high_p99_latency"]
+                },
+                {"edge_kind": "calls", "direction": "backward"}
+            ],
+            "dst_kind": "span",
+            "possible_dst_states": ["HIGH_ERROR_RATE", "HIGH_AVG_LATENCY", "HIGH_P99_LATENCY", "MISSING_SPAN"],
+            "confidence": 0.7,
+            "first_hop_config": {
+                "require_src_states": false,
+                "require_dst_states": true,
+                "lenient_dst_state_match": true
+            }
+        },
+        {"_comment": "===== Span → Pod → Span (JVM Stress Resource Contention via Pod) ====="},
+        {
+            "name": "RULE_SPAN_JVM_STRESS_TO_SIBLING_VIA_POD",
+            "rule_id": "span_010",
+            "description": "JVM stress span affects sibling spans via pod resource contention. Requires pod to have HIGH_MEMORY/HIGH_CPU state to validate resource contention causality.",
+            "src_kind": "span",
+            "src_states": ["HIGH_AVG_LATENCY", "HIGH_P99_LATENCY"],
+            "path": [
+                {
+                    "edge_kind": "includes",
+                    "direction": "backward",
+                    "intermediate_kind": "service"
+                },
+                {
+                    "edge_kind": "routes_to",
+                    "direction": "forward",
+                    "intermediate_kind": "pod",
+                    "intermediate_states": ["high_memory", "high_cpu"]
+                },
+                {
+                    "edge_kind": "routes_to",
+                    "direction": "backward",
+                    "intermediate_kind": "service"
+                },
+                {"edge_kind": "includes", "direction": "forward"}
+            ],
+            "dst_kind": "span",
+            "possible_dst_states": ["HIGH_AVG_LATENCY", "HIGH_P99_LATENCY", "TIMEOUT"],
+            "confidence": 0.8,
+            "first_hop_config": {
+                "require_src_states": true,
+                "require_dst_states": false,
+                "lenient_dst_state_match": true
+            }
+        }
+    ],
+    "notes": {
+        "optimization": "Multi-granularity injection support - rules for container, pod, and service starting points",
+        "version_2.3_changes": [
+            "Added span_009: INJECTION_AFFECTED spans propagate to callers for infrastructure faults"
+        ],
+        "version_2.2_changes": [
+            "Added first_hop_config to service_001 and service_002 for explicit first-hop validation",
+            "Removed unused rule_categories section"
+        ],
+        "version_2.1_changes": [
+            "Added container_001: Container resource faults to spans via multi-hop",
+            "Added container_002: Container restart to missing spans via multi-hop",
+            "Added pod_001: Pod resource faults to spans via multi-hop"
+        ],
+        "removed_from_v2.0-streamlined": [
+            "span_005: Circuit breaker (no usage data)",
+            "network_001, network_002: Pod network faults (0 usage)",
+            "disk_004, disk_005, disk_006: Pod disk faults (0 usage)",
+            "stress_003, stress_004: Pod resource competition (0 usage)"
+        ],
+        "architecture": {
+            "preprocessor": "Container RESTARTING → Span MISSING_SPAN (before rule propagation)",
+            "injection_point_enhancer": "Infrastructure faults → Mark injection service spans as INJECTION_AFFECTED",
+            "first_hop_container": "Container[injection] → Pod → Service → Span (container_001/002)",
+            "first_hop_pod": "Pod[injection] → Service → Span (pod_001)",
+            "first_hop_service": "Service[injection] → Span (service_001/002) - uses first_hop_config for lenient matching",
+            "first_hop_span": "Span[injection] → Caller Spans (span_003/004 as first hop for HTTP faults)",
+            "main_engine": "Span → Span chains (span_003-009)",
+            "propagation_source_note": "HTTP Response fault handling uses fault_category in StartingPointResolver, not rule-level propagation_source"
+        },
+        "first_hop_config_note": "Service rules use first_hop_config with lenient matching since service is a dummy aggregation node without observable states",
+        "service_002_note": "Kept despite 0 usage for completeness - captures first-hop error propagation to spans"
+    }
+}

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/builtin_rules.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/builtin_rules.py
@@ -142,10 +142,3 @@ def get_rules_for_place_kind(place_kind: PlaceKind, as_source: bool = True) -> l
         return [rule for rule in _get_builtin_rules_list() if rule.src_kind == place_kind]
     else:
         return [rule for rule in _get_builtin_rules_list() if rule.dst_kind == place_kind]
-
-
-def visualize_builtin_rules(output_path: str | None = None, format: str = "png") -> str:
-    from rcabench_platform.v3.internal.reasoning.rules.visualizer import visualize_rules
-
-    dot = visualize_rules(_get_builtin_rules_list(), output_path=output_path, format=format, group_by_place_kind=True)
-    return dot.source  # type: ignore[no-any-return]

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/builtin_rules.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/builtin_rules.py
@@ -1,0 +1,151 @@
+"""Built-in fault propagation rules aligned with ChaosMesh fault injection.
+
+These rules encode realistic fault propagation patterns based on ChaosMesh
+injection capabilities in cloud-native environments.
+
+Rules are loaded from builtin_rules.json. The PropagationRule model automatically
+converts string values to the appropriate enum types during initialization.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from rcabench_platform.v3.internal.reasoning.models.graph import DepKind, PlaceKind
+from rcabench_platform.v3.internal.reasoning.rules.schema import PropagationRule
+
+# ==============================================================================
+# JSON Rules Loading
+# ==============================================================================
+
+# JSON files are co-located with this module.
+_RULES_JSON_PATH = Path(__file__).parent / "builtin_rules.json"
+_rules_cache: dict[str, PropagationRule] | None = None
+
+
+def _load_rules_from_json() -> dict[str, PropagationRule]:
+    """Load rules from JSON file and return as dict keyed by rule name."""
+    global _rules_cache
+    if _rules_cache is not None:
+        return _rules_cache
+
+    with open(_RULES_JSON_PATH, encoding="utf-8") as f:
+        data = json.load(f)
+
+    rules: dict[str, PropagationRule] = {}
+    for rule_data in data.get("rules", []):
+        # Skip comment-only entries
+        if "_comment" in rule_data and len(rule_data) == 1:
+            continue
+
+        rule_name = rule_data.pop("name", None)
+        if rule_name is None:
+            rule_name = f"RULE_{rule_data.get('rule_id', 'unknown').upper()}"
+
+        # Remove fields not in PropagationRule model
+        rule_data.pop("_comment", None)
+
+        # Convert state strings to lowercase to match enum values
+        # Original code used enums like SpanState.HIGH_AVG_LATENCY whose .value is 'high_avg_latency'
+        if "src_states" in rule_data:
+            rule_data["src_states"] = [s.lower() for s in rule_data["src_states"]]
+        if "possible_dst_states" in rule_data:
+            rule_data["possible_dst_states"] = [s.lower() for s in rule_data["possible_dst_states"]]
+
+        # Create PropagationRule - validators handle string-to-enum conversion
+        rule = PropagationRule(**rule_data)
+        rules[rule_name] = rule
+
+    _rules_cache = rules
+    return rules
+
+
+def _get_rules_dict() -> dict[str, PropagationRule]:
+    """Get the cached rules dictionary."""
+    return _load_rules_from_json()
+
+
+# ==============================================================================
+# Dynamic Module Attributes for Backward Compatibility
+# ==============================================================================
+# This allows: from builtin_rules import RULE_POD_KILL_TO_CONTAINER
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically provide rule variables like RULE_POD_KILL_TO_CONTAINER."""
+    if name.startswith("RULE_"):
+        rules = _get_rules_dict()
+        if name in rules:
+            return rules[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """List available module attributes including dynamic rule names."""
+    base = [
+        "BUILTIN_RULES",
+        "get_builtin_rules",
+        "get_rules_for_edge_kind",
+        "get_rules_for_place_kind",
+        "visualize_builtin_rules",
+    ]
+    rules = _get_rules_dict()
+    return base + list(rules.keys())
+
+
+# ==============================================================================
+# Rule Database
+# ==============================================================================
+
+
+def _get_builtin_rules_list() -> list[PropagationRule]:
+    """Get the ordered list of builtin rules."""
+    return list(_get_rules_dict().values())
+
+
+# Lazy-loaded BUILTIN_RULES for backward compatibility
+# Use property-like access through module __getattr__
+class _BuiltinRulesProxy:
+    """Proxy object that behaves like a list but loads rules lazily."""
+
+    def __iter__(self):
+        return iter(_get_builtin_rules_list())
+
+    def __len__(self):
+        return len(_get_builtin_rules_list())
+
+    def __getitem__(self, idx):
+        return _get_builtin_rules_list()[idx]
+
+    def copy(self):
+        return _get_builtin_rules_list().copy()
+
+    def __repr__(self):
+        return repr(_get_builtin_rules_list())
+
+
+BUILTIN_RULES: list[PropagationRule] = _BuiltinRulesProxy()  # type: ignore[assignment]
+
+
+def get_builtin_rules() -> list[PropagationRule]:
+    return _get_builtin_rules_list().copy()
+
+
+def get_rules_for_edge_kind(edge_kind: DepKind) -> list[PropagationRule]:
+    return [rule for rule in _get_builtin_rules_list() if rule.edge_kind == edge_kind]
+
+
+def get_rules_for_place_kind(place_kind: PlaceKind, as_source: bool = True) -> list[PropagationRule]:
+    if as_source:
+        return [rule for rule in _get_builtin_rules_list() if rule.src_kind == place_kind]
+    else:
+        return [rule for rule in _get_builtin_rules_list() if rule.dst_kind == place_kind]
+
+
+def visualize_builtin_rules(output_path: str | None = None, format: str = "png") -> str:
+    from rcabench_platform.v3.internal.reasoning.rules.visualizer import visualize_rules
+
+    dot = visualize_rules(_get_builtin_rules_list(), output_path=output_path, format=format, group_by_place_kind=True)
+    return dot.source  # type: ignore[no-any-return]

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/propagation_rules_example.json
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/propagation_rules_example.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "propagation_rules_schema.json",
+  "description": "Propagation rule definitions - reference for Agent to generate new rules",
+  
+  "available_node_kinds": [
+    "machine", "namespace", "deployment", "replica_set", "stateful_set",
+    "daemon_set", "pod", "container", "service", "span",
+    "pvc", "pv", "configmap", "secret", "ingress", "endpoints", "function"
+  ],
+  
+  "available_edge_kinds": [
+    "owns", "routes_to", "scales", "manages", "schedules", 
+    "runs", "claims", "binds_to", "calls", "includes", 
+    "related_to", "mounts", "exposes", "depends_on", "affects"
+  ],
+  
+  "available_directions": ["forward", "backward"],
+  
+  "available_states": {
+    "machine": ["UNKNOWN"],
+    "namespace": ["ACTIVE", "UNKNOWN"],
+    "deployment": ["AVAILABLE", "DEGRADED", "FAILED", "UNKNOWN"],
+    "stateful_set": ["READY", "DEGRADED", "FAILED", "UNKNOWN"],
+    "replica_set": ["AVAILABLE", "DEGRADED", "FAILED", "UNKNOWN"],
+    "daemon_set": ["UNKNOWN"],
+    "pod": [
+      "HEALTHY", "KILLED", "PROCESS_PAUSED",
+      "HIGH_CPU", "HIGH_MEMORY", "HIGH_DISK_USAGE", "HIGH_NETWORK_ERRORS", 
+      "HIGH_HTTP_LATENCY", "HIGH_GC_PRESSURE",
+      "DISK_SLOW", "DISK_FAULT", "DISK_CORRUPTION", "DISK_PERMISSION",
+      "NETWORK_DELAY", "NETWORK_LOSS", "NETWORK_DUPLICATION", "NETWORK_CORRUPTION", 
+      "NETWORK_REORDERING", "NETWORK_BANDWIDTH_LIMIT", "NETWORK_PARTITION", "DNS_ERROR",
+      "CLOCK_SKEW", "NO_CPU_AVAILABLE", "NO_MEMORY_AVAILABLE"
+    ],
+    "container": [
+      "HEALTHY", "KILLED", "PROCESS_PAUSED",
+      "HIGH_CPU", "HIGH_MEMORY", "HIGH_DISK_USAGE",
+      "DISK_SLOW", "DISK_FAULT", "DISK_CORRUPTION", "DISK_PERMISSION",
+      "CLOCK_SKEW", "NO_CPU_AVAILABLE", "NO_MEMORY_AVAILABLE"
+    ],
+    "service": ["HEALTHY", "HIGH_ERROR_RATE", "HIGH_LATENCY", "UNAVAILABLE"],
+    "span": [
+      "HEALTHY", "HIGH_P99_LATENCY", "HIGH_AVG_LATENCY", "HIGH_ERROR_RATE",
+      "TIMEOUT", "HIGH_LOG_ERROR", "CONNECTION_RESET", "MALFORMED_RESPONSE"
+    ]
+  },
+
+  "default_states": {
+    "machine": "UNKNOWN",
+    "namespace": "ACTIVE",
+    "deployment": "AVAILABLE",
+    "stateful_set": "READY",
+    "replica_set": "AVAILABLE",
+    "daemon_set": "UNKNOWN",
+    "pod": "HEALTHY",
+    "container": "HEALTHY",
+    "service": "HEALTHY",
+    "span": "HEALTHY"
+  },
+
+  "rules": [
+    {
+      "_comment": "===== Single-hop Rules =====",
+      "_usage": "Use edge_kind + direction for direct neighbor propagation"
+    },
+    {
+      "rule_id": "pod_kill_to_container",
+      "description": "Pod termination causes all containers to be killed",
+      "src_kind": "pod",
+      "src_states": ["KILLED"],
+      "edge_kind": "runs",
+      "direction": "forward",
+      "dst_kind": "container",
+      "possible_dst_states": ["KILLED"],
+      "confidence": 0.95
+    },
+    {
+      "rule_id": "container_high_cpu_to_pod",
+      "description": "Container CPU stress aggregates to pod-level metrics",
+      "src_kind": "container",
+      "src_states": ["HIGH_CPU"],
+      "edge_kind": "runs",
+      "direction": "backward",
+      "dst_kind": "pod",
+      "possible_dst_states": ["HIGH_CPU"],
+      "confidence": 0.85
+    },
+    {
+      "rule_id": "pod_high_cpu_to_container_starvation",
+      "description": "Pod CPU saturation causes resource starvation in sibling containers",
+      "src_kind": "pod",
+      "src_states": ["HIGH_CPU"],
+      "edge_kind": "runs",
+      "direction": "forward",
+      "dst_kind": "container",
+      "possible_dst_states": ["NO_CPU_AVAILABLE"],
+      "confidence": 0.7
+    },
+    {
+      "rule_id": "span_latency_to_caller",
+      "description": "Downstream span latency propagates back to upstream caller spans (callee slow → caller waits)",
+      "src_kind": "span",
+      "src_states": ["HIGH_AVG_LATENCY", "HIGH_P99_LATENCY"],
+      "edge_kind": "calls",
+      "direction": "backward",
+      "dst_kind": "span",
+      "possible_dst_states": ["HIGH_AVG_LATENCY", "HIGH_P99_LATENCY", "TIMEOUT"],
+      "confidence": 0.8
+    },
+    {
+      "rule_id": "span_error_to_caller",
+      "description": "Downstream span errors propagate back to upstream caller spans (callee error → caller sees error)",
+      "src_kind": "span",
+      "src_states": ["HIGH_ERROR_RATE", "TIMEOUT", "CONNECTION_RESET", "MALFORMED_RESPONSE"],
+      "edge_kind": "calls",
+      "direction": "backward",
+      "dst_kind": "span",
+      "possible_dst_states": ["HIGH_ERROR_RATE", "TIMEOUT", "HIGH_LOG_ERROR"],
+      "confidence": 0.8,
+      "edge_condition": {
+        "field": "data.abnormal_error_rate",
+        "operator": ">",
+        "value": 0.05
+      }
+    },
+
+    {
+      "_comment": "===== Multi-hop Rules =====",
+      "_usage": "Use path array for causal chains spanning multiple nodes"
+    },
+    {
+      "rule_id": "pod_network_delay_to_span",
+      "description": "Pod network delay propagates through Service to Span latency",
+      "src_kind": "pod",
+      "src_states": ["NETWORK_DELAY", "NETWORK_BANDWIDTH_LIMIT"],
+      "path": [
+        {"edge_kind": "routes_to", "direction": "backward", "intermediate_kind": "service"},
+        {"edge_kind": "includes", "direction": "forward"}
+      ],
+      "dst_kind": "span",
+      "possible_dst_states": ["HIGH_AVG_LATENCY", "HIGH_P99_LATENCY"],
+      "confidence": 0.85
+    },
+    {
+      "rule_id": "pod_network_loss_to_span",
+      "description": "Pod network packet loss propagates through Service to Span errors",
+      "src_kind": "pod",
+      "src_states": ["NETWORK_LOSS", "NETWORK_CORRUPTION", "NETWORK_PARTITION", "DNS_ERROR"],
+      "path": [
+        {"edge_kind": "routes_to", "direction": "backward", "intermediate_kind": "service"},
+        {"edge_kind": "includes", "direction": "forward"}
+      ],
+      "dst_kind": "span",
+      "possible_dst_states": ["HIGH_ERROR_RATE", "TIMEOUT", "CONNECTION_RESET"],
+      "confidence": 0.85
+    },
+    {
+      "rule_id": "container_disk_fault_to_span",
+      "description": "Container disk I/O fault propagates through Pod and Service to Span errors",
+      "src_kind": "container",
+      "src_states": ["DISK_FAULT", "DISK_CORRUPTION"],
+      "path": [
+        {"edge_kind": "runs", "direction": "backward", "intermediate_kind": "pod"},
+        {"edge_kind": "routes_to", "direction": "backward", "intermediate_kind": "service"},
+        {"edge_kind": "includes", "direction": "forward"}
+      ],
+      "dst_kind": "span",
+      "possible_dst_states": ["HIGH_ERROR_RATE", "TIMEOUT", "MALFORMED_RESPONSE"],
+      "confidence": 0.75
+    }
+  ],
+
+  "edge_condition_operators": [">", "<", ">=", "<=", "==", "!="],
+  
+  "edge_data_fields": {
+    "calls": {
+      "description": "Statistics for span-to-span call edges",
+      "fields": {
+        "baseline_call_count": "Total calls during baseline period",
+        "baseline_error_count": "Error count (5xx) during baseline period",
+        "baseline_error_rate": "Computed: baseline_error_count / baseline_call_count",
+        "baseline_avg_latency": "Average latency in seconds (baseline)",
+        "baseline_median_latency": "Median (p50) latency in seconds (baseline)",
+        "baseline_p90_latency": "P90 latency in seconds (baseline)",
+        "baseline_p99_latency": "P99 latency in seconds (baseline)",
+        "abnormal_call_count": "Total calls during abnormal period",
+        "abnormal_error_count": "Error count (5xx) during abnormal period",
+        "abnormal_error_rate": "Computed: abnormal_error_count / abnormal_call_count",
+        "abnormal_avg_latency": "Average latency in seconds (abnormal)",
+        "abnormal_median_latency": "Median (p50) latency in seconds (abnormal)",
+        "abnormal_p90_latency": "P90 latency in seconds (abnormal)",
+        "abnormal_p99_latency": "P99 latency in seconds (abnormal)"
+      }
+    }
+  },
+
+  "topology_reference": {
+    "namespace --owns--> deployment|stateful_set|service": "Namespace contains workloads",
+    "deployment --scales--> replica_set": "Deployment manages ReplicaSet",
+    "replica_set|stateful_set --manages--> pod": "Controller manages Pods",
+    "machine --schedules--> pod": "Node schedules Pod",
+    "pod --runs--> container": "Pod runs containers",
+    "pod --claims--> pvc": "Pod claims persistent volume",
+    "pvc --binds_to--> pv": "PVC binds to PV",
+    "container --mounts--> pvc|configmap|secret": "Container mounts volumes",
+    "service --routes_to--> pod": "Service routes traffic to Pods",
+    "service --includes--> span|function": "Service contains API endpoints",
+    "service --exposes--> endpoints": "Service exposes endpoints",
+    "span --calls--> span": "Span calls Span (distributed tracing RPC)"
+  }
+}

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/propagation_rules_schema.json
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/propagation_rules_schema.json
@@ -1,0 +1,237 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "propagation_rules_schema.json",
+  "title": "Propagation Rules Schema",
+  "description": "JSON Schema for fault propagation rule definitions",
+  "type": "object",
+  "properties": {
+    "description": {
+      "type": "string",
+      "description": "Description of the rules file"
+    },
+    "available_node_kinds": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/node_kind" },
+      "description": "List of available node types"
+    },
+    "available_edge_kinds": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/edge_kind" },
+      "description": "List of available edge types"
+    },
+    "available_directions": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/direction" },
+      "description": "List of available propagation directions"
+    },
+    "available_states": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "description": "Map of node_kind to available states"
+    },
+    "default_states": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Map of node_kind to default (healthy) state"
+    },
+    "rules": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/rule" },
+      "description": "List of propagation rules"
+    },
+    "edge_condition_operators": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Available comparison operators for edge conditions"
+    },
+    "edge_data_fields": {
+      "type": "object",
+      "description": "Documentation of available edge data fields by edge type"
+    },
+    "topology_reference": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Reference documentation for topology edge relationships"
+    }
+  },
+  "required": ["rules"],
+
+  "definitions": {
+    "node_kind": {
+      "type": "string",
+      "enum": [
+        "machine", "namespace", "deployment", "replica_set", "stateful_set",
+        "daemon_set", "pod", "container", "service", "span",
+        "pvc", "pv", "configmap", "secret", "ingress", "endpoints", "function"
+      ],
+      "description": "Type of node in the topology graph"
+    },
+
+    "edge_kind": {
+      "type": "string",
+      "enum": [
+        "owns", "routes_to", "scales", "manages", "schedules",
+        "runs", "claims", "binds_to", "calls", "includes",
+        "related_to", "mounts", "exposes", "depends_on", "affects"
+      ],
+      "description": "Type of edge in the topology graph"
+    },
+
+    "direction": {
+      "type": "string",
+      "enum": ["forward", "backward"],
+      "description": "Propagation direction along the edge"
+    },
+
+    "path_hop": {
+      "type": "object",
+      "properties": {
+        "edge_kind": { "$ref": "#/definitions/edge_kind" },
+        "direction": { "$ref": "#/definitions/direction" },
+        "intermediate_kind": { "$ref": "#/definitions/node_kind" },
+        "intermediate_states": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Allowed states at intermediate node. If specified, the intermediate node must have at least one of these states for the path to be valid. Use ['healthy', 'unknown'] to bypass nodes without detected anomalies."
+        },
+        "edge_condition": { "$ref": "#/definitions/edge_condition" }
+      },
+      "required": ["edge_kind", "direction"],
+      "additionalProperties": false,
+      "description": "A single hop in a multi-hop propagation path"
+    },
+
+    "edge_condition": {
+      "type": "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "description": "Field path to check, e.g., 'data.abnormal_error_rate'"
+        },
+        "operator": {
+          "type": "string",
+          "enum": [">", "<", ">=", "<=", "==", "!="],
+          "description": "Comparison operator"
+        },
+        "value": {
+          "type": "number",
+          "description": "Value to compare against"
+        }
+      },
+      "required": ["field", "operator", "value"],
+      "additionalProperties": false,
+      "description": "Condition on edge data for rule to apply"
+    },
+
+    "rule": {
+      "type": "object",
+      "properties": {
+        "_comment": {
+          "type": "string",
+          "description": "Optional comment (ignored)"
+        },
+        "_usage": {
+          "type": "string",
+          "description": "Optional usage hint (ignored)"
+        },
+        "rule_id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "description": "Unique identifier for the rule (snake_case)"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the propagation"
+        },
+        "src_kind": {
+          "$ref": "#/definitions/node_kind",
+          "description": "Source node type"
+        },
+        "src_states": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "description": "Source states that trigger this propagation"
+        },
+        "edge_kind": {
+          "$ref": "#/definitions/edge_kind",
+          "description": "[Single-hop] Edge type for propagation"
+        },
+        "direction": {
+          "$ref": "#/definitions/direction",
+          "description": "[Single-hop] Propagation direction"
+        },
+        "path": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/path_hop" },
+          "minItems": 1,
+          "description": "[Multi-hop] Sequence of hops from src to dst"
+        },
+        "dst_kind": {
+          "$ref": "#/definitions/node_kind",
+          "description": "Destination node type"
+        },
+        "possible_dst_states": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "description": "Possible resulting states in destination node"
+        },
+        "edge_condition": {
+          "$ref": "#/definitions/edge_condition",
+          "description": "[Single-hop] Optional condition on edge data"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.8,
+          "description": "Confidence score for this rule (0.0 to 1.0)"
+        },
+        "min_delay": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Minimum propagation delay in seconds"
+        },
+        "max_delay": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Maximum propagation delay in seconds"
+        },
+        "source": {
+          "type": "string",
+          "enum": ["builtin", "llm_generated", "manual"],
+          "default": "builtin",
+          "description": "Origin of this rule"
+        }
+      },
+      "required": ["rule_id", "description", "src_kind", "src_states", "dst_kind", "possible_dst_states"],
+      "oneOf": [
+        {
+          "properties": {
+            "edge_kind": { "$ref": "#/definitions/edge_kind" },
+            "direction": { "$ref": "#/definitions/direction" }
+          },
+          "required": ["edge_kind", "direction"],
+          "not": { "required": ["path"] }
+        },
+        {
+          "properties": {
+            "path": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/path_hop" },
+              "minItems": 1
+            }
+          },
+          "required": ["path"],
+          "not": { "required": ["edge_kind", "direction"] }
+        }
+      ],
+      "additionalProperties": false,
+      "description": "A fault propagation rule"
+    }
+  }
+}

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/schema.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/schema.py
@@ -9,11 +9,11 @@ by expressing complete causal chains.
 
 from collections.abc import Callable
 from enum import auto
-from rcabench_platform.compat import StrEnum
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from rcabench_platform.compat import StrEnum
 from rcabench_platform.v3.internal.reasoning.models.graph import DepKind, Edge, PlaceKind
 
 if TYPE_CHECKING:
@@ -39,7 +39,11 @@ class PathHop(BaseModel):
     )
     intermediate_states: list[str] | None = Field(
         default=None,
-        description="Allowed states at intermediate node. If specified, the intermediate node must have at least one of these states for the path to be valid. Use ['healthy', 'unknown'] to bypass nodes without detected anomalies.",
+        description=(
+            "Allowed states at intermediate node. If specified, the intermediate node must have at "
+            "least one of these states for the path to be valid. Use ['healthy', 'unknown'] to "
+            "bypass nodes without detected anomalies."
+        ),
     )
     edge_condition: Callable[[Edge], bool] | None = Field(
         default=None,
@@ -168,7 +172,11 @@ class PropagationRule(BaseModel):
 
     propagation_source: Literal["injection_point", "caller", "callee"] | None = Field(
         default="injection_point",
-        description="Where propagation starts: injection_point=physical injection location, caller=for response faults where caller observes delay, callee=for request faults where callee processes fault",
+        description=(
+            "Where propagation starts: injection_point=physical injection location, "
+            "caller=for response faults where caller observes delay, "
+            "callee=for request faults where callee processes fault"
+        ),
     )
 
     first_hop_config: FirstHopConfig | None = Field(

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/schema.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/schema.py
@@ -1,0 +1,323 @@
+"""Rule schema for bidirectional fault propagation.
+
+Rules define how faults propagate through the topology based on node states,
+edge types, and edge data conditions.
+
+Supports both single-hop and multi-hop propagation paths to reduce false positives
+by expressing complete causal chains.
+"""
+
+from collections.abc import Callable
+from enum import auto
+from rcabench_platform.compat import StrEnum
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from rcabench_platform.v3.internal.reasoning.models.graph import DepKind, Edge, PlaceKind
+
+if TYPE_CHECKING:
+    pass
+
+
+class PropagationDirection(StrEnum):
+    FORWARD = auto()  # Propagate along edge direction (src → dst)
+    BACKWARD = auto()  # Propagate against edge direction (dst → src)
+
+
+class PathHop(BaseModel):
+    """A single hop in a multi-hop propagation path.
+
+    Represents one edge traversal: node_A --[edge_kind, direction]--> node_B
+    """
+
+    edge_kind: DepKind = Field(description="Edge type for this hop")
+    direction: PropagationDirection = Field(description="Traversal direction for this hop")
+    intermediate_kind: PlaceKind | None = Field(
+        default=None,
+        description="Expected PlaceKind of intermediate node (None for last hop)",
+    )
+    intermediate_states: list[str] | None = Field(
+        default=None,
+        description="Allowed states at intermediate node. If specified, the intermediate node must have at least one of these states for the path to be valid. Use ['healthy', 'unknown'] to bypass nodes without detected anomalies.",
+    )
+    edge_condition: Callable[[Edge], bool] | None = Field(
+        default=None,
+        description="Optional condition on edge data for this hop",
+    )
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @field_validator("intermediate_states", mode="after")
+    @classmethod
+    def normalize_intermediate_states(cls, v: list[str] | None) -> list[str] | None:
+        """Normalize state names to lowercase for consistent matching."""
+        if v is None:
+            return None
+        return [s.lower() for s in v]
+
+
+class FirstHopConfig(BaseModel):
+    """Configuration for first-hop validation behavior.
+
+    First-hop validation has different semantics depending on source PlaceKind:
+    - Span injection: Must validate anomalous states at source
+    - Service injection: Service is a dummy aggregation node, lenient matching
+    - Container/Pod injection: May not have exact rule states at injection point
+
+    This config allows rules to override default first-hop behavior.
+    """
+
+    require_src_states: bool = Field(
+        default=False,
+        description="If True, source must have states matching rule.src_states. "
+        "Span injection requires this; non-span injection is lenient by default.",
+    )
+    require_dst_states: bool = Field(
+        default=True,
+        description="If True, destination must have detected states. Always True for valid propagation paths.",
+    )
+    lenient_dst_state_match: bool = Field(
+        default=False,
+        description="If True, accept any detected states at destination, "
+        "not just rule.possible_dst_states. Useful for service->span first hop.",
+    )
+
+
+class PropagationRule(BaseModel):
+    """A single fault propagation rule.
+
+    Supports both single-hop and multi-hop propagation paths:
+    - Single-hop: Use edge_kind + direction (backward compatible)
+    - Multi-hop: Use path (list of PathHop), more precise causal chains
+
+    Examples:
+        # Single-hop: Pod KILLED --runs--> Container KILLED
+        PropagationRule(
+            src_kind=PlaceKind.pod,
+            src_states=[PodState.KILLED],
+            edge_kind=DepKind.runs,
+            direction=PropagationDirection.FORWARD,
+            dst_kind=PlaceKind.container,
+            possible_dst_states=[ContainerState.KILLED]
+        )
+
+        # Multi-hop: Pod NETWORK_DELAY --routes_to(BACKWARD)--> Service --includes(BACKWARD)--> Span
+        PropagationRule(
+            src_kind=PlaceKind.pod,
+            src_states=[PodState.NETWORK_DELAY],
+            path=[
+                PathHop(edge_kind=DepKind.routes_to, direction=BACKWARD, intermediate_kind=PlaceKind.service),
+                PathHop(edge_kind=DepKind.includes, direction=BACKWARD)
+            ],
+            dst_kind=PlaceKind.span,
+            possible_dst_states=[SpanState.HIGH_AVG_LATENCY]
+        )
+    """
+
+    rule_id: str = Field(description="Unique identifier for the rule")
+
+    description: str = Field(description="Human-readable description")
+
+    # Source node constraints
+    src_kind: PlaceKind = Field(description="Source node PlaceKind")
+    src_states: list[str] = Field(description="Source states that trigger propagation")
+
+    # Path specification: single-hop (legacy) or multi-hop (recommended)
+    edge_kind: DepKind | None = Field(default=None, description="[Single-hop] Edge type for propagation")
+    direction: PropagationDirection | None = Field(default=None, description="[Single-hop] Propagation direction")
+    path: list[PathHop] | None = Field(
+        default=None,
+        description="[Multi-hop] Sequence of hops from src to dst. Mutually exclusive with edge_kind+direction",
+    )
+
+    # Destination node constraints
+    dst_kind: PlaceKind = Field(description="Destination node PlaceKind")
+    possible_dst_states: list[str] = Field(description="Possible resulting states in destination node")
+
+    # Optional edge data condition (for single-hop only, use PathHop.edge_condition for multi-hop)
+    edge_condition: Callable[[Edge], bool] | None = Field(
+        default=None,
+        description="[Single-hop] Optional function to check edge data",
+    )
+
+    # Rule metadata
+    confidence: float = Field(
+        default=0.8,
+        ge=0.0,
+        le=1.0,
+        description="Confidence score for this propagation rule",
+    )
+
+    # Temporal constraints for causality verification
+    min_delay: float | None = Field(
+        default=None,
+        ge=0.0,
+        description="Minimum propagation delay in seconds",
+    )
+    max_delay: float | None = Field(
+        default=None,
+        ge=0.0,
+        description="Maximum propagation delay in seconds",
+    )
+
+    source: str = Field(
+        default="builtin",
+        description="Source of the rule (builtin, llm_rag, manual)",
+    )
+
+    propagation_source: Literal["injection_point", "caller", "callee"] | None = Field(
+        default="injection_point",
+        description="Where propagation starts: injection_point=physical injection location, caller=for response faults where caller observes delay, callee=for request faults where callee processes fault",
+    )
+
+    first_hop_config: FirstHopConfig | None = Field(
+        default=None,
+        description="Override first-hop validation behavior. If None, uses defaults based on src_kind: "
+        "span requires src_states; service is lenient with dst_states; container/pod are lenient with src_states.",
+    )
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @field_validator("src_states", mode="after")
+    @classmethod
+    def normalize_src_states(cls, v: list[str]) -> list[str]:
+        """Normalize state names to lowercase for consistent matching."""
+        return [s.lower() for s in v]
+
+    @field_validator("possible_dst_states", mode="after")
+    @classmethod
+    def normalize_dst_states(cls, v: list[str]) -> list[str]:
+        """Normalize state names to lowercase for consistent matching."""
+        return [s.lower() for s in v]
+
+    @field_validator("path", mode="after")
+    @classmethod
+    def validate_path_xor_single_hop(cls, v, info):
+        """Ensure either path OR (edge_kind+direction) is specified, not both."""
+        edge_kind = info.data.get("edge_kind")
+        direction = info.data.get("direction")
+
+        has_single_hop = edge_kind is not None and direction is not None
+        has_path = v is not None and len(v) > 0
+
+        if has_single_hop and has_path:
+            raise ValueError("Cannot specify both path and (edge_kind, direction). Use one or the other.")
+
+        if not has_single_hop and not has_path:
+            raise ValueError("Must specify either path or (edge_kind, direction)")
+
+        return v
+
+    @property
+    def is_multi_hop(self) -> bool:
+        """Check if this rule uses multi-hop path."""
+        return self.path is not None and len(self.path) > 0
+
+    @property
+    def hop_count(self) -> int:
+        """Get number of hops in the propagation path."""
+        if self.is_multi_hop:
+            return len(self.path)  # type: ignore[arg-type]
+        return 1
+
+
+class RuleMatchResult(BaseModel):
+    """Result of matching a rule against a graph edge."""
+
+    rule: PropagationRule
+    matched: bool
+    src_node_id: int
+    dst_node_id: int
+    edge: Edge
+    reason: str = Field(description="Why the rule matched or didn't match")
+
+
+def match_rule(
+    rule: PropagationRule,
+    src_node_id: int,
+    src_node_kind: PlaceKind,
+    src_state: str,
+    edge: Edge,
+    dst_node_id: int,
+    dst_node_kind: PlaceKind,
+) -> RuleMatchResult:
+    """Check if a rule matches a given edge and node states.
+
+    Args:
+        rule: The propagation rule to match
+        src_node_id: Source node ID
+        src_node_kind: Source node PlaceKind
+        src_state: Current state of source node (single state string for compatibility)
+        edge: The edge connecting nodes
+        dst_node_id: Destination node ID
+        dst_node_kind: Destination node PlaceKind
+
+    Returns:
+        RuleMatchResult indicating if rule matched and why
+    """
+    # Check source PlaceKind
+    if src_node_kind != rule.src_kind:
+        return RuleMatchResult(
+            rule=rule,
+            matched=False,
+            src_node_id=src_node_id,
+            dst_node_id=dst_node_id,
+            edge=edge,
+            reason=f"Source kind mismatch: expected {rule.src_kind}, got {src_node_kind}",
+        )
+
+    # Check source state
+    if src_state not in rule.src_states:
+        return RuleMatchResult(
+            rule=rule,
+            matched=False,
+            src_node_id=src_node_id,
+            dst_node_id=dst_node_id,
+            edge=edge,
+            reason=f"Source state {src_state} not in trigger states {rule.src_states}",
+        )
+
+    # Check edge kind
+    if edge.kind != rule.edge_kind:
+        return RuleMatchResult(
+            rule=rule,
+            matched=False,
+            src_node_id=src_node_id,
+            dst_node_id=dst_node_id,
+            edge=edge,
+            reason=f"Edge kind mismatch: expected {rule.edge_kind}, got {edge.kind}",
+        )
+
+    # Check destination PlaceKind
+    if dst_node_kind != rule.dst_kind:
+        return RuleMatchResult(
+            rule=rule,
+            matched=False,
+            src_node_id=src_node_id,
+            dst_node_id=dst_node_id,
+            edge=edge,
+            reason=f"Destination kind mismatch: expected {rule.dst_kind}, got {dst_node_kind}",
+        )
+
+    # Check edge condition if specified
+    if rule.edge_condition is not None:
+        if not rule.edge_condition(edge):
+            return RuleMatchResult(
+                rule=rule,
+                matched=False,
+                src_node_id=src_node_id,
+                dst_node_id=dst_node_id,
+                edge=edge,
+                reason="Edge condition not satisfied",
+            )
+
+    # All checks passed
+    return RuleMatchResult(
+        rule=rule,
+        matched=True,
+        src_node_id=src_node_id,
+        dst_node_id=dst_node_id,
+        edge=edge,
+        reason="Rule matched successfully",
+    )

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/utils/serde.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/utils/serde.py
@@ -12,12 +12,25 @@ from ..logging import logger
 
 
 def json_default(obj):
-    if isinstance(obj, set):
+    if isinstance(obj, (set, frozenset)):
         return list(obj)
     elif isinstance(obj, Path):
         return str(obj)
     elif isinstance(obj, datetime.datetime):
         return obj.isoformat()
+    elif hasattr(obj, "model_dump"):
+        return obj.model_dump()
+    try:
+        import numpy as np
+
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, np.integer):
+            return int(obj)
+        if isinstance(obj, np.floating):
+            return float(obj)
+    except ImportError:
+        pass
     raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
 
 


### PR DESCRIPTION
## Summary

Ports the `rca_label/src/reason/` fault-propagation labeler (~10k LOC) into `rcabench-platform/src/rcabench_platform/v3/internal/reasoning/`, wired alongside `detector` as a peer labeling pipeline. Produces `causal_graph.json` + `result.json` next to the detector's parquet outputs in the datapack dir — downstream consumers read the files directly via the existing `GET /api/v2/injections/:id/files/download` endpoint, so no server-side change is needed.

## What's in the package

- `models/` — HyperGraph, state enums, injection resolver, propagation result
- `algorithms/` — bidirectional BFS propagator, rule matcher, state detector / enhancer, starting-point resolver, temporal validator, topology explorer, baseline detector
- `rules/` — 13 built-in propagation rules (JSON) + schema
- `loaders/parquet_loader.py` — reads detector's `{normal,abnormal}_*.parquet` + `conclusion.parquet`; rebuilds full K8s + trace topology at runtime (no external topology dep)
- `exporters/pattern_exporter.py`
- `cli.py` — Typer sub-app with `run` / `batch`

## Wiring

- `cli/reason.py` mounts the sub-app onto `rcabench_platform.v3.cli.main:app` via `add_typer`
- `docker/reason/{Dockerfile,entrypoint.sh}` mirror `docker/detector/`
- `scripts/docker.py` `CONTEXTS` gains `reason` — picked up by `build all` / `update_all`

## Scope cuts vs rca_label

- Tests, visualization (`rules/visualizer.py`, `graph_viz.web.server`, `--no-viz`, uvicorn entry), LLM-lib log suppression — all dropped per migration plan
- `CausalNode/Edge/Graph` now consumed from `sdk/evaluation/causal_graph.py` (deleted duplicate port)
- `sdk/utils/serde.json_default` extended with `frozenset` / numpy / pydantic `model_dump` branches — shared improvement
- `StrEnum` routed through `rcabench_platform.compat` for py3.10

## Generalizations beyond verbatim port (AegisLab datapack compat)

- `injection.json.fault_type` accepts string (`"PodKill"`) or int index (legacy `rca_label`)
- `injection.json.ground_truth` accepts `list[dict]` (AegisLab batch form) or `dict` (legacy)
- Removed `ts-ui-dashboard` hardcodes: split `CALLER_LIKE_SERVICES` (span-service disambiguation; includes frontend aggregators `front-end`/`ts-ui-dashboard`) from `LOADGEN_LIKE_SERVICES` (filtered from alarm-detection baseline; `loadgenerator`/`locust`/`wrk2`/`dsb-wrk2`/`k6` — synthetic traffic only)

## Verified

- All imports resolve; `get_builtin_rules()` loads 13 rules
- `cli/reason.py reason run --data-dir <converted>` end-to-end on:
  - `sockshop0-carts-pod-kill-gdfp28`: pipeline green → `no_alarms.marker` (baseline coverage gap in datapack, not a migration defect)
  - `sockshop0-users-pod-failure-wnhnql`: pipeline green through graph build (88 nodes / 108 edges), alarm detection (`front-end::GET /login`, 27155× latency), injection resolution (exact_pod_match to `pod:users-0`), rule matching (`container_001`, `container_002` accepted) → `no_paths.marker`
- The sockshop `no_paths` case surfaced a cross-algorithm gap between the trace-based alarm detector and the metrics-based state_detector — captured as a follow-up design proposal (see below).

## Follow-up

See `rcabench-platform/docs/reasoning-state-abstraction-proposal.md` for the cross-benchmark state abstraction design (tracking issue to be opened). Not in scope for this PR.

## Test plan

- [ ] `uv sync --all-extras`
- [ ] `uv run python -c "from rcabench_platform.v3.internal.reasoning.cli import app; from rcabench_platform.v3.internal.reasoning.rules.builtin_rules import get_builtin_rules; print(len(get_builtin_rules()))"` → 13
- [ ] `uv run cli/reason.py reason --help` → lists `run` / `batch`
- [ ] `uv run cli/reason.py reason run --data-dir <any converted/ datapack>` → graph builds; writes `causal_graph.json` / `result.json` / `no_alarms.marker` / `no_paths.marker` next to the parquets
- [ ] `scripts/docker.py build reason` (or `build all`) succeeds once base image is built

🤖 Generated with [Claude Code](https://claude.com/claude-code)