### PR TITLE
fix(reasoning): real-datapack adaptation, 97/100 success on TrainTicket (Phase 7 prep)

### DIFF
--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
@@ -347,6 +347,29 @@ def _build_visualization_paths(
 # =============================================================================
 
 
+def _earliest_abnormal_seconds(abnormal_traces: pl.DataFrame) -> int:
+    """Earliest abnormal-trace timestamp normalized to unix seconds.
+
+    Mirrors ``ir/adapters/traces.py::_ts_seconds`` so the InjectionAdapter seed
+    lands on the same time axis as trace adapter transitions regardless of how
+    parquet stores ``time`` (Datetime[ns]/[us]/[ms], or int nanos/micros/secs).
+    """
+    if abnormal_traces.height == 0 or "time" not in abnormal_traces.columns:
+        return 0
+    raw = abnormal_traces["time"].min()
+    if raw is None:
+        return 0
+    if isinstance(raw, datetime):
+        return int(raw.timestamp())
+    if isinstance(raw, int):
+        if raw > 10**14:
+            return raw // 1_000_000_000
+        if raw > 10**11:
+            return raw // 1_000
+        return raw
+    return int(raw)  # type: ignore[arg-type]
+
+
 def run_single_case(
     data_dir: Path,
     max_hops: int,
@@ -416,9 +439,7 @@ def run_single_case(
         # at the start of the abnormal window).
         baseline_traces = loader.load_traces("normal")
         abnormal_traces = loader.load_traces("abnormal")
-        injection_at = (
-            int(abnormal_traces["time"].min()) if abnormal_traces.height > 0 else 0  # type: ignore[arg-type]
-        )
+        injection_at = _earliest_abnormal_seconds(abnormal_traces)
         ctx = AdapterContext(datapack_dir=data_dir, case_name=case_name)
         timelines = run_reasoning_ir(
             graph=graph,

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/loaders/parquet_loader.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/loaders/parquet_loader.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -160,6 +161,35 @@ CALLER_LIKE_SERVICES: set[str] = LOADGEN_LIKE_SERVICES | {
 
 def _is_caller_like(service_name: str) -> bool:
     return service_name.lower() in CALLER_LIKE_SERVICES
+
+
+def _ts_to_int_seconds(values) -> np.ndarray:
+    """Coerce a per-pod/container timestamp list to int64 unix-seconds.
+
+    Real OTel parquet emits ``time`` as ``Datetime[ns]``; after a groupby agg the
+    list contains ``datetime.datetime`` objects, so a naive ``np.array(...)`` gives
+    dtype=object which crashes every downstream ``int(np.min(ts))`` /
+    ``range(ts_min, ts_max+1)`` site in the IR adapters. Normalize once at the
+    boundary so consumers never have to know what shape the parquet stored.
+    """
+    arr = np.asarray(values)
+    if arr.dtype == np.int64 or arr.dtype == np.int32:
+        return arr.astype(np.int64, copy=False)
+    if arr.dtype.kind == "M":  # numpy datetime64
+        return arr.astype("datetime64[s]").astype(np.int64)
+    if arr.dtype == object and arr.size > 0 and isinstance(arr.flat[0], datetime):
+        return np.fromiter((int(x.timestamp()) for x in arr), dtype=np.int64, count=arr.size)
+    if arr.dtype.kind == "i":
+        x = arr.astype(np.int64, copy=False)
+        # Heuristic match to ir/adapters/traces._ts_seconds: detect ns/μs/s ints
+        if x.size > 0:
+            sample = int(x.flat[0])
+            if sample > 10**14:
+                return x // 1_000_000_000
+            if sample > 10**11:
+                return x // 1_000
+        return x
+    return arr.astype(np.int64, copy=False)
 
 
 def _resolve_span_service(span_name: str, service_names: list[str]) -> str | None:
@@ -461,8 +491,13 @@ class ParquetDataLoader:
         loadgens = list(LOADGEN_LIKE_SERVICES)
 
         def filter_root_spans(df: pl.DataFrame) -> pl.DataFrame:
+            # Backend "root" = first server-side span the request hits, regardless of whether
+            # an instrumented loadgen produced an outer client/root span above it. Using
+            # parent_span_id=="" alone breaks on TrainTicket-style data where 100% of true
+            # roots belong to the loadgenerator and the actual frontend (ts-ui-dashboard)
+            # only ever appears as a Server-kind child.
             return df.filter(
-                (pl.col("parent_span_id") == "") & (~pl.col("service_name").str.to_lowercase().is_in(loadgens))
+                (pl.col("attr.span_kind") == "Server") & (~pl.col("service_name").str.to_lowercase().is_in(loadgens))
             )
 
         baseline_root = filter_root_spans(baseline_traces)
@@ -1492,7 +1527,7 @@ class ParquetDataLoader:
                         result[entity] = ({}, {})
 
                     abnormal_metrics = result[entity][1]
-                    abnormal_metrics[metric] = (np.array(row["timestamps"]), np.array(row["values"]))
+                    abnormal_metrics[metric] = (_ts_to_int_seconds(row["timestamps"]), np.array(row["values"]))
 
             if len(baseline_gauge) > 0:
                 baseline_grouped = baseline_gauge.group_by([entity_col, "metric"]).agg(
@@ -1507,7 +1542,7 @@ class ParquetDataLoader:
                         result[entity] = ({}, {})
 
                     baseline_metrics = result[entity][0]
-                    baseline_metrics[metric] = (np.array(row["timestamps"]), np.array(row["values"]))
+                    baseline_metrics[metric] = (_ts_to_int_seconds(row["timestamps"]), np.array(row["values"]))
 
         # Process histogram metrics - optimized with group_by
         if hist_metrics:
@@ -1537,7 +1572,10 @@ class ParquetDataLoader:
                             result[entity] = ({}, {})
 
                         abnormal_metrics = result[entity][1]
-                        abnormal_metrics[f"{metric}{suffix}"] = (np.array(row["timestamps"]), np.array(row["values"]))
+                        abnormal_metrics[f"{metric}{suffix}"] = (
+                            _ts_to_int_seconds(row["timestamps"]),
+                            np.array(row["values"]),
+                        )
 
                 # Baseline period
                 if len(baseline_hist) > 0 and stat_col in baseline_hist.columns:
@@ -1553,7 +1591,10 @@ class ParquetDataLoader:
                             result[entity] = ({}, {})
 
                         baseline_metrics = result[entity][0]
-                        baseline_metrics[f"{metric}{suffix}"] = (np.array(row["timestamps"]), np.array(row["values"]))
+                        baseline_metrics[f"{metric}{suffix}"] = (
+                            _ts_to_int_seconds(row["timestamps"]),
+                            np.array(row["values"]),
+                        )
 
         # Process sum metrics - optimized with group_by
         if sum_metrics_list:
@@ -1575,7 +1616,7 @@ class ParquetDataLoader:
                         result[entity] = ({}, {})
 
                     abnormal_metrics = result[entity][1]
-                    abnormal_metrics[metric] = (np.array(row["timestamps"]), np.array(row["values"]))
+                    abnormal_metrics[metric] = (_ts_to_int_seconds(row["timestamps"]), np.array(row["values"]))
 
             # Baseline period
             if len(baseline_sum) > 0:
@@ -1591,7 +1632,7 @@ class ParquetDataLoader:
                         result[entity] = ({}, {})
 
                     baseline_metrics = result[entity][0]
-                    baseline_metrics[metric] = (np.array(row["timestamps"]), np.array(row["values"]))
+                    baseline_metrics[metric] = (_ts_to_int_seconds(row["timestamps"]), np.array(row["values"]))
 
         return result
 
@@ -1746,7 +1787,7 @@ class ParquetDataLoader:
                     .sort("time")
                     .select(["time", "value"])
                 )
-                baseline_timestamps = baseline_data.select("time").to_series().to_numpy()
+                baseline_timestamps = _ts_to_int_seconds(baseline_data.select("time").to_series().to_list())
                 baseline_values = baseline_data.select("value").to_series().to_numpy()
 
                 # Get abnormal gauge data
@@ -1757,7 +1798,7 @@ class ParquetDataLoader:
                     .sort("time")
                     .select(["time", "value"])
                 )
-                abnormal_timestamps = abnormal_data.select("time").to_series().to_numpy()
+                abnormal_timestamps = _ts_to_int_seconds(abnormal_data.select("time").to_series().to_list())
                 abnormal_values = abnormal_data.select("value").to_series().to_numpy()
 
                 if len(abnormal_values) == 0:


### PR DESCRIPTION
## Summary

Three fixes that surfaced running the canonical-state IR pipeline against actual TrainTicket OTel parquets. All three were predicted in PR #182 review (comment 4318684407 on #163) as deferred real-data blockers; they now have ground-truth validation.

## What changes

1. **`loaders/parquet_loader.py::identify_alarm_nodes_v2`** — switch backend-root-span detection from `parent_span_id == ""` to `attr.span_kind == "Server"`. The old condition broke on TT data where the OTel-instrumented `loadgenerator` owns 100% of true roots and the actual frontend (`ts-ui-dashboard`) only ever appears as a Server-kind child. With the fix: 21k normal + 14k abnormal backend entries visible vs 0 before.

2. **`cli.py::_earliest_abnormal_seconds`** — new helper that normalizes the earliest abnormal-trace timestamp to int unix-seconds across `Datetime[ns]/[us]/[ms]` and integer nanos/micros/seconds. Replaces a naive `int(abnormal_traces["time"].min())` that raised `TypeError` on real polars `Datetime[ns]`.

3. **`loaders/parquet_loader.py::_ts_to_int_seconds`** — applied at all 8 sites that populate `node.{baseline,abnormal}_metrics`. Coerces the per-pod/container/service `ts` numpy arrays to `int64` unix-seconds at the loader boundary so consumers (`ir/adapters/k8s_metrics`, `ir/adapters/jvm`) never see `dtype=object` datetime arrays.

## Empirical validation

Ran on 100 randomly-sampled cases across ts0–ts9 namespaces (`/home/ddq/AoyangSpace/dataset/rca/`):

| Outcome | Count |
|---|---|
| Success (paths > 0) | **97** |
| `no_paths` | 3 |
| crash / error | 0 |

Per-fault-category breakdown for successes:
- abort 9/9, body 6/6, code 6/6, corrupt 6/6, delay 6/6, exception 5/5, failure 4/4, latency 2/2, loss 6/6, method 4/4, partition 6/6, path 2/2, return 6/6, stress 12/12
- bandwidth 5/6, kill 12/14

## The 3 `no_paths` cases — same root pattern, out of scope here

Fully analyzed; injection node resolves correctly to ground-truth in every case, but the alarm-bearing trace chains do not pass through the injected service:

- `ts5-ts-user-service-pod-kill` → killing user-service breaks endpoints (e.g. `trips/left`) whose normal call chain does not touch user-service. Effect comes through Spring auth-filter / retry storm — implicit, not in trace topology.
- `ts5-ts-auth-service-container-kill` → identical pattern: auth-service kill breaks payment/cancel endpoints whose chains never call auth-service in normal time.
- `ts4-ts-basic-service-bandwidth` / `ts0-mysql-container-kill` (sweep-1 result) → same shape; mysql additionally has zero trace coverage at all (JDBC not auto-instrumented).

A namespace-fallback or co-anomaly weak-edge layer would address these. Tracked as a separate concern; not part of this PR.

## Test plan

- [x] `just ci` green on Python 3.10/3.11/3.12/3.13 (198 tests)
- [x] End-to-end run on 100 real TT datapacks: 97 success, 3 no_paths, 0 crashes
- [ ] Decide whether to add namespace-fallback / co-anomaly edges for the 3 stragglers (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)