### PR TITLE
feat(aegisctl): --auto for inject guided to request server-side ns allocation (#166)

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/inject_guided.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_guided.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"aegis/cmd/aegisctl/client"
@@ -56,6 +57,15 @@ var (
 	guidedInstall               bool
 	guidedInstallReadyTimeoutSec int
 	guidedSkipRestartPedestal   bool
+
+	// #166: --auto asks the server to pick a free deployed namespace from
+	// the system's pool at submit time, instead of the user pre-naming one.
+	// Mutually exclusive with --namespace. The chosen ns is surfaced in the
+	// submit response so scripts can read it back without parsing trace
+	// logs. Honors only the explicit-flag path; saved session configs that
+	// already have `namespace` set keep their value unless --auto is passed
+	// (in which case the namespace is cleared just for this apply).
+	guidedAutoAllocate bool
 
 	// Test seams: replace with fakes in unit tests.
 	guidedInstallerHook chartInstaller
@@ -300,6 +310,7 @@ func init() {
 	f.BoolVar(&guidedInstall, "install", false, "Before app discovery, if --namespace has no pods, shell out to 'aegisctl pedestal chart install <system>' and wait for readiness (requires --system and --namespace)")
 	f.IntVar(&guidedInstallReadyTimeoutSec, "install-ready-timeout", 600, "Seconds --install waits for pods in the target namespace to reach Ready before continuing with discovery")
 	f.BoolVar(&guidedSkipRestartPedestal, "skip-restart-pedestal", false, "On --apply, hint the backend's RestartPedestal task to skip the helm install when the release is already healthy (task still runs; only the install step short-circuits)")
+	f.BoolVar(&guidedAutoAllocate, "auto", false, "On --apply, ask the server to pick a free deployed namespace from the system's pool (mutually exclusive with --namespace; allocated namespace surfaces in submit response). See #166.")
 
 	// --apply envelope flags (mirror the injection YAML contract)
 	f.StringVar(&guidedApplyPedestalName, "pedestal-name", "", "Pedestal container name (required with --apply)")
@@ -348,6 +359,15 @@ func submitGuidedApply(cfg guidedcli.GuidedConfig) error {
 	if guidedApplyInterval <= guidedApplyPreDuration {
 		return usageErrorf("--interval must be greater than --pre-duration")
 	}
+	if guidedAutoAllocate && strings.TrimSpace(cfg.Namespace) != "" && strings.TrimSpace(guidedNamespace) != "" {
+		// Only fire the conflict error when the user explicitly passed
+		// --namespace alongside --auto. A namespace inherited from the
+		// saved session config gets silently overridden below.
+		return usageErrorf("--auto cannot be combined with --namespace; pick one")
+	}
+	if guidedAutoAllocate {
+		cfg.Namespace = ""
+	}
 	if err := requireAPIContext(true); err != nil {
 		return err
 	}
@@ -383,6 +403,9 @@ func submitGuidedApply(cfg guidedcli.GuidedConfig) error {
 	}
 	if guidedSkipRestartPedestal {
 		envelope["skip_restart_pedestal"] = true
+	}
+	if guidedAutoAllocate {
+		envelope["auto_allocate"] = true
 	}
 	if flagDryRun {
 		output.PrintJSON(map[string]any{
@@ -452,6 +475,9 @@ func submitGuidedApplyWithOptions(projectName string, cfg guidedcli.GuidedConfig
 	}
 	if guidedSkipRestartPedestal {
 		envelope["skip_restart_pedestal"] = true
+	}
+	if guidedAutoAllocate {
+		envelope["auto_allocate"] = true
 	}
 
 	c := newClient()

--- a/AegisLab/src/cmd/aegisctl/cmd/inject_types.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_types.go
@@ -83,6 +83,10 @@ type injectSubmitItem struct {
 	Index   int    `json:"index"`
 	TraceID string `json:"trace_id"`
 	TaskID  string `json:"task_id"`
+	// AllocatedNamespace surfaces the server-picked namespace when the
+	// submit was AutoAllocate=true (see #166). Empty for explicit-ns
+	// submits.
+	AllocatedNamespace string `json:"allocated_namespace,omitempty"`
 }
 
 // ContainerRef references a container image with optional overrides. It is


### PR DESCRIPTION
## Summary

PR-B of the #166 plan. Pairs with PR #167 (PR-A) to expose the server's auto-allocate path on the CLI.

## What's in this PR

- **\`--auto\` flag** on \`aegisctl inject guided\`. On \`--apply\`, sets \`auto_allocate: true\` in the submit envelope and clears \`cfg.Namespace\` so the server picks a free deployed slot.
- **\`--auto\` + \`--namespace\` is a usage error** (mutually exclusive).
- **Saved-session ns inherited from a previous \`/inject guided --next\` step gets silently overridden** when \`--auto\` is passed — only an *explicit* \`--namespace\` flag triggers the conflict guard. Reasoning: users who saved a session with a specific ns and now want \"just any free one\" shouldn't have to wipe the saved file.
- **\`injectSubmitItem.AllocatedNamespace\`** mirrors the new server-side response field, so callers see the chosen ns in the response JSON without parsing trace logs.

## Decision points worth reviewing

1. **No default-on.** When user omits both \`--namespace\` and \`--auto\`, behavior is unchanged (guidedcli's \`normalizeSystemSelection\` defaults to ns index 0). I deliberately did NOT make \`--auto\` the default when \`--namespace\` is missing, because:
   - That would change the meaning of every existing scripted invocation.
   - Saved-session configs without a ns currently get a deterministic default; switching to dynamic allocation would surprise scripts that key on the trace by ns name.
   - Explicit opt-in is fine for v1; default-on is a separate UX decision that deserves its own discussion.
2. **Auto-clearing ns when \`--auto\` is set.** I clear \`cfg.Namespace\` only on the wire (just before envelope construction). I do NOT mutate the saved session config — next session run still has whatever was there. This is consistent with how \`--auto\` is an apply-time concern, not a session-state mutation.
3. **No regression-side change.** \`aegisctl regression run\` doesn't get \`--auto\` here. Regression cases ship with explicit ns and \`--auto-install\` already covers the bootstrap UX. Open to extending if anyone uses regression-style runs against a shared pool.

## Test plan

- [ ] **Currently can't local-build** — main is broken (PR #150 deps bump introduced k8s.io/api@0.36.0 vs sigs.k8s.io/controller-runtime@0.23.3 incompat). Same blocker as PR #167. CI will check both once main is fixed.
- [ ] Manual once unblocked:
  - \`aegisctl inject guided --apply --auto --system sockshop ...\` → submit with \`auto_allocate: true\`, no \`namespace\` in cfg → response includes \`allocated_namespace\` and trace runs against that ns.
  - \`aegisctl inject guided --apply --auto --namespace sockshop3 ...\` → exits with \"--auto cannot be combined with --namespace\".
  - \`aegisctl inject guided --apply --auto ...\` against a pool with no free slot → server returns 500 with \"pool exhausted\" hint; CLI surfaces it.

## Depends on

- **PR #167** (PR-A) — backend \`auto_allocate\` field. Until that ships, \`--auto\` is a no-op (server ignores unknown JSON field).

## Related

- Closes part of #166 (CLI surface for auto-allocate).
- Builds on PR #164 + PR #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)