### PR TITLE
chore(deploy): switch byte-cluster chaos-mesh to OperationsPAI fork images

### DIFF
--- a/AegisLab/manifests/byte-cluster/chaos-mesh.values.yaml
+++ b/AegisLab/manifests/byte-cluster/chaos-mesh.values.yaml
@@ -1,9 +1,18 @@
 images:
-  # Prefer the CN mirror lineage: pair-diag-cn-guangzhou.cr.volces.com/pair/*
-  # The Byte cluster can pull directly from the pair mirror, so use it as-is.
-  registry: pair-diag-cn-guangzhou.cr.volces.com/pair
+  # Use the OperationsPAI fork of chaos-mesh, mirrored from docker.io/opspai/* via
+  # the Volces Shanghai pair registry. The fork carries patches we need
+  # (notably RuntimeMutatorChaos / mutator-agent JVM injection) that upstream
+  # v2.8.0 does not have.
+  registry: pair-cn-shanghai.cr.volces.com/opspai
+  tag: 20260425-517f3df
 
+# The chart's default per-image `repository` values are `chaos-mesh/<name>`,
+# which would resolve to `pair-cn-shanghai.cr.volces.com/opspai/chaos-mesh/<name>`
+# under the registry above. Override each component's repository to drop the
+# `chaos-mesh/` prefix so images resolve to opspai/<name>.
 controllerManager:
+  image:
+    repository: chaos-mesh
   podChaos:
     podFailure:
       pauseImage: pair-diag-cn-guangzhou.cr.volces.com/pair/google-containers/pause:latest
@@ -12,3 +21,18 @@ chaosDaemon:
   hostNetwork: true
   runtime: containerd
   socketPath: /run/containerd/containerd.sock
+  image:
+    repository: chaos-daemon
+
+dashboard:
+  image:
+    repository: chaos-dashboard
+
+# chaos-coredns is upstream (only DNSChaos needs it; no fork patches).
+# Pin it to the existing pair/ mirror of upstream chaos-mesh/chaos-coredns
+# so we don't have to re-mirror it under opspai.
+dnsServer:
+  image:
+    registry: pair-diag-cn-guangzhou.cr.volces.com/pair
+    repository: chaos-mesh/chaos-coredns
+    tag: v0.2.6


### PR DESCRIPTION
## Summary

Switch the byte-cluster chaos-mesh deploy from upstream v2.8.0 (mirrored under `pair-diag-cn-guangzhou.cr.volces.com/pair/chaos-mesh/*`) to the OperationsPAI fork's controller-manager / chaos-daemon / chaos-dashboard images, pushed under `docker.io/opspai/*` and consumed via the Volces Shanghai mirror at `pair-cn-shanghai.cr.volces.com/opspai/*`.

### Why

- We hit `exit 101` on JVMChaos against the upstream v2.8.0 images on the byte cluster. The upstream `nsexec sh -c` flow assumes a specific shell layout that doesn't hold across the runtime images we tried.
- The OperationsPAI fork (https://github.com/OperationsPAI/chaos-mesh) carries fork-specific patches we want in the cluster, notably the `RuntimeMutatorChaos` CRD and the `mutator-agent` JVM injection path that depends on `OperationsPAI/java-runtime-mutator`.
- The fork's CI `Upload Image` workflow is gated on `github.repository == 'chaos-mesh/chaos-mesh'` and is skipped on every fork run, so there are no pre-built fork images anywhere — they had to be built locally.

### Build provenance

| Field | Value |
| --- | --- |
| Fork repo | https://github.com/OperationsPAI/chaos-mesh |
| Fork commit | `517f3df45e546bb527f20a0a32be96242e8cb6ba` (`fix(cm-008): Fix git config in release workflow`) |
| Mutator-agent source | `OperationsPAI/java-runtime-mutator@main`, built with `mvn clean package -DskipTests` and baked into `chaos-daemon` at `/usr/local/byteman/lib/mutator-agent.jar` |
| Image tag | `20260425-517f3df` |
| Build host | linux/amd64 (single-arch) |
| Dashboard UI | NOT embedded (`UI=0`). API still serves; only the React bundle is missing. |

### Images pushed

All images pushed to `docker.io` and verified live on the Volces Shanghai mirror at `pair-cn-shanghai.cr.volces.com/opspai/<name>:<tag>`.

| Image | Manifest-list digest | linux/amd64 manifest digest |
| --- | --- | --- |
| `docker.io/opspai/chaos-mesh:20260425-517f3df`      | `sha256:c6b2c4f7183889b331a1eb927ffdab9d8a5f146c6a7dd795ae0ecf50346ae647` | `sha256:4433b5164fe09a1bb9e46ebdd49df63354413174f66b0fedf946abcf7ca9949e` |
| `docker.io/opspai/chaos-daemon:20260425-517f3df`    | `sha256:c2481fccd68d1e0574c5dd715bb1f73cf909872bf9af1ab51d11c7ab84208cc6` | `sha256:8119a30d4292d476cdf3449e10ba8bdaa579874bba1c88c9f98e0b105a80e377` |
| `docker.io/opspai/chaos-dashboard:20260425-517f3df` | `sha256:283396394ff77d39a04c33a4ab34a08961ef86f522ed909fd93b90d696418e81` | `sha256:206ef2f64bcbe76ba0480a42f81fef96f0569e8e82c11d1e77f6caa3ff08d3cc` |

Volces mirror confirmation (`docker manifest inspect` returned the OCI image-index for each at the same tag): all three OK at push time.

### Resolved chart images (after this PR's values)

```
controllerManager: pair-cn-shanghai.cr.volces.com/opspai/chaos-mesh:20260425-517f3df
chaosDaemon:       pair-cn-shanghai.cr.volces.com/opspai/chaos-daemon:20260425-517f3df
dashboard:         pair-cn-shanghai.cr.volces.com/opspai/chaos-dashboard:20260425-517f3df
dnsServer:         pair-diag-cn-guangzhou.cr.volces.com/pair/chaos-mesh/chaos-coredns:v0.2.6
```

`chaos-coredns` has no fork patches, so it stays on the existing upstream mirror; the values file pins `dnsServer.image.{registry,repository,tag}` explicitly so it doesn't follow the new opspai global registry.

### What is NOT in this PR

- `manifests/cn_mirror/chaos-mesh.yaml` (consumed by `scripts/start.sh` for the kind dev cluster) is left on upstream v2.8.0 — that's a different deploy target and per the task brief should not change.
- No fork-specific feature gates / runtime-mutator config flags are flipped on; that can be a follow-up once the operator confirms the new daemon is healthy.
- `chaos-kernel` and `chaos-dlv` from the fork were not built or pushed (the byte-cluster install doesn't reference them).

## Reseed / redeploy steps

After merge, on the byte cluster:

```bash
helm upgrade --install chaos-mesh chaos-mesh/chaos-mesh \
  --namespace chaos-mesh \
  --version 2.8.0 \
  -f AegisLab/manifests/byte-cluster/chaos-mesh.values.yaml \
  --wait --timeout 10m

kubectl -n chaos-mesh rollout status deploy/chaos-controller-manager
kubectl -n chaos-mesh rollout status deploy/chaos-dashboard
kubectl -n chaos-mesh rollout status daemonset/chaos-daemon
```

Then re-run the JVMChaos repro that triggered exit 101 to confirm it now lands.

## Test plan

- [ ] `helm lint AegisLab/manifests/byte-cluster/chaos-mesh.values.yaml` against chart 2.8.0 (passes locally)
- [ ] `helm template` resolves the four image refs as listed above (verified locally)
- [ ] On byte cluster: `helm upgrade --install chaos-mesh ... -f AegisLab/manifests/byte-cluster/chaos-mesh.values.yaml` succeeds and all chaos-mesh pods reach Ready
- [ ] JVMChaos against a benchmark namespace no longer returns `exit 101`
- [ ] `aegisctl regression run otel-demo-guided` end-to-end still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)