### PR TITLE
feat(inject): auto-allocate namespace when AutoAllocate=true (#166)

### DIFF
--- a/AegisLab/src/infra/k8s/gateway.go
+++ b/AegisLab/src/infra/k8s/gateway.go
@@ -113,6 +113,27 @@ func (g *Gateway) EnsureNamespace(ctx context.Context, name string) (bool, error
 	return true, nil
 }
 
+// NamespaceHasWorkload reports whether the given namespace contains at least
+// one pod (any phase). Used by the submit-time namespace allocator (#166) to
+// distinguish "deployed slot, currently idle" from "registered count slot,
+// no workload" — the latter can't satisfy guided BuildInjection because pod
+// listing would return empty and "app X not found" would surface to the
+// user. Callers treat (false, nil) as "skip this slot, try next".
+func (g *Gateway) NamespaceHasWorkload(ctx context.Context, namespace string) (bool, error) {
+	client := getK8sClient()
+	if client == nil {
+		return false, fmt.Errorf("kubernetes client not available")
+	}
+	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("list pods in %q: %w", namespace, err)
+	}
+	return len(pods.Items) > 0, nil
+}
+
 func (g *Gateway) CheckHealth(ctx context.Context) error {
 	if getK8sRestConfig() == nil {
 		return fmt.Errorf("kubernetes config not available")

--- a/AegisLab/src/module/injection/alloc.go
+++ b/AegisLab/src/module/injection/alloc.go
@@ -1,0 +1,206 @@
+package injection
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"aegis/config"
+	"aegis/consts"
+	redisinfra "aegis/infra/redis"
+
+	chaos "github.com/OperationsPAI/chaos-experiment/handler"
+	goredis "github.com/redis/go-redis/v9"
+)
+
+// ErrPoolExhausted is returned by AllocateNamespaceForRestart when every
+// 0..count-1 slot of a system is either lock-active or has no deployed
+// workload. Callers should surface an actionable hint suggesting
+// `aegisctl inject guided --install --namespace <system>N` to expand the
+// pool — see #166 for the design tradeoffs.
+var ErrPoolExhausted = errors.New("namespace pool exhausted: every slot is locked or has no deployed workload")
+
+// WorkloadProbe checks whether `namespace` has at least one pod deployed.
+// Injected by callers so tests don't need a live cluster. Production wiring
+// uses a closure around k8s.Gateway.NamespaceHasWorkload.
+type WorkloadProbe func(ctx context.Context, namespace string) (bool, error)
+
+const (
+	allocLockTTL        = 10 * time.Second
+	allocLockKeyPattern = "alloc:%s"
+)
+
+// AllocateNamespaceForRestart claims a free, deployed slot for `system`,
+// acquires its Redis namespace lock under `traceID`, and returns the chosen
+// namespace name. Hole-fill only — walks 0..count-1 in ascending order and
+// returns the first slot satisfying:
+//
+//   - currently not lock-active (no other trace owns the namespace lock or
+//     the existing lock has expired by `now`)
+//   - workload deployed (at least one pod present per `probe`)
+//
+// Returns ErrPoolExhausted when no qualifying slot exists. Returns other
+// errors for Redis/probe failures.
+//
+// Race-safety: a per-system Redis SetNX lock at `alloc:<system>` (TTL 10s)
+// serializes concurrent allocators so two parallel submits cannot both end
+// up with the same slot. The chosen namespace is locked under `traceID`
+// immediately so when RestartPedestal eventually runs and calls
+// monitor.AcquireNamespaceForRestart with the same traceID, the
+// same-owner re-acquire path treats it as success (see
+// consumer/namespace_lock_store.go acquire(): TraceID == traceID
+// short-circuits the busy check).
+//
+// Caller is responsible for setting `task.TraceID = traceID` before calling
+// common.SubmitTaskWithDB so the eventual RestartPedestal's traceID matches
+// the allocator's claim.
+//
+// NOTE: this lock-acquire path mirrors consumer/namespace_lock_store.go to
+// keep the two callers (submit-time allocator vs. runtime monitor) writing
+// to the same hash layout. If consumer's store changes its key format or
+// fields, this code must follow. A shared package would be cleaner; not
+// done here to avoid a chaossystem→consumer→injection cycle. See #166
+// follow-ups.
+func AllocateNamespaceForRestart(
+	ctx context.Context,
+	redis *redisinfra.Gateway,
+	system string,
+	endTime time.Time,
+	traceID string,
+	probe WorkloadProbe,
+) (string, error) {
+	if redis == nil {
+		return "", fmt.Errorf("redis gateway required")
+	}
+	if traceID == "" {
+		return "", fmt.Errorf("traceID required")
+	}
+
+	cfg, ok := config.GetChaosSystemConfigManager().Get(chaos.SystemType(system))
+	if !ok {
+		return "", fmt.Errorf("system %q not registered", system)
+	}
+	if cfg.Count <= 0 {
+		return "", ErrPoolExhausted
+	}
+	template := nsTemplateFromPattern(cfg.NsPattern)
+	if template == "" {
+		return "", fmt.Errorf("invalid ns_pattern for system %s: %q", system, cfg.NsPattern)
+	}
+
+	allocKey := fmt.Sprintf(allocLockKeyPattern, system)
+	acquired, err := redis.SetNX(ctx, allocKey, traceID, allocLockTTL)
+	if err != nil {
+		return "", fmt.Errorf("acquire allocator lock for %s: %w", system, err)
+	}
+	if !acquired {
+		return "", fmt.Errorf("allocator busy for system %s, retry shortly", system)
+	}
+	defer func() {
+		_, _ = redis.DeleteKey(context.Background(), allocKey)
+	}()
+
+	now := time.Now()
+	for idx := 0; idx < cfg.Count; idx++ {
+		ns := fmt.Sprintf(template, idx)
+
+		active, err := nsLockActive(ctx, redis, ns, now)
+		if err != nil {
+			return "", fmt.Errorf("check lock for %s: %w", ns, err)
+		}
+		if active {
+			continue
+		}
+
+		if probe != nil {
+			hasWorkload, probeErr := probe(ctx, ns)
+			if probeErr != nil {
+				return "", fmt.Errorf("probe workload in %s: %w", ns, probeErr)
+			}
+			if !hasWorkload {
+				continue
+			}
+		}
+
+		if err := nsLockAcquire(ctx, redis, ns, endTime, traceID, now); err != nil {
+			// A concurrent runtime task may have grabbed it after our
+			// active-check; try the next slot rather than fail the whole
+			// allocation.
+			continue
+		}
+		return ns, nil
+	}
+
+	return "", ErrPoolExhausted
+}
+
+// nsTemplateFromPattern mirrors config.convertPatternToTemplate (private
+// there). Converts "^sockshop\d+$" → "sockshop%d" so the allocator can
+// fmt.Sprintf each candidate slot.
+func nsTemplateFromPattern(pattern string) string {
+	template := pattern
+	if len(template) > 0 && template[0] == '^' {
+		template = template[1:]
+	}
+	if len(template) > 0 && template[len(template)-1] == '$' {
+		template = template[:len(template)-1]
+	}
+	return regexp.MustCompile(`\\d\+`).ReplaceAllString(template, "%d")
+}
+
+// nsLockActive mirrors consumer/namespace_lock_store.go isActive(). Returns
+// true when the namespace lock has a non-empty trace_id and end_time is in
+// the future. Uses the same monitor:ns:<ns> hash layout.
+func nsLockActive(ctx context.Context, redis *redisinfra.Gateway, ns string, now time.Time) (bool, error) {
+	key := fmt.Sprintf(consts.NamespaceKeyPattern, ns)
+	endTimeStr, err := redis.HashGet(ctx, key, "end_time")
+	if err != nil && err != goredis.Nil {
+		return false, err
+	}
+	traceID, err := redis.HashGet(ctx, key, "trace_id")
+	if err != nil && err != goredis.Nil {
+		return false, err
+	}
+	if traceID == "" || endTimeStr == "" {
+		return false, nil
+	}
+	endTime, err := strconv.ParseInt(endTimeStr, 10, 64)
+	if err != nil {
+		return false, err
+	}
+	return now.Unix() < endTime, nil
+}
+
+// nsLockAcquire mirrors consumer/namespace_lock_store.go acquire(). Atomic
+// WATCH+MULTI upsert of (end_time, trace_id) on monitor:ns:<ns>. Same Redis
+// layout as the consumer-side lock store so a subsequent
+// monitor.AcquireNamespaceForRestart with the same traceID re-acquires
+// idempotently.
+func nsLockAcquire(ctx context.Context, redis *redisinfra.Gateway, ns string, endTime time.Time, traceID string, now time.Time) error {
+	key := fmt.Sprintf(consts.NamespaceKeyPattern, ns)
+	return redis.Watch(ctx, func(tx *goredis.Tx) error {
+		endTimeStr, err := tx.HGet(ctx, key, "end_time").Result()
+		if err != nil && err != goredis.Nil {
+			return err
+		}
+		existingTrace, err := tx.HGet(ctx, key, "trace_id").Result()
+		if err != nil && err != goredis.Nil {
+			return err
+		}
+		if existingTrace != "" && existingTrace != traceID && endTimeStr != "" {
+			existingEnd, parseErr := strconv.ParseInt(endTimeStr, 10, 64)
+			if parseErr == nil && now.Unix() < existingEnd {
+				return fmt.Errorf("namespace %s locked by %s", ns, existingTrace)
+			}
+		}
+		_, err = tx.TxPipelined(ctx, func(pipe goredis.Pipeliner) error {
+			pipe.HSet(ctx, key, "end_time", endTime.Unix())
+			pipe.HSet(ctx, key, "trace_id", traceID)
+			return nil
+		})
+		return err
+	}, key)
+}

--- a/AegisLab/src/module/injection/api_types.go
+++ b/AegisLab/src/module/injection/api_types.go
@@ -394,6 +394,17 @@ type SubmitInjectionReq struct {
 	// normal. Use when the caller has already installed the chart out-of-band
 	// (e.g. `aegisctl pedestal chart install` + preflight readiness wait).
 	SkipRestartPedestal bool `json:"skip_restart_pedestal" binding:"omitempty"`
+
+	// AutoAllocate, when true, asks the server to choose a free deployed
+	// namespace from the system's pool for any guided config whose
+	// `namespace` is empty. The chosen namespace is locked at submit time
+	// (see #166) and surfaced in SubmitInjectionResp.AllocatedNamespaces.
+	// Hole-fill only — the allocator does not bootstrap fresh slots; if
+	// every 0..count-1 slot is busy or has no workload, submit fails with
+	// a pool-exhausted error and a hint to use `--install --namespace`
+	// to expand the pool. Configs that already specify a namespace
+	// continue to honor PR #164's hard-constraint path unchanged.
+	AutoAllocate bool `json:"auto_allocate" binding:"omitempty"`
 }
 
 func (req *SubmitInjectionReq) GuidedSpecs() [][]guidedcli.GuidedConfig {
@@ -608,6 +619,12 @@ type SubmitInjectionItem struct {
 	Index   int    `json:"index"` // Index of the batch this injection belongs to
 	TraceID string `json:"trace_id"`
 	TaskID  string `json:"task_id"`
+	// AllocatedNamespace, when non-empty, is the namespace the server picked
+	// for this batch in response to AutoAllocate=true (or that was bumped
+	// in via the explicit-namespace count-bump path). Mirrors what gets
+	// written into RestartRequiredNamespace so callers can confirm which
+	// slot their submit landed on without waiting for the trace log.
+	AllocatedNamespace string `json:"allocated_namespace,omitempty"`
 }
 
 // Structured warnings about duplications and conflicts

--- a/AegisLab/src/module/injection/service.go
+++ b/AegisLab/src/module/injection/service.go
@@ -12,6 +12,7 @@ import (
 
 	"aegis/consts"
 	"aegis/dto"
+	"aegis/infra/k8s"
 	loki "aegis/infra/loki"
 	redis "aegis/infra/redis"
 	"aegis/model"
@@ -22,8 +23,42 @@ import (
 	"aegis/utils"
 
 	chaos "github.com/OperationsPAI/chaos-experiment/handler"
+	"github.com/OperationsPAI/chaos-experiment/pkg/guidedcli"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
+
+// allocatedSlot pairs the namespace chosen by AllocateNamespaceForRestart
+// with the pre-generated traceID under which the namespace lock was taken.
+// Both flow into the per-batch task built later: namespace into the
+// payload's RestartRequiredNamespace, traceID into task.TraceID.
+type allocatedSlot struct {
+	namespace string
+	traceID   string
+}
+
+// batchNeedsAutoAllocate reports whether at least one config in the batch
+// has an empty namespace and would therefore benefit from server-side
+// allocation. Returns false when every config already names a namespace
+// (caller leaves the explicit-ns path of #164 alone).
+func batchNeedsAutoAllocate(batch []guidedcli.GuidedConfig) bool {
+	for _, cfg := range batch {
+		if strings.TrimSpace(cfg.Namespace) == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// defaultWorkloadProbe is the production WorkloadProbe used by the
+// AutoAllocate submit path. Returns true when the namespace contains at
+// least one pod (any phase). Tests override this seam.
+func defaultWorkloadProbe() WorkloadProbe {
+	gw := k8s.NewGateway(nil)
+	return func(ctx context.Context, namespace string) (bool, error) {
+		return gw.NamespaceHasWorkload(ctx, namespace)
+	}
+}
 
 // ChaosSystemWriter is the narrow contract injection.Service needs from
 // chaossystem to register guided namespaces with the system's namespace
@@ -240,6 +275,38 @@ func (s *Service) SubmitFaultInjection(ctx context.Context, req *SubmitInjection
 		return nil, fmt.Errorf("no guided specs available for fault injection")
 	}
 
+	// #166: AutoAllocate path — for any batch whose configs leave namespace
+	// empty, pick a free deployed slot from the system's pool *now*, before
+	// BuildInjection's submit-time pod listing runs. The chosen ns is
+	// locked under a pre-generated traceID; the matching task built below
+	// inherits that traceID so RestartPedestal's same-owner re-acquire
+	// finds the lock already held by itself. If allocation fails for any
+	// batch, this short-circuits and the request returns the error — no
+	// rollback of earlier successful allocations in v1; their locks expire
+	// naturally because the corresponding tasks were never submitted.
+	allocations := make(map[int]allocatedSlot, len(guidedSpecs))
+	if req.AutoAllocate {
+		// Sized to comfortably cover restart + injection + a slack buffer.
+		lockEndTime := time.Now().Add(time.Duration(req.Interval+10) * time.Minute)
+		probe := defaultWorkloadProbe()
+		for batchIdx, batch := range guidedSpecs {
+			if !batchNeedsAutoAllocate(batch) {
+				continue
+			}
+			traceID := uuid.NewString()
+			allocatedNs, allocErr := AllocateNamespaceForRestart(ctx, s.redis, pedestalItem.ContainerName, lockEndTime, traceID, probe)
+			if allocErr != nil {
+				return nil, fmt.Errorf("auto-allocate batch %d for system %s: %w (hint: run `aegisctl inject guided --install --namespace %s<N>` to expand the pool)", batchIdx, pedestalItem.ContainerName, allocErr, pedestalItem.ContainerName)
+			}
+			allocations[batchIdx] = allocatedSlot{namespace: allocatedNs, traceID: traceID}
+			for cfgIdx := range guidedSpecs[batchIdx] {
+				if strings.TrimSpace(guidedSpecs[batchIdx][cfgIdx].Namespace) == "" {
+					guidedSpecs[batchIdx][cfgIdx].Namespace = allocatedNs
+				}
+			}
+		}
+	}
+
 	// Break the submit→restart-pedestal chicken-and-egg: on a first run,
 	// the target namespace doesn't exist yet (RestartPedestal hasn't run),
 	// so guidedcli.BuildInjection's pod listing would 500. Pre-create any
@@ -257,6 +324,10 @@ func (s *Service) SubmitFaultInjection(ctx context.Context, req *SubmitInjection
 		item, warning, err := parseBatchGuidedSpecs(ctx, pedestalItem.ContainerName, i, guidedSpecs[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse guided spec batch %d: %w", i, err)
+		}
+		if alloc, ok := allocations[i]; ok {
+			item.allocatedNamespace = alloc.namespace
+			item.preallocTraceID = alloc.traceID
 		}
 		if warning != "" {
 			parseWarnings = append(parseWarnings, warning)
@@ -358,6 +429,15 @@ func (s *Service) SubmitFaultInjection(ctx context.Context, req *SubmitInjection
 				consts.TaskExtraInjectionAlgorithms: len(req.Algorithms),
 			},
 		}
+		// #166: AutoAllocate locked the chosen namespace under
+		// item.preallocTraceID at submit time. Pin the task's TraceID to that
+		// value so monitor.AcquireNamespaceForRestart at runtime treats it
+		// as a same-owner re-acquire (idempotent) instead of seeing a
+		// foreign-owner busy lock. Empty preallocTraceID falls through to
+		// SubmitTaskWithDB's normal uuid generation.
+		if item.preallocTraceID != "" {
+			task.TraceID = item.preallocTraceID
+		}
 		task.SetGroupCtx(ctx)
 
 		if err := common.SubmitTaskWithDB(ctx, db, s.redis, task); err != nil {
@@ -365,9 +445,10 @@ func (s *Service) SubmitFaultInjection(ctx context.Context, req *SubmitInjection
 		}
 
 		injectionItems = append(injectionItems, SubmitInjectionItem{
-			Index:   item.index,
-			TraceID: task.TraceID,
-			TaskID:  task.TaskID,
+			Index:              item.index,
+			TraceID:            task.TraceID,
+			TaskID:             task.TaskID,
+			AllocatedNamespace: item.allocatedNamespace,
 		})
 	}
 

--- a/AegisLab/src/module/injection/submit.go
+++ b/AegisLab/src/module/injection/submit.go
@@ -121,6 +121,13 @@ type injectionProcessItem struct {
 	faultDuration int
 	guidedConfigs []guidedcli.GuidedConfig
 	executeTime   time.Time
+	// allocatedNamespace and preallocTraceID are populated by the
+	// AutoAllocate submit path (#166) when the server picks a namespace at
+	// submit time. The pre-generated traceID is later assigned to the
+	// task's TraceID so the runtime RestartPedestal's same-owner re-acquire
+	// matches the allocator's existing lock. Empty otherwise.
+	allocatedNamespace string
+	preallocTraceID    string
 }
 
 func flattenYAMLToParameters(data map[string]any, prefix string) []dto.ParameterSpec {


### PR DESCRIPTION
## Summary

PR-A of the #166 plan (commented [here](https://github.com/OperationsPAI/aegis/issues/166#issuecomment-4317829899)). When a submit sets \`auto_allocate: true\` and a guided config leaves \`namespace\` empty, the server picks a free deployed slot from the system's pool, locks it, and threads the choice through to RestartPedestal via PR #164's existing \`RestartRequiredNamespace\` path.

## Decisions baked in (per #166 thread)

1. **Redis SetNX \`alloc:<system>\`** for per-system allocator serialization (TTL 10s). Not etcd Txn.
2. **Lowest-index-first hole-fill**, deterministic.
3. **\`AutoAllocate\` lives on \`SubmitInjectionReq\` envelope**, not on \`GuidedConfig\` — pure backend, no chaos-experiment lib bump.
4. **Hole-fill only** — fresh slots without workload return \`ErrPoolExhausted\`. Bootstrap is PR-C scope.
5. **Submit-time allocation**, not runtime, so submit response surfaces the chosen ns and BuildInjection's pod-listing has a real ns to work against.

## What's in this PR

- **\`module/injection/alloc.go\`** — new \`AllocateNamespaceForRestart(ctx, redis, system, endTime, traceID, probe)\`. Walks 0..count-1, skips lock-active slots and slots without workload, locks the chosen ns under traceID using the same \`monitor:ns:<ns>\` hash format as \`consumer/namespace_lock_store.go\` so the consumer-side re-acquire treats it as same-owner (idempotent). Held under \`alloc:<system>\` Redis SetNX for the duration of the walk.
- **\`SubmitInjectionReq.AutoAllocate bool\`** — new field. Default false preserves existing behavior.
- **\`SubmitInjectionItem.AllocatedNamespace string\`** — new response field surfacing the chosen ns to callers.
- **\`SubmitFaultInjection\`** — when AutoAllocate=true, pre-generates a UUID traceID per batch, calls allocator, fills \`cfg.Namespace\` for empty configs, sets \`task.TraceID\` to the pre-generated value so the runtime monitor's same-owner re-acquire matches the allocator's claim.
- **\`k8s.Gateway.NamespaceHasWorkload\`** — production WorkloadProbe.

## Decision points worth reviewing

1. **No fresh-slot bootstrap.** v1 rejects pool exhaustion with an actionable error (\"run \`--install --namespace <sys>N\`\"). PR-C will add \`AllowBootstrap\` flag for synchronous helm-install at submit time. Open to flipping the default if reviewers prefer a slower-but-friendlier UX.
2. **Lock layout duplicated between \`module/injection/alloc.go\` and \`consumer/namespace_lock_store.go\`.** Both write to \`monitor:ns:<ns>\` hash with \`end_time\` + \`trace_id\` fields. Extracting a shared package would close the duplication but requires a wider refactor (\`consumer\` already imports \`module/injection\`, so we'd need a new neutral package). Not done here. **Risk**: if consumer's lock store changes its key/field format, alloc.go needs to follow. The format lives in \`consts.NamespaceKeyPattern\` so the key itself is centralized; only the field names (\"end_time\", \"trace_id\") drift independently.
3. **Allocator failure aborts the whole submit, not just the affected batch.** When batch 3 of 5 fails to allocate, batches 0-2's locks are held but their tasks were never submitted — the locks expire naturally via endTime (~\`Interval+10\` minutes). Cleaner than partial submits with mixed states. v1 doesn't release-on-error; consider for v2.
4. **One ns per batch.** Within a batch, all configs share one ns lock at runtime (existing semantics), so \`firstGuidedNamespace\` already collapses per-config namespaces to one. Allocator returns one ns; we fill it into every empty-cfg in that batch.
5. **TraceID pre-generation.** \`SubmitTaskWithDB\` honors a pre-set \`TraceID\` (only generates uuid when empty). Pre-setting is the cleanest way to make allocator's lock and runtime's re-acquire match without changing the lock store's same-owner check.

## Test plan

- [ ] **Currently can't local-build** — main is broken (\`k8s.io/client-go@0.36.0\` dropped \`scheduling/v1alpha1\` that \`sigs.k8s.io/controller-runtime@0.23.3\` still imports; no newer controller-runtime exists). PR #150's bump appears to be the cause. **This PR adds zero new k8s imports** — the breakage is purely upstream of this change. CI will surface both.
- [ ] **Unit tests deferred** to a follow-up commit once main builds — the allocator is small and lockstep with the existing namespace lock store, but a clean unit test for it needs a Redis stub.
- [ ] **Manual repro on cluster** (after main is unblocked):
  - \`POST /inject\` with \`auto_allocate: true\` + empty namespace → response includes \`allocated_namespace: \"sockshop0\"\` (or whatever the first deployed-and-free slot is) → trace runs against that ns.
  - Same call when all slots busy → 500 with \`pool exhausted\` and the install-hint.

## Related

- Closes part of #166 (auto-allocate path)
- Builds on PR #164 (\`RestartRequiredNamespace\` runtime path)
- Refs #156 / #157 / #161

## Follow-ups already scoped

- **PR-B** (in progress this session) — aegisctl learns \`--auto\` flag.
- **PR-C** (deferred) — bootstrap-on-allocate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)