### PR TITLE
fix(chaos-experiment): clarify 'container index out of range' groundtruth errors

### DIFF
--- a/chaos-experiment/handler/endpoint_provider.go
+++ b/chaos-experiment/handler/endpoint_provider.go
@@ -43,11 +43,11 @@ func getContainerInfoByIndex(ctx context.Context, system systemconfig.SystemType
 		return nil, err
 	}
 
-	if containerIdx < 0 || containerIdx >= len(containers) {
-		return nil, fmt.Errorf("container index out of range: %d (max: %d)", containerIdx, len(containers)-1)
+	info, err := selectContainerByIndex(containers, system, namespace, containerIdx)
+	if err != nil {
+		return nil, err
 	}
-
-	return &containers[containerIdx], nil
+	return &info, nil
 }
 
 func getAllHTTPEndpointInfos(system systemconfig.SystemType) ([]resourcelookup.AppEndpointPair, error) {

--- a/chaos-experiment/handler/groundtruth.go
+++ b/chaos-experiment/handler/groundtruth.go
@@ -8,6 +8,38 @@ import (
 	"github.com/OperationsPAI/chaos-experiment/internal/systemconfig"
 )
 
+// selectContainerByIndex resolves a container by its index against a snapshot
+// of the namespace's container list. It produces an actionable error when the
+// list is empty (typically a label-key mismatch or a stale cache reading a
+// transient namespace state) versus when the index merely overruns a populated
+// list. The previous implementation collapsed both cases into the unhelpful
+// "container index out of range: N (max: -1)" message, which made it look like
+// a code bug when the real issue was the runtime resource snapshot.
+func selectContainerByIndex(
+	containers []resourcelookup.ContainerInfo,
+	system systemconfig.SystemType,
+	namespace string,
+	containerIdx int,
+) (resourcelookup.ContainerInfo, error) {
+	if len(containers) == 0 {
+		labelKey := systemconfig.GetAppLabelKey(system)
+		return resourcelookup.ContainerInfo{}, fmt.Errorf(
+			"no containers found for system %q in namespace %q (app-label key %q): "+
+				"pods may not yet be scheduled, the namespace may be wrong, or pod labels do not match the configured key; "+
+				"requested container index %d",
+			system, namespace, labelKey, containerIdx,
+		)
+	}
+	if containerIdx < 0 || containerIdx >= len(containers) {
+		return resourcelookup.ContainerInfo{}, fmt.Errorf(
+			"container index out of range for system %q in namespace %q: "+
+				"index %d, %d containers available (valid range 0..%d)",
+			system, namespace, containerIdx, len(containers), len(containers)-1,
+		)
+	}
+	return containers[containerIdx], nil
+}
+
 // MetricType defines the type of metrics for groundtruth
 type MetricType string
 
@@ -75,11 +107,10 @@ func GetGroundtruthFromContainerIdx(ctx context.Context, system systemconfig.Sys
 		return Groundtruth{}, fmt.Errorf("failed to get containers: %w", err)
 	}
 
-	if containerIdx < 0 || containerIdx >= len(containers) {
-		return Groundtruth{}, fmt.Errorf("container index out of range: %d (max: %d)", containerIdx, len(containers)-1)
+	containerInfo, err := selectContainerByIndex(containers, system, namespace, containerIdx)
+	if err != nil {
+		return Groundtruth{}, err
 	}
-
-	containerInfo := containers[containerIdx]
 
 	// Create and populate the groundtruth
 	gt := Groundtruth{

--- a/chaos-experiment/handler/groundtruth_test.go
+++ b/chaos-experiment/handler/groundtruth_test.go
@@ -1,0 +1,105 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/OperationsPAI/chaos-experiment/internal/resourcelookup"
+	"github.com/OperationsPAI/chaos-experiment/internal/systemconfig"
+)
+
+func TestSelectContainerByIndex_EmptyListGivesActionableError(t *testing.T) {
+	// Reproduces the sockshop "max: -1" failure: GetGroundtruth runs at a
+	// moment when no pods carry the configured app-label key, so the
+	// container snapshot is empty. The previous implementation reported
+	// "container index out of range: 5 (max: -1)" which gave the user no hint
+	// that the list was actually empty.
+	_, err := selectContainerByIndex(
+		nil, // empty list
+		systemconfig.SystemSockShop,
+		"sockshop1",
+		5,
+	)
+	if err == nil {
+		t.Fatal("expected error for empty container list, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"no containers found",
+		`system "sockshop"`,
+		`namespace "sockshop1"`,
+		"index 5",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q is missing required substring %q", msg, want)
+		}
+	}
+	// And it must NOT report the bogus "max: -1" any longer.
+	if strings.Contains(msg, "max: -1") {
+		t.Errorf("error %q still contains the unhelpful 'max: -1' phrasing", msg)
+	}
+}
+
+func TestSelectContainerByIndex_OutOfRangeReportsCount(t *testing.T) {
+	containers := []resourcelookup.ContainerInfo{
+		{PodName: "p1", AppLabel: "front-end", ContainerName: "front-end"},
+		{PodName: "p2", AppLabel: "catalogue", ContainerName: "catalogue"},
+	}
+	_, err := selectContainerByIndex(
+		containers,
+		systemconfig.SystemSockShop,
+		"sockshop1",
+		7,
+	)
+	if err == nil {
+		t.Fatal("expected error for out-of-range index, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"out of range",
+		"index 7",
+		"2 containers available",
+		"valid range 0..1",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q is missing required substring %q", msg, want)
+		}
+	}
+}
+
+func TestSelectContainerByIndex_NegativeIndexHandled(t *testing.T) {
+	containers := []resourcelookup.ContainerInfo{
+		{PodName: "p1", AppLabel: "front-end", ContainerName: "front-end"},
+	}
+	_, err := selectContainerByIndex(
+		containers,
+		systemconfig.SystemSockShop,
+		"sockshop1",
+		-1,
+	)
+	if err == nil {
+		t.Fatal("expected error for negative index, got nil")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("expected out-of-range error, got %q", err.Error())
+	}
+}
+
+func TestSelectContainerByIndex_ValidIndexReturnsEntry(t *testing.T) {
+	containers := []resourcelookup.ContainerInfo{
+		{PodName: "p1", AppLabel: "front-end", ContainerName: "front-end"},
+		{PodName: "p2", AppLabel: "catalogue", ContainerName: "catalogue"},
+	}
+	got, err := selectContainerByIndex(
+		containers,
+		systemconfig.SystemSockShop,
+		"sockshop1",
+		1,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != containers[1] {
+		t.Errorf("got %+v, want %+v", got, containers[1])
+	}
+}

--- a/chaos-experiment/handler/handler.go
+++ b/chaos-experiment/handler/handler.go
@@ -573,7 +573,10 @@ func parseInjection(ctx context.Context, instance Injection) (map[string]any, er
 					break
 				}
 				if int(index) < 0 || int(index) >= len(containers) {
-					return nil, fmt.Errorf("container index out of range: %d (max: %d)", index, len(containers)-1)
+					return nil, fmt.Errorf(
+						"container index out of range in namespace %q: index %d, %d containers available (valid range 0..%d)",
+						namespace, index, len(containers), len(containers)-1,
+					)
 				}
 
 				value = containers[index]

--- a/chaos-experiment/pkg/guidedcli/k8s.go
+++ b/chaos-experiment/pkg/guidedcli/k8s.go
@@ -27,6 +27,14 @@ func safeContainers(namespace string) ([]resourcelookup.ContainerInfo, error) {
 	result := make([]resourcelookup.ContainerInfo, 0)
 	for _, pod := range pods {
 		appLabel := pod.Labels[labelKey]
+		// Match systemCache.GetAllContainers semantics: pods that don't carry
+		// the configured app-label key cannot be groundtruth targets and must
+		// be filtered out, otherwise the submit-time and groundtruth-time
+		// container lists drift, which previously surfaced as
+		// "container index out of range: N (max: -1)" at groundtruth time.
+		if appLabel == "" {
+			continue
+		}
 		for _, container := range pod.Spec.Containers {
 			result = append(result, resourcelookup.ContainerInfo{
 				PodName:       pod.Name,


### PR DESCRIPTION
## Summary

- Surfaced today on sockshop1 (Oracle Coherence chart, 1-container StatefulSet pods): 6/10 CPUStress / MemoryStress submissions failed at groundtruth resolution with the unhelpful \`container index out of range: 5 (max: -1)\`. The \`max: -1\` was hiding the real signal — the container list at groundtruth time was *empty*, not just over-indexed.
- Introduces \`selectContainerByIndex()\` in \`handler/groundtruth.go\` that distinguishes \"no containers found\" from \"index past end\" and includes the system, namespace, and configured app-label key in the message. Reused from \`endpoint_provider.go\`; the third indexer in \`handler.go\` gets the same shape.
- Aligns \`pkg/guidedcli/safeContainers\` with \`internal/resourcelookup.systemCache.GetAllContainers\`: both now skip pods that don't carry the configured app-label key. They previously disagreed, which let submit-time validation accept an index that groundtruth-time resolution could not honor.

## Root cause (2-3 sentences)

\`GetGroundtruthFromContainerIdx\` (handler/groundtruth.go) re-resolves the container list at groundtruth time via \`systemCache.GetAllContainers\` and indexes into it with the \`ContainerIdx\` baked into the spec at submit time. When the runtime list is empty (e.g., the namespace/labels are stale, the cache is cold, or pods don't carry the configured app-label key), the indexer reports \`max: -1\`, which looks like a code bug but is actually a runtime resource snapshot issue. The submit-time and groundtruth-time code paths also have subtly different filters (\`safeContainers\` previously kept pods with empty app-label values, the cache always dropped them), so an index that was valid at submit time could fall off the end at groundtruth time even with stable pods.

## Behavior diff

Before:
\`\`\`
container index out of range: 5 (max: -1)
\`\`\`

After (empty list):
\`\`\`
no containers found for system \"sockshop\" in namespace \"sockshop1\" (app-label key \"app\"): pods may not yet be scheduled, the namespace may be wrong, or pod labels do not match the configured key; requested container index 5
\`\`\`

After (legitimate over-index):
\`\`\`
container index out of range for system \"sockshop\" in namespace \"sockshop1\": index 7, 2 containers available (valid range 0..1)
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test -run 'TestSelectContainerByIndex' ./handler/\` — 4 new tests pass (empty list, out-of-range, negative index, valid index)
- [x] \`go test -short ./handler/ ./internal/resourcelookup/ ./pkg/guidedcli/\` — only failure is pre-existing flaky \`TestGenerateRandomAction\` (random JVM index against live cluster, unrelated)
- [ ] Re-run the failing sockshop1 CPUStress / MemoryStress batch and confirm errors now name the namespace + app-label key

🤖 Generated with [Claude Code](https://claude.com/claude-code)