### PR TITLE
feat(injection): bulk inject-candidate endpoint + aegisctl candidates ls (#181 layers 2+3)

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/inject_candidates.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_candidates.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+
+	"aegis/cmd/aegisctl/client"
+	"aegis/cmd/aegisctl/output"
+
+	"github.com/spf13/cobra"
+)
+
+// injectCandidate mirrors chaossystem.InjectCandidateResp. Kept local so the
+// CLI binary doesn't need to import the backend module — same pattern as
+// systemPrereqResp in system_prereqs.go.
+type injectCandidate struct {
+	System        string `json:"system"`
+	SystemType    string `json:"system_type,omitempty"`
+	Namespace     string `json:"namespace"`
+	App           string `json:"app"`
+	ChaosType     string `json:"chaos_type"`
+	Container     string `json:"container,omitempty"`
+	TargetService string `json:"target_service,omitempty"`
+	Domain        string `json:"domain,omitempty"`
+	Class         string `json:"class,omitempty"`
+	Method        string `json:"method,omitempty"`
+	MutatorConfig string `json:"mutator_config,omitempty"`
+	Route         string `json:"route,omitempty"`
+	HTTPMethod    string `json:"http_method,omitempty"`
+	Database      string `json:"database,omitempty"`
+	Table         string `json:"table,omitempty"`
+	Operation     string `json:"operation,omitempty"`
+}
+
+type injectCandidatesResp struct {
+	Count      int               `json:"count"`
+	Candidates []injectCandidate `json:"candidates"`
+}
+
+// --- flags ---
+var (
+	candidatesSystem    string
+	candidatesNamespace string
+)
+
+// injectCandidatesCmd is the parent for `aegisctl inject candidates ...`.
+// Currently exposes only `ls`; future tooling (e.g. `score`, `pick`) plugs
+// in as siblings.
+var injectCandidatesCmd = &cobra.Command{
+	Use:   "candidates",
+	Short: "Bulk operations on the inject-candidate pool for a system",
+	Long: `Bulk operations on the inject-candidate pool for a system.
+
+Replaces the previous N-round-trip walk through 'aegisctl inject guided' for
+adversarial / coverage-driven loops that need the full candidate pool up front.
+
+  aegisctl inject candidates ls --system sockshop --namespace sockshop1
+  aegisctl inject candidates ls --system sockshop --namespace sockshop1 --output json | jq .
+`,
+}
+
+// injectCandidatesLsCmd implements `aegisctl inject candidates ls`.
+//
+// Default output is a table summary (one row per candidate, aggregated by
+// chaos_type + leaf identity). --output json emits the verbatim backend
+// payload for piping into Python / shell scripts.
+var injectCandidatesLsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List every (app, chaos_type, target) candidate for a system+namespace",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if candidatesSystem == "" {
+			return usageErrorf("--system is required")
+		}
+		if candidatesNamespace == "" {
+			return usageErrorf("--namespace is required")
+		}
+
+		c := newClient()
+		path := fmt.Sprintf("/api/v2/systems/by-name/%s/inject-candidates?namespace=%s",
+			url.PathEscape(candidatesSystem),
+			url.QueryEscape(candidatesNamespace),
+		)
+		var resp client.APIResponse[injectCandidatesResp]
+		if err := c.Get(path, &resp); err != nil {
+			return err
+		}
+
+		// JSON output is the contract our tools/enumerate.sh replacement
+		// consumes — we emit the candidates slice directly (not the
+		// envelope) so the shape stays flat: [{system, namespace, app,
+		// chaos_type, params}, ...].
+		if output.OutputFormat(flagOutput) == output.FormatJSON {
+			output.PrintJSON(resp.Data.Candidates)
+			return nil
+		}
+
+		headers := []string{"APP", "CHAOS-TYPE", "TARGET"}
+		rows := make([][]string, 0, len(resp.Data.Candidates))
+		for _, c := range resp.Data.Candidates {
+			rows = append(rows, []string{c.App, c.ChaosType, formatCandidateTarget(c)})
+		}
+		output.PrintTable(headers, rows)
+		output.PrintInfo(fmt.Sprintf("Total: %d candidates", resp.Data.Count))
+		return nil
+	},
+}
+
+// formatCandidateTarget collapses the per-leaf identity fields into a single
+// human-readable cell. Order matches the natural target dimension for each
+// chaos family (container > http endpoint > network target > dns > jvm
+// method > db op > mutator config). At most one of these is non-empty for
+// any single candidate.
+func formatCandidateTarget(c injectCandidate) string {
+	switch {
+	case c.Container != "":
+		return "container=" + c.Container
+	case c.Route != "" || c.HTTPMethod != "":
+		return c.HTTPMethod + " " + c.Route
+	case c.TargetService != "":
+		return "->" + c.TargetService
+	case c.Domain != "":
+		return "domain=" + c.Domain
+	case c.MutatorConfig != "":
+		return c.Class + "#" + c.Method + " [" + c.MutatorConfig + "]"
+	case c.Class != "" || c.Method != "":
+		return c.Class + "#" + c.Method
+	case c.Database != "":
+		return c.Database + "/" + c.Table + "/" + c.Operation
+	default:
+		return ""
+	}
+}
+
+func init() {
+	injectCandidatesLsCmd.Flags().StringVar(&candidatesSystem, "system", "", "System short code (e.g. sockshop, ts)")
+	injectCandidatesLsCmd.Flags().StringVar(&candidatesNamespace, "namespace", "", "Target namespace (e.g. sockshop1)")
+	_ = injectCandidatesLsCmd.MarkFlagRequired("system")
+	_ = injectCandidatesLsCmd.MarkFlagRequired("namespace")
+
+	injectCandidatesCmd.AddCommand(injectCandidatesLsCmd)
+	injectCmd.AddCommand(injectCandidatesCmd)
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/inject_candidates_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_candidates_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"aegis/cmd/aegisctl/output"
+)
+
+// TestInjectCandidatesLsJSONOutput pins the agent-facing JSON contract: the
+// CLI emits the candidates slice verbatim (not the {count, candidates}
+// envelope) so callers can pipe straight into jq / Python without unwrapping.
+func TestInjectCandidatesLsJSONOutput(t *testing.T) {
+	// Backend stub that returns three candidates with mixed leaf shapes.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/systems/by-name/sockshop/inject-candidates" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("namespace"); got != "sockshop1" {
+			t.Errorf("namespace query = %q, want sockshop1", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":200,"message":"ok","data":{"count":3,"candidates":[
+			{"system":"sockshop","namespace":"sockshop1","app":"frontend","chaos_type":"PodKill"},
+			{"system":"sockshop","namespace":"sockshop1","app":"frontend","chaos_type":"HTTPRequestAbort","route":"/api","http_method":"POST"},
+			{"system":"sockshop","namespace":"sockshop1","app":"frontend","chaos_type":"JVMLatency","class":"com.x.A","method":"doIt"}
+		]}}`))
+	}))
+	defer srv.Close()
+
+	oldServer, oldToken, oldOutput := flagServer, flagToken, flagOutput
+	t.Cleanup(func() { flagServer, flagToken, flagOutput = oldServer, oldToken, oldOutput })
+	flagServer = srv.URL
+	flagToken = "test-token"
+	flagOutput = string(output.FormatJSON)
+
+	candidatesSystem = "sockshop"
+	candidatesNamespace = "sockshop1"
+	t.Cleanup(func() {
+		candidatesSystem = ""
+		candidatesNamespace = ""
+	})
+
+	got, runErr := captureStdout(t, func() error {
+		return injectCandidatesLsCmd.RunE(injectCandidatesLsCmd, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("injectCandidatesLsCmd.RunE: %v", runErr)
+	}
+
+	// Must parse as JSON ARRAY of three candidates (not the envelope).
+	var arr []map[string]any
+	if err := json.Unmarshal([]byte(got), &arr); err != nil {
+		t.Fatalf("output is not a JSON array: %v\n%s", err, got)
+	}
+	if len(arr) != 3 {
+		t.Fatalf("want 3 candidates, got %d", len(arr))
+	}
+	if arr[0]["chaos_type"] != "PodKill" {
+		t.Errorf("first candidate chaos_type = %v, want PodKill", arr[0]["chaos_type"])
+	}
+	if arr[1]["route"] != "/api" || arr[1]["http_method"] != "POST" {
+		t.Errorf("HTTP candidate has wrong target fields: %+v", arr[1])
+	}
+	if arr[2]["class"] != "com.x.A" || arr[2]["method"] != "doIt" {
+		t.Errorf("JVM candidate has wrong target fields: %+v", arr[2])
+	}
+}
+
+func TestInjectCandidatesLsRequiresFlags(t *testing.T) {
+	candidatesSystem = ""
+	candidatesNamespace = ""
+	t.Cleanup(func() {
+		candidatesSystem = ""
+		candidatesNamespace = ""
+	})
+
+	if err := injectCandidatesLsCmd.RunE(injectCandidatesLsCmd, nil); err == nil {
+		t.Fatal("expected error when --system/--namespace are missing")
+	} else if !strings.Contains(err.Error(), "--system is required") {
+		t.Errorf("error should mention --system; got %v", err)
+	}
+
+	candidatesSystem = "sockshop"
+	if err := injectCandidatesLsCmd.RunE(injectCandidatesLsCmd, nil); err == nil {
+		t.Fatal("expected error when --namespace is missing")
+	} else if !strings.Contains(err.Error(), "--namespace is required") {
+		t.Errorf("error should mention --namespace; got %v", err)
+	}
+}
+

--- a/AegisLab/src/module/chaossystem/api_types.go
+++ b/AegisLab/src/module/chaossystem/api_types.go
@@ -184,6 +184,42 @@ type SystemChartResp struct {
 	PedestalTag string         `json:"pedestal_tag"`
 }
 
+// InjectCandidateResp represents a single (app, chaos_type, target) tuple
+// produced by the bulk enumeration endpoint (issue #181). Shape is flat and
+// stable so external callers (Python loops, shell pipelines, the
+// `tools/enumerate.sh` replacement) can consume it without unwrapping a
+// nested envelope.
+//
+// Numerical parameter fields (latency, cpu_load, ...) are intentionally
+// omitted: enumeration only fixes the leaf identity. Callers fill in
+// policy-specific param values before submitting via guidedcli.BuildInjection.
+type InjectCandidateResp struct {
+	System        string `json:"system"`
+	SystemType    string `json:"system_type,omitempty"`
+	Namespace     string `json:"namespace"`
+	App           string `json:"app"`
+	ChaosType     string `json:"chaos_type"`
+	Container     string `json:"container,omitempty"`
+	TargetService string `json:"target_service,omitempty"`
+	Domain        string `json:"domain,omitempty"`
+	Class         string `json:"class,omitempty"`
+	Method        string `json:"method,omitempty"`
+	MutatorConfig string `json:"mutator_config,omitempty"`
+	Route         string `json:"route,omitempty"`
+	HTTPMethod    string `json:"http_method,omitempty"`
+	Database      string `json:"database,omitempty"`
+	Table         string `json:"table,omitempty"`
+	Operation     string `json:"operation,omitempty"`
+}
+
+// InjectCandidatesResp wraps the candidate slice with a count for
+// agent-friendly logs / progress reporting. The candidates field is the
+// payload; count is a derivative for convenience.
+type InjectCandidatesResp struct {
+	Count      int                   `json:"count"`
+	Candidates []InjectCandidateResp `json:"candidates"`
+}
+
 // SystemPrerequisiteResp is one system prerequisite in API responses (issue
 // #115). Spec is the raw JSON payload the seed loader stored; its shape is
 // dictated by Kind (e.g. kind=helm -> {chart,namespace,version}).

--- a/AegisLab/src/module/chaossystem/handler.go
+++ b/AegisLab/src/module/chaossystem/handler.go
@@ -321,6 +321,35 @@ func (h *Handler) MarkPrerequisite(c *gin.Context) {
 	dto.SuccessResponse(c, resp)
 }
 
+// ListInjectCandidatesHandler returns every reachable (app, chaos_type, target)
+// tuple for a system+namespace pair (issue #181). One request replaces the
+// N-round-trip walk through `aegisctl inject guided` for adversarial /
+// coverage-driven loops.
+//
+//	@Summary		List inject candidates for a system+namespace
+//	@Description	Bulk enumeration of every (app, chaos_type, target) tuple reachable for the given system short code and namespace. Numerical params (latency, cpu_load, ...) are NOT expanded — the caller fills those in before submitting. Replaces the previous N-round-trip walk through `aegisctl inject guided`.
+//	@Tags			Systems
+//	@ID				list_system_inject_candidates
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			name		path		string										true	"System short code"
+//	@Param			namespace	query		string										true	"Target namespace (e.g. sockshop1)"
+//	@Success		200			{object}	dto.GenericResponse[InjectCandidatesResp]	"Candidates retrieved"
+//	@Failure		400			{object}	dto.GenericResponse[any]					"Missing namespace or invalid system code"
+//	@Failure		404			{object}	dto.GenericResponse[any]					"System not found"
+//	@Failure		500			{object}	dto.GenericResponse[any]					"k8s/resourcelookup failure"
+//	@Router			/api/v2/systems/by-name/{name}/inject-candidates [get]
+//	@x-api-type		{"admin":"true","sdk":"true"}
+func (h *Handler) ListInjectCandidates(c *gin.Context) {
+	name := c.Param("name")
+	namespace := c.Query("namespace")
+	resp, err := h.service.ListInjectCandidates(c.Request.Context(), name, namespace)
+	if httpx.HandleServiceError(c, err) {
+		return
+	}
+	dto.SuccessResponse(c, resp)
+}
+
 // ListChaosSystemMetadataHandler handles listing metadata for a chaos system
 //
 //	@Summary		List chaos system metadata

--- a/AegisLab/src/module/chaossystem/handler_service.go
+++ b/AegisLab/src/module/chaossystem/handler_service.go
@@ -20,6 +20,7 @@ type HandlerService interface {
 	ReseedSystems(context.Context, *ReseedSystemReq) (*initialization.ReseedReport, error)
 	ListPrerequisites(context.Context, string) ([]SystemPrerequisiteResp, error)
 	MarkPrerequisite(context.Context, string, int, *MarkPrerequisiteReq) (*SystemPrerequisiteResp, error)
+	ListInjectCandidates(context.Context, string, string) (*InjectCandidatesResp, error)
 }
 
 func AsHandlerService(service *Service) HandlerService {

--- a/AegisLab/src/module/chaossystem/inject_candidates_test.go
+++ b/AegisLab/src/module/chaossystem/inject_candidates_test.go
@@ -1,0 +1,119 @@
+package chaossystem
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"aegis/consts"
+	"aegis/model"
+
+	"github.com/OperationsPAI/chaos-experiment/pkg/guidedcli"
+)
+
+// TestListInjectCandidatesReturnsFlatJSON pins the API contract for #181:
+// the bulk endpoint returns a flat list of GuidedConfig-shaped tuples with
+// system/namespace/app/chaos_type/target identifiers populated. Numerical
+// params stay nil — callers fill them in before submitting.
+func TestListInjectCandidatesReturnsFlatJSON(t *testing.T) {
+	service, db, _ := newMetadataService(t)
+	const systemName = "bench-cand"
+	cleanup := seedSystemInViper(t, systemName, false)
+	defer cleanup()
+
+	anchor := &model.DynamicConfig{
+		Key:          systemKey(systemName, fieldCount),
+		DefaultValue: "1",
+		ValueType:    consts.ConfigValueTypeInt,
+	}
+	if err := db.Create(anchor).Error; err != nil {
+		t.Fatalf("seed anchor: %v", err)
+	}
+
+	// Stub the in-process enumerator: 3 candidates with mixed leaf shapes
+	// (pod-level, http, jvm) so we can assert the JSON shape covers each
+	// target dimension.
+	prev := enumerateCandidatesFn
+	defer func() { enumerateCandidatesFn = prev }()
+	enumerateCandidatesFn = func(ctx context.Context, system, namespace string) ([]guidedcli.GuidedConfig, error) {
+		if system != systemName {
+			t.Errorf("enumerator called with system=%q, want %q", system, systemName)
+		}
+		if namespace != "bench-cand0" {
+			t.Errorf("enumerator called with namespace=%q, want bench-cand0", namespace)
+		}
+		return []guidedcli.GuidedConfig{
+			{System: system, SystemType: "ts", Namespace: namespace, App: "frontend", ChaosType: "PodKill"},
+			{System: system, SystemType: "ts", Namespace: namespace, App: "frontend", ChaosType: "HTTPRequestAbort", Route: "/api", HTTPMethod: "POST"},
+			{System: system, SystemType: "ts", Namespace: namespace, App: "frontend", ChaosType: "JVMLatency", Class: "com.example.A", Method: "doIt"},
+		}, nil
+	}
+
+	resp, err := service.ListInjectCandidates(context.Background(), systemName, "bench-cand0")
+	if err != nil {
+		t.Fatalf("ListInjectCandidates: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("ListInjectCandidates: nil response")
+	}
+	if resp.Count != 3 || len(resp.Candidates) != 3 {
+		t.Fatalf("count mismatch: count=%d candidates=%d", resp.Count, len(resp.Candidates))
+	}
+
+	// Pod-level: no target identifiers populated.
+	pod := resp.Candidates[0]
+	if pod.ChaosType != "PodKill" || pod.App != "frontend" || pod.Container != "" {
+		t.Errorf("pod-level candidate shape wrong: %+v", pod)
+	}
+
+	// HTTP: route + http_method present, no domain/class/etc.
+	http := resp.Candidates[1]
+	if http.ChaosType != "HTTPRequestAbort" || http.Route != "/api" || http.HTTPMethod != "POST" {
+		t.Errorf("http candidate shape wrong: %+v", http)
+	}
+	if http.Container != "" || http.Domain != "" || http.Class != "" {
+		t.Errorf("http candidate has stray identifiers: %+v", http)
+	}
+
+	// JVM: class + method present.
+	jvm := resp.Candidates[2]
+	if jvm.ChaosType != "JVMLatency" || jvm.Class != "com.example.A" || jvm.Method != "doIt" {
+		t.Errorf("jvm candidate shape wrong: %+v", jvm)
+	}
+}
+
+func TestListInjectCandidatesRejectsEmptyNamespace(t *testing.T) {
+	service, db, _ := newMetadataService(t)
+	const systemName = "bench-cand-empty"
+	cleanup := seedSystemInViper(t, systemName, false)
+	defer cleanup()
+
+	anchor := &model.DynamicConfig{
+		Key:          systemKey(systemName, fieldCount),
+		DefaultValue: "1",
+		ValueType:    consts.ConfigValueTypeInt,
+	}
+	if err := db.Create(anchor).Error; err != nil {
+		t.Fatalf("seed anchor: %v", err)
+	}
+
+	_, err := service.ListInjectCandidates(context.Background(), systemName, "")
+	if err == nil {
+		t.Fatal("expected ListInjectCandidates to reject empty namespace")
+	}
+	if !errors.Is(err, consts.ErrBadRequest) {
+		t.Errorf("error should wrap ErrBadRequest, got %v", err)
+	}
+}
+
+func TestListInjectCandidatesNotFoundForUnseededSystem(t *testing.T) {
+	service, _, _ := newMetadataService(t)
+
+	_, err := service.ListInjectCandidates(context.Background(), "no-such-system", "no-such-system0")
+	if err == nil {
+		t.Fatal("expected ListInjectCandidates to return ErrNotFound for unseeded system")
+	}
+	if !errors.Is(err, consts.ErrNotFound) {
+		t.Errorf("error should wrap ErrNotFound, got %v", err)
+	}
+}

--- a/AegisLab/src/module/chaossystem/routes.go
+++ b/AegisLab/src/module/chaossystem/routes.go
@@ -24,6 +24,9 @@ func RoutesAdmin(handler *Handler) framework.RouteRegistrar {
 					// Prerequisites (issue #115) — read is system_read gated so
 					// the default admin flow can surface status in dashboards.
 					systemRead.GET("/by-name/:name/prerequisites", handler.ListPrerequisites)
+					// Bulk inject-candidate enumeration (issue #181) — agent
+					// loops fetch the full pool in one round-trip.
+					systemRead.GET("/by-name/:name/inject-candidates", handler.ListInjectCandidates)
 				}
 
 				systemConfigure := systems.Group("", middleware.RequireSystemConfigure)

--- a/AegisLab/src/module/chaossystem/service.go
+++ b/AegisLab/src/module/chaossystem/service.go
@@ -19,8 +19,14 @@ import (
 	"aegis/service/initialization"
 
 	chaos "github.com/OperationsPAI/chaos-experiment/handler"
+	"github.com/OperationsPAI/chaos-experiment/pkg/guidedcli"
 	"github.com/sirupsen/logrus"
 )
+
+// enumerateCandidatesFn is the indirection used by ListInjectCandidates so
+// tests can inject a fixture without standing up a fake k8s API. Defaults to
+// the real in-process enumerator from chaos-experiment.
+var enumerateCandidatesFn = guidedcli.EnumerateAllCandidates
 
 // systemField is an internal enum of the injection.system.<name>.<field>
 // suffixes we manage. Keeping this tight (instead of free-form map keys)
@@ -578,6 +584,60 @@ func (s *Service) ListPrerequisites(_ context.Context, name string) ([]SystemPre
 		out = append(out, *NewSystemPrerequisiteResp(&rows[i]))
 	}
 	return out, nil
+}
+
+// ListInjectCandidates returns every reachable (app, chaos_type, target)
+// tuple for the given system+namespace, with one entry per leaf in the
+// guided enumeration tree (issue #181). Replaces the previous N-round-trip
+// walk through `aegisctl inject guided` for adversarial / coverage-driven
+// loops that need the full candidate pool up front.
+//
+// Existence of the system is checked before the enumeration so callers get
+// a clean 404 for an unknown short code instead of an opaque "system X is
+// not registered" error coming from chaos-experiment.
+func (s *Service) ListInjectCandidates(ctx context.Context, name, namespace string) (*InjectCandidatesResp, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("system name is required: %w", consts.ErrBadRequest)
+	}
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace is required: %w", consts.ErrBadRequest)
+	}
+	if _, err := s.lookupByName(name); err != nil {
+		return nil, err
+	}
+
+	configs, err := enumerateCandidatesFn(ctx, name, namespace)
+	if err != nil {
+		// k8s/resourcelookup failures bubble up as 500. The CLI surfaces
+		// the wrapped error message so callers see "list pods in
+		// sockshop1: ..." rather than a bare "internal error".
+		return nil, fmt.Errorf("enumerate candidates for %s/%s: %w: %w", name, namespace, err, consts.ErrInternal)
+	}
+
+	out := make([]InjectCandidateResp, 0, len(configs))
+	for _, c := range configs {
+		out = append(out, InjectCandidateResp{
+			System:        c.System,
+			SystemType:    c.SystemType,
+			Namespace:     c.Namespace,
+			App:           c.App,
+			ChaosType:     c.ChaosType,
+			Container:     c.Container,
+			TargetService: c.TargetService,
+			Domain:        c.Domain,
+			Class:         c.Class,
+			Method:        c.Method,
+			MutatorConfig: c.MutatorConfig,
+			Route:         c.Route,
+			HTTPMethod:    c.HTTPMethod,
+			Database:      c.Database,
+			Table:         c.Table,
+			Operation:     c.Operation,
+		})
+	}
+	return &InjectCandidatesResp{Count: len(out), Candidates: out}, nil
 }
 
 // MarkPrerequisite updates the status of one prerequisite. aegisctl is the

--- a/chaos-experiment/pkg/guidedcli/enumerate.go
+++ b/chaos-experiment/pkg/guidedcli/enumerate.go
@@ -1,0 +1,282 @@
+package guidedcli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/OperationsPAI/chaos-experiment/internal/systemconfig"
+)
+
+// EnumerateAllCandidates returns every reachable (app, chaos_type, target) tuple
+// for the given system+namespace, with one entry per leaf in the guided
+// enumeration tree. Equivalent to walking GuidedResolve from empty state to
+// ready_to_apply for every branch, but in-process — no HTTP round-trips.
+//
+// Numerical parameter grids (CPULoad, CPUWorker, Latency, ...) are NOT expanded.
+// The returned GuidedConfig leaves these fields nil and callers fill them with
+// policy-specific defaults before BuildInjection. The shape is otherwise
+// identical to a guided-resolve "ready_to_apply" GuidedConfig.
+//
+// Cost is dominated by one pod-list per namespace plus the resourcelookup
+// cache populates (single pass through static metadata). After the first call
+// per system, subsequent enumerations are nearly free.
+func EnumerateAllCandidates(ctx context.Context, system, namespace string) ([]GuidedConfig, error) {
+	cfg := GuidedConfig{System: system, Namespace: namespace}
+	if err := normalizeSystemSelection(&cfg); err != nil {
+		return nil, fmt.Errorf("enumerate candidates: %w", err)
+	}
+	if cfg.SystemType == "" {
+		return nil, fmt.Errorf("enumerate candidates: system %q is not registered", system)
+	}
+
+	systemType, err := systemconfig.ParseSystemType(cfg.SystemType)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate candidates: %w", err)
+	}
+	if err := systemconfig.SetCurrentSystem(systemType); err != nil {
+		return nil, fmt.Errorf("enumerate candidates: %w", err)
+	}
+
+	apps, err := enumerateAppLabelsHook(ctx, cfg.Namespace, systemType)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate candidates: list apps in %s: %w", cfg.Namespace, err)
+	}
+
+	out := make([]GuidedConfig, 0)
+	for _, app := range apps {
+		appCfg := cfg
+		appCfg.App = app
+
+		// Mirror availableChaosTypeOptions gating: chaos types are gated on
+		// the resources the app actually has. Walk each gate in turn and
+		// generate one GuidedConfig per leaf.
+		containers, _ := enumerateContainersByAppHook(ctx, systemType, cfg.Namespace, app)
+		endpoints, _ := enumerateHTTPEndpointsByAppHook(systemType, app)
+		networkTargets, _ := enumerateNetworkTargetsByAppHook(systemType, app)
+		dnsDomains, _ := enumerateDNSDomainsByAppHook(systemType, app)
+		methods, _ := enumerateJVMMethodsByAppHook(systemType, app)
+		dbOps, _ := enumerateDatabaseOpsByAppHook(systemType, app)
+		mutatorTargets, _ := enumerateRuntimeMutatorMethodsByAppHook(systemType, app)
+
+		// Pod-level chaos: 1 leaf per app for PodKill/PodFailure (no
+		// sub-target). ContainerKill/CPUStress/MemoryStress/TimeSkew = 1
+		// leaf per container.
+		if len(containers) > 0 {
+			out = append(out,
+				withChaosType(appCfg, "PodKill"),
+				withChaosType(appCfg, "PodFailure"),
+			)
+			for _, c := range containers {
+				cc := withChaosType(appCfg, "ContainerKill")
+				cc.Container = c
+				out = append(out, cc)
+
+				cs := withChaosType(appCfg, "CPUStress")
+				cs.Container = c
+				out = append(out, cs)
+
+				ms := withChaosType(appCfg, "MemoryStress")
+				ms.Container = c
+				out = append(out, ms)
+
+				ts := withChaosType(appCfg, "TimeSkew")
+				ts.Container = c
+				out = append(out, ts)
+			}
+		}
+
+		// HTTP chaos: leaves = httpEndpointsByApp.
+		if len(endpoints) > 0 {
+			httpTypes := []string{
+				"HTTPRequestAbort",
+				"HTTPResponseAbort",
+				"HTTPRequestDelay",
+				"HTTPResponseDelay",
+				"HTTPResponseReplaceBody",
+				"HTTPResponsePatchBody",
+				"HTTPRequestReplacePath",
+				"HTTPRequestReplaceMethod",
+				"HTTPResponseReplaceCode",
+			}
+			for _, ct := range httpTypes {
+				for _, ep := range endpoints {
+					hc := withChaosType(appCfg, ct)
+					hc.Route = ep.Route
+					hc.HTTPMethod = ep.Method
+					out = append(out, hc)
+				}
+			}
+		}
+
+		// Network chaos: leaves = networkTargetsByApp.
+		if len(networkTargets) > 0 {
+			netTypes := []string{
+				"NetworkDelay",
+				"NetworkPartition",
+				"NetworkLoss",
+				"NetworkDuplicate",
+				"NetworkCorrupt",
+				"NetworkBandwidth",
+			}
+			for _, ct := range netTypes {
+				for _, t := range networkTargets {
+					nc := withChaosType(appCfg, ct)
+					nc.TargetService = t
+					out = append(out, nc)
+				}
+			}
+		}
+
+		// DNS chaos: leaves = dnsDomainsByApp.
+		if len(dnsDomains) > 0 {
+			dnsTypes := []string{"DNSError", "DNSRandom"}
+			for _, ct := range dnsTypes {
+				for _, d := range dnsDomains {
+					dc := withChaosType(appCfg, ct)
+					dc.Domain = d.Domain
+					out = append(out, dc)
+				}
+			}
+		}
+
+		// JVM method chaos (non-MySQL / non-mutator): leaves = jvmMethodsByApp.
+		// JVMGarbageCollector: 1 leaf per app (no sub-target) but only when
+		// the app has any JVM methods recorded — same gate that
+		// availableChaosTypeOptions uses.
+		if len(methods) > 0 {
+			out = append(out, withChaosType(appCfg, "JVMGarbageCollector"))
+
+			methodTypes := []string{
+				"JVMLatency",
+				"JVMReturn",
+				"JVMException",
+				"JVMCPUStress",
+				"JVMMemoryStress",
+			}
+			for _, ct := range methodTypes {
+				for _, m := range methods {
+					mc := withChaosType(appCfg, ct)
+					mc.Class = m.ClassName
+					mc.Method = m.MethodName
+					out = append(out, mc)
+				}
+			}
+		}
+
+		// JVM MySQL chaos: leaves = databaseOpsByApp.
+		if len(dbOps) > 0 {
+			dbTypes := []string{"JVMMySQLLatency", "JVMMySQLException"}
+			for _, ct := range dbTypes {
+				for _, op := range dbOps {
+					dc := withChaosType(appCfg, ct)
+					dc.Database = op.DBName
+					dc.Table = op.TableName
+					dc.Operation = op.OperationType
+					out = append(out, dc)
+				}
+			}
+		}
+
+		// JVMRuntimeMutator: leaves = (mutator method) × (mutator config per
+		// method). Match resolveJVMRuntimeMutator's two-step expansion.
+		if len(mutatorTargets) > 0 {
+			// Group mutators by (class, method) so each method emits one
+			// candidate per mutator config — mirrors the guided two-step
+			// walk: pick method, then pick mutator config.
+			byMethod := map[string][]runtimeMutatorTarget{}
+			methodOrder := make([]string, 0)
+			for _, t := range mutatorTargets {
+				key := t.ClassName + "#" + t.MethodName
+				if _, seen := byMethod[key]; !seen {
+					methodOrder = append(methodOrder, key)
+				}
+				byMethod[key] = append(byMethod[key], t)
+			}
+			for _, key := range methodOrder {
+				for _, t := range byMethod[key] {
+					mc := withChaosType(appCfg, "JVMRuntimeMutator")
+					mc.Class = t.ClassName
+					mc.Method = t.MethodName
+					mc.MutatorConfig = runtimeMutatorKey(t)
+					out = append(out, mc)
+				}
+			}
+		}
+	}
+
+	sortCandidates(out)
+	return out, nil
+}
+
+// withChaosType returns a copy of cfg with ChaosType set. Defensive copy keeps
+// each candidate independent of others (no aliasing).
+func withChaosType(cfg GuidedConfig, chaosType string) GuidedConfig {
+	cfg.ChaosType = chaosType
+	return cfg
+}
+
+// sortCandidates orders the result deterministically: by app, then chaos type,
+// then the leaf-identifying fields. Lets callers (and tests) compare against
+// a fixed expected slice without flakiness.
+func sortCandidates(items []GuidedConfig) {
+	sort.SliceStable(items, func(i, j int) bool {
+		a, b := items[i], items[j]
+		if a.App != b.App {
+			return a.App < b.App
+		}
+		if a.ChaosType != b.ChaosType {
+			return a.ChaosType < b.ChaosType
+		}
+		if a.Container != b.Container {
+			return a.Container < b.Container
+		}
+		if a.HTTPMethod != b.HTTPMethod {
+			return a.HTTPMethod < b.HTTPMethod
+		}
+		if a.Route != b.Route {
+			return a.Route < b.Route
+		}
+		if a.TargetService != b.TargetService {
+			return a.TargetService < b.TargetService
+		}
+		if a.Domain != b.Domain {
+			return a.Domain < b.Domain
+		}
+		if a.Class != b.Class {
+			return a.Class < b.Class
+		}
+		if a.Method != b.Method {
+			return a.Method < b.Method
+		}
+		if a.MutatorConfig != b.MutatorConfig {
+			return a.MutatorConfig < b.MutatorConfig
+		}
+		if a.Database != b.Database {
+			return a.Database < b.Database
+		}
+		if a.Table != b.Table {
+			return a.Table < b.Table
+		}
+		return a.Operation < b.Operation
+	})
+}
+
+// --- testable indirection: package-level hooks default to the real helpers,
+// allowing unit tests to inject fixture data without standing up a fake k8s
+// API server or seeding the resourcelookup cache. Tests should restore each
+// hook (defer) so they don't leak fixtures into other tests.
+
+var (
+	enumerateAppLabelsHook                  = func(ctx context.Context, namespace string, systemType systemconfig.SystemType) ([]string, error) {
+		return safeAppLabels(ctx, namespace, systemType)
+	}
+	enumerateContainersByAppHook            = containersByApp
+	enumerateHTTPEndpointsByAppHook         = httpEndpointsByApp
+	enumerateNetworkTargetsByAppHook        = networkTargetsByApp
+	enumerateDNSDomainsByAppHook            = dnsDomainsByApp
+	enumerateJVMMethodsByAppHook            = jvmMethodsByApp
+	enumerateDatabaseOpsByAppHook           = databaseOpsByApp
+	enumerateRuntimeMutatorMethodsByAppHook = runtimeMutatorMethodsByApp
+)
+

--- a/chaos-experiment/pkg/guidedcli/enumerate_test.go
+++ b/chaos-experiment/pkg/guidedcli/enumerate_test.go
@@ -1,0 +1,293 @@
+package guidedcli
+
+import (
+	"context"
+	"testing"
+
+	"github.com/OperationsPAI/chaos-experiment/internal/resourcelookup"
+	"github.com/OperationsPAI/chaos-experiment/internal/systemconfig"
+)
+
+// installEnumerateFixture rewires the package-level hooks to a tiny
+// in-memory fixture and returns a teardown that restores the originals.
+// Tests should always defer the teardown — the hooks are package-level
+// state, so leakage would corrupt other tests in the same package run.
+func installEnumerateFixture(t *testing.T, fx enumerateFixture) func() {
+	t.Helper()
+
+	originals := struct {
+		apps          func(ctx context.Context, namespace string, systemType systemconfig.SystemType) ([]string, error)
+		containers    func(ctx context.Context, systemType systemconfig.SystemType, namespace, app string) ([]string, error)
+		http          func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppEndpointPair, error)
+		network       func(systemType systemconfig.SystemType, app string) ([]string, error)
+		dns           func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppDNSPair, error)
+		jvmMethods    func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppMethodPair, error)
+		dbOps         func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppDatabasePair, error)
+		runtimeMutator func(systemType systemconfig.SystemType, app string) ([]runtimeMutatorTarget, error)
+	}{
+		apps:           enumerateAppLabelsHook,
+		containers:     enumerateContainersByAppHook,
+		http:           enumerateHTTPEndpointsByAppHook,
+		network:        enumerateNetworkTargetsByAppHook,
+		dns:            enumerateDNSDomainsByAppHook,
+		jvmMethods:     enumerateJVMMethodsByAppHook,
+		dbOps:          enumerateDatabaseOpsByAppHook,
+		runtimeMutator: enumerateRuntimeMutatorMethodsByAppHook,
+	}
+
+	enumerateAppLabelsHook = func(ctx context.Context, namespace string, systemType systemconfig.SystemType) ([]string, error) {
+		return fx.apps, nil
+	}
+	enumerateContainersByAppHook = func(ctx context.Context, systemType systemconfig.SystemType, namespace, app string) ([]string, error) {
+		return fx.containersByApp[app], nil
+	}
+	enumerateHTTPEndpointsByAppHook = func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppEndpointPair, error) {
+		return fx.httpByApp[app], nil
+	}
+	enumerateNetworkTargetsByAppHook = func(systemType systemconfig.SystemType, app string) ([]string, error) {
+		return fx.networkByApp[app], nil
+	}
+	enumerateDNSDomainsByAppHook = func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppDNSPair, error) {
+		return fx.dnsByApp[app], nil
+	}
+	enumerateJVMMethodsByAppHook = func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppMethodPair, error) {
+		return fx.jvmMethodsByApp[app], nil
+	}
+	enumerateDatabaseOpsByAppHook = func(systemType systemconfig.SystemType, app string) ([]resourcelookup.AppDatabasePair, error) {
+		return fx.dbOpsByApp[app], nil
+	}
+	enumerateRuntimeMutatorMethodsByAppHook = func(systemType systemconfig.SystemType, app string) ([]runtimeMutatorTarget, error) {
+		return fx.mutatorByApp[app], nil
+	}
+
+	return func() {
+		enumerateAppLabelsHook = originals.apps
+		enumerateContainersByAppHook = originals.containers
+		enumerateHTTPEndpointsByAppHook = originals.http
+		enumerateNetworkTargetsByAppHook = originals.network
+		enumerateDNSDomainsByAppHook = originals.dns
+		enumerateJVMMethodsByAppHook = originals.jvmMethods
+		enumerateDatabaseOpsByAppHook = originals.dbOps
+		enumerateRuntimeMutatorMethodsByAppHook = originals.runtimeMutator
+	}
+}
+
+type enumerateFixture struct {
+	apps            []string
+	containersByApp map[string][]string
+	httpByApp       map[string][]resourcelookup.AppEndpointPair
+	networkByApp    map[string][]string
+	dnsByApp        map[string][]resourcelookup.AppDNSPair
+	jvmMethodsByApp map[string][]resourcelookup.AppMethodPair
+	dbOpsByApp      map[string][]resourcelookup.AppDatabasePair
+	mutatorByApp    map[string][]runtimeMutatorTarget
+}
+
+func TestEnumerateAllCandidates_LeafCount(t *testing.T) {
+	// Tiny fixture: 1 app, 2 containers, 3 http endpoints, 2 network
+	// targets, 1 dns domain, 2 jvm methods, 1 db op, 2 runtime mutators
+	// on the same method.
+	//
+	// Expected leaf count:
+	//   pod-level: 2 (PodKill + PodFailure) + 4*2 (Container+CPU+Mem+Time × 2 containers)
+	//            = 2 + 8 = 10
+	//   http: 9 chaos types × 3 endpoints = 27
+	//   network: 6 × 2 = 12
+	//   dns: 2 × 1 = 2
+	//   jvm: 1 (GC) + 5 chaos types × 2 methods = 1 + 10 = 11
+	//   db: 2 × 1 = 2
+	//   mutator: 1 method × 2 mutator configs = 2
+	//   total: 10 + 27 + 12 + 2 + 11 + 2 + 2 = 66
+	teardown := installEnumerateFixture(t, enumerateFixture{
+		apps: []string{"frontend"},
+		containersByApp: map[string][]string{
+			"frontend": {"frontend", "sidecar"},
+		},
+		httpByApp: map[string][]resourcelookup.AppEndpointPair{
+			"frontend": {
+				{AppName: "frontend", Method: "GET", Route: "/", ServerAddress: "frontend"},
+				{AppName: "frontend", Method: "GET", Route: "/health", ServerAddress: "frontend"},
+				{AppName: "frontend", Method: "POST", Route: "/api", ServerAddress: "frontend"},
+			},
+		},
+		networkByApp: map[string][]string{
+			"frontend": {"backend", "auth"},
+		},
+		dnsByApp: map[string][]resourcelookup.AppDNSPair{
+			"frontend": {{AppName: "frontend", Domain: "external.example.com"}},
+		},
+		jvmMethodsByApp: map[string][]resourcelookup.AppMethodPair{
+			"frontend": {
+				{AppName: "frontend", ClassName: "com.example.A", MethodName: "doIt"},
+				{AppName: "frontend", ClassName: "com.example.B", MethodName: "alsoDoIt"},
+			},
+		},
+		dbOpsByApp: map[string][]resourcelookup.AppDatabasePair{
+			"frontend": {
+				{AppName: "frontend", DBName: "shop", TableName: "orders", OperationType: "select"},
+			},
+		},
+		mutatorByApp: map[string][]runtimeMutatorTarget{
+			"frontend": {
+				{AppName: "frontend", ClassName: "com.example.A", MethodName: "doIt", MutationTypeName: "constant", MutationFrom: "1", MutationTo: "0"},
+				{AppName: "frontend", ClassName: "com.example.A", MethodName: "doIt", MutationTypeName: "constant", MutationFrom: "1", MutationTo: "9"},
+			},
+		},
+	})
+	defer teardown()
+
+	// sockshop is registered as a builtin system, and matchSystemInstance
+	// resolves "sockshop0" to it. Use sockshop0 here so normalizeSystemSelection
+	// doesn't reject the input on a fresh cluster-less test run.
+	got, err := EnumerateAllCandidates(context.Background(), "sockshop0", "sockshop0")
+	if err != nil {
+		t.Fatalf("EnumerateAllCandidates returned error: %v", err)
+	}
+
+	const want = 66
+	if len(got) != want {
+		t.Fatalf("leaf count mismatch: want %d, got %d\n%s", want, len(got), debugByChaosType(got))
+	}
+
+	// Spot-check chaos-type breakdown.
+	wantBreakdown := map[string]int{
+		"PodKill":                  1,
+		"PodFailure":               1,
+		"ContainerKill":            2,
+		"CPUStress":                2,
+		"MemoryStress":             2,
+		"TimeSkew":                 2,
+		"HTTPRequestAbort":         3,
+		"HTTPResponseAbort":        3,
+		"HTTPRequestDelay":         3,
+		"HTTPResponseDelay":        3,
+		"HTTPResponseReplaceBody":  3,
+		"HTTPResponsePatchBody":    3,
+		"HTTPRequestReplacePath":   3,
+		"HTTPRequestReplaceMethod": 3,
+		"HTTPResponseReplaceCode":  3,
+		"NetworkDelay":             2,
+		"NetworkPartition":         2,
+		"NetworkLoss":              2,
+		"NetworkDuplicate":         2,
+		"NetworkCorrupt":           2,
+		"NetworkBandwidth":         2,
+		"DNSError":                 1,
+		"DNSRandom":                1,
+		"JVMGarbageCollector":      1,
+		"JVMLatency":               2,
+		"JVMReturn":                2,
+		"JVMException":             2,
+		"JVMCPUStress":             2,
+		"JVMMemoryStress":          2,
+		"JVMMySQLLatency":          1,
+		"JVMMySQLException":        1,
+		"JVMRuntimeMutator":        2,
+	}
+	gotBreakdown := map[string]int{}
+	for _, c := range got {
+		gotBreakdown[c.ChaosType]++
+	}
+	for ct, want := range wantBreakdown {
+		if gotBreakdown[ct] != want {
+			t.Errorf("chaos_type=%s: want %d, got %d", ct, want, gotBreakdown[ct])
+		}
+	}
+
+	// Validate every candidate carries the system+namespace+app context — agents
+	// downstream depend on the JSON shape staying flat (see issue #181 caller
+	// requirement: "{system, namespace, app, chaos_type, params}").
+	for i, c := range got {
+		if c.System == "" || c.Namespace == "" || c.App == "" || c.ChaosType == "" {
+			t.Errorf("candidate %d missing identifiers: %+v", i, c)
+		}
+	}
+}
+
+func TestEnumerateAllCandidates_EmptyAppListGivesEmptySlice(t *testing.T) {
+	teardown := installEnumerateFixture(t, enumerateFixture{
+		apps: nil,
+	})
+	defer teardown()
+
+	got, err := EnumerateAllCandidates(context.Background(), "sockshop0", "sockshop0")
+	if err != nil {
+		t.Fatalf("EnumerateAllCandidates returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty result for app-less namespace, got %d candidates", len(got))
+	}
+}
+
+func TestEnumerateAllCandidates_GatesChaosTypesOnEmptyResources(t *testing.T) {
+	// App with no http endpoints / network / dns / jvm should produce only
+	// the pod-level candidates (which are gated on containers).
+	teardown := installEnumerateFixture(t, enumerateFixture{
+		apps: []string{"only-pod"},
+		containersByApp: map[string][]string{
+			"only-pod": {"only-pod"},
+		},
+	})
+	defer teardown()
+
+	got, err := EnumerateAllCandidates(context.Background(), "sockshop0", "sockshop0")
+	if err != nil {
+		t.Fatalf("EnumerateAllCandidates returned error: %v", err)
+	}
+
+	// Want: PodKill, PodFailure, ContainerKill, CPUStress, MemoryStress, TimeSkew (× 1 container)
+	// total: 2 + 4 = 6
+	if len(got) != 6 {
+		t.Fatalf("want 6 pod-level candidates, got %d\n%s", len(got), debugByChaosType(got))
+	}
+	for _, c := range got {
+		if c.HTTPMethod != "" || c.Route != "" || c.TargetService != "" || c.Domain != "" || c.Class != "" {
+			t.Errorf("expected pod-level candidate to have empty target identifiers, got %+v", c)
+		}
+	}
+}
+
+func TestEnumerateAllCandidates_RejectsUnknownSystem(t *testing.T) {
+	teardown := installEnumerateFixture(t, enumerateFixture{apps: []string{"unused"}})
+	defer teardown()
+
+	_, err := EnumerateAllCandidates(context.Background(), "no-such-system-12345", "no-such-system-12345")
+	if err == nil {
+		t.Fatal("expected EnumerateAllCandidates to error on unknown system")
+	}
+}
+
+// debugByChaosType is a t.Helper friend: turns a slice of candidates into a
+// printable breakdown for assertion failure messages. Kept private — only
+// the in-package tests need it.
+func debugByChaosType(items []GuidedConfig) string {
+	counts := map[string]int{}
+	for _, c := range items {
+		counts[c.ChaosType]++
+	}
+	out := ""
+	for k, v := range counts {
+		out += k + ": " + itoa(v) + "\n"
+	}
+	return out
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	if neg {
+		return "-" + digits
+	}
+	return digits
+}


### PR DESCRIPTION
## Summary

Layers 2 and 3 of issue #181, stacked on PR #183 (which lands the `guidedcli.EnumerateAllCandidates` library function this PR consumes).

**Backend (layer 2):** `GET /api/v2/systems/by-name/<code>/inject-candidates?namespace=<ns>` returning a flat envelope `{count, candidates: [{system, namespace, app, chaos_type, target}, ...]}`. Wired into the `chaossystem` module under the existing `systemRead` JWT-gated route group; resolver delegates straight to `guidedcli.EnumerateAllCandidates`. Package-level indirection (`enumerateCandidatesFn`) lets unit tests stub the enumerator without standing up a fake k8s API.

**aegisctl (layer 3):** `aegisctl inject candidates ls --system <code> --namespace <ns> [--output json|table]`. Default output is a per-row table summary; `--output json` emits the candidates slice **verbatim** (without the `{count, candidates}` envelope) so Python / shell loops can pipe straight into `jq` without unwrapping. Same pattern as the existing `tools/enumerate.sh` JSON shape.

## Stacking

- Branch base: `feat/issue-181-bulk-enum` (PR #183)
- After PR #183 merges to `main`, GitHub will auto-rebase this PR onto `main`.

## Test plan

- [x] Service unit tests: `TestListInjectCandidatesReturnsFlatJSON`, `TestListInjectCandidatesRejectsEmptyNamespace`, `TestListInjectCandidatesNotFoundForUnseededSystem`.
- [x] CLI unit tests: `TestInjectCandidatesLsJSONOutput` (httptest.Server stub asserting JSON-array shape), `TestInjectCandidatesLsRequiresFlags`.
- [x] `go build -tags duckdb_arrow ./...` from `AegisLab/src` is green.
- [x] Verified `tests/cmd/aegisctl/cmd/inject_*` and `module/chaossystem/inject_candidates_test.go` pass; pre-existing failures in `TestInjectGuidedApplyFailsFastWithoutProject` and `TestPedestalChartInstallValidation/backend_chart_values_are_written_to_temp_file` reproduce on `origin/main` and are not caused by this PR.

Closes #181 (when stacked on top of #183).

🤖 Generated with [Claude Code](https://claude.com/claude-code)