### PR TITLE
feat(inject): bootstrap-on-allocate when AllowBootstrap=true (#166 PR-C)

### DIFF
--- a/AegisLab/src/module/injection/alloc.go
+++ b/AegisLab/src/module/injection/alloc.go
@@ -18,10 +18,42 @@ import (
 
 // ErrPoolExhausted is returned by AllocateNamespaceForRestart when every
 // 0..count-1 slot of a system is either lock-active or has no deployed
-// workload. Callers should surface an actionable hint suggesting
-// `aegisctl inject guided --install --namespace <system>N` to expand the
-// pool — see #166 for the design tradeoffs.
+// workload, AND opts.AllowBootstrap is false. Callers should surface an
+// actionable hint suggesting `aegisctl inject guided --install
+// --namespace <system>N` to expand the pool — see #166 for the design
+// tradeoffs.
 var ErrPoolExhausted = errors.New("namespace pool exhausted: every slot is locked or has no deployed workload")
+
+// AllocateOptions tunes the allocator behaviour without bloating the call
+// signature. v1 has only one knob (AllowBootstrap); future flags drop in
+// here.
+type AllocateOptions struct {
+	// AllowBootstrap, when true, lets the allocator extend the system's
+	// count by 1 when no existing slot qualifies (PR-C, #166). The new
+	// slot is reserved by locking the next ns name (<system><count>) and
+	// bumping the chaos-system count via CountWriter. AllocateResult.Fresh
+	// is set so callers know to skip submit-time BuildInjection for this
+	// slot — RestartPedestal at runtime helm-installs before the
+	// FaultInjection task runs.
+	AllowBootstrap bool
+
+	// CountWriter is required when AllowBootstrap is true. Used to bump
+	// `injection.system.<system>.count` so config.GetAllNamespaces()
+	// includes the new slot. Ignored when AllowBootstrap is false.
+	CountWriter ChaosSystemWriter
+}
+
+// AllocateResult is the return shape of AllocateNamespaceForRestart.
+type AllocateResult struct {
+	// Namespace is the chosen pool slot (e.g. "sockshop3"). Always
+	// non-empty on success.
+	Namespace string
+	// Fresh reports whether this allocation was satisfied by bumping the
+	// pool (AllowBootstrap path) rather than by filling a hole. Fresh
+	// slots have no workload at submit time and need RestartPedestal to
+	// install before the inject task can find pods.
+	Fresh bool
+}
 
 // WorkloadProbe checks whether `namespace` has at least one pod deployed.
 // Injected by callers so tests don't need a live cluster. Production wiring
@@ -71,45 +103,48 @@ func AllocateNamespaceForRestart(
 	endTime time.Time,
 	traceID string,
 	probe WorkloadProbe,
-) (string, error) {
+	opts AllocateOptions,
+) (AllocateResult, error) {
 	if redis == nil {
-		return "", fmt.Errorf("redis gateway required")
+		return AllocateResult{}, fmt.Errorf("redis gateway required")
 	}
 	if traceID == "" {
-		return "", fmt.Errorf("traceID required")
+		return AllocateResult{}, fmt.Errorf("traceID required")
+	}
+	if opts.AllowBootstrap && opts.CountWriter == nil {
+		return AllocateResult{}, fmt.Errorf("AllowBootstrap requires CountWriter")
 	}
 
 	cfg, ok := config.GetChaosSystemConfigManager().Get(chaos.SystemType(system))
 	if !ok {
-		return "", fmt.Errorf("system %q not registered", system)
-	}
-	if cfg.Count <= 0 {
-		return "", ErrPoolExhausted
+		return AllocateResult{}, fmt.Errorf("system %q not registered", system)
 	}
 	template := nsTemplateFromPattern(cfg.NsPattern)
 	if template == "" {
-		return "", fmt.Errorf("invalid ns_pattern for system %s: %q", system, cfg.NsPattern)
+		return AllocateResult{}, fmt.Errorf("invalid ns_pattern for system %s: %q", system, cfg.NsPattern)
 	}
 
 	allocKey := fmt.Sprintf(allocLockKeyPattern, system)
 	acquired, err := redis.SetNX(ctx, allocKey, traceID, allocLockTTL)
 	if err != nil {
-		return "", fmt.Errorf("acquire allocator lock for %s: %w", system, err)
+		return AllocateResult{}, fmt.Errorf("acquire allocator lock for %s: %w", system, err)
 	}
 	if !acquired {
-		return "", fmt.Errorf("allocator busy for system %s, retry shortly", system)
+		return AllocateResult{}, fmt.Errorf("allocator busy for system %s, retry shortly", system)
 	}
 	defer func() {
 		_, _ = redis.DeleteKey(context.Background(), allocKey)
 	}()
 
 	now := time.Now()
+
+	// Pass 1: hole-fill. Walk existing slots lowest-index first.
 	for idx := 0; idx < cfg.Count; idx++ {
 		ns := fmt.Sprintf(template, idx)
 
-		active, err := nsLockActive(ctx, redis, ns, now)
-		if err != nil {
-			return "", fmt.Errorf("check lock for %s: %w", ns, err)
+		active, lockErr := nsLockActive(ctx, redis, ns, now)
+		if lockErr != nil {
+			return AllocateResult{}, fmt.Errorf("check lock for %s: %w", ns, lockErr)
 		}
 		if active {
 			continue
@@ -118,7 +153,7 @@ func AllocateNamespaceForRestart(
 		if probe != nil {
 			hasWorkload, probeErr := probe(ctx, ns)
 			if probeErr != nil {
-				return "", fmt.Errorf("probe workload in %s: %w", ns, probeErr)
+				return AllocateResult{}, fmt.Errorf("probe workload in %s: %w", ns, probeErr)
 			}
 			if !hasWorkload {
 				continue
@@ -131,10 +166,28 @@ func AllocateNamespaceForRestart(
 			// allocation.
 			continue
 		}
-		return ns, nil
+		return AllocateResult{Namespace: ns, Fresh: false}, nil
 	}
 
-	return "", ErrPoolExhausted
+	// Pass 2: bootstrap a fresh slot at index = count, if allowed.
+	if !opts.AllowBootstrap {
+		return AllocateResult{}, ErrPoolExhausted
+	}
+	freshNs := fmt.Sprintf(template, cfg.Count)
+	bumped, bumpErr := opts.CountWriter.EnsureCountForNamespace(ctx, system, freshNs)
+	if bumpErr != nil {
+		return AllocateResult{}, fmt.Errorf("bootstrap-allocate: bump count for %s to register %s: %w", system, freshNs, bumpErr)
+	}
+	if !bumped {
+		// Count already covered this index — race with another allocator
+		// that just bumped. Fall through and lock anyway; if THAT
+		// allocator also locked it, our acquire returns busy and we
+		// fail clearly.
+	}
+	if err := nsLockAcquire(ctx, redis, freshNs, endTime, traceID, now); err != nil {
+		return AllocateResult{}, fmt.Errorf("bootstrap-allocate: lock new slot %s: %w", freshNs, err)
+	}
+	return AllocateResult{Namespace: freshNs, Fresh: true}, nil
 }
 
 // nsTemplateFromPattern mirrors config.convertPatternToTemplate (private

--- a/AegisLab/src/module/injection/api_types.go
+++ b/AegisLab/src/module/injection/api_types.go
@@ -405,6 +405,15 @@ type SubmitInjectionReq struct {
 	// to expand the pool. Configs that already specify a namespace
 	// continue to honor PR #164's hard-constraint path unchanged.
 	AutoAllocate bool `json:"auto_allocate" binding:"omitempty"`
+
+	// AllowBootstrap, in combination with AutoAllocate, lets the server
+	// extend the system's pool when no existing slot qualifies. The server
+	// bumps `injection.system.<system>.count` by 1, locks the new ns, and
+	// returns it as a "fresh" slot. RestartPedestal at runtime helm-
+	// installs into the fresh slot before the FaultInjection task runs;
+	// submit-time BuildInjection's pod listing is skipped for fresh
+	// slots since pods don't exist yet. See PR-C of #166.
+	AllowBootstrap bool `json:"allow_bootstrap" binding:"omitempty"`
 }
 
 func (req *SubmitInjectionReq) GuidedSpecs() [][]guidedcli.GuidedConfig {

--- a/AegisLab/src/module/injection/service.go
+++ b/AegisLab/src/module/injection/service.go
@@ -31,10 +31,14 @@ import (
 // allocatedSlot pairs the namespace chosen by AllocateNamespaceForRestart
 // with the pre-generated traceID under which the namespace lock was taken.
 // Both flow into the per-batch task built later: namespace into the
-// payload's RestartRequiredNamespace, traceID into task.TraceID.
+// payload's RestartRequiredNamespace, traceID into task.TraceID. Fresh
+// indicates a bootstrapped slot (no workload yet); the submit path must
+// skip BuildInjection pod-listing and trust RestartPedestal to install
+// before the inject task runs.
 type allocatedSlot struct {
 	namespace string
 	traceID   string
+	fresh     bool
 }
 
 // batchNeedsAutoAllocate reports whether at least one config in the batch
@@ -289,19 +293,24 @@ func (s *Service) SubmitFaultInjection(ctx context.Context, req *SubmitInjection
 		// Sized to comfortably cover restart + injection + a slack buffer.
 		lockEndTime := time.Now().Add(time.Duration(req.Interval+10) * time.Minute)
 		probe := defaultWorkloadProbe()
+		allocOpts := AllocateOptions{
+			AllowBootstrap: req.AllowBootstrap,
+			CountWriter:    s.chaosSystems,
+		}
 		for batchIdx, batch := range guidedSpecs {
 			if !batchNeedsAutoAllocate(batch) {
 				continue
 			}
 			traceID := uuid.NewString()
-			allocatedNs, allocErr := AllocateNamespaceForRestart(ctx, s.redis, pedestalItem.ContainerName, lockEndTime, traceID, probe)
+			result, allocErr := AllocateNamespaceForRestart(ctx, s.redis, pedestalItem.ContainerName, lockEndTime, traceID, probe, allocOpts)
 			if allocErr != nil {
-				return nil, fmt.Errorf("auto-allocate batch %d for system %s: %w (hint: run `aegisctl inject guided --install --namespace %s<N>` to expand the pool)", batchIdx, pedestalItem.ContainerName, allocErr, pedestalItem.ContainerName)
+				hint := fmt.Sprintf("run `aegisctl inject guided --install --namespace %s<N>` to expand the pool, or pass --allow-bootstrap", pedestalItem.ContainerName)
+				return nil, fmt.Errorf("auto-allocate batch %d for system %s: %w (hint: %s)", batchIdx, pedestalItem.ContainerName, allocErr, hint)
 			}
-			allocations[batchIdx] = allocatedSlot{namespace: allocatedNs, traceID: traceID}
+			allocations[batchIdx] = allocatedSlot{namespace: result.Namespace, traceID: traceID, fresh: result.Fresh}
 			for cfgIdx := range guidedSpecs[batchIdx] {
 				if strings.TrimSpace(guidedSpecs[batchIdx][cfgIdx].Namespace) == "" {
-					guidedSpecs[batchIdx][cfgIdx].Namespace = allocatedNs
+					guidedSpecs[batchIdx][cfgIdx].Namespace = result.Namespace
 				}
 			}
 		}
@@ -321,11 +330,28 @@ func (s *Service) SubmitFaultInjection(ctx context.Context, req *SubmitInjection
 	processedItems := make([]injectionProcessItem, 0, len(guidedSpecs))
 	var parseWarnings []string
 	for i := range guidedSpecs {
+		alloc, hasAlloc := allocations[i]
+		// Fresh bootstrapped slots have no workload yet, so the submit-time
+		// guidedcli.BuildInjection inside parseBatchGuidedSpecs would fail
+		// at `app X not found in namespace Y` because pod listing returns
+		// empty. Build the item directly from the request-supplied fields
+		// — system-type sanity check has already been done implicitly by
+		// the allocator (it ran against the pedestal's system), and
+		// groundtruth dedup warnings don't apply since fresh slots can't
+		// collide with other batches in the same submit (each gets its
+		// own ns).
+		if hasAlloc && alloc.fresh {
+			item := buildFreshSlotItem(i, guidedSpecs[i])
+			item.allocatedNamespace = alloc.namespace
+			item.preallocTraceID = alloc.traceID
+			processedItems = append(processedItems, item)
+			continue
+		}
 		item, warning, err := parseBatchGuidedSpecs(ctx, pedestalItem.ContainerName, i, guidedSpecs[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse guided spec batch %d: %w", i, err)
 		}
-		if alloc, ok := allocations[i]; ok {
+		if hasAlloc {
 			item.allocatedNamespace = alloc.namespace
 			item.preallocTraceID = alloc.traceID
 		}

--- a/AegisLab/src/module/injection/submit.go
+++ b/AegisLab/src/module/injection/submit.go
@@ -102,6 +102,29 @@ func mergeSpecServicesForDupCheck(uniqueServices map[string]int, specServices []
 	return warnings
 }
 
+// buildFreshSlotItem produces an injectionProcessItem for a batch whose
+// namespace was bootstrapped (PR-C of #166): the slot has no deployed
+// workload at submit time, so we can't run guidedcli.BuildInjection's
+// pod-listing without a spurious "app not found" error. Skip the
+// validation entirely; pull maxDuration from the request fields and let
+// the runtime FaultInjection task do the real BuildInjection after
+// RestartPedestal has helm-installed the workload. Cross-spec
+// groundtruth dedup is skipped because fresh slots are exclusive — no
+// other batch lands here in the same submit.
+func buildFreshSlotItem(batchIndex int, configs []guidedcli.GuidedConfig) injectionProcessItem {
+	maxDuration := 0
+	for _, cfg := range configs {
+		if cfg.Duration != nil && *cfg.Duration > maxDuration {
+			maxDuration = *cfg.Duration
+		}
+	}
+	return injectionProcessItem{
+		index:         batchIndex,
+		faultDuration: maxDuration,
+		guidedConfigs: configs,
+	}
+}
+
 // firstGuidedNamespace returns the first non-empty `namespace` among the
 // given guided configs. Used by SubmitFaultInjection to promote the
 // user-supplied namespace into RestartPedestal's payload as a hard


### PR DESCRIPTION
## Summary

PR-C of the #166 plan. **Stacked on PR #167 (PR-A)** — base branch is \`feat/166-pr-a-allocate-namespace\`, not main. When AutoAllocate hits an exhausted pool, AllowBootstrap=true tells the allocator to bump count and use the new slot instead of erroring out.

## What's in this PR

- **\`AllocateOptions\`** with \`AllowBootstrap bool\` and \`CountWriter ChaosSystemWriter\` (reuses PR #164's chaossystem writer seam).
- **\`AllocateResult\` { Namespace, Fresh }** replaces the bare \`(string, error)\` return. \`Fresh=true\` flags bootstrapped slots so the submit path knows to skip pod-listing.
- **Allocator pass-2**: when hole-fill exhausts, if AllowBootstrap is true, allocator picks \`<system><count>\`, calls \`EnsureCountForNamespace\` to bump etcd, locks the new ns. Returns \`{Namespace, Fresh: true}\`.
- **\`SubmitInjectionReq.AllowBootstrap\`** request field.
- **\`buildFreshSlotItem\`** in \`submit.go\` produces a minimal \`injectionProcessItem\` for fresh-slot batches without calling \`guidedcli.BuildInjection\`. Skips the pod-listing that would fail \"app not found\". Skips groundtruth dedup since fresh slots are exclusive.

## Decision points worth reviewing

1. **Submit returns immediately; install happens at runtime.** I deliberately did NOT add a synchronous helm install at submit time. The user gets a fast submit response with the new ns name; RestartPedestal at runtime does the actual install before the FaultInjection task runs. Tradeoff: install errors surface as a failed RestartPedestal task instead of a synchronous submit error, but the alternative (blocking submit for several minutes) felt worse for v1. Open to feedback.
2. **Skip BuildInjection for fresh slots, NOT for hole-filled slots.** Hole-filled slots have workloads, so guided validation works. Fresh slots don't — and BuildInjection's \`safeAppLabels\` call would 500 on missing pods. \`buildFreshSlotItem\` synthesizes the minimal info without calling into chaos-experiment. Cost: user-side guided config typos (wrong app name, etc.) won't be caught at submit; they surface later when the runtime FaultInjection task tries BuildInjection in the now-installed ns.
3. **No rollback on partial failure.** If batch 3 of 5 fails after batches 0-2 successfully allocated, those locks are held and (for fresh slots) counts are bumped. Locks expire via TTL; counts stay bumped (probably fine — pool can remain larger). A v2 could add explicit rollback.
4. **No aegisctl flag in this PR.** PR-B (#168) added \`--auto\`; an \`--allow-bootstrap\` flag is a small follow-up either to PR-B or as a fourth PR. Not blocking PR-C from merging.
5. **Race window between count bump and ns lock.** Inside the alloc:<system> Redis lock so concurrent allocators are serialized. Even if EnsureCountForNamespace returns \"already covered\" (another allocator already bumped), the subsequent ns-lock acquire serializes correctly — if THAT allocator also locked the same ns, our acquire returns busy and the request fails with a clear error.

## Test plan

- [ ] **Currently can't local-build** — same upstream main breakage as PR #167. CI will surface once main is fixed.
- [ ] Manual once unblocked:
  - \`POST /inject\` with \`auto_allocate: true\`, \`allow_bootstrap: true\`, all pool slots busy → response includes \`allocated_namespace: \"<system>\" + count\`, count bumped by 1, RestartPedestal helm-installs the new slot, FaultInjection runs.
  - Same call with \`allow_bootstrap: false\` → ErrPoolExhausted with hint.
  - Concurrent submits both with allow_bootstrap → only one bumps count, the other gets a different fresh slot at next index.

## Stack order for merge

1. PR #167 (PR-A) — must merge first.
2. This PR (PR-C) — auto-rebases on main once PR-A merges.
3. PR #168 (PR-B) — independent of PR-C; merges anytime after PR-A.

## Related

- Depends on PR #167 (allocator foundation).
- Builds on PR #164 (chaossystem writer + RestartRequiredNamespace runtime path).
- Closes the bootstrap leg of #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)