### PR TITLE
fix(inject): #166 bootstrap path keeps reusing same fresh slot

### DIFF
--- a/AegisLab/src/module/chaossystem/service.go
+++ b/AegisLab/src/module/chaossystem/service.go
@@ -66,7 +66,12 @@ func systemKey(name string, field systemField) string {
 // config_histories. The systems table is gone.
 type Service struct {
 	repo *Repository
-	etcd *etcd.Gateway
+	etcd chaosSystemEtcd
+}
+
+type chaosSystemEtcd interface {
+	Get(ctx context.Context, key string) (string, error)
+	Put(ctx context.Context, key, value string, ttl time.Duration) error
 }
 
 func NewService(repo *Repository, etcdGw *etcd.Gateway) *Service {
@@ -666,6 +671,9 @@ func (s *Service) applyChange(ctx context.Context, system string, field systemFi
 
 	if err := s.publishKey(ctx, key, newValue); err != nil {
 		return err
+	}
+	if err := config.SetViperValue(key, newValue, anchor.ValueType); err != nil {
+		return fmt.Errorf("failed to update local viper cache for %s: %w", key, err)
 	}
 
 	_ = s.repo.WriteHistory(&model.ConfigHistory{

--- a/AegisLab/src/module/chaossystem/service_test.go
+++ b/AegisLab/src/module/chaossystem/service_test.go
@@ -3,16 +3,36 @@ package chaossystem
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
+	"aegis/config"
 	"aegis/consts"
 	"aegis/model"
 	"aegis/service/common"
 
+	chaos "github.com/OperationsPAI/chaos-experiment/handler"
 	"github.com/spf13/viper"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+type fakeEtcd struct {
+	data map[string]string
+}
+
+func (f *fakeEtcd) Get(_ context.Context, key string) (string, error) {
+	if value, ok := f.data[key]; ok {
+		return value, nil
+	}
+	return "", fmt.Errorf("key not found: %s", key)
+}
+
+func (f *fakeEtcd) Put(_ context.Context, key, value string, _ time.Duration) error {
+	f.data[key] = value
+	return nil
+}
 
 // newMetadataService spins up an in-memory service stripped of the etcd
 // gateway. It is sufficient for exercising the metadata upsert / list flow —
@@ -30,10 +50,10 @@ func newMetadataService(t *testing.T) (*Service, *gorm.DB, *common.DBMetadataSto
 	}
 
 	store := common.NewDBMetadataStore(db)
-	// NewService enforces a non-nil etcd gateway; this test only exercises
-	// metadata upsert / list (no etcd writes), so build the struct directly
-	// rather than spinning up a fake gateway.
-	svc := &Service{repo: NewRepository(db)}
+	svc := &Service{
+		repo: NewRepository(db),
+		etcd: &fakeEtcd{data: map[string]string{}},
+	}
 	return svc, db, store
 }
 
@@ -197,6 +217,68 @@ func TestEnsureCountForNamespaceRejectsMismatch(t *testing.T) {
 	}
 	if !errors.Is(err, consts.ErrBadRequest) {
 		t.Errorf("EnsureCountForNamespace: error should wrap ErrBadRequest; got %v", err)
+	}
+}
+
+// TestEnsureCountForNamespaceKeepsBootstrapIndexMoving reproduces the stale
+// count bug from alloc.go pass 2: each bootstrap allocation computes the
+// candidate namespace from the current config count, then asks
+// EnsureCountForNamespace to extend the pool. The local config must update
+// immediately or every call keeps reusing the same fresh slot until the etcd
+// watcher eventually catches up.
+func TestEnsureCountForNamespaceKeepsBootstrapIndexMoving(t *testing.T) {
+	service, db, _ := newMetadataService(t)
+	const systemName = "sockshop"
+	cleanup := seedSystemInViper(t, systemName, false)
+	defer cleanup()
+
+	anchor := &model.DynamicConfig{
+		Key:          systemKey(systemName, fieldCount),
+		DefaultValue: "1",
+		ValueType:    consts.ConfigValueTypeInt,
+		Scope:        consts.ConfigScopeGlobal,
+	}
+	if err := db.Create(anchor).Error; err != nil {
+		t.Fatalf("seed anchor: %v", err)
+	}
+
+	etcdKey := consts.ConfigEtcdGlobalPrefix + anchor.Key
+	service.etcd.(*fakeEtcd).data[etcdKey] = "1"
+
+	got := make([]string, 0, 3)
+	for i := 0; i < 3; i++ {
+		cfg, ok := config.GetChaosSystemConfigManager().Get(chaos.SystemType(systemName))
+		if !ok {
+			t.Fatalf("system %s not found in config manager", systemName)
+		}
+		ns := fmt.Sprintf("%s%d", systemName, cfg.Count)
+		got = append(got, ns)
+
+		bumped, err := service.EnsureCountForNamespace(context.Background(), systemName, ns)
+		if err != nil {
+			t.Fatalf("EnsureCountForNamespace(%s): %v", ns, err)
+		}
+		if !bumped {
+			t.Fatalf("EnsureCountForNamespace(%s): expected bump", ns)
+		}
+	}
+
+	want := []string{"sockshop1", "sockshop2", "sockshop3"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("bootstrap sequence = %v, want %v", got, want)
+		}
+	}
+
+	cfg, ok := config.GetChaosSystemConfigManager().Get(chaos.SystemType(systemName))
+	if !ok {
+		t.Fatalf("system %s missing after bumps", systemName)
+	}
+	if cfg.Count != 4 {
+		t.Fatalf("final count = %d, want 4", cfg.Count)
+	}
+	if service.etcd.(*fakeEtcd).data[etcdKey] != "4" {
+		t.Fatalf("etcd count = %s, want 4", service.etcd.(*fakeEtcd).data[etcdKey])
 	}
 }
 


### PR DESCRIPTION
## Summary

`AllocateNamespaceForRestart`'s pass-2 bootstrap branch always picks `fmt.Sprintf(template, cfg.Count)`. After the first bootstrap allocation, `chaossystem.EnsureCountForNamespace` writes the new count to etcd, but **never refreshes the local Viper store**, so the in-process `config.GetChaosSystemConfigManager().Get(...)` keeps returning the old `count`. Every subsequent `--auto --allow-bootstrap` call therefore re-picks the same `sockshop1`, then fails at `nsLockAcquire` because the previous owner still holds it. `aegisctl system list` likewise stays at the stale `count` until the producer pod restarts and re-reads etcd from scratch.

This bug was not caught by #166 PR-A's tests because they only covered single-call allocation, not a sequence.

## Reproducer (10/10 hits in today's sockshop campaign)

```
# After deleting all sockshop ns, with sockshop count=1:
aegisctl inject guided --apply --auto --allow-bootstrap ... → returns sockshop1 ✓
# next call (any) →
Failed to submit fault injection: auto-allocate batch 0 for system sockshop:
  bootstrap-allocate: lock new slot sockshop1: namespace sockshop1 locked by 24e91bda-...
```

## Root cause

(b) — chaossystem write path stale-cache, NOT a Redis race or `alloc.go` arithmetic bug.

`chaossystem/service.go` `applyChange` writes the new count to etcd via the dynamic-config API, but doesn't write it back to the local Viper instance that backs `config.GetChaosSystemConfigManager()`. The Viper update arrives only via the etcd-watch goroutine, which can race with subsequent allocator calls in the same producer pod.

## Fix

After `applyChange` writes etcd, immediately set the new value in local Viper. This makes the change visible to in-process callers right away; the etcd-watch path is still authoritative for cross-process sync.

## Test

Added `TestEnsureCountForNamespace_SequentialBootstrap` in `chaossystem/service_test.go` simulating three sequential bootstrap allocations on a fresh system. Asserts the sequence advances `sockshop1 → sockshop2 → sockshop3`. The test fails without this fix and passes with it.

## Test plan

- [x] `go test ./module/chaossystem/...` passes (regression test green).
- [x] `go build -tags duckdb_arrow ./main.go` clean.
- [ ] CI green.
- [ ] Reviewer eyeballs the Viper write — confirm we're not creating a write-after-watch loop.

## How this was discovered

While running an injection-loop campaign on sockshop, every bootstrap submission after the first reused the same slot index. Investigation traced through alloc.go (innocent, just reads cfg.Count), through Redis allocator-lock (innocent, serializes correctly), to the chaossystem write path which logs `bumped chaos-system count` but doesn't actually update the in-process view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)