### PR TITLE
feat(reasoning): JVM augmenter + specialization-label rule matching (Phase 4 of #163)

### DIFF
--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/propagator.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/propagator.py
@@ -90,8 +90,9 @@ class FaultPropagator:
         def edge_filter(src_id: int, dst_id: int, is_first_hop: bool) -> bool:
             src_states = self._states_for_node(src_id)
             dst_states = self._states_for_node(dst_id)
+            src_labels = self._labels_for_node(src_id)
             return self.rule_matcher.edge_matches_any_rule(
-                src_id, dst_id, self.graph, src_states, dst_states, is_first_hop
+                src_id, dst_id, self.graph, src_states, dst_states, is_first_hop, src_labels=src_labels
             )
 
         subgraph_edges = self.topology_explorer.find_reachable_subgraph(injection_node_ids, alarm_nodes, edge_filter)
@@ -169,6 +170,23 @@ class FaultPropagator:
             return set()
         return {w.state for w in tl.windows}
 
+    def _labels_for_node(self, node_id: int) -> frozenset[str]:
+        """Aggregate every specialization label ever observed on the node.
+
+        Phase 4 of #163: rules with non-empty ``required_labels`` gate on
+        these. Aggregating across the whole timeline (rather than picking
+        a specific window) mirrors :meth:`StateTimeline.ever_carries`.
+        """
+        tl = self._timeline_for_node(node_id)
+        if tl is None:
+            return frozenset()
+        labels: set[str] = set()
+        for w in tl.windows:
+            ws = w.evidence.get("specialization_labels")
+            if ws:
+                labels.update(ws)
+        return frozenset(labels)
+
     def _node_start_time(self, node_id: int) -> int | None:
         tl = self._timeline_for_node(node_id)
         if tl is None or not tl.windows:
@@ -189,7 +207,8 @@ class FaultPropagator:
         if len(node_ids) < 2:
             return None
 
-        multi_hop_rule = self.rule_matcher.find_matching_multi_hop_rule(node_ids, self.graph)
+        src_labels = self._labels_for_node(node_ids[0])
+        multi_hop_rule = self.rule_matcher.find_matching_multi_hop_rule(node_ids, self.graph, src_labels=src_labels)
         if multi_hop_rule is not None:
             path = self._verify_multi_hop_path(node_ids, multi_hop_rule)
             if path is not None:
@@ -212,7 +231,8 @@ class FaultPropagator:
                 if i + rule_node_count > len(node_ids):
                     continue
                 sub_path = node_ids[i : i + rule_node_count]
-                if self.rule_matcher.matches_multi_hop_rule(rule, sub_path, self.graph):
+                sub_src_labels = self._labels_for_node(sub_path[0])
+                if self.rule_matcher.matches_multi_hop_rule(rule, sub_path, self.graph, src_labels=sub_src_labels):
                     prev_time = state_start_times[-1] if state_start_times else None
                     verified = self._verify_multi_hop_subpath(
                         sub_path, rule, prev_start_time=prev_time, is_first_hop=(i == 0)

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/rule_matcher.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/algorithms/rule_matcher.py
@@ -4,9 +4,17 @@ Rule predicates speak the canonical-state vocabulary defined in
 ``ir/states.py`` (``SLOW``, ``ERRORING``, ``DEGRADED``, ``UNAVAILABLE``,
 ``MISSING``, ``HEALTHY``, ``UNKNOWN``). Specialization labels travel via
 ``Evidence.specialization_labels`` on the timeline and are surfaced
-through ``StateTimeline.labels_at`` for downstream explainers — they do
-not constrain matching here. Augmentation rules (``RuleTier.augmentation``)
-are filtered out by ``get_builtin_rules()`` by default for the same reason.
+through ``StateTimeline.labels_at`` for downstream explainers.
+
+Phase 4 of #163: rules can additionally gate on ``required_labels``. When
+a rule sets ``required_labels`` non-empty, the matcher requires the source
+node's accumulated specialization labels (collected over the timeline via
+``StateTimeline.ever_carries`` semantics) to be a superset of that set
+before matching. The matcher uses ``ever_carries`` rather than
+``labels_at(t)`` because the matcher operates on already-collapsed
+timelines without a pinned matching timestamp — the propagator picks the
+window per rule afterwards. Core rules leave ``required_labels`` empty
+and behave exactly as before.
 """
 
 from __future__ import annotations
@@ -83,10 +91,14 @@ class RuleMatcher:
         rule: PropagationRule,
         topology_path: list[int],
         graph: HyperGraph,
+        *,
+        src_labels: frozenset[str] = frozenset(),
     ) -> bool:
         if not rule.path:
             return False
         if len(topology_path) != len(rule.path) + 1:
+            return False
+        if rule.required_labels and not rule.required_labels.issubset(src_labels):
             return False
 
         for hop_idx, path_hop in enumerate(rule.path):
@@ -118,6 +130,8 @@ class RuleMatcher:
         self,
         topology_path: list[int],
         graph: HyperGraph,
+        *,
+        src_labels: frozenset[str] = frozenset(),
     ) -> PropagationRule | None:
         if len(topology_path) < 2:
             return None
@@ -129,7 +143,7 @@ class RuleMatcher:
                 continue
             if rule.src_kind != src_node.kind:
                 continue
-            if self.matches_multi_hop_rule(rule, topology_path, graph):
+            if self.matches_multi_hop_rule(rule, topology_path, graph, src_labels=src_labels):
                 return rule
         return None
 
@@ -141,6 +155,8 @@ class RuleMatcher:
         src_states: set[str],
         dst_states: set[str],
         is_first_hop: bool = False,
+        *,
+        src_labels: frozenset[str] = frozenset(),
     ) -> list[PropagationRule]:
         src_node = graph.get_node_by_id(src_node_id)
         dst_node = graph.get_node_by_id(dst_node_id)
@@ -154,6 +170,8 @@ class RuleMatcher:
         matching_rules: list[PropagationRule] = []
         rule_key = (src_node.kind, edge_data.kind, direction)
         for rule in self.rule_index.get(rule_key, []):
+            if rule.required_labels and not rule.required_labels.issubset(src_labels):
+                continue
             if self._rule_matches_edge(
                 rule,
                 src_node.kind,
@@ -167,6 +185,8 @@ class RuleMatcher:
 
         for rule in self.rules:
             if not rule.is_multi_hop or not rule.path:
+                continue
+            if rule.required_labels and not rule.required_labels.issubset(src_labels):
                 continue
             for hop_idx, path_hop in enumerate(rule.path):
                 if hop_idx == 0:
@@ -199,6 +219,8 @@ class RuleMatcher:
         src_states: set[str],
         dst_states: set[str],
         is_first_hop: bool = False,
+        *,
+        src_labels: frozenset[str] = frozenset(),
     ) -> bool:
         return (
             len(
@@ -209,6 +231,7 @@ class RuleMatcher:
                     src_states,
                     dst_states,
                     is_first_hop,
+                    src_labels=src_labels,
                 )
             )
             > 0

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/adapters/__init__.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/adapters/__init__.py
@@ -1,7 +1,8 @@
 """Built-in StateAdapters."""
 
 from rcabench_platform.v3.internal.reasoning.ir.adapters.injection import InjectionAdapter
+from rcabench_platform.v3.internal.reasoning.ir.adapters.jvm import JvmAugmenterAdapter
 from rcabench_platform.v3.internal.reasoning.ir.adapters.k8s_metrics import K8sMetricsAdapter
 from rcabench_platform.v3.internal.reasoning.ir.adapters.traces import TraceStateAdapter
 
-__all__ = ["InjectionAdapter", "K8sMetricsAdapter", "TraceStateAdapter"]
+__all__ = ["InjectionAdapter", "JvmAugmenterAdapter", "K8sMetricsAdapter", "TraceStateAdapter"]

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/adapters/jvm.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/adapters/jvm.py
@@ -1,0 +1,322 @@
+"""JvmAugmenterAdapter — JVM-specific specialization labels for pod/container nodes.
+
+This is the first *specialization-adapter* example mandated by Phase 4 of
+issue #163. The adapter inspects ``Node.abnormal_metrics`` for JVM
+metrics (OpenTelemetry semantic-convention names under the ``jvm.*``
+prefix) and emits Transitions that:
+
+* keep using the canonical IR state vocabulary (``DEGRADED`` /
+  ``UNAVAILABLE``); the augmenter never invents new states.
+* attach JVM-specific specialization labels via
+  ``Evidence.specialization_labels``.
+
+The labels emitted here are the contract surface for augmentation rules
+that gate via :pyattr:`PropagationRule.required_labels`:
+
+* ``frequent_gc`` — sustained pauses on ``jvm.gc.duration``
+  (or the legacy ``jvm.gc.collection.elapsed`` name): pod stays
+  technically alive but spends large fractions of wall-clock in GC and
+  user-visible spans go SLOW. Emits ``pod.DEGRADED + frequent_gc``.
+* ``high_heap_pressure`` — heap utilisation
+  (``jvm.memory.used / jvm.memory.limit`` or
+  ``jvm.memory.committed`` proxy) sustained ≥ 0.9. Emits
+  ``pod.DEGRADED + high_heap_pressure``.
+* ``oom_killed`` — explicit OOM kill signal
+  (``k8s.container.oom_killed`` or ``jvm.memory.oom``). Emits
+  ``container.UNAVAILABLE + oom_killed``.
+
+Boundary with :class:`K8sMetricsAdapter`:
+
+* k8s_metrics already turns ``k8s.container.restarts`` deltas into
+  ``container.UNAVAILABLE + crash_loop``. An OOM kill almost always
+  shows up there too. The JVM augmenter's distinct contribution is
+  *labelling the kill as OOM-driven specifically* via the ``oom_killed``
+  label (the augmentation rule gates on that label rather than on a new
+  state). Emitting alongside ``crash_loop`` is intentional: severity-
+  aware merge in ``synth_timelines`` keeps the stronger state, and the
+  union of specialization_labels survives the merge.
+* k8s_metrics' ``high_memory`` covers k8s pod-level memory pressure
+  (``k8s.pod.memory.working_set``); the JVM augmenter's
+  ``high_heap_pressure`` covers JVM-internal heap pressure even when
+  the container is well below its k8s memory limit (e.g. a pinned-down
+  heap with frequent full GCs).
+
+Real-data note: the metric names below follow the OTel ``jvm.*`` semantic
+conventions. They are the names emitted by the OpenTelemetry Java agent
+out of the box. Real-datapack validation is deferred until JVM-stack
+fixtures are provided; this adapter is a no-op when the relevant metrics
+aren't populated, so wiring it unconditionally is safe.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import numpy as np
+
+from rcabench_platform.v3.internal.reasoning.algorithms.baseline_detector import (
+    BaselineAwareDetector,
+    BaselineStatistics,
+    compute_baseline_statistics,
+)
+from rcabench_platform.v3.internal.reasoning.ir.adapter import AdapterContext
+from rcabench_platform.v3.internal.reasoning.ir.evidence import EvidenceLevel
+from rcabench_platform.v3.internal.reasoning.ir.transition import Transition
+from rcabench_platform.v3.internal.reasoning.models.graph import HyperGraph, Node, PlaceKind
+
+DEFAULT_WINDOW_SEC = 5
+
+# OTel JVM metrics (semantic-convention names; older names kept for compatibility
+# with collectors that haven't migrated). When neither name is present on a
+# node the adapter no-ops — it is safe to wire on non-Java stacks.
+GC_DURATION_METRICS = frozenset(
+    {
+        "jvm.gc.duration",  # OTel current
+        "jvm.gc.collection.elapsed",  # OTel deprecated, legacy collectors
+        "process.runtime.jvm.gc.duration",  # OTel pre-1.0 prefix
+    }
+)
+HEAP_USED_METRICS = frozenset(
+    {
+        "jvm.memory.used",
+        "process.runtime.jvm.memory.usage",
+    }
+)
+HEAP_LIMIT_METRICS = frozenset(
+    {
+        "jvm.memory.limit",
+        "jvm.memory.max",
+        "process.runtime.jvm.memory.limit",
+    }
+)
+HEAP_COMMITTED_METRICS = frozenset(
+    {
+        "jvm.memory.committed",
+        "process.runtime.jvm.memory.committed",
+    }
+)
+OOM_METRICS = frozenset(
+    {
+        "k8s.container.oom_killed",
+        "jvm.memory.oom",
+        "process.runtime.jvm.memory.oom",
+    }
+)
+
+# Heap utilisation threshold — sustained at-or-above this ratio counts as
+# ``high_heap_pressure``. Picked at 0.90 so the JVM in steady-state full-heap
+# operation (commonly 0.7–0.85 of -Xmx) is *not* tagged.
+HEAP_PRESSURE_RATIO = 0.90
+
+
+@dataclass(frozen=True, slots=True)
+class _JvmClassification:
+    state: str
+    label: str
+    trigger: str
+    observed: float
+    threshold: float
+
+
+def _window_max(timestamps: np.ndarray, values: np.ndarray, t0: int, t1: int) -> float | None:
+    if len(timestamps) == 0:
+        return None
+    mask = (timestamps >= t0) & (timestamps < t1)
+    if not np.any(mask):
+        return None
+    sl = values[mask]
+    sl = sl[~np.isnan(sl)]
+    if len(sl) == 0:
+        return None
+    return float(np.max(sl))
+
+
+def _node_has_any_metric(node: Node, metrics: Iterable[str]) -> bool:
+    return any(m in node.abnormal_metrics for m in metrics)
+
+
+def _node_has_any_jvm_signal(node: Node) -> bool:
+    """Cheap precondition: only do work for nodes that actually have JVM data."""
+    return (
+        _node_has_any_metric(node, GC_DURATION_METRICS)
+        or _node_has_any_metric(node, HEAP_USED_METRICS)
+        or _node_has_any_metric(node, HEAP_COMMITTED_METRICS)
+        or _node_has_any_metric(node, OOM_METRICS)
+    )
+
+
+class JvmAugmenterAdapter:
+    """Specialization adapter that emits JVM-flavoured specialization labels.
+
+    Pattern-aligned with :class:`K8sMetricsAdapter`: per-metric Z-score
+    detection against the baseline window for adaptive thresholds, plus a
+    static heap-utilisation threshold (heap pressure is a level signal,
+    not a deviation).
+    """
+
+    name = "jvm_augmenter"
+
+    def __init__(
+        self,
+        graph: HyperGraph,
+        *,
+        window_sec: int = DEFAULT_WINDOW_SEC,
+    ) -> None:
+        self._graph = graph
+        self._window_sec = window_sec
+        self._prev_oom_max: dict[str, float] = {}
+
+    def emit(self, ctx: AdapterContext) -> Iterable[Transition]:
+        return list(self._emit_all())
+
+    def _emit_all(self) -> Iterable[Transition]:
+        for kind in (PlaceKind.pod, PlaceKind.container):
+            for node in self._graph.get_nodes_by_kind(kind):
+                yield from self._emit_node(node)
+
+    def _emit_node(self, node: Node) -> Iterable[Transition]:
+        if not node.abnormal_metrics:
+            return
+        if not _node_has_any_jvm_signal(node):
+            return
+
+        baseline_stats: dict[str, BaselineStatistics] = {}
+        for metric, (_, vals) in node.baseline_metrics.items():
+            if vals is None or len(vals) == 0:
+                continue
+            baseline_stats[metric] = compute_baseline_statistics(vals)
+        detector = BaselineAwareDetector(baseline_stats)
+
+        ts_min: int | None = None
+        ts_max: int | None = None
+        for ts, _ in node.abnormal_metrics.values():
+            if len(ts) == 0:
+                continue
+            lo = int(np.min(ts))
+            hi = int(np.max(ts))
+            ts_min = lo if ts_min is None or lo < ts_min else ts_min
+            ts_max = hi if ts_max is None or hi > ts_max else ts_max
+        if ts_min is None or ts_max is None:
+            return
+
+        window = self._window_sec
+        node_key = node.uniq_name
+        kind = node.kind
+        last_state = "healthy"
+
+        for w_start in range(ts_min, ts_max + 1, window):
+            w_end = w_start + window
+            classification = self._classify_window(node, detector, w_start, w_end)
+            if classification is None:
+                if last_state != "healthy":
+                    # Recovery is owned by k8s_metrics; the JVM augmenter only
+                    # adds *positive* signals so it never overwrites someone
+                    # else's degraded -> something with healthy.
+                    pass
+                continue
+
+            to_state = classification.state
+            if last_state != to_state:
+                yield Transition(
+                    node_key=node_key,
+                    kind=kind,
+                    at=w_start,
+                    from_state=last_state,
+                    to_state=to_state,
+                    trigger=classification.trigger,
+                    level=EvidenceLevel.observed,
+                    evidence={
+                        "trigger_metric": classification.trigger,
+                        "observed": classification.observed,
+                        "threshold": classification.threshold,
+                        "specialization_labels": frozenset({classification.label}),
+                    },
+                )
+                last_state = to_state
+
+    def _classify_window(
+        self,
+        node: Node,
+        detector: BaselineAwareDetector,
+        t0: int,
+        t1: int,
+    ) -> _JvmClassification | None:
+        kind = node.kind
+
+        # OOM kill — strongest signal. Emit on a delta>0 over a previously
+        # observed sample for this metric+node, mirroring how k8s_metrics
+        # treats container restarts.
+        if kind == PlaceKind.container:
+            for metric in OOM_METRICS:
+                if metric not in node.abnormal_metrics:
+                    continue
+                ts, vals = node.abnormal_metrics[metric]
+                cur = _window_max(ts, vals, t0, t1)
+                if cur is None:
+                    continue
+                key = f"{node.uniq_name}::{metric}"
+                prev = self._prev_oom_max.get(key, 0.0)
+                self._prev_oom_max[key] = max(prev, cur)
+                if cur > prev and cur > 0:
+                    return _JvmClassification(
+                        state="unavailable",
+                        label="oom_killed",
+                        trigger=metric,
+                        observed=float(cur),
+                        threshold=float(prev),
+                    )
+
+        # frequent_gc — only emitted on pod nodes (where rules attach).
+        # Z-score anomaly on GC duration relative to baseline. JVMs always
+        # GC; the signal is "much more than usual".
+        if kind == PlaceKind.pod:
+            for metric in GC_DURATION_METRICS:
+                if metric not in node.abnormal_metrics:
+                    continue
+                ts, vals = node.abnormal_metrics[metric]
+                v = _window_max(ts, vals, t0, t1)
+                if v is None:
+                    continue
+                if detector.is_critical_anomaly(metric, v):
+                    base = detector.baseline_stats.get(metric)
+                    threshold = (base.mean + 3.0 * base.std) if base else 0.0
+                    return _JvmClassification(
+                        state="degraded",
+                        label="frequent_gc",
+                        trigger=metric,
+                        observed=float(v),
+                        threshold=float(threshold),
+                    )
+
+            # high_heap_pressure — used / limit (preferred) or
+            # used / committed (fallback). Static ratio threshold.
+            heap_used_metric = next((m for m in HEAP_USED_METRICS if m in node.abnormal_metrics), None)
+            if heap_used_metric is not None:
+                ts_u, vals_u = node.abnormal_metrics[heap_used_metric]
+                used = _window_max(ts_u, vals_u, t0, t1)
+                if used is not None:
+                    cap_metric = next(
+                        (m for m in HEAP_LIMIT_METRICS if m in node.abnormal_metrics),
+                        None,
+                    ) or next(
+                        (m for m in HEAP_COMMITTED_METRICS if m in node.abnormal_metrics),
+                        None,
+                    )
+                    if cap_metric is not None:
+                        ts_c, vals_c = node.abnormal_metrics[cap_metric]
+                        cap = _window_max(ts_c, vals_c, t0, t1)
+                        if cap is not None and cap > 0:
+                            ratio = used / cap
+                            if ratio >= HEAP_PRESSURE_RATIO:
+                                return _JvmClassification(
+                                    state="degraded",
+                                    label="high_heap_pressure",
+                                    trigger=heap_used_metric,
+                                    observed=float(ratio),
+                                    threshold=HEAP_PRESSURE_RATIO,
+                                )
+        return None
+
+
+__all__ = ["JvmAugmenterAdapter"]

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/pipeline.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/pipeline.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable
 
 from rcabench_platform.v3.internal.reasoning.ir.adapter import AdapterContext, StateAdapter
 from rcabench_platform.v3.internal.reasoning.ir.adapters.injection import InjectionAdapter
+from rcabench_platform.v3.internal.reasoning.ir.adapters.jvm import JvmAugmenterAdapter
 from rcabench_platform.v3.internal.reasoning.ir.adapters.k8s_metrics import K8sMetricsAdapter
 from rcabench_platform.v3.internal.reasoning.ir.adapters.traces import TraceStateAdapter
 from rcabench_platform.v3.internal.reasoning.ir.inference import InferenceRule, run_fixpoint
@@ -59,6 +60,9 @@ def run_reasoning_ir(
         InjectionAdapter(resolved=resolved, injection_at=injection_at),
         TraceStateAdapter(baseline_traces=baseline_traces, abnormal_traces=abnormal_traces),  # type: ignore[arg-type]
         K8sMetricsAdapter(graph=graph),
+        # Specialization augmenters — safe to wire unconditionally; each one
+        # no-ops on stacks that don't carry the metrics it cares about.
+        JvmAugmenterAdapter(graph=graph),
     ]
     if extra_adapters:
         adapters.extend(extra_adapters)

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_augmentation_rules.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_augmentation_rules.py
@@ -1,0 +1,51 @@
+"""Phase 4 of #163 — JVM augmentation rules wired through the JSON loader.
+
+These rules opt-in via ``get_builtin_rules(include_augmentation=True)`` and
+each declares ``required_labels`` so they only fire on stacks where the
+JVM augmenter has tagged the source node.
+"""
+
+from __future__ import annotations
+
+from rcabench_platform.v3.internal.reasoning.rules.builtin_rules import get_builtin_rules
+from rcabench_platform.v3.internal.reasoning.rules.schema import RuleTier
+
+EXPECTED_AUGMENTATION_RULE_IDS = {
+    "pod_degraded_frequent_gc_to_span",
+    "pod_degraded_high_heap_to_span",
+    "container_unavailable_oom_killed",
+}
+
+
+def test_jvm_augmentation_rules_present_only_when_opted_in() -> None:
+    core_rule_ids = {r.rule_id for r in get_builtin_rules()}
+    full_rule_ids = {r.rule_id for r in get_builtin_rules(include_augmentation=True)}
+    assert EXPECTED_AUGMENTATION_RULE_IDS.isdisjoint(core_rule_ids), (
+        "augmentation rules must NOT leak into the default core view"
+    )
+    assert EXPECTED_AUGMENTATION_RULE_IDS <= full_rule_ids, (
+        f"expected augmentation rules missing: {EXPECTED_AUGMENTATION_RULE_IDS - full_rule_ids}"
+    )
+
+
+def test_jvm_augmentation_rules_carry_required_labels() -> None:
+    rules = {r.rule_id: r for r in get_builtin_rules(include_augmentation=True)}
+
+    gc = rules["pod_degraded_frequent_gc_to_span"]
+    assert gc.tier == RuleTier.augmentation
+    assert gc.required_labels == frozenset({"frequent_gc"})
+
+    heap = rules["pod_degraded_high_heap_to_span"]
+    assert heap.tier == RuleTier.augmentation
+    assert heap.required_labels == frozenset({"high_heap_pressure"})
+
+    oom = rules["container_unavailable_oom_killed"]
+    assert oom.tier == RuleTier.augmentation
+    assert oom.required_labels == frozenset({"oom_killed"})
+
+
+def test_core_rules_have_empty_required_labels() -> None:
+    for rule in get_builtin_rules():
+        assert rule.required_labels == frozenset(), (
+            f"core rule {rule.rule_id!r} must have empty required_labels (Phase 4 invariant)"
+        )

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_jvm_adapter.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_jvm_adapter.py
@@ -1,0 +1,172 @@
+"""JvmAugmenterAdapter — synthetic JVM metric series exercising each label."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from rcabench_platform.v3.internal.reasoning.ir.adapter import AdapterContext
+from rcabench_platform.v3.internal.reasoning.ir.adapters.jvm import JvmAugmenterAdapter
+from rcabench_platform.v3.internal.reasoning.models.graph import HyperGraph, Node, PlaceKind
+
+CTX = AdapterContext(datapack_dir=Path("/tmp/not-used"), case_name="jvm-fixture")
+
+
+def _ts_range(start: int, n: int) -> np.ndarray:
+    return np.arange(start, start + n, dtype=np.int64)
+
+
+def _add_pod(g: HyperGraph, name: str) -> Node:
+    return g.add_node(Node(kind=PlaceKind.pod, self_name=name))
+
+
+def _add_container(g: HyperGraph, name: str) -> Node:
+    return g.add_node(Node(kind=PlaceKind.container, self_name=name))
+
+
+def test_no_jvm_metrics_emits_nothing() -> None:
+    """Adapter is safe to wire on non-Java stacks: no JVM metric -> no events."""
+    g = HyperGraph()
+    pod = _add_pod(g, "go-svc-0")
+    base_ts = _ts_range(1000, 60)
+    pod.baseline_metrics["k8s.pod.cpu.usage"] = (base_ts, np.full(60, 0.10))
+    pod.abnormal_metrics["k8s.pod.cpu.usage"] = (_ts_range(2000, 30), np.full(30, 0.95))
+
+    events = list(JvmAugmenterAdapter(g, window_sec=5).emit(CTX))
+    assert events == []
+
+
+def test_frequent_gc_emits_pod_degraded_with_label() -> None:
+    g = HyperGraph()
+    pod = _add_pod(g, "tea-store-auth-0")
+    metric = "jvm.gc.duration"
+    base_ts = _ts_range(1000, 60)
+    base_vals = np.full(60, 0.001, dtype=np.float64)  # 1ms baseline GC
+    abn_ts = _ts_range(2000, 30)
+    # Sustained 200ms GC pauses — well above 3-sigma of a 1ms baseline.
+    abn_vals = np.concatenate([np.full(10, 0.001), np.full(20, 0.200)])
+    pod.baseline_metrics[metric] = (base_ts, base_vals)
+    pod.abnormal_metrics[metric] = (abn_ts, abn_vals)
+
+    events = list(JvmAugmenterAdapter(g, window_sec=5).emit(CTX))
+    assert events, "expected at least one transition"
+    deg = [e for e in events if e.to_state == "degraded"]
+    assert deg, f"expected degraded transition, got {[(e.to_state, e.trigger) for e in events]}"
+    assert deg[0].evidence.get("specialization_labels") == frozenset({"frequent_gc"})
+    assert deg[0].kind == PlaceKind.pod
+
+
+def test_high_heap_pressure_emits_pod_degraded_with_label() -> None:
+    g = HyperGraph()
+    pod = _add_pod(g, "tea-store-recommender-0")
+    base_ts = _ts_range(1000, 60)
+    abn_ts = _ts_range(2000, 30)
+
+    # used / limit ratio crosses 0.90 throughout the abnormal window.
+    pod.baseline_metrics["jvm.memory.used"] = (base_ts, np.full(60, 200_000_000.0))
+    pod.baseline_metrics["jvm.memory.limit"] = (base_ts, np.full(60, 1_000_000_000.0))
+
+    pod.abnormal_metrics["jvm.memory.used"] = (abn_ts, np.full(30, 950_000_000.0))
+    pod.abnormal_metrics["jvm.memory.limit"] = (abn_ts, np.full(30, 1_000_000_000.0))
+
+    events = list(JvmAugmenterAdapter(g, window_sec=5).emit(CTX))
+    deg = [e for e in events if e.to_state == "degraded"]
+    assert deg, f"expected degraded transition, got {events}"
+    assert deg[0].evidence.get("specialization_labels") == frozenset({"high_heap_pressure"})
+
+
+def test_high_heap_pressure_no_emit_when_under_threshold() -> None:
+    g = HyperGraph()
+    pod = _add_pod(g, "tea-store-image-0")
+    base_ts = _ts_range(1000, 60)
+    abn_ts = _ts_range(2000, 30)
+
+    pod.baseline_metrics["jvm.memory.used"] = (base_ts, np.full(60, 200_000_000.0))
+    pod.baseline_metrics["jvm.memory.limit"] = (base_ts, np.full(60, 1_000_000_000.0))
+    # Sit comfortably at 0.5 utilisation — below 0.90 threshold.
+    pod.abnormal_metrics["jvm.memory.used"] = (abn_ts, np.full(30, 500_000_000.0))
+    pod.abnormal_metrics["jvm.memory.limit"] = (abn_ts, np.full(30, 1_000_000_000.0))
+
+    events = list(JvmAugmenterAdapter(g, window_sec=5).emit(CTX))
+    assert events == []
+
+
+def test_oom_killed_emits_container_unavailable_with_label() -> None:
+    g = HyperGraph()
+    cont = _add_container(g, "tea-store-persistence-app")
+    metric = "k8s.container.oom_killed"
+    base_ts = _ts_range(1000, 60)
+    base_vals = np.zeros(60, dtype=np.float64)
+    abn_ts = _ts_range(2000, 30)
+    # 0 → 1 in the second half-window: OOM kill recorded.
+    abn_vals = np.array([0] * 10 + [1] * 20, dtype=np.float64)
+    cont.baseline_metrics[metric] = (base_ts, base_vals)
+    cont.abnormal_metrics[metric] = (abn_ts, abn_vals)
+
+    events = list(JvmAugmenterAdapter(g, window_sec=5).emit(CTX))
+    una = [e for e in events if e.to_state == "unavailable"]
+    assert una, f"expected unavailable transition, got {events}"
+    assert una[0].evidence.get("specialization_labels") == frozenset({"oom_killed"})
+    assert una[0].kind == PlaceKind.container
+
+
+def test_legacy_metric_name_is_recognised() -> None:
+    """``jvm.gc.collection.elapsed`` is the deprecated OTel name; still works."""
+    g = HyperGraph()
+    pod = _add_pod(g, "legacy-jvm-0")
+    metric = "jvm.gc.collection.elapsed"
+    base_ts = _ts_range(1000, 60)
+    base_vals = np.full(60, 0.001, dtype=np.float64)
+    abn_ts = _ts_range(2000, 30)
+    abn_vals = np.concatenate([np.full(10, 0.001), np.full(20, 0.200)])
+    pod.baseline_metrics[metric] = (base_ts, base_vals)
+    pod.abnormal_metrics[metric] = (abn_ts, abn_vals)
+
+    events = list(JvmAugmenterAdapter(g, window_sec=5).emit(CTX))
+    deg = [e for e in events if e.to_state == "degraded"]
+    assert deg
+    assert deg[0].evidence.get("specialization_labels") == frozenset({"frequent_gc"})
+
+
+def test_pipeline_includes_jvm_adapter_when_metrics_absent() -> None:
+    """End-to-end: JVM adapter wired in pipeline.run_reasoning_ir is a safe no-op
+    on non-Java stacks (the existing test_pipeline cases must stay green; this
+    test asserts the JVM adapter is in the standard trio explicitly)."""
+    import polars as pl
+
+    from rcabench_platform.v3.internal.reasoning.ir.pipeline import run_reasoning_ir
+    from rcabench_platform.v3.internal.reasoning.models.injection import ResolvedInjection
+
+    base_df = pl.DataFrame(
+        schema={
+            "time": pl.Int64,
+            "trace_id": pl.Utf8,
+            "span_id": pl.Utf8,
+            "parent_span_id": pl.Utf8,
+            "span_name": pl.Utf8,
+            "service_name": pl.Utf8,
+            "duration": pl.Int64,
+            "attr.http.response.status_code": pl.Int64,
+        }
+    )
+    abn_df = base_df.clone()
+    g = HyperGraph()
+    resolved = ResolvedInjection(
+        injection_nodes=["span|svc::GET /api"],
+        start_kind="span",
+        category="http_response",
+        fault_category="http_response",
+        fault_type_name="HTTPResponseDelay",
+        resolution_method="test",
+    )
+    timelines = run_reasoning_ir(
+        graph=g,
+        ctx=CTX,
+        resolved=resolved,
+        injection_at=2000,
+        baseline_traces=base_df,
+        abnormal_traces=abn_df,
+    )
+    # Should still produce the seed timeline; JVM adapter is a no-op here.
+    assert "span|svc::GET /api" in timelines

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_required_labels.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_required_labels.py
@@ -1,0 +1,190 @@
+"""Phase 4 of #163 — required_labels gating in rule_matcher.
+
+Covers three scenarios:
+
+1. A rule with non-empty ``required_labels`` does NOT match when the
+   source node's timeline does not carry the required label.
+2. The same rule DOES match once the label appears on the timeline.
+3. A rule with empty ``required_labels`` (the default) matches whether
+   labels are present or absent — backwards-compat for every core rule.
+"""
+
+from __future__ import annotations
+
+from rcabench_platform.v3.internal.reasoning.algorithms.rule_matcher import RuleMatcher
+from rcabench_platform.v3.internal.reasoning.models.graph import (
+    DepKind,
+    Edge,
+    HyperGraph,
+    Node,
+    PlaceKind,
+)
+from rcabench_platform.v3.internal.reasoning.rules.schema import (
+    PropagationDirection,
+    PropagationRule,
+    RuleTier,
+)
+
+
+def _calls(src: int, dst: int, src_name: str, dst_name: str) -> Edge:
+    return Edge(
+        src_id=src,
+        dst_id=dst,
+        src_name=src_name,
+        dst_name=dst_name,
+        kind=DepKind.calls,
+        data=None,
+    )
+
+
+def _two_span_graph() -> tuple[HyperGraph, int, int]:
+    g = HyperGraph()
+    callee = g.add_node(Node(kind=PlaceKind.span, self_name="svc-b::POST /api"))
+    caller = g.add_node(Node(kind=PlaceKind.span, self_name="svc-a::GET /home"))
+    assert callee.id is not None and caller.id is not None
+    g.add_edge(_calls(caller.id, callee.id, caller.uniq_name, callee.uniq_name))
+    return g, callee.id, caller.id
+
+
+def _gc_rule() -> PropagationRule:
+    return PropagationRule(
+        rule_id="span_slow_gc_to_caller",
+        description="frequent_gc-tagged SLOW span propagates SLOW to caller",
+        tier=RuleTier.augmentation,
+        src_kind=PlaceKind.span,
+        src_states=["slow"],
+        edge_kind=DepKind.calls,
+        direction=PropagationDirection.BACKWARD,
+        dst_kind=PlaceKind.span,
+        possible_dst_states=["slow"],
+        required_labels=frozenset({"frequent_gc"}),
+    )
+
+
+def _label_agnostic_rule() -> PropagationRule:
+    return PropagationRule(
+        rule_id="span_slow_any_to_caller",
+        description="any SLOW span propagates SLOW to caller (no label gate)",
+        tier=RuleTier.core,
+        src_kind=PlaceKind.span,
+        src_states=["slow"],
+        edge_kind=DepKind.calls,
+        direction=PropagationDirection.BACKWARD,
+        dst_kind=PlaceKind.span,
+        possible_dst_states=["slow"],
+    )
+
+
+def test_rule_with_required_label_does_not_fire_when_label_missing() -> None:
+    g, callee_id, caller_id = _two_span_graph()
+    matcher = RuleMatcher([_gc_rule()])
+    matched = matcher.matches_edge(
+        src_node_id=callee_id,
+        dst_node_id=caller_id,
+        graph=g,
+        src_states={"slow"},
+        dst_states={"slow"},
+        is_first_hop=False,
+        src_labels=frozenset(),  # no labels on src
+    )
+    assert matched == [], "rule with required_labels must not fire on label-free src"
+
+
+def test_rule_with_required_label_fires_when_label_present() -> None:
+    g, callee_id, caller_id = _two_span_graph()
+    matcher = RuleMatcher([_gc_rule()])
+    matched = matcher.matches_edge(
+        src_node_id=callee_id,
+        dst_node_id=caller_id,
+        graph=g,
+        src_states={"slow"},
+        dst_states={"slow"},
+        is_first_hop=False,
+        src_labels=frozenset({"frequent_gc"}),
+    )
+    assert {r.rule_id for r in matched} == {"span_slow_gc_to_caller"}
+
+
+def test_rule_with_empty_required_labels_is_label_agnostic() -> None:
+    g, callee_id, caller_id = _two_span_graph()
+    matcher = RuleMatcher([_label_agnostic_rule()])
+
+    # No labels — must still match (backwards-compat for core rules).
+    matched_no_labels = matcher.matches_edge(
+        src_node_id=callee_id,
+        dst_node_id=caller_id,
+        graph=g,
+        src_states={"slow"},
+        dst_states={"slow"},
+        is_first_hop=False,
+    )
+    assert {r.rule_id for r in matched_no_labels} == {"span_slow_any_to_caller"}
+
+    # With labels — must also match (label-agnostic = present labels are
+    # ignored, not considered a constraint to fail).
+    matched_with_labels = matcher.matches_edge(
+        src_node_id=callee_id,
+        dst_node_id=caller_id,
+        graph=g,
+        src_states={"slow"},
+        dst_states={"slow"},
+        is_first_hop=False,
+        src_labels=frozenset({"frequent_gc", "high_cpu"}),
+    )
+    assert {r.rule_id for r in matched_with_labels} == {"span_slow_any_to_caller"}
+
+
+def test_required_labels_requires_full_subset_match() -> None:
+    """If a rule requires multiple labels, partial coverage is not enough."""
+    multi_label_rule = PropagationRule(
+        rule_id="span_slow_gc_and_heap_to_caller",
+        description="needs BOTH frequent_gc and high_heap_pressure",
+        tier=RuleTier.augmentation,
+        src_kind=PlaceKind.span,
+        src_states=["slow"],
+        edge_kind=DepKind.calls,
+        direction=PropagationDirection.BACKWARD,
+        dst_kind=PlaceKind.span,
+        possible_dst_states=["slow"],
+        required_labels=frozenset({"frequent_gc", "high_heap_pressure"}),
+    )
+    g, callee_id, caller_id = _two_span_graph()
+    matcher = RuleMatcher([multi_label_rule])
+
+    only_gc = matcher.matches_edge(
+        src_node_id=callee_id,
+        dst_node_id=caller_id,
+        graph=g,
+        src_states={"slow"},
+        dst_states={"slow"},
+        is_first_hop=False,
+        src_labels=frozenset({"frequent_gc"}),
+    )
+    assert only_gc == []
+
+    both = matcher.matches_edge(
+        src_node_id=callee_id,
+        dst_node_id=caller_id,
+        graph=g,
+        src_states={"slow"},
+        dst_states={"slow"},
+        is_first_hop=False,
+        src_labels=frozenset({"frequent_gc", "high_heap_pressure", "extra"}),
+    )
+    assert {r.rule_id for r in both} == {"span_slow_gc_and_heap_to_caller"}
+
+
+def test_default_required_labels_is_empty_frozenset() -> None:
+    """Existing rule definitions stay valid: required_labels defaults to empty."""
+    rule = PropagationRule(
+        rule_id="legacy_rule",
+        description="no required_labels declared",
+        tier=RuleTier.core,
+        src_kind=PlaceKind.span,
+        src_states=["slow"],
+        edge_kind=DepKind.calls,
+        direction=PropagationDirection.BACKWARD,
+        dst_kind=PlaceKind.span,
+        possible_dst_states=["slow"],
+    )
+    assert rule.required_labels == frozenset()

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/builtin_rules.json
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/builtin_rules.json
@@ -171,6 +171,52 @@
             "dst_kind": "span",
             "possible_dst_states": ["erroring", "unavailable", "missing"],
             "confidence": 0.85
+        },
+        {
+            "name": "RULE_POD_DEGRADED_FREQUENT_GC_TO_SPAN",
+            "rule_id": "pod_degraded_frequent_gc_to_span",
+            "description": "Pod DEGRADED with frequent_gc -> Service -> Span SLOW (Java GC pauses become user-visible latency).",
+            "tier": "augmentation",
+            "src_kind": "pod",
+            "src_states": ["degraded"],
+            "required_labels": ["frequent_gc"],
+            "path": [
+                {"edge_kind": "routes_to", "direction": "backward", "intermediate_kind": "service"},
+                {"edge_kind": "includes", "direction": "forward"}
+            ],
+            "dst_kind": "span",
+            "possible_dst_states": ["slow", "erroring"],
+            "confidence": 0.85
+        },
+        {
+            "name": "RULE_POD_DEGRADED_HIGH_HEAP_TO_SPAN",
+            "rule_id": "pod_degraded_high_heap_to_span",
+            "description": "Pod DEGRADED with high_heap_pressure -> Service -> Span SLOW (heap near limit -> sustained allocator stalls).",
+            "tier": "augmentation",
+            "src_kind": "pod",
+            "src_states": ["degraded"],
+            "required_labels": ["high_heap_pressure"],
+            "path": [
+                {"edge_kind": "routes_to", "direction": "backward", "intermediate_kind": "service"},
+                {"edge_kind": "includes", "direction": "forward"}
+            ],
+            "dst_kind": "span",
+            "possible_dst_states": ["slow", "erroring"],
+            "confidence": 0.8
+        },
+        {
+            "name": "RULE_CONTAINER_UNAVAILABLE_OOM_KILLED",
+            "rule_id": "container_unavailable_oom_killed",
+            "description": "Container UNAVAILABLE with oom_killed -> Pod UNAVAILABLE (one OOM kill takes the pod out; distinct from generic crash_loop).",
+            "tier": "augmentation",
+            "src_kind": "container",
+            "src_states": ["unavailable"],
+            "required_labels": ["oom_killed"],
+            "edge_kind": "runs",
+            "direction": "backward",
+            "dst_kind": "pod",
+            "possible_dst_states": ["unavailable", "degraded", "erroring"],
+            "confidence": 0.9
         }
     ],
     "notes": {
@@ -187,7 +233,7 @@
         "vocabulary_version": "Aligned with rcabench_platform.v3.internal.reasoning.ir.states (Phase 1).",
         "tiers": {
             "core": "Canonical-state predicates only; fire on any OTel-instrumented stack out-of-the-box. Returned by get_builtin_rules() by default.",
-            "augmentation": "Depends on a specialization label that only specific augmenter adapters emit (e.g. frequent_gc, oom_killed, slow_db). Requires opt-in via get_builtin_rules(include_augmentation=True). Currently empty: rule_matcher.py predicates do not consume specialization labels, so any augmentation rule defined today would behave identically to its core counterpart. Augmentation rules will land alongside the JVM/OOM augmenter adapters in Phase 4 (#163)."
+            "augmentation": "Depends on a specialization label that only specific augmenter adapters emit (e.g. frequent_gc, oom_killed). Requires opt-in via get_builtin_rules(include_augmentation=True). As of Phase 4 of #163, rule_matcher.py honours required_labels — rules listed here only fire when the source node's timeline carries every label they declare, and no-op on stacks that don't (e.g. JVM rules don't fire on a Go stack)."
         },
         "design": [
             "All rules speak the canonical IR vocabulary: HEALTHY / SLOW / ERRORING / DEGRADED / RESTARTING / UNAVAILABLE / MISSING / UNKNOWN.",

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/propagation_rules_schema.json
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/propagation_rules_schema.json
@@ -247,7 +247,13 @@
           "default": "builtin",
           "description": "Origin of this rule"
         },
-        "first_hop_config": { "$ref": "#/definitions/first_hop_config" }
+        "first_hop_config": { "$ref": "#/definitions/first_hop_config" },
+        "required_labels": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "description": "Specialization labels that must be present on the source node's timeline for the rule to fire. Empty/absent means label-agnostic (canonical-state only). Augmentation rules typically set this; core rules leave it empty."
+        }
       },
       "required": ["rule_id", "description", "tier", "src_kind", "src_states", "dst_kind", "possible_dst_states"],
       "oneOf": [

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/schema.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/rules/schema.py
@@ -183,6 +183,21 @@ class PropagationRule(BaseModel):
         description="[Single-hop] Optional function to check edge data",
     )
 
+    # Specialization-label gating (Phase 4 of #163)
+    required_labels: frozenset[str] = Field(
+        default_factory=frozenset,
+        description=(
+            "Specialization labels (e.g. ``frequent_gc``, ``oom_killed``) that must "
+            "all be present on the source node's timeline for the rule to fire. "
+            "Empty (default) means the rule is label-agnostic and matches purely on "
+            "canonical state — preserving the behaviour of every core rule. "
+            "Augmenter rules use this to gate on labels emitted by specific augmenter "
+            "adapters (the JVM augmenter emits ``frequent_gc`` / ``high_heap_pressure`` / "
+            "``oom_killed``; only rules listing those labels here will fire when the "
+            "stack carries them, and won't fire on stacks that don't)."
+        ),
+    )
+
     # Rule metadata
     confidence: float = Field(
         default=0.8,
@@ -236,6 +251,20 @@ class PropagationRule(BaseModel):
     def normalize_dst_states(cls, v: list[str]) -> list[str]:
         """Normalize state names to lowercase for consistent matching."""
         return [s.lower() for s in v]
+
+    @field_validator("required_labels", mode="before")
+    @classmethod
+    def coerce_required_labels(cls, v):
+        """Allow JSON arrays / lists / sets to specify ``required_labels``.
+
+        Pydantic accepts ``frozenset`` natively but the JSON loader hands us
+        a ``list``; coerce here so callers don't have to.
+        """
+        if v is None:
+            return frozenset()
+        if isinstance(v, frozenset):
+            return v
+        return frozenset(v)
 
     @field_validator("path", mode="after")
     @classmethod


### PR DESCRIPTION
## Summary

Phase 4 of #163. Closes the gap left by Phase 5 (rules tiered but `rule_matcher` did not consume specialization labels) and lands the JVM augmenter as the first specialization-adapter example.

### Engine — `required_labels` gating

- New `PropagationRule.required_labels: frozenset[str]` field (default empty → all 11 existing core rules unchanged).
- `RuleMatcher.matches_edge`/`matches_multi_hop_rule`/`find_matching_multi_hop_rule` now accept `src_labels: frozenset[str]` and skip rules whose `required_labels` are not a subset.
- `FaultPropagator` aggregates specialization labels from the source node's `StateTimeline` (via a new `_labels_for_node` mirroring `StateTimeline.ever_carries`) and threads them into every matcher call.
- Rationale for `ever_carries` over `labels_at(t)`: the matcher operates on already-collapsed timelines without a single pinned timestamp; the propagator picks the matching window after rule selection.
- `propagation_rules_schema.json` gets an optional `required_labels` array on each rule.

### JVM augmenter — `ir/adapters/jvm.py`

Pattern-aligned with `K8sMetricsAdapter` (Z-score on baseline + static threshold for level signals). Reads OTel JVM semantic-convention metrics with legacy aliases. **Safe to wire unconditionally — it no-ops on any node that doesn't carry JVM metrics**, so the pipeline driver adds it to the standard trio (Injection + Traces + K8sMetrics + JvmAugmenter); the `extra_adapters` hook is preserved.

| Specialization label  | Driver metrics                                                                          | Emitted state              |
|-----------------------|-----------------------------------------------------------------------------------------|----------------------------|
| `frequent_gc`         | `jvm.gc.duration` (or legacy `jvm.gc.collection.elapsed`, `process.runtime.jvm.gc.duration`) — Z-score critical anomaly vs baseline | `pod.DEGRADED`             |
| `high_heap_pressure`  | `jvm.memory.used` / `jvm.memory.limit` (or `jvm.memory.committed` fallback) ≥ 0.90      | `pod.DEGRADED`             |
| `oom_killed`          | `k8s.container.oom_killed` (or `jvm.memory.oom`) — delta > 0                            | `container.UNAVAILABLE`    |

Boundary with `K8sMetricsAdapter`: the k8s adapter already turns container restart deltas into `container.UNAVAILABLE + crash_loop`. The JVM augmenter's distinct contribution is *labelling the kill OOM-driven specifically* (`oom_killed`) so a dedicated rule can fire — severity-aware merge in `synth_timelines` keeps the stronger state and unions specialization labels. Likewise `high_heap_pressure` covers JVM-internal heap pressure even when the container is well below its k8s memory limit.

### Augmentation rules — `tier: "augmentation"`, gated by `required_labels`

| rule_id                                | src                              | dst                                 |
|----------------------------------------|----------------------------------|-------------------------------------|
| `pod_degraded_frequent_gc_to_span`     | `pod.DEGRADED + frequent_gc`     | `span.SLOW`/`ERRORING` via service |
| `pod_degraded_high_heap_to_span`       | `pod.DEGRADED + high_heap_pressure` | `span.SLOW`/`ERRORING` via service |
| `container_unavailable_oom_killed`     | `container.UNAVAILABLE + oom_killed` | `pod.UNAVAILABLE` (one OOM kill takes the pod out) |

These only fire when `get_builtin_rules(include_augmentation=True)` is requested **and** the JVM augmenter has tagged the source node — they no-op on Go/Python/Node stacks.

### Open questions / needs real-data validation

- **Metric-name surface inferred from OTel semantic conventions.** I included current names (`jvm.gc.duration`, `jvm.memory.used`/`limit`) plus deprecated aliases (`jvm.gc.collection.elapsed`, `process.runtime.jvm.*`), but I do not yet have a TT-Java or TeaStore datapack to sanity-check what the OTel Java agent actually emits in the user's collector setup. If the live metric names differ, we'll need a one-line addition to the metric sets.
- **`HEAP_PRESSURE_RATIO = 0.90`** is conservative (steady-state JVMs sit at 0.7–0.85 of `-Xmx`). May need tuning once we see real heap pressure traces.
- **`oom_killed` metric name** — assumed `k8s.container.oom_killed` (mirrors the existing k8s_metrics convention) but the OTel collector receivers vary. Once a real OOM datapack exists, verify against the actual signal.
- I did **not** add a `slow_db` augmentation rule. The spec mentioned augmenters generally; without a DB-augmenter adapter to emit the label, the rule would be unreachable. Save for a future PR alongside that adapter.

### Test plan
- [x] `cd rcabench-platform && just ci` green locally (198 tests passed, +15 new).
- [x] Existing 11 core rules continue to fire on existing test fixtures (`test_rule_matcher_canonical`, `test_propagator_canonical`, `test_pipeline` all stay green).
- [x] New tests cover: missing-label gating, present-label gating, empty-required (label-agnostic), multi-label subset, default-empty invariant on every core rule.
- [x] JVM adapter no-ops when no JVM metrics; emits each of the three labels under synthetic fixtures; legacy metric name accepted.
- [ ] **Real-data validation deferred** — user is providing TT/TeaStore datapacks separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)