### PR TITLE
fix(inject): #176 surface chaos-experiment resolver errors instead of fake duration error

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/inject_guided.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_guided.go
@@ -255,6 +255,17 @@ current stage's selection, and --apply to submit the finalized config.`,
 		}
 
 		if guidedApply {
+			// Issue #176: short-circuit before shipping an un-normalized
+			// config to the backend when the local resolver reported errors.
+			// Without this guard, finalizeOrRequest's failure path returns
+			// cfg with Duration=nil (normalizeDuration only runs on success),
+			// which the server's uniform validator then rejects with a
+			// misleading "specs[0][0].duration must be greater than 0"
+			// instead of the actual builder error (e.g. JVM method not
+			// found, mem_type unset, etc.).
+			if err := guidedResolveErr(response); err != nil {
+				return err
+			}
 			return submitGuidedApply(response.Config)
 		}
 
@@ -348,6 +359,67 @@ func init() {
 	f.IntVar(&guidedStatusCode, "status-code", 0, "HTTP status code")
 
 	injectCmd.AddCommand(injectGuidedCmd)
+}
+
+// guidedResolveErr inspects a GuidedResponse for resolver errors or a
+// non-final stage and returns a usage-coded error surfacing them to the user.
+// Returns nil when the response is safe to submit.
+//
+// Background (issue #176): chaos-experiment's finalizeOrRequest returns the
+// caller's config un-normalized (Duration still nil, etc.) whenever its
+// per-type builder fails. If the CLI ships that config to /inject anyway,
+// the server's uniform validator rejects it with a generic
+// "specs[0][0].duration must be greater than 0" that hides the real builder
+// error (missing JVM method, missing mem_type, decode failure, ...). We must
+// fail fast on the client and surface every resolver error so the user can
+// fix the actual root cause.
+func guidedResolveErr(response *guidedcli.GuidedResponse) error {
+	if response == nil {
+		return usageErrorf("guided resolver returned no response")
+	}
+	if len(response.Errors) == 0 && (response.Stage == "" || response.Stage == "ready_to_apply" || response.Stage == "applied") {
+		return nil
+	}
+
+	// Build a preamble that names what failed so the user knows which
+	// (chaos_type, app, class, method, ...) tuple to fix.
+	cfg := response.Config
+	preamble := "guided resolver did not finalize the config"
+	if strings.TrimSpace(cfg.ChaosType) != "" {
+		preamble = fmt.Sprintf("guided resolver failed for chaos_type=%s", strings.TrimSpace(cfg.ChaosType))
+		identifiers := make([]string, 0, 4)
+		if v := strings.TrimSpace(cfg.App); v != "" {
+			identifiers = append(identifiers, fmt.Sprintf("app=%s", v))
+		}
+		if v := strings.TrimSpace(cfg.Class); v != "" {
+			identifiers = append(identifiers, fmt.Sprintf("class=%s", v))
+		}
+		if v := strings.TrimSpace(cfg.Method); v != "" {
+			identifiers = append(identifiers, fmt.Sprintf("method=%s", v))
+		}
+		if v := strings.TrimSpace(cfg.Container); v != "" {
+			identifiers = append(identifiers, fmt.Sprintf("container=%s", v))
+		}
+		if len(identifiers) > 0 {
+			preamble = fmt.Sprintf("%s (%s)", preamble, strings.Join(identifiers, ", "))
+		}
+	}
+
+	if len(response.Errors) == 0 {
+		return usageErrorf("%s: stage=%q is not ready_to_apply (refusing to submit un-normalized config to /inject)",
+			preamble, response.Stage)
+	}
+
+	// Preserve every resolver error so the user sees the full set, not just
+	// the first one.
+	if len(response.Errors) == 1 {
+		return usageErrorf("%s: %s", preamble, response.Errors[0])
+	}
+	bullets := make([]string, 0, len(response.Errors))
+	for _, e := range response.Errors {
+		bullets = append(bullets, "  - "+e)
+	}
+	return usageErrorf("%s:\n%s", preamble, strings.Join(bullets, "\n"))
 }
 
 // submitGuidedApply wraps a finalized GuidedConfig in the SubmitInjectionReq

--- a/AegisLab/src/cmd/aegisctl/cmd/inject_guided_resolve_err_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_guided_resolve_err_test.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/OperationsPAI/chaos-experiment/pkg/guidedcli"
+)
+
+// TestGuidedResolveErr_HappyPath asserts that a finalized response with no
+// errors and stage=ready_to_apply does not trip the short-circuit.
+func TestGuidedResolveErr_HappyPath(t *testing.T) {
+	resp := &guidedcli.GuidedResponse{
+		Stage: "ready_to_apply",
+	}
+	if err := guidedResolveErr(resp); err != nil {
+		t.Fatalf("expected nil error for ready_to_apply with no errors; got %v", err)
+	}
+}
+
+// TestGuidedResolveErr_AppliedStageOK guards the rare case where the
+// resolver actually performed an apply locally (cfg.Apply=true, not the
+// aegisctl path) — that's still a terminal-success stage.
+func TestGuidedResolveErr_AppliedStageOK(t *testing.T) {
+	resp := &guidedcli.GuidedResponse{
+		Stage: "applied",
+	}
+	if err := guidedResolveErr(resp); err != nil {
+		t.Fatalf("expected nil error for applied stage; got %v", err)
+	}
+}
+
+// TestGuidedResolveErr_FailFastOnResolverErrors is the primary issue-#176
+// guard: when the local resolver returns a non-empty Errors slice, the CLI
+// must fail with usage exit code and surface the resolver error verbatim
+// instead of shipping an un-normalized config to /inject (which would
+// produce the misleading "duration must be greater than 0" server-side).
+func TestGuidedResolveErr_FailFastOnResolverErrors(t *testing.T) {
+	resp := &guidedcli.GuidedResponse{
+		Stage: "fill_required_fields",
+		Config: guidedcli.GuidedConfig{
+			ChaosType: "JVMMemoryStress",
+			App:       "shipping",
+			Class:     "com.example.ShippingResource",
+			Method:    "ship",
+		},
+		Errors: []string{
+			`jvm method "ship" not found under app "shipping" class "com.example.ShippingResource"`,
+		},
+	}
+	err := guidedResolveErr(resp)
+	if err == nil {
+		t.Fatalf("expected error when resolver reports errors; got nil")
+	}
+	if code := exitCodeFor(err); code != ExitCodeUsage {
+		t.Fatalf("expected ExitCodeUsage (%d); got %d", ExitCodeUsage, code)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "JVMMemoryStress") {
+		t.Fatalf("error message must include the chaos_type for context; got %q", msg)
+	}
+	if !strings.Contains(msg, "app=shipping") {
+		t.Fatalf("error message must include identifier (app=); got %q", msg)
+	}
+	if !strings.Contains(msg, "jvm method") {
+		t.Fatalf("error message must surface the resolver's actual error; got %q", msg)
+	}
+	// Crucially: must not mention the misleading server-side duration check.
+	if strings.Contains(msg, "duration must be greater than 0") {
+		t.Fatalf("error message must not regurgitate the misleading server validator message; got %q", msg)
+	}
+}
+
+// TestGuidedResolveErr_PreservesAllErrors ensures every resolver error
+// reaches the user, not just the first.
+func TestGuidedResolveErr_PreservesAllErrors(t *testing.T) {
+	resp := &guidedcli.GuidedResponse{
+		Stage: "fill_required_fields",
+		Config: guidedcli.GuidedConfig{
+			ChaosType: "JVMException",
+			App:       "auth",
+		},
+		Errors: []string{
+			"exception_opt is required",
+			"class not found in cache",
+			"resource lookup timed out",
+		},
+	}
+	err := guidedResolveErr(resp)
+	if err == nil {
+		t.Fatalf("expected error; got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"exception_opt is required", "class not found in cache", "resource lookup timed out"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error message must preserve resolver error %q; got %q", want, msg)
+		}
+	}
+}
+
+// TestGuidedResolveErr_NonFinalStageFailsEvenWithoutErrors covers the edge
+// case where the resolver returns a non-final stage (e.g. still asking for
+// more fields) but happens not to populate Errors[]. Submitting that
+// response would still ship an incomplete config to the server.
+func TestGuidedResolveErr_NonFinalStageFailsEvenWithoutErrors(t *testing.T) {
+	resp := &guidedcli.GuidedResponse{
+		Stage: "fill_required_fields",
+		Config: guidedcli.GuidedConfig{
+			ChaosType: "JVMMemoryStress",
+		},
+	}
+	err := guidedResolveErr(resp)
+	if err == nil {
+		t.Fatalf("expected error for non-final stage; got nil")
+	}
+	if code := exitCodeFor(err); code != ExitCodeUsage {
+		t.Fatalf("expected ExitCodeUsage (%d); got %d", ExitCodeUsage, code)
+	}
+	if !strings.Contains(err.Error(), "fill_required_fields") {
+		t.Fatalf("error message must surface the stage; got %q", err.Error())
+	}
+}
+
+// TestGuidedResolveErr_NilResponse hardens against a nil pointer (defensive;
+// guidedcli.Resolve returning nil with err==nil shouldn't happen but a
+// caller mistake would otherwise panic in submit).
+func TestGuidedResolveErr_NilResponse(t *testing.T) {
+	if err := guidedResolveErr(nil); err == nil {
+		t.Fatalf("expected error for nil response; got nil")
+	}
+}

--- a/AegisLab/src/module/injection/api_types.go
+++ b/AegisLab/src/module/injection/api_types.go
@@ -454,8 +454,27 @@ func (req *SubmitInjectionReq) Validate() error {
 			if strings.TrimSpace(spec.ChaosType) == "" {
 				return fmt.Errorf("specs[%d][%d].chaos_type is required", i, j)
 			}
-			if spec.Duration == nil || *spec.Duration <= 0 {
-				return fmt.Errorf("specs[%d][%d].duration must be greater than 0", i, j)
+			// Issue #176: distinguish "resolver never set Duration" from
+			// "resolver set Duration to a bad value". The chaos-experiment
+			// guidedcli's finalizeOrRequest only runs normalizeDuration on
+			// the success branch, so a nil Duration on the wire means the
+			// resolver bailed out (builder error: missing JVM method, unset
+			// mem_type, decode failure, ...) and shipped an un-normalized
+			// config. Surface that hypothesis instead of regurgitating a
+			// generic "duration > 0" message that hides the real cause.
+			// Defense-in-depth: aegisctl already short-circuits on
+			// response.Errors before reaching here, but a non-aegisctl
+			// caller (or a future bug in the CLI) would otherwise still
+			// hit the misleading message.
+			if spec.Duration == nil {
+				return fmt.Errorf(
+					"specs[%d][%d].duration is missing for chaos_type=%q — the chaos-experiment guided resolver typically default-fills duration on success, "+
+						"so a missing duration usually means the resolver hit a builder error (missing required field, JVM method not in cache, mem_type decode failure, ...) "+
+						"and shipped an un-normalized config; re-run the guided session and check the resolver's `errors` field, or pass `duration` explicitly",
+					i, j, strings.TrimSpace(spec.ChaosType))
+			}
+			if *spec.Duration <= 0 {
+				return fmt.Errorf("specs[%d][%d].duration must be greater than 0 (got %d)", i, j, *spec.Duration)
 			}
 		}
 	}

--- a/AegisLab/src/module/injection/guided_submit_test.go
+++ b/AegisLab/src/module/injection/guided_submit_test.go
@@ -79,14 +79,32 @@ func TestSubmitInjectionReqValidateRejectsEmptyBatch(t *testing.T) {
 	require.ErrorContains(t, err, "must contain at least one guided config")
 }
 
+// TestSubmitInjectionReqValidateRejectsMissingDuration is the issue-#176
+// defense-in-depth assertion: when the resolver fails to default-fill
+// Duration (i.e. the chaos-experiment builder errored and shipped an
+// un-normalized config), the validator must point at the resolver as the
+// likely cause, NOT regurgitate the generic "duration > 0" message.
 func TestSubmitInjectionReqValidateRejectsMissingDuration(t *testing.T) {
 	req := validSubmitInjectionReq()
 	req.Specs[0][0].Duration = nil
+	req.Specs[0][0].ChaosType = "JVMMemoryStress"
 
 	err := req.Validate()
-	require.ErrorContains(t, err, "duration must be greater than 0")
+	require.Error(t, err)
+	msg := err.Error()
+	require.Contains(t, msg, "duration is missing")
+	require.Contains(t, msg, "JVMMemoryStress")
+	require.Contains(t, msg, "guided resolver")
+	// Crucially: must NOT say "must be greater than 0" for the nil case —
+	// that's the misleading message that issue #176 traced to.
+	require.NotContains(t, msg, "duration must be greater than 0")
 }
 
+// TestSubmitInjectionReqValidateRejectsNonPositiveDuration covers the case
+// where the resolver did normalize duration but a caller explicitly set it
+// to a non-positive value. The old "must be greater than 0" message is
+// still the right one here (it's accurate now); we keep the assertion to
+// guard against the two error paths swapping again.
 func TestSubmitInjectionReqValidateRejectsNonPositiveDuration(t *testing.T) {
 	req := validSubmitInjectionReq()
 	zero := 0


### PR DESCRIPTION
## Summary

Closes #176.

Two-layer fix for the misleading server-side `Validation failed: specs[0][0].duration must be greater than 0` 400 that surfaces whenever the chaos-experiment guided resolver's per-type builder fails (missing JVM method, unset `mem_type`, decode failure, etc.). The 400 hides the real builder error and sends users hunting for a `--duration` flag when the actual root cause is a different parameter.

## Two-layer fix

### 1. CLI short-circuits on resolver errors (primary)

`AegisLab/src/cmd/aegisctl/cmd/inject_guided.go` — `aegisctl inject guided --apply` now inspects `response.Errors` and `response.Stage` before calling `submitGuidedApply`. If the resolver flagged errors or did not reach `ready_to_apply`/`applied`, the command fails with `ExitCodeUsage` (2) and surfaces:

- A preamble naming the failing tuple: `guided resolver failed for chaos_type=JVMMemoryStress (app=shipping, class=..., method=...)`.
- Every error from `response.Errors` (preserved as-is, never truncated to the first one).

This is the architectural defect described in #176 — `chaos-experiment/pkg/guidedcli/resolver.go:1043-1054` only runs `normalizeDuration` on the success branch, so a builder failure ships `Duration: nil` to the server which then hits the duration validator first.

### 2. Backend duration validator is now context-aware (defense-in-depth)

`AegisLab/src/module/injection/api_types.go:457-459` previously emitted a single `duration must be greater than 0` regardless of whether `Duration` was `nil` or `<= 0`. Now:

- `Duration == nil` returns a message that explicitly points at the chaos-experiment guided resolver as the likely cause and tells the user to re-run guided + check the resolver `errors` field, or pass `--duration` explicitly.
- `Duration <= 0` keeps the old wording (it's accurate when the caller really did set a non-positive value) and now includes the actual value seen.

This protects non-aegisctl callers and a future buggy CLI client from rediscovering the same misleading message. It is the smallest change that could be made — no schema/resolver-state plumbing was needed.

## Reproducer (from issue)

```
aegisctl inject guided --apply --reset-config --no-save-config --non-interactive \
  --output json --system-type sockshop \
  --pedestal-name sockshop --pedestal-tag 1.1.1 \
  --benchmark-name clickhouse --benchmark-tag 1.0.0 \
  --interval 10 --pre-duration 5 \
  --chaos-type JVMMemoryStress --app shipping --namespace sockshop4 \
  --skip-restart-pedestal --skip-stale-check \
  --container coherence \
  --class com.oracle.coherence.examples.sockshop.helidon.shipping.ShippingResource \
  --method ship --memory-size 256 --mem-type heap
```

Before: `Error: API error 400: Validation failed: specs[0][0].duration must be greater than 0` (only after stripping --duration; the failure mode is environment-state-dependent — resource cache miss, kubeconfig context, or transient pod listing failure).

After: the CLI fails locally with the actual builder error (e.g. `jvm method "ship" not found under app "shipping"`) and `ExitCodeUsage` (2), without round-tripping to the server.

## Test summary

- `AegisLab/src/cmd/aegisctl/cmd/inject_guided_resolve_err_test.go` (new) — 6 cases:
  - happy path (`stage=ready_to_apply` + no errors) returns nil
  - `applied` stage returns nil (rare cfg.Apply=true path)
  - **the issue-#176 guard**: `fill_required_fields` + `Errors=[jvm method ... not found]` returns ExitCodeUsage with chaos_type + identifier + the resolver error in the message, and crucially does NOT contain `duration must be greater than 0`
  - all resolver errors preserved (multi-error case)
  - non-final stage with empty Errors[] still fails (defensive)
  - nil response handled
- `AegisLab/src/module/injection/guided_submit_test.go` — updated `TestSubmitInjectionReqValidateRejectsMissingDuration` to assert the new context-aware message (mentions "guided resolver", chaos_type, and "duration is missing"; explicitly NOT the old generic phrase). The non-positive case keeps the old assertion since that wording is still right when Duration was set to a bad value.

Builds: `go build -tags duckdb_arrow ./...` from `AegisLab/src` and `go build ./...` from `chaos-experiment` both clean.
Tests: `go test -tags duckdb_arrow ./module/injection/...` and `go test -tags duckdb_arrow ./cmd/aegisctl/cmd/... -run 'GuidedResolveErr|MissingDuration|NonPositiveDuration'` green. (One pre-existing failure in `TestPedestalChartInstallValidation/backend_chart_values_are_written_to_temp_file` reproduces on origin/main, unrelated to this PR.)

## Test plan

- [x] `go build -tags duckdb_arrow ./...` (AegisLab/src) clean
- [x] `go build ./...` (chaos-experiment) clean
- [x] `go test -tags duckdb_arrow ./module/injection/...` green
- [x] `go test -tags duckdb_arrow ./cmd/aegisctl/cmd/...` — new tests green; pre-existing chart-install failure unrelated
- [ ] CI green
- [ ] Reviewer: confirm `ExitCodeUsage` is the right convention for resolver-state errors (vs. introducing a new `ExitCodeResolverFailure`); usage felt correct since these are user-supplied parameter problems detected locally

## Note on prior PRs

This complements #173 / #175 by closing the last error-surfacing gap discovered during the inject loop campaign. #173 fixed three blockers found running auto-allocate on sockshop; #175 fixed the bootstrap-allocator stale-cache bug. #176 is the last "misleading error message" item from that campaign — once this lands, an aegisctl user hitting a JVM resolver miss should see the actual root cause without bouncing through a confusing 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)