### PR TITLE
feat(guidedcli): bulk inject-candidate enumeration library (#181 layer 1)

### DIFF
--- a/chaos-experiment/pkg/guidedcli/enumerate.go
+++ b/chaos-experiment/pkg/guidedcli/enumerate.go
@@ -1,0 +1,282 @@
+package guidedcli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/OperationsPAI/chaos-experiment/internal/systemconfig"
+)
+
+// EnumerateAllCandidates returns every reachable (app, chaos_type, target) tuple
+// for the given system+namespace, with one entry per leaf in the guided
+// enumeration tree. Equivalent to walking GuidedResolve from empty state to
+// ready_to_apply for every branch, but in-process — no HTTP round-trips.
+//
+// Numerical parameter grids (CPULoad, CPUWorker, Latency, ...) are NOT expanded.
+// The returned GuidedConfig leaves these fields nil and callers fill them with
+// policy-specific defaults before BuildInjection. The shape is otherwise
+// identical to a guided-resolve "ready_to_apply" GuidedConfig.
+//
+// Cost is dominated by one pod-list per namespace plus the resourcelookup
+// cache populates (single pass through static metadata). After the first call
+// per system, subsequent enumerations are nearly free.
+func EnumerateAllCandidates(ctx context.Context, system, namespace string) ([]GuidedConfig, error) {
+	cfg := GuidedConfig{System: system, Namespace: namespace}
+	if err := normalizeSystemSelection(&cfg); err != nil {
+		return nil, fmt.Errorf("enumerate candidates: %w", err)
+	}
+	if cfg.SystemType == "" {
+		return nil, fmt.Errorf("enumerate candidates: system %q is not registered", system)
+	}
+
+	systemType, err := systemconfig.ParseSystemType(cfg.SystemType)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate candidates: %w", err)
+	}
+	if err := systemconfig.SetCurrentSystem(systemType); err != nil {
+		return nil, fmt.Errorf("enumerate candidates: %w", err)
+	}
+
+	apps, err := enumerateAppLabelsHook(ctx, cfg.Namespace, systemType)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate candidates: list apps in %s: %w", cfg.Namespace, err)
+	}
+
+	out := make([]GuidedConfig, 0)
+	for _, app := range apps {
+		appCfg := cfg
+		appCfg.App = app
+
+		// Mirror availableChaosTypeOptions gating: chaos types are gated on
+		// the resources the app actually has. Walk each gate in turn and
+		// generate one GuidedConfig per leaf.
+		containers, _ := enumerateContainersByAppHook(ctx, systemType, cfg.Namespace, app)
+		endpoints, _ := enumerateHTTPEndpointsByAppHook(systemType, app)
+		networkTargets, _ := enumerateNetworkTargetsByAppHook(systemType, app)
+		dnsDomains, _ := enumerateDNSDomainsByAppHook(systemType, app)
+		methods, _ := enumerateJVMMethodsByAppHook(systemType, app)
+		dbOps, _ := enumerateDatabaseOpsByAppHook(systemType, app)
+		mutatorTargets, _ := enumerateRuntimeMutatorMethodsByAppHook(systemType, app)
+
+		// Pod-level chaos: 1 leaf per app for PodKill/PodFailure (no
+		// sub-target). ContainerKill/CPUStress/MemoryStress/TimeSkew = 1
+		// leaf per container.
+		if len(containers) > 0 {
+			out = append(out,
+				withChaosType(appCfg, "PodKill"),
+				withChaosType(appCfg, "PodFailure"),
+			)
+			for _, c := range containers {
+				cc := withChaosType(appCfg, "ContainerKill")
+				cc.Container = c
+				out = append(out, cc)
+
+				cs := withChaosType(appCfg, "CPUStress")
+				cs.Container = c
+				out = append(out, cs)
+
+				ms := withChaosType(appCfg, "MemoryStress")
+				ms.Container = c
+				out = append(out, ms)
+
+				ts := withChaosType(appCfg, "TimeSkew")
+				ts.Container = c
+				out = append(out, ts)
+			}
+		}
+
+		// HTTP chaos: leaves = httpEndpointsByApp.
+		if len(endpoints) > 0 {
+			httpTypes := []string{
+				"HTTPRequestAbort",
+				"HTTPResponseAbort",
+				"HTTPRequestDelay",
+				"HTTPResponseDelay",
+				"HTTPResponseReplaceBody",
+				"HTTPResponsePatchBody",
+				"HTTPRequestReplacePath",
+				"HTTPRequestReplaceMethod",
+				"HTTPResponseReplaceCode",
+			}
+			for _, ct := range httpTypes {
+				for _, ep := range endpoints {
+					hc := withChaosType(appCfg, ct)
+					hc.Route = ep.Route
+					hc.HTTPMethod = ep.Method
+					out = append(out, hc)
+				}
+			}
+		}
+
+		// Network chaos: leaves = networkTargetsByApp.
+		if len(networkTargets) > 0 {
+			netTypes := []string{
+				"NetworkDelay",
+				"NetworkPartition",
+				"NetworkLoss",
+				"NetworkDuplicate",
+				"NetworkCorrupt",
+				"NetworkBandwidth",
+			}
+			for _, ct := range netTypes {
+				for _, t := range networkTargets {
+					nc := withChaosType(appCfg, ct)
+					nc.TargetService = t
+					out = append(out, nc)
+				}
+			}
+		}
+
+		// DNS chaos: leaves = dnsDomainsByApp.
+		if len(dnsDomains) > 0 {
+			dnsTypes := []string{"DNSError", "DNSRandom"}
+			for _, ct := range dnsTypes {
+				for _, d := range dnsDomains {
+					dc := withChaosType(appCfg, ct)
+					dc.Domain = d.Domain
+					out = append(out, dc)
+				}
+			}
+		}
+
+		// JVM method chaos (non-MySQL / non-mutator): leaves = jvmMethodsByApp.
+		// JVMGarbageCollector: 1 leaf per app (no sub-target) but only when
+		// the app has any JVM methods recorded — same gate that
+		// availableChaosTypeOptions uses.
+		if len(methods) > 0 {
+			out = append(out, withChaosType(appCfg, "JVMGarbageCollector"))
+
+			methodTypes := []string{
+				"JVMLatency",
+				"JVMReturn",
+				"JVMException",
+				"JVMCPUStress",
+				"JVMMemoryStress",
+			}
+			for _, ct := range methodTypes {
+				for _, m := range methods {
+					mc := withChaosType(appCfg, ct)
+					mc.Class = m.ClassName
+					mc.Method = m.MethodName
+					out = append(out, mc)
+				}
+			}
+		}
+
+		// JVM MySQL chaos: leaves = databaseOpsByApp.
+		if len(dbOps) > 0 {
+			dbTypes := []string{"JVMMySQLLatency", "JVMMySQLException"}
+			for _, ct := range dbTypes {
+				for _, op := range dbOps {
+					dc := withChaosType(appCfg, ct)
+					dc.Database = op.DBName
+					dc.Table = op.TableName
+					dc.Operation = op.OperationType
+					out = append(out, dc)
+				}
+			}
+		}
+
+		// JVMRuntimeMutator: leaves = (mutator method) × (mutator config per
+		// method). Match resolveJVMRuntimeMutator's two-step expansion.
+		if len(mutatorTargets) > 0 {
+			// Group mutators by (class, method) so each method emits one
+			// candidate per mutator config — mirrors the guided two-step
+			// walk: pick method, then pick mutator config.
+			byMethod := map[string][]runtimeMutatorTarget{}
+			methodOrder := make([]string, 0)
+			for _, t := range mutatorTargets {
+				key := t.ClassName + "#" + t.MethodName
+				if _, seen := byMethod[key]; !seen {
+					methodOrder = append(methodOrder, key)
+				}
+				byMethod[key] = append(byMethod[key], t)
+			}
+			for _, key := range methodOrder {
+				for _, t := range byMethod[key] {
+					mc := withChaosType(appCfg, "JVMRuntimeMutator")
+					mc.Class = t.ClassName
+					mc.Method = t.MethodName
+					mc.MutatorConfig = runtimeMutatorKey(t)
+					out = append(out, mc)
+				}
+			}
+		}
+	}
+
+	sortCandidates(out)
+	return out, nil
+}
+
+// withChaosType returns a copy of cfg with ChaosType set. Defensive copy keeps
+// each candidate independent of others (no aliasing).
+func withChaosType(cfg GuidedConfig, chaosType string) GuidedConfig {
+	cfg.ChaosType = chaosType
+	return cfg
+}
+
+// sortCandidates orders the result deterministically: by app, then chaos type,
+// then the leaf-identifying fields. Lets callers (and tests) compare against
+// a fixed expected slice without flakiness.
+func sortCandidates(items []GuidedConfig) {
+	sort.SliceStable(items, func(i, j int) bool {
+		a, b := items[i], items[j]
+		if a.App != b.App {
+			return a.App < b.App
+		}
+		if a.ChaosType != b.ChaosType {
+			return a.ChaosType < b.ChaosType
+		}
+		if a.Container != b.Container {
+			return a.Container < b.Container
+		}
+		if a.HTTPMethod != b.HTTPMethod {
+			return a.HTTPMethod < b.HTTPMethod
+		}
+		if a.Route != b.Route {
+			return a.Route < b.Route
+		}
+		if a.TargetService != b.TargetService {
+			return a.TargetService < b.TargetService
+		}
+		if a.Domain != b.Domain {
+			return a.Domain < b.Domain
+		}
+		if a.Class != b.Class {
+			return a.Class < b.Class
+		}
+		if a.Method != b.Method {
+			return a.Method < b.Method
+		}
+		if a.MutatorConfig != b.MutatorConfig {
+			return a.MutatorConfig < b.MutatorConfig
+		}
+		if a.Database != b.Database {
+			return a.Database < b.Database
+		}
+		if a.Table != b.Table {
+			return a.Table < b.Table
+		}
+		return a.Operation < b.Operation
+	})
+}
+
+// --- testable indirection: package-level hooks default to the real helpers,
+// allowing unit tests to inject fixture data without standing up a fake k8s
+// API server or seeding the resourcelookup cache. Tests should restore each
+// hook (defer) so they don't leak fixtures into other tests.
+
+var (
+	enumerateAppLabelsHook                  = func(ctx context.Context, namespace string, systemType systemconfig.SystemType) ([]string, error) {
+		return safeAppLabels(ctx, namespace, systemType)
+	}
+	enumerateContainersByAppHook            = containersByApp
+	enumerateHTTPEndpointsByAppHook         = httpEndpointsByApp
+	enumerateNetworkTargetsByAppHook        = networkTargetsByApp
+	enumerateDNSDomainsByAppHook            = dnsDomainsByApp
+	enumerateJVMMethodsByAppHook            = jvmMethodsByApp
+	enumerateDatabaseOpsByAppHook           = databaseOpsByApp
+	enumerateRuntimeMutatorMethodsByAppHook = runtimeMutatorMethodsByApp
+)
+

--- a/chaos-experiment/pkg/guidedcli/enumerate_test.go
+++ b/chaos-experiment/pkg/guidedcli/enumerate_test.go
@@ -1,0 +1,293 @@
+package guidedcli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/OperationsPAI/chaos-experiment/internal/resourcelookup"
+	"github.com/OperationsPAI/chaos-experiment/internal/systemconfig"
+)
+
+// installEnumerateFixture rewires the package-level hooks to a tiny
+// in-memory fixture and returns a teardown that restores the originals.
+// Tests should always defer the teardown — the hooks are package-level
+// state, so leakage would corrupt other tests in the same package run.
+func installEnumerateFixture(t *testing.T, fx enumerateFixture) func() {
+	t.Helper()
+
+	originals := struct {
+		apps          func(ctx context.Context, namespace string, systemType systemconfig.SystemType) ([]string, error)
+		containers    func(ctx context.Context, systemType systemconfig.SystemType, namespace, app string) ([]string, error)
+		http          func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppEndpointPair, error)
+		network       func(systemType systemconfig.SystemType, app string) ([]string, error)
+		dns           func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppDNSPair, error)
+		jvmMethods    func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppMethodPair, error)
+		dbOps         func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppDatabasePair, error)
+		runtimeMutator func(systemType systemconfig.SystemType, app string) ([]runtimeMutatorTarget, error)
+	}{
+		apps:           enumerateAppLabelsHook,
+		containers:     enumerateContainersByAppHook,
+		http:           enumerateHTTPEndpointsByAppHook,
+		network:        enumerateNetworkTargetsByAppHook,
+		dns:            enumerateDNSDomainsByAppHook,
+		jvmMethods:     enumerateJVMMethodsByAppHook,
+		dbOps:          enumerateDatabaseOpsByAppHook,
+		runtimeMutator: enumerateRuntimeMutatorMethodsByAppHook,
+	}
+
+	enumerateAppLabelsHook = func(ctx context.Context, namespace string, systemType systemconfig.SystemType) ([]string, error) {
+		return fx.apps, nil
+	}
+	enumerateContainersByAppHook = func(ctx context.Context, systemType systemconfig.SystemType, namespace, app string) ([]string, error) {
+		return fx.containersByApp[app], nil
+	}
+	enumerateHTTPEndpointsByAppHook = func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppEndpointPair, error) {
+		return fx.httpByApp[app], nil
+	}
+	enumerateNetworkTargetsByAppHook = func(systemType systemconfig.SystemType, app string) ([]string, error) {
+		return fx.networkByApp[app], nil
+	}
+	enumerateDNSDomainsByAppHook = func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppDNSPair, error) {
+		return fx.dnsByApp[app], nil
+	}
+	enumerateJVMMethodsByAppHook = func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppMethodPair, error) {
+		return fx.jvmMethodsByApp[app], nil
+	}
+	enumerateDatabaseOpsByAppHook = func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppDatabasePair, error) {
+		return fx.dbOpsByApp[app], nil
+	}
+	enumerateRuntimeMutatorMethodsByAppHook = func(systemType systemconfig.SystemType, app string) ([]runtimeMutatorTarget, error) {
+		return fx.mutatorByApp[app], nil
+	}
+
+	return func() {
+		enumerateAppLabelsHook = originals.apps
+		enumerateContainersByAppHook = originals.containers
+		enumerateHTTPEndpointsByAppHook = originals.http
+		enumerateNetworkTargetsByAppHook = originals.network
+		enumerateDNSDomainsByAppHook = originals.dns
+		enumerateJVMMethodsByAppHook = originals.jvmMethods
+		enumerateDatabaseOpsByAppHook = originals.dbOps
+		enumerateRuntimeMutatorMethodsByAppHook = originals.runtimeMutator
+	}
+}
+
+type enumerateFixture struct {
+	apps            []string
+	containersByApp map[string][]string
+	httpByApp       map[string][]resourcelookup.AppEndpointPair
+	networkByApp    map[string][]string
+	dnsByApp        map[string][]resourcelookup.AppDNSPair
+	jvmMethodsByApp map[string][]resourcelookup.AppMethodPair
+	dbOpsByApp      map[string][]resourcelookup.AppDatabasePair
+	mutatorByApp    map[string][]runtimeMutatorTarget
+}
+
+func TestEnumerateAllCandidates_LeafCount(t *testing.T) {
+	// Tiny fixture: 1 app, 2 containers, 3 http endpoints, 2 network
+	// targets, 1 dns domain, 2 jvm methods, 1 db op, 2 runtime mutators
+	// on the same method.
+	//
+	// Expected leaf count:
+	//   pod-level: 2 (PodKill + PodFailure) + 4*2 (Container+CPU+Mem+Time × 2 containers)
+	//            = 2 + 8 = 10
+	//   http: 9 chaos types × 3 endpoints = 27
+	//   network: 6 × 2 = 12
+	//   dns: 2 × 1 = 2
+	//   jvm: 1 (GC) + 5 chaos types × 2 methods = 1 + 10 = 11
+	//   db: 2 × 1 = 2
+	//   mutator: 1 method × 2 mutator configs = 2
+	//   total: 10 + 27 + 12 + 2 + 11 + 2 + 2 = 66
+	teardown := installEnumerateFixture(t, enumerateFixture{
+		apps: []string{"frontend"},
+		containersByApp: map[string][]string{
+			"frontend": {"frontend", "sidecar"},
+		},
+		httpByApp: map[string][]resourcelookup.AppEndpointPair{
+			"frontend": {
+				{AppName: "frontend", Method: "GET", Route: "/", ServerAddress: "frontend"},
+				{AppName: "frontend", Method: "GET", Route: "/health", ServerAddress: "frontend"},
+				{AppName: "frontend", Method: "POST", Route: "/api", ServerAddress: "frontend"},
+			},
+		},
+		networkByApp: map[string][]string{
+			"frontend": {"backend", "auth"},
+		},
+		dnsByApp: map[string][]resourcelookup.AppDNSPair{
+			"frontend": {{AppName: "frontend", Domain: "external.example.com"}},
+		},
+		jvmMethodsByApp: map[string][]resourcelookup.AppMethodPair{
+			"frontend": {
+				{AppName: "frontend", ClassName: "com.example.A", MethodName: "doIt"},
+				{AppName: "frontend", ClassName: "com.example.B", MethodName: "alsoDoIt"},
+			},
+		},
+		dbOpsByApp: map[string][]resourcelookup.AppDatabasePair{
+			"frontend": {
+				{AppName: "frontend", DBName: "shop", TableName: "orders", OperationType: "select"},
+			},
+		},
+		mutatorByApp: map[string][]runtimeMutatorTarget{
+			"frontend": {
+				{AppName: "frontend", ClassName: "com.example.A", MethodName: "doIt", MutationTypeName: "constant", MutationFrom: "1", MutationTo: "0"},
+				{AppName: "frontend", ClassName: "com.example.A", MethodName: "doIt", MutationTypeName: "constant", MutationFrom: "1", MutationTo: "9"},
+			},
+		},
+	})
+	defer teardown()
+
+	// sockshop is registered as a builtin system, and matchSystemInstance
+	// resolves "sockshop0" to it. Use sockshop0 here so normalizeSystemSelection
+	// doesn't reject the input on a fresh cluster-less test run.
+	got, err := EnumerateAllCandidates(context.Background(), "sockshop0", "sockshop0")
+	if err != nil {
+		t.Fatalf("EnumerateAllCandidates returned error: %v", err)
+	}
+
+	const want = 66
+	if len(got) != want {
+		t.Fatalf("leaf count mismatch: want %d, got %d\n%s", want, len(got), debugByChaosType(got))
+	}
+
+	// Spot-check chaos-type breakdown.
+	wantBreakdown := map[string]int{
+		"PodKill":                  1,
+		"PodFailure":               1,
+		"ContainerKill":            2,
+		"CPUStress":                2,
+		"MemoryStress":             2,
+		"TimeSkew":                 2,
+		"HTTPRequestAbort":         3,
+		"HTTPResponseAbort":        3,
+		"HTTPRequestDelay":         3,
+		"HTTPResponseDelay":        3,
+		"HTTPResponseReplaceBody":  3,
+		"HTTPResponsePatchBody":    3,
+		"HTTPRequestReplacePath":   3,
+		"HTTPRequestReplaceMethod": 3,
+		"HTTPResponseReplaceCode":  3,
+		"NetworkDelay":             2,
+		"NetworkPartition":         2,
+		"NetworkLoss":              2,
+		"NetworkDuplicate":         2,
+		"NetworkCorrupt":           2,
+		"NetworkBandwidth":         2,
+		"DNSError":                 1,
+		"DNSRandom":                1,
+		"JVMGarbageCollector":      1,
+		"JVMLatency":               2,
+		"JVMReturn":                2,
+		"JVMException":             2,
+		"JVMCPUStress":             2,
+		"JVMMemoryStress":          2,
+		"JVMMySQLLatency":          1,
+		"JVMMySQLException":        1,
+		"JVMRuntimeMutator":        2,
+	}
+	gotBreakdown := map[string]int{}
+	for _, c := range got {
+		gotBreakdown[c.ChaosType]++
+	}
+	for ct, want := range wantBreakdown {
+		if gotBreakdown[ct] != want {
+			t.Errorf("chaos_type=%s: want %d, got %d", ct, want, gotBreakdown[ct])
+		}
+	}
+
+	// Validate every candidate carries the system+namespace+app context — agents
+	// downstream depend on the JSON shape staying flat (see issue #181 caller
+	// requirement: "{system, namespace, app, chaos_type, params}").
+	for i, c := range got {
+		if c.System == "" || c.Namespace == "" || c.App == "" || c.ChaosType == "" {
+			t.Errorf("candidate %d missing identifiers: %+v", i, c)
+		}
+	}
+}
+
+func TestEnumerateAllCandidates_EmptyAppListGivesEmptySlice(t *testing.T) {
+	teardown := installEnumerateFixture(t, enumerateFixture{
+		apps: nil,
+	})
+	defer teardown()
+
+	got, err := EnumerateAllCandidates(context.Background(), "sockshop0", "sockshop0")
+	if err != nil {
+		t.Fatalf("EnumerateAllCandidates returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result for app-less namespace, got %d candidates", len(got))
+	}
+}
+
+func TestEnumerateAllCandidates_GatesChaosTypesOnEmptyResources(t *testing.T) {
+	// App with no http endpoints / network / dns / jvm should produce only
+	// the pod-level candidates (which are gated on containers).
+	teardown := installEnumerateFixture(t, enumerateFixture{
+		apps: []string{"only-pod"},
+		containersByApp: map[string][]string{
+			"only-pod": {"only-pod"},
+		},
+	})
+	defer teardown()
+
+	got, err := EnumerateAllCandidates(context.Background(), "sockshop0", "sockshop0")
+	if err != nil {
+		t.Fatalf("EnumerateAllCandidates returned error: %v", err)
+	}
+
+	// Want: PodKill, PodFailure, ContainerKill, CPUStress, MemoryStress, TimeSkew (× 1 container)
+	// total: 2 + 4 = 6
+	if len(got) != 6 {
+		t.Fatalf("want 6 pod-level candidates, got %d\n%s", len(got), debugByChaosType(got))
+	}
+	for _, c := range got {
+		if c.HTTPMethod != "" || c.Route != "" || c.TargetService != "" || c.Domain != "" || c.Class != "" {
+			t.Errorf("expected pod-level candidate to have empty target identifiers, got %+v", c)
+		}
+	}
+}
+
+func TestEnumerateAllCandidates_RejectsUnknownSystem(t *testing.T) {
+	teardown := installEnumerateFixture(t, enumerateFixture{apps: []string{"unused"}})
+	defer teardown()
+
+	_, err := EnumerateAllCandidates(context.Background(), "no-such-system-12345", "no-such-system-12345")
+	if err == nil {
+		t.Fatal("expected EnumerateAllCandidates to error on unknown system")
+	}
+}
+
+// debugByChaosType is a t.Helper friend: turns a slice of candidates into a
+// printable breakdown for assertion failure messages. Kept private — only
+// the in-package tests need it.
+func debugByChaosType(items []GuidedConfig) string {
+	counts := map[string]int{}
+	for _, c := range items {
+		counts[c.ChaosType]++
+	}
+	out := ""
+	for k, v := range counts {
+		out += k + ": " + itoa(v) + "\n"
+	}
+	return out
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	if neg {
+		return "-" + digits
+	}
+	return digits
+}


### PR DESCRIPTION
## Summary

- Adds `guidedcli.EnumerateAllCandidates(ctx, system, namespace)` — one in-process call returning every reachable `(app, chaos_type, target)` leaf for a given system+namespace.
- Replaces the previous N-round-trip walk through `aegisctl inject guided` for adversarial / coverage-driven loops (`/inject-loop`, `/handle-incident`, anti-detector campaigns) that need the candidate pool up front.
- Reuses the existing helpers (`safeAppLabels`, `containersByApp`, `httpEndpointsByApp`, `networkTargetsByApp`, `dnsDomainsByApp`, `jvmMethodsByApp`, `databaseOpsByApp`, `runtimeMutatorMethodsByApp`) — no duplication of chaos-type gating logic.
- Numerical parameter grids (CPULoad, Latency, ...) are NOT expanded; callers fill those in before `BuildInjection`. Result shape matches the flat `{system, namespace, app, chaos_type, target}` contract called out in issue #181.

This is **layer 1** of issue #181. Layers 2 (backend `GET /api/v2/systems/by-name/<code>/inject-candidates`) and 3 (`aegisctl inject candidates ls`) follow in a second PR that depends on this one.

## Test plan

- [x] Unit test `TestEnumerateAllCandidates_LeafCount` — fixture with 1 app × all 7 resource categories asserts the expected 66-leaf count and per-chaos-type breakdown.
- [x] Unit test `TestEnumerateAllCandidates_GatesChaosTypesOnEmptyResources` — pinning that resourceless apps emit only pod-level candidates.
- [x] Unit test `TestEnumerateAllCandidates_EmptyAppListGivesEmptySlice` — empty namespaces don't crash.
- [x] Unit test `TestEnumerateAllCandidates_RejectsUnknownSystem` — bad system names surface a clean error.
- [x] `go build ./...` from `chaos-experiment/` is green.

Closes part of #181.

🤖 Generated with [Claude Code](https://claude.com/claude-code)