### PR TITLE
chore(seed): bump sockshop image tag to 20260425-df5a26f

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -131,19 +131,19 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: 20260423-3ecac5f
+              default_value: 20260425-df5a26f
               overridable: true
             - key: frontend.image.tag
               type: 0
               category: 1
               value_type: 0
-              default_value: 20260423-3ecac5f
+              default_value: 20260425-df5a26f
               overridable: true
             - key: loadgen.image.tag
               type: 0
               category: 1
               value_type: 0
-              default_value: 20260423-3ecac5f
+              default_value: 20260425-df5a26f
               overridable: true
             - key: otel.instrumentation
               type: 0


### PR DESCRIPTION
## Summary

Adopts the post-merge build of LGU-SE-Internal/coherence-helidon-sockshop-sample @ `df5a26f` (their PR [#23](https://github.com/LGU-SE-Internal/coherence-helidon-sockshop-sample/pull/23)), which switches all six Java service jib base images from `gcr.io/distroless/java21-debian12` → `:debug`. The `:debug` variant adds busybox at `/busybox/sh`, which chaos-mesh's JVMChaos implementation needs inside the **target pod's** mount namespace to stage byteman before `bminstall`.

Without `sh` in the target image, every JVMChaos experiment fails:

```
Failed to apply chaos: rpc error: code = Unknown desc = exit status 101
```

Discovered while running an inject-loop campaign on sockshop today (Round 2: 5/5 JVMChaos experiments failed). Daemon log shows the exact `nsexec -m … -- sh -c "mkdir -p /usr/local/byteman/lib/"` step that 101's. Switching to a shell-bearing image fixes it without other changes.

## Verification

- 8/8 services pushed to `docker.io/opspai/ss-*` at tag `20260425-df5a26f`. Volces Shanghai mirror auto-synced (verified `ss-carts` digest matches).
- Diff scoped to the `sockshop` block of the seed; no other system's image tag is touched.

## Test plan

- [x] All 8 image manifests reachable on `docker.io` and on Volces mirror.
- [ ] Reseed (or backend restart, per aegis convention) so the new `default_value` takes effect.
- [ ] `helm uninstall` + reinstall any existing sockshop releases in the cluster to roll pods onto the new tag — running pods don't auto-update on seed bump.
- [ ] Run one JVMChaos against the reinstalled sockshop and confirm it now succeeds (no exit 101).

## Notes

This is the prerequisite for re-running the JVM track of the inject-loop campaign on sockshop. The chaos-mesh design dependency on shell+writable layout *inside* the target pod is the same architectural concern flagged in chaos-mesh#4184 (closed without resolution); for now, switching to `:debug` is the minimal-blast-radius fix on our side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)