### PR TITLE
fix: 3 main-branch blockers found running auto-allocate inject loop

### DIFF
--- a/AegisLab/src/Dockerfile
+++ b/AegisLab/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 
 ARG GO_BUILD_TAGS
 ARG GOPROXY="https://proxy.golang.org,direct"

--- a/AegisLab/src/app/http_modules.go
+++ b/AegisLab/src/app/http_modules.go
@@ -35,5 +35,8 @@ func ExecutionInjectionOwnerModules() fx.Option {
 }
 
 func ProducerHTTPModules() fx.Option {
-	return fx.Options(producerHTTPModules()...)
+	return fx.Options(
+		fx.Options(producerHTTPModules()...),
+		fx.Provide(chaosSystemWriterAdapter),
+	)
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/inject_guided.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_guided.go
@@ -67,6 +67,11 @@ var (
 	// (in which case the namespace is cleared just for this apply).
 	guidedAutoAllocate bool
 
+	// #166 PR-C: pair with --auto to let the server bootstrap a fresh pool
+	// slot (helm install workload + bump system count) when every existing
+	// slot is occupied. No-op without --auto.
+	guidedAllowBootstrap bool
+
 	// Test seams: replace with fakes in unit tests.
 	guidedInstallerHook chartInstaller
 	guidedPodListerHook PodLister
@@ -311,6 +316,7 @@ func init() {
 	f.IntVar(&guidedInstallReadyTimeoutSec, "install-ready-timeout", 600, "Seconds --install waits for pods in the target namespace to reach Ready before continuing with discovery")
 	f.BoolVar(&guidedSkipRestartPedestal, "skip-restart-pedestal", false, "On --apply, hint the backend's RestartPedestal task to skip the helm install when the release is already healthy (task still runs; only the install step short-circuits)")
 	f.BoolVar(&guidedAutoAllocate, "auto", false, "On --apply, ask the server to pick a free deployed namespace from the system's pool (mutually exclusive with --namespace; allocated namespace surfaces in submit response). See #166.")
+	f.BoolVar(&guidedAllowBootstrap, "allow-bootstrap", false, "Pair with --auto: when no deployed slot is free, let the server bootstrap a fresh slot (helm install + bump system count) instead of failing with pool-exhausted. No-op without --auto. See #166 PR-C.")
 
 	// --apply envelope flags (mirror the injection YAML contract)
 	f.StringVar(&guidedApplyPedestalName, "pedestal-name", "", "Pedestal container name (required with --apply)")
@@ -407,6 +413,9 @@ func submitGuidedApply(cfg guidedcli.GuidedConfig) error {
 	if guidedAutoAllocate {
 		envelope["auto_allocate"] = true
 	}
+	if guidedAllowBootstrap {
+		envelope["allow_bootstrap"] = true
+	}
 	if flagDryRun {
 		output.PrintJSON(map[string]any{
 			"dry_run":    true,
@@ -478,6 +487,9 @@ func submitGuidedApplyWithOptions(projectName string, cfg guidedcli.GuidedConfig
 	}
 	if guidedAutoAllocate {
 		envelope["auto_allocate"] = true
+	}
+	if guidedAllowBootstrap {
+		envelope["allow_bootstrap"] = true
 	}
 
 	c := newClient()


### PR DESCRIPTION
## Summary

Three independent fixes for bugs hit while running an auto-allocate fault-injection loop on sockshop today. Each is small and self-contained; bundled into one PR because none of them are testable in isolation without the other two.

### 1. Dockerfile go base 1.24 → 1.26

`AegisLab/src/go.mod` was bumped to `go 1.26.0` by #150, but `AegisLab/src/Dockerfile` still pinned `golang:1.24-bookworm`. Local `docker build` fails with:

```
go: go.mod requires go >= 1.26.0 (running go 1.24.13; GOTOOLCHAIN=local)
ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

CI may be passing because GitHub-hosted shared workflows pin a different toolchain.

### 2. ProducerHTTPModules missing `chaosSystemWriterAdapter` Provide

`#156` introduced `injection.ChaosSystemWriter` (narrow interface) and the `chaosSystemWriterAdapter` Provide that bridges `chaossystem.Writer` → `injection.ChaosSystemWriter`. The Provide was registered only in `ExecutionInjectionOwnerModules()` (used by consumer / runtime-worker-service paths). But `ProducerHTTPModules()` (used by producer / api-gateway / both modes) loads `injection.Module` without this adapter, so fx panics at startup:

```
[Fx] ERROR  Failed to start
failed to build *injection.Service:
missing dependencies for function "aegis/module/injection".NewService
  /app/module/injection/service.go:88:
missing type: injection.ChaosSystemWriter (did you mean to Provide it?)
```

Reproduced by deploying `loop-20260425` image to cluster — api-gateway pod CrashLoopBackOff. Fix is to register the adapter inside `ProducerHTTPModules()` too.

### 3. `aegisctl inject guided --allow-bootstrap` flag

`#166 PR-C` added backend support for `allow_bootstrap: true` on the inject submit envelope (lets the allocator extend the system pool when no deployed slot is free). PR-B added `--auto` to aegisctl but forgot to wire `--allow-bootstrap`, so users can't actually opt into the new path from the CLI. This patch adds the flag and threads it through both submit envelope sites.

## How this was discovered

A loop campaign on sockshop tried `aegisctl inject guided --apply --auto --allow-bootstrap ...`. (1) Image build failed → fix Dockerfile. (2) New image rolled out, api-gateway crashed → fix fx wiring. (3) CLI didn't expose the flag — added it.

## Test plan

- [x] `docker build -f AegisLab/src/Dockerfile .` succeeds locally with go 1.26 base.
- [x] Cluster pods Ready after helm upgrade with new image (`api-gateway`, `runtime-worker-service`).
- [x] `aegisctl inject guided --apply --auto --allow-bootstrap` accepted by backend, returns `allocated_namespace: sockshop1`.
- [ ] CI: docker workflow passes.
- [ ] Reviewer eyeballs the fx Provide site — it's the kind of thing that's easy to also-add in an unrelated module without realizing.

## Notes

There is a separate, deeper bug in the `--auto --allow-bootstrap` path where every subsequent call after the first reuses the same fresh slot index — that's #166 follow-up and being investigated separately. This PR doesn't fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)