### PR TITLE
refactor(reasoning): classify rules core vs augmentation + cleanup (Phase 5 of #163)

### DIFF
--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/rule_matcher.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/rule_matcher.py
@@ -3,8 +3,10 @@
 Rule predicates speak the canonical-state vocabulary defined in
 ``ir/states.py`` (``SLOW``, ``ERRORING``, ``DEGRADED``, ``UNAVAILABLE``,
 ``MISSING``, ``HEALTHY``, ``UNKNOWN``). Specialization labels travel via
-``Evidence.specialization_labels`` and are matched separately when a rule
-opts in via the ``required_labels`` predicate.
+``Evidence.specialization_labels`` on the timeline and are surfaced
+through ``StateTimeline.labels_at`` for downstream explainers — they do
+not constrain matching here. Augmentation rules (``RuleTier.augmentation``)
+are filtered out by ``get_builtin_rules()`` by default for the same reason.
 """
 
 from __future__ import annotations

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_rule_matcher_canonical.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_rule_matcher_canonical.py
@@ -16,6 +16,7 @@ from rcabench_platform.v3.internal.reasoning.rules.schema import (
     PathHop,
     PropagationDirection,
     PropagationRule,
+    RuleTier,
 )
 
 
@@ -217,6 +218,7 @@ def test_extra_rule_can_target_specialization_label_for_augmenters() -> None:
     custom = PropagationRule(
         rule_id="custom_jvm_gc",
         description="JVM GC induced SLOW propagates SLOW",
+        tier=RuleTier.augmentation,
         src_kind=PlaceKind.span,
         src_states=["slow"],
         edge_kind=DepKind.calls,

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_rule_tiers.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_rule_tiers.py
@@ -1,0 +1,114 @@
+"""Phase 5 — rule tier classification tests.
+
+Verifies that:
+
+* Every rule in ``builtin_rules.json`` has a ``tier`` field whose value is
+  within :class:`RuleTier`.
+* ``propagation_rules_schema.json`` validates the example file
+  (``propagation_rules_example.json``) after the Phase 5 schema bump.
+* ``get_builtin_rules()`` returns only ``core`` rules by default; opting
+  in via ``include_augmentation=True`` returns the union of both tiers.
+* The Phase 2B ``RULE_POD_DEGRADED_TO_SPAN.src_states`` cleanup landed —
+  no rule still lists ``"restarting"`` because no adapter emits it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from rcabench_platform.v3.internal.reasoning.rules.builtin_rules import (
+    _RULES_JSON_PATH,
+    get_builtin_rules,
+)
+from rcabench_platform.v3.internal.reasoning.rules.schema import RuleTier
+
+_SCHEMA_PATH = Path(_RULES_JSON_PATH).parent / "propagation_rules_schema.json"
+_EXAMPLE_PATH = Path(_RULES_JSON_PATH).parent / "propagation_rules_example.json"
+
+
+def _load_json(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_every_rule_in_builtin_rules_json_has_a_tier_within_enum() -> None:
+    data = _load_json(_RULES_JSON_PATH)
+    valid_tiers = {tier.value for tier in RuleTier}
+    assert valid_tiers == {"core", "augmentation"}
+
+    rules = data.get("rules", [])
+    assert len(rules) > 0, "builtin_rules.json must define at least one rule"
+
+    for rule in rules:
+        assert "tier" in rule, f"rule {rule.get('rule_id')!r} is missing the 'tier' field"
+        assert rule["tier"] in valid_tiers, (
+            f"rule {rule.get('rule_id')!r} has tier={rule['tier']!r} not in {valid_tiers}"
+        )
+
+
+def test_schema_validates_builtin_rules_json() -> None:
+    schema = _load_json(_SCHEMA_PATH)
+    data = _load_json(_RULES_JSON_PATH)
+    jsonschema.validate(data, schema)
+
+
+def test_schema_validates_propagation_rules_example() -> None:
+    schema = _load_json(_SCHEMA_PATH)
+    example = _load_json(_EXAMPLE_PATH)
+    jsonschema.validate(example, schema)
+
+
+def test_get_builtin_rules_returns_only_core_by_default() -> None:
+    rules = get_builtin_rules()
+    assert len(rules) > 0
+    for rule in rules:
+        assert rule.tier == RuleTier.core, f"default get_builtin_rules() leaked augmentation rule {rule.rule_id!r}"
+
+
+def test_get_builtin_rules_with_augmentation_is_superset_of_default() -> None:
+    core = {r.rule_id for r in get_builtin_rules()}
+    full = {r.rule_id for r in get_builtin_rules(include_augmentation=True)}
+    assert core <= full, "include_augmentation=True must be a superset of the default"
+
+
+def test_pod_degraded_to_span_no_longer_lists_restarting() -> None:
+    """Phase 2B-review nit: no adapter emits pod.restarting; container restarts
+    map to container.unavailable + crash_loop instead. Make sure the dead
+    alternative is gone from the rule.
+    """
+    rules = {r.rule_id: r for r in get_builtin_rules(include_augmentation=True)}
+    rule = rules.get("pod_degraded_to_span")
+    assert rule is not None, "pod_degraded_to_span rule must exist"
+    assert "restarting" not in rule.src_states, (
+        "pod_degraded_to_span.src_states must not contain 'restarting' "
+        "(no adapter emits pod.restarting; see RULE_POD_DEGRADED_TO_SPAN cleanup)."
+    )
+
+
+def test_phase5_required_core_rules_present() -> None:
+    """Confirm the canonical-state coverage gap from Phase 5 is closed."""
+    rule_ids = {r.rule_id for r in get_builtin_rules()}
+    required = {
+        "pod_unavailable_to_container",  # pod.UNAVAILABLE -> container.UNAVAILABLE
+        "pod_unavailable_to_span",  # pod.UNAVAILABLE -> span.MISSING
+        "pod_unavailable_to_service",  # pod.UNAVAILABLE -> service.UNAVAILABLE rollup
+        "pod_degraded_to_span",  # pod.DEGRADED -> span.SLOW
+        "container_unavailable_to_pod",  # container.UNAVAILABLE -> pod.DEGRADED
+    }
+    missing = required - rule_ids
+    assert not missing, f"Phase 5 core coverage missing rules: {sorted(missing)}"
+
+
+@pytest.mark.parametrize("include_augmentation", [False, True])
+def test_get_builtin_rules_returns_a_fresh_copy(include_augmentation: bool) -> None:
+    """Mutating the returned list must not corrupt the cache."""
+    a = get_builtin_rules(include_augmentation=include_augmentation)
+    b = get_builtin_rules(include_augmentation=include_augmentation)
+    assert a is not b
+    a.clear()
+    fresh = get_builtin_rules(include_augmentation=include_augmentation)
+    assert len(fresh) > 0

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/builtin_rules.json
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/builtin_rules.json
@@ -1,13 +1,14 @@
 {
     "$schema": "propagation_rules_schema.json",
-    "description": "Canonical-state fault propagation rules (Phase 2B IR vocabulary)",
-    "source": "Phase 2B rewrite — predicates speak SLOW / ERRORING / DEGRADED / UNAVAILABLE / MISSING / HEALTHY / UNKNOWN only",
-    "version": "3.0-canonical-state",
+    "description": "Canonical-state fault propagation rules (Phase 5 — tiered).",
+    "source": "Phase 5 audit — every rule classified as core (canonical-state-only, fires on any OTel-instrumented stack) or augmentation (depends on specialization labels from a specific augmenter).",
+    "version": "3.1-tiered",
     "rules": [
         {
             "name": "RULE_CONTAINER_UNAVAILABLE_TO_SPAN",
             "rule_id": "container_unavailable_to_span",
             "description": "Container UNAVAILABLE -> Pod -> Service -> Span MISSING/UNAVAILABLE",
+            "tier": "core",
             "src_kind": "container",
             "src_states": ["unavailable"],
             "path": [
@@ -28,6 +29,7 @@
             "name": "RULE_CONTAINER_DEGRADED_TO_SPAN",
             "rule_id": "container_degraded_to_span",
             "description": "Container DEGRADED -> Pod -> Service -> Span SLOW/ERRORING",
+            "tier": "core",
             "src_kind": "container",
             "src_states": ["degraded"],
             "path": [
@@ -45,9 +47,49 @@
             "confidence": 0.8
         },
         {
+            "name": "RULE_CONTAINER_UNAVAILABLE_TO_POD",
+            "rule_id": "container_unavailable_to_pod",
+            "description": "Container UNAVAILABLE -> Pod DEGRADED (one bad container degrades the pod, structural).",
+            "tier": "core",
+            "src_kind": "container",
+            "src_states": ["unavailable"],
+            "edge_kind": "runs",
+            "direction": "backward",
+            "dst_kind": "pod",
+            "possible_dst_states": ["degraded", "unavailable", "erroring"],
+            "confidence": 0.85
+        },
+        {
+            "name": "RULE_POD_UNAVAILABLE_TO_CONTAINER",
+            "rule_id": "pod_unavailable_to_container",
+            "description": "Pod UNAVAILABLE -> all Containers UNAVAILABLE (containment, structural).",
+            "tier": "core",
+            "src_kind": "pod",
+            "src_states": ["unavailable"],
+            "edge_kind": "runs",
+            "direction": "forward",
+            "dst_kind": "container",
+            "possible_dst_states": ["unavailable", "erroring"],
+            "confidence": 0.95
+        },
+        {
+            "name": "RULE_POD_UNAVAILABLE_TO_SERVICE",
+            "rule_id": "pod_unavailable_to_service",
+            "description": "Pod UNAVAILABLE -> Service UNAVAILABLE/DEGRADED (rollup; the only routable backend went away).",
+            "tier": "core",
+            "src_kind": "pod",
+            "src_states": ["unavailable"],
+            "edge_kind": "routes_to",
+            "direction": "backward",
+            "dst_kind": "service",
+            "possible_dst_states": ["unavailable", "degraded", "erroring"],
+            "confidence": 0.85
+        },
+        {
             "name": "RULE_POD_UNAVAILABLE_TO_SPAN",
             "rule_id": "pod_unavailable_to_span",
-            "description": "Pod UNAVAILABLE -> Service -> Span MISSING/UNAVAILABLE",
+            "description": "Pod UNAVAILABLE -> Service -> Span MISSING/UNAVAILABLE (no requests served).",
+            "tier": "core",
             "src_kind": "pod",
             "src_states": ["unavailable"],
             "path": [
@@ -61,9 +103,10 @@
         {
             "name": "RULE_POD_DEGRADED_TO_SPAN",
             "rule_id": "pod_degraded_to_span",
-            "description": "Pod DEGRADED/RESTARTING -> Service -> Span SLOW/ERRORING",
+            "description": "Pod DEGRADED -> Service -> Span SLOW/ERRORING (resource pressure causes latency).",
+            "tier": "core",
             "src_kind": "pod",
-            "src_states": ["degraded", "restarting"],
+            "src_states": ["degraded"],
             "path": [
                 {"edge_kind": "routes_to", "direction": "backward", "intermediate_kind": "service"},
                 {"edge_kind": "includes", "direction": "forward"}
@@ -76,6 +119,7 @@
             "name": "RULE_SERVICE_TO_SPAN",
             "rule_id": "service_to_span",
             "description": "Service-level fault propagates into its spans (first hop, lenient).",
+            "tier": "core",
             "src_kind": "service",
             "src_states": ["slow", "erroring", "degraded", "unavailable"],
             "edge_kind": "includes",
@@ -93,6 +137,7 @@
             "name": "RULE_SPAN_SLOW_TO_CALLER",
             "rule_id": "span_slow_to_caller",
             "description": "SLOW span propagates SLOW to its caller (callee->caller via reverse calls edge).",
+            "tier": "core",
             "src_kind": "span",
             "src_states": ["slow"],
             "edge_kind": "calls",
@@ -105,6 +150,7 @@
             "name": "RULE_SPAN_ERRORING_TO_CALLER",
             "rule_id": "span_erroring_to_caller",
             "description": "ERRORING span propagates ERRORING to its caller.",
+            "tier": "core",
             "src_kind": "span",
             "src_states": ["erroring"],
             "edge_kind": "calls",
@@ -117,6 +163,7 @@
             "name": "RULE_SPAN_UNAVAILABLE_TO_CALLER",
             "rule_id": "span_unavailable_to_caller",
             "description": "UNAVAILABLE/MISSING span propagates ERRORING/UNAVAILABLE to its caller.",
+            "tier": "core",
             "src_kind": "span",
             "src_states": ["unavailable", "missing"],
             "edge_kind": "calls",
@@ -138,10 +185,14 @@
             "missing"
         ],
         "vocabulary_version": "Aligned with rcabench_platform.v3.internal.reasoning.ir.states (Phase 1).",
+        "tiers": {
+            "core": "Canonical-state predicates only; fire on any OTel-instrumented stack out-of-the-box. Returned by get_builtin_rules() by default.",
+            "augmentation": "Depends on a specialization label that only specific augmenter adapters emit (e.g. frequent_gc, oom_killed, slow_db). Requires opt-in via get_builtin_rules(include_augmentation=True). Currently empty: rule_matcher.py predicates do not consume specialization labels, so any augmentation rule defined today would behave identically to its core counterpart. Augmentation rules will land alongside the JVM/OOM augmenter adapters in Phase 4 (#163)."
+        },
         "design": [
-            "Three propagation chains kept: UNAVAILABLE chain (container/pod -> span), SLOW chain (callee SLOW -> caller SLOW), ERRORING chain (callee ERRORING -> caller ERRORING).",
-            "Specialization labels are NOT matched in the JSON predicate; rule_matcher exposes them via Evidence.specialization_labels for future augmenters.",
-            "All TT-vocabulary predicates (HIGH_CPU, OOM_KILLED, INJECTION_AFFECTED, MISSING_SPAN, etc.) are dropped — InjectionAdapter seeds canonical-state semantics directly."
+            "All rules speak the canonical IR vocabulary: HEALTHY / SLOW / ERRORING / DEGRADED / RESTARTING / UNAVAILABLE / MISSING / UNKNOWN.",
+            "Specialization labels (e.g. high_cpu, crash_loop, pod_killed from K8sMetricsAdapter) ride on Evidence.specialization_labels and are surfaced via StateTimeline.labels_at — they do not constrain JSON-rule matching today.",
+            "Phase 2B-review cleanup: removed 'restarting' from RULE_POD_DEGRADED_TO_SPAN.src_states because no adapter emits pod.restarting (container restart -> container.unavailable + crash_loop instead)."
         ]
     }
 }

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/builtin_rules.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/builtin_rules.py
@@ -3,8 +3,18 @@
 These rules encode realistic fault propagation patterns based on ChaosMesh
 injection capabilities in cloud-native environments.
 
-Rules are loaded from builtin_rules.json. The PropagationRule model automatically
-converts string values to the appropriate enum types during initialization.
+Rules are loaded from ``builtin_rules.json``. The :class:`PropagationRule`
+model automatically converts string values to the appropriate enum types
+during initialization.
+
+Each rule carries a :class:`RuleTier` classification:
+
+* ``core`` rules speak only canonical IR states and fire on any
+  OTel-instrumented stack out-of-the-box. They are returned by
+  :func:`get_builtin_rules` by default.
+* ``augmentation`` rules depend on specialization labels emitted by
+  specific augmenter adapters. They are skipped by default and must be
+  opted-in via ``get_builtin_rules(include_augmentation=True)``.
 """
 
 from __future__ import annotations
@@ -14,7 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from rcabench_platform.v3.internal.reasoning.models.graph import DepKind, PlaceKind
-from rcabench_platform.v3.internal.reasoning.rules.schema import PropagationRule
+from rcabench_platform.v3.internal.reasoning.rules.schema import PropagationRule, RuleTier
 
 # ==============================================================================
 # JSON Rules Loading
@@ -63,7 +73,7 @@ def _load_rules_from_json() -> dict[str, PropagationRule]:
 
 
 def _get_rules_dict() -> dict[str, PropagationRule]:
-    """Get the cached rules dictionary."""
+    """Get the cached rules dictionary (every rule, both tiers)."""
     return _load_rules_from_json()
 
 
@@ -100,45 +110,72 @@ def __dir__() -> list[str]:
 # ==============================================================================
 
 
-def _get_builtin_rules_list() -> list[PropagationRule]:
-    """Get the ordered list of builtin rules."""
+def _get_all_rules_list() -> list[PropagationRule]:
+    """Get the ordered list of every loaded rule (both tiers)."""
     return list(_get_rules_dict().values())
+
+
+def _get_core_rules_list() -> list[PropagationRule]:
+    """Get only ``core`` tier rules."""
+    return [rule for rule in _get_all_rules_list() if rule.tier == RuleTier.core]
 
 
 # Lazy-loaded BUILTIN_RULES for backward compatibility
 # Use property-like access through module __getattr__
 class _BuiltinRulesProxy:
-    """Proxy object that behaves like a list but loads rules lazily."""
+    """Proxy object that behaves like a list but loads rules lazily.
+
+    Returns *core* rules to match ``get_builtin_rules()`` default semantics.
+    """
 
     def __iter__(self):
-        return iter(_get_builtin_rules_list())
+        return iter(_get_core_rules_list())
 
     def __len__(self):
-        return len(_get_builtin_rules_list())
+        return len(_get_core_rules_list())
 
     def __getitem__(self, idx):
-        return _get_builtin_rules_list()[idx]
+        return _get_core_rules_list()[idx]
 
     def copy(self):
-        return _get_builtin_rules_list().copy()
+        return _get_core_rules_list().copy()
 
     def __repr__(self):
-        return repr(_get_builtin_rules_list())
+        return repr(_get_core_rules_list())
 
 
 BUILTIN_RULES: list[PropagationRule] = _BuiltinRulesProxy()  # type: ignore[assignment]
 
 
-def get_builtin_rules() -> list[PropagationRule]:
-    return _get_builtin_rules_list().copy()
+def get_builtin_rules(*, include_augmentation: bool = False) -> list[PropagationRule]:
+    """Return built-in propagation rules.
+
+    Args:
+        include_augmentation: If ``False`` (default), return only ``core``
+            rules — those whose predicates speak the canonical IR state
+            vocabulary and therefore fire on any OTel-instrumented stack.
+            If ``True``, also include ``augmentation`` rules that depend
+            on specialization labels emitted by specific augmenter
+            adapters (e.g. JVM, OOM augmenters).
+    """
+    if include_augmentation:
+        return _get_all_rules_list().copy()
+    return _get_core_rules_list().copy()
 
 
-def get_rules_for_edge_kind(edge_kind: DepKind) -> list[PropagationRule]:
-    return [rule for rule in _get_builtin_rules_list() if rule.edge_kind == edge_kind]
+def get_rules_for_edge_kind(edge_kind: DepKind, *, include_augmentation: bool = False) -> list[PropagationRule]:
+    rules = get_builtin_rules(include_augmentation=include_augmentation)
+    return [rule for rule in rules if rule.edge_kind == edge_kind]
 
 
-def get_rules_for_place_kind(place_kind: PlaceKind, as_source: bool = True) -> list[PropagationRule]:
+def get_rules_for_place_kind(
+    place_kind: PlaceKind,
+    as_source: bool = True,
+    *,
+    include_augmentation: bool = False,
+) -> list[PropagationRule]:
+    rules = get_builtin_rules(include_augmentation=include_augmentation)
     if as_source:
-        return [rule for rule in _get_builtin_rules_list() if rule.src_kind == place_kind]
+        return [rule for rule in rules if rule.src_kind == place_kind]
     else:
-        return [rule for rule in _get_builtin_rules_list() if rule.dst_kind == place_kind]
+        return [rule for rule in rules if rule.dst_kind == place_kind]

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/propagation_rules_example.json
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/propagation_rules_example.json
@@ -34,6 +34,7 @@
     {
       "rule_id": "span_slow_to_caller",
       "description": "SLOW callee span propagates SLOW to its caller (callee waits the caller).",
+      "tier": "core",
       "src_kind": "span",
       "src_states": ["slow"],
       "edge_kind": "calls",
@@ -45,6 +46,7 @@
     {
       "rule_id": "span_erroring_to_caller",
       "description": "ERRORING callee span propagates ERRORING to its caller.",
+      "tier": "core",
       "src_kind": "span",
       "src_states": ["erroring"],
       "edge_kind": "calls",
@@ -57,6 +59,7 @@
     {
       "rule_id": "pod_unavailable_to_span",
       "description": "Pod UNAVAILABLE -> Service -> Span MISSING/UNAVAILABLE.",
+      "tier": "core",
       "src_kind": "pod",
       "src_states": ["unavailable"],
       "path": [

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/propagation_rules_schema.json
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/propagation_rules_schema.json
@@ -101,6 +101,12 @@
       "description": "Canonical IR state vocabulary (Phase 2)."
     },
 
+    "rule_tier": {
+      "type": "string",
+      "enum": ["core", "augmentation"],
+      "description": "Rule classification — core (canonical-state only, fires on any OTel stack) vs augmentation (depends on specialization labels from a specific augmenter)."
+    },
+
     "path_hop": {
       "type": "object",
       "properties": {
@@ -176,6 +182,10 @@
           "type": "string",
           "description": "Human-readable description of the propagation"
         },
+        "tier": {
+          "$ref": "#/definitions/rule_tier",
+          "description": "Rule classification (core vs augmentation)"
+        },
         "src_kind": {
           "$ref": "#/definitions/node_kind",
           "description": "Source node type"
@@ -239,7 +249,7 @@
         },
         "first_hop_config": { "$ref": "#/definitions/first_hop_config" }
       },
-      "required": ["rule_id", "description", "src_kind", "src_states", "dst_kind", "possible_dst_states"],
+      "required": ["rule_id", "description", "tier", "src_kind", "src_states", "dst_kind", "possible_dst_states"],
       "oneOf": [
         {
           "properties": {

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/schema.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/schema.py
@@ -5,6 +5,16 @@ edge types, and edge data conditions.
 
 Supports both single-hop and multi-hop propagation paths to reduce false positives
 by expressing complete causal chains.
+
+Rules are tiered (``RuleTier``):
+
+* ``core`` — operates only on canonical IR states (``HEALTHY``/``SLOW``/
+  ``ERRORING``/``DEGRADED``/``UNAVAILABLE``/``MISSING``/``RESTARTING``/
+  ``UNKNOWN``) and topology kinds. Should fire on any OTel-instrumented
+  stack out-of-the-box.
+* ``augmentation`` — requires specialization labels (e.g. ``frequent_gc``,
+  ``oom_killed``) that only specific augmenter adapters emit. Optional;
+  used for richer explanations and loaded only when explicitly requested.
 """
 
 from collections.abc import Callable
@@ -20,6 +30,23 @@ from rcabench_platform.v3.internal.reasoning.models.graph import DepKind, Edge, 
 class PropagationDirection(StrEnum):
     FORWARD = auto()  # Propagate along edge direction (src → dst)
     BACKWARD = auto()  # Propagate against edge direction (dst → src)
+
+
+class RuleTier(StrEnum):
+    """Tier classification for propagation rules.
+
+    ``core``: rule predicates speak only the canonical IR state vocabulary
+    (and topology kinds), so the rule fires on any OTel-instrumented stack
+    out-of-the-box. ``get_builtin_rules()`` returns these by default.
+
+    ``augmentation``: rule depends on a specialization label that only
+    specific augmenter adapters emit (e.g. ``frequent_gc`` from a JVM
+    augmenter). These are skipped by default and opt-in via
+    ``get_builtin_rules(include_augmentation=True)``.
+    """
+
+    core = auto()
+    augmentation = auto()
 
 
 class PathHop(BaseModel):
@@ -95,6 +122,9 @@ class PropagationRule(BaseModel):
     Examples:
         # Single-hop: Span SLOW --calls(BACKWARD)--> Span SLOW
         PropagationRule(
+            rule_id="span_slow_to_caller",
+            description="...",
+            tier=RuleTier.core,
             src_kind=PlaceKind.span,
             src_states=["slow"],
             edge_kind=DepKind.calls,
@@ -105,6 +135,9 @@ class PropagationRule(BaseModel):
 
         # Multi-hop: Pod UNAVAILABLE --routes_to(BACKWARD)--> Service --includes(FORWARD)--> Span
         PropagationRule(
+            rule_id="pod_unavailable_to_span",
+            description="...",
+            tier=RuleTier.core,
             src_kind=PlaceKind.pod,
             src_states=["unavailable"],
             path=[
@@ -119,6 +152,14 @@ class PropagationRule(BaseModel):
     rule_id: str = Field(description="Unique identifier for the rule")
 
     description: str = Field(description="Human-readable description")
+
+    tier: RuleTier = Field(
+        description=(
+            "Rule classification — `core` rules speak only canonical IR states and "
+            "fire on any OTel-instrumented stack; `augmentation` rules depend on "
+            "specialization labels emitted by specific augmenter adapters."
+        ),
+    )
 
     # Source node constraints
     src_kind: PlaceKind = Field(description="Source node PlaceKind")


### PR DESCRIPTION
## Summary

Phase 5 of OperationsPAI/aegis#163 — audit canonical-state propagation rules, encode a `tier` (`core` vs `augmentation`) on `PropagationRule`, close structural-coverage gaps in `builtin_rules.json`, and clean up two review nits surfaced during Phase 2B.

### Tiering scheme

`tier: core` — rule predicates speak only the canonical IR state vocabulary (`HEALTHY`/`SLOW`/`ERRORING`/`DEGRADED`/`UNAVAILABLE`/`MISSING`/`UNKNOWN`) and topology kinds. Fires on any OTel-instrumented stack out-of-the-box. Returned by `get_builtin_rules()` by default.

`tier: augmentation` — rule depends on a specialization label (e.g. `frequent_gc`, `oom_killed`, `slow_db`) that only specific augmenter adapters emit. Skipped by default; opt in via `get_builtin_rules(include_augmentation=True)`.

### Classification table

| rule_id | src→dst | tier | notes |
|---|---|---|---|
| `container_unavailable_to_span` | container → span (multi-hop) | core | unchanged |
| `container_degraded_to_span` | container → span (multi-hop) | core | unchanged |
| `container_unavailable_to_pod` | container → pod | core | **new** — one bad container degrades the pod |
| `pod_unavailable_to_container` | pod → container | core | **new** — containment, structural |
| `pod_unavailable_to_service` | pod → service | core | **new** — single routable backend gone, rollup |
| `pod_unavailable_to_span` | pod → span (multi-hop) | core | unchanged |
| `pod_degraded_to_span` | pod → span (multi-hop) | core | dropped dead `"restarting"` alternative |
| `service_to_span` | service → span | core | unchanged |
| `span_slow_to_caller` | span → span | core | unchanged |
| `span_erroring_to_caller` | span → span | core | unchanged |
| `span_unavailable_to_caller` | span → span | core | unchanged |

**Final count: 11 core, 0 augmentation.**

### Why no augmentation rules today?

`rule_matcher.py` matches purely on canonical state and topology kind — it does not consume `Evidence.specialization_labels`. Defining an augmentation rule today would behave identically to a core rule, so we'd be adding noise. The tier infrastructure is in place; concrete augmentation rules will land alongside the JVM/OOM augmenter adapters in Phase 4 of #163. The JSON `notes.tiers.augmentation` field documents this.

### Cleanup nits

- `RULE_POD_DEGRADED_TO_SPAN.src_states` listed `"restarting"`, but no adapter emits `pod.restarting` — container restarts map to `container.unavailable + crash_loop` instead. Removed.
- `algorithms/rule_matcher.py` docstring claimed labels were matched via a `required_labels` field that does not exist. Dropped the claim; new wording explains specialization labels ride on `Evidence.specialization_labels` for downstream explainers and the matcher itself stays label-agnostic.

### Tests

New `ir_tests/test_rule_tiers.py`:

- Every rule in `builtin_rules.json` has a `tier` whose value is in the enum
- `propagation_rules_schema.json` validates both `builtin_rules.json` and `propagation_rules_example.json` (jsonschema)
- `get_builtin_rules()` returns only `core` rules; `include_augmentation=True` is a superset
- `pod_degraded_to_span` no longer lists `"restarting"`
- Phase 5 required-coverage rule_ids are all present
- `get_builtin_rules()` returns a fresh copy each call (cache safety)

`test_rule_matcher_canonical.py` updated: the inline custom rule now sets `tier=RuleTier.augmentation` to demonstrate that label-bearing rules can be layered alongside built-ins.

## Open questions

None — the rule set divides cleanly along the tier boundary today. Open whether `service_to_span` should split into per-state child rules (one per src state) once augmentation rules force pre-rule normalization; deferring that until Phase 4 lands a real augmenter adapter that needs it.

## Test plan

- [x] `cd rcabench-platform && just ci` passes (ruff format, ruff check, pyright 0/0/0, 78 tests, uv build)
- [x] Tests pass on Python 3.10, 3.11, 3.12, 3.13 (`uv run --python <ver> --all-extras pytest …/ir_tests/`)
- [x] `get_builtin_rules()` default returns 11 core rules; `include_augmentation=True` returns same 11 (no augmentation rules defined yet)
- [x] Existing Phase 2B tests (`test_rule_matcher_canonical.py`, `test_propagator_canonical.py`) still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)