### PR TITLE
fix(infra/k8s): replace logrus.Fatalf in lazy-init paths with error returns (#193)

### DIFF
--- a/AegisLab/src/infra/k8s/controller.go
+++ b/AegisLab/src/infra/k8s/controller.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"sync"
@@ -77,7 +78,7 @@ type Controller struct {
 	cancelFunc       context.CancelFunc
 }
 
-func newController() *Controller {
+func newController() (*Controller, error) {
 	crdInformers := make(map[string]map[schema.GroupVersionResource]cache.SharedIndexInformer)
 	activeNamespaces := make(map[string]bool)
 
@@ -85,8 +86,13 @@ func newController() *Controller {
 		options.LabelSelector = fmt.Sprintf("%s=%s", consts.K8sLabelAppID, consts.AppID)
 	}
 
+	client, err := getK8sClient()
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes client not available: %w", err)
+	}
+
 	platformFactory := informers.NewSharedInformerFactoryWithOptions(
-		getK8sClient(),
+		client,
 		resyncPeriod,
 		informers.WithNamespace(config.GetString("k8s.namespace")),
 		informers.WithTweakListOptions(tweakListOptions),
@@ -111,7 +117,7 @@ func newController() *Controller {
 		podInformer:      podInformer,
 		queue:            queue,
 		chaosGVRs:        chaosGVRs,
-	}
+	}, nil
 }
 
 func (c *Controller) Initialize(ctx context.Context, cancelFunc context.CancelFunc, callback Callback) {
@@ -122,7 +128,13 @@ func (c *Controller) Initialize(ctx context.Context, cancelFunc context.CancelFu
 	c.callback = callback
 
 	if err := c.startJobAndPodInformers(); err != nil {
-		logrus.Fatalf("Failed to start Job and Pod informers: %v", err)
+		// Bootstrap-time failure: informers are required for the consumer
+		// to observe Job/Pod/CRD events at all. Without them no workflow
+		// callbacks fire and the process is effectively a no-op. We use
+		// an explicit Errorf+os.Exit(1) (instead of logrus.Fatalf) so the
+		// fail-fast intent is obvious in source per issue #193.
+		logrus.Errorf("Bootstrap failure: failed to start Job and Pod informers: %v", err)
+		os.Exit(1)
 	}
 
 	go c.startQueueWorker()
@@ -167,8 +179,12 @@ func (c *Controller) AddNamespaceInformers(namespaces []string) error {
 
 		// Create new factory for this namespace
 		logrus.Debugf("Creating new CRD informers for namespace: %s", namespace)
+		dynClient, err := getK8sDynamicClient()
+		if err != nil {
+			return fmt.Errorf("kubernetes dynamic client not available: %w", err)
+		}
 		chaosFactory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(
-			getK8sDynamicClient(),
+			dynClient,
 			resyncPeriod,
 			namespace,
 			tweakListOptions,
@@ -626,7 +642,11 @@ func (c *Controller) checkRecoveryStatus(item QueueItem) error {
 		"name":      item.Name,
 	})
 
-	obj, err := getK8sDynamicClient().
+	dyn, err := getK8sDynamicClient()
+	if err != nil {
+		return fmt.Errorf("kubernetes dynamic client not available: %w", err)
+	}
+	obj, err := dyn.
 		Resource(*item.GVR).
 		Namespace(item.Namespace).
 		Get(context.Background(), item.Name, metav1.GetOptions{})
@@ -810,7 +830,12 @@ func checkPodReason(pod *corev1.Pod, reason string) bool {
 
 func handlePodError(ctx context.Context, pod *corev1.Pod, job *batchv1.Job, reason string) {
 	// Get Pod events
-	events, err := getK8sClient().CoreV1().Events(pod.Namespace).List(ctx, metav1.ListOptions{
+	client, err := getK8sClient()
+	if err != nil {
+		logrus.WithField("pod_name", pod.Name).Errorf("kubernetes client not available, cannot fetch events: %v", err)
+		return
+	}
+	events, err := client.CoreV1().Events(pod.Namespace).List(ctx, metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("involvedObject.name=%s", pod.Name),
 	})
 	if err != nil {

--- a/AegisLab/src/infra/k8s/crd.go
+++ b/AegisLab/src/infra/k8s/crd.go
@@ -40,7 +40,10 @@ func DeleteChaosCRDsByLabel(ctx context.Context, chaosGVRs []schema.GroupVersion
 		warnings []error
 	)
 
-	dyn := getK8sDynamicClient()
+	dyn, err := getK8sDynamicClient()
+	if err != nil {
+		return nil, []error{fmt.Errorf("kubernetes dynamic client not available: %w", err)}
+	}
 	for i := range chaosGVRs {
 		gvr := chaosGVRs[i]
 		list, err := dyn.Resource(gvr).Namespace("").List(ctx, metav1.ListOptions{
@@ -80,8 +83,13 @@ func deleteCRD(ctx context.Context, gvr *schema.GroupVersionResource, namespace,
 		"name":      name,
 	})
 
+	dyn, err := getK8sDynamicClient()
+	if err != nil {
+		return fmt.Errorf("kubernetes dynamic client not available: %w", err)
+	}
+
 	// 1. Check if resource exists
-	obj, err := getK8sDynamicClient().Resource(*gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	obj, err := dyn.Resource(*gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
@@ -96,7 +104,7 @@ func deleteCRD(ctx context.Context, gvr *schema.GroupVersionResource, namespace,
 	}
 
 	// 3. Execute deletion (idempotent operation)
-	_, err = getK8sDynamicClient().Resource(*gvr).Namespace(namespace).Patch(
+	_, err = dyn.Resource(*gvr).Namespace(namespace).Patch(
 		timeoutCtx,
 		name,
 		types.MergePatchType,
@@ -113,7 +121,7 @@ func deleteCRD(ctx context.Context, gvr *schema.GroupVersionResource, namespace,
 
 	logEntry.Info("Successfully cleared finalizers")
 
-	err = getK8sDynamicClient().Resource(*gvr).Namespace(namespace).Delete(ctx, name, deleteOptions)
+	err = dyn.Resource(*gvr).Namespace(namespace).Delete(ctx, name, deleteOptions)
 	if err != nil && !errors.IsNotFound(err) {
 		if timeoutCtx.Err() != nil {
 			return fmt.Errorf("timeout while deleting CRD %s/%s: %v", namespace, name, timeoutCtx.Err())

--- a/AegisLab/src/infra/k8s/gateway.go
+++ b/AegisLab/src/infra/k8s/gateway.go
@@ -29,8 +29,11 @@ type Gateway struct {
 
 var (
 	k8sRestConfig    *rest.Config
+	k8sRestConfigErr error
 	k8sClient        *kubernetes.Clientset
+	k8sClientErr     error
 	k8sDynamicClient *dynamic.DynamicClient
+	k8sDynamicErr    error
 	k8sController    *Controller
 
 	k8sRestConfigOnce    sync.Once
@@ -41,9 +44,25 @@ var (
 
 func NewGateway(controller *Controller) *Gateway {
 	if controller == nil {
-		controller = getK8sController()
+		// Best-effort lazy controller init. Errors here used to be
+		// logrus.Fatalf-fatal via the underlying client construction
+		// (issue #193); now they are surfaced via getK8sController's
+		// error log and the Gateway can still serve methods that don't
+		// touch the controller (e.g. NamespaceHasWorkload, EnsureNamespace).
+		controller, _ = getK8sController()
 	}
 	return &Gateway{controller: controller}
+}
+
+// k8sClientNotAvailableErr formats the canonical error returned by request-path
+// callers when the lazy-init Kubernetes client could not be constructed.
+// Replaces the previous logrus.Fatalf-on-init behavior so a transient API
+// failure does not crash the backend (issue #193).
+func k8sClientNotAvailableErr(err error) error {
+	if err == nil {
+		return fmt.Errorf("kubernetes client not available")
+	}
+	return fmt.Errorf("kubernetes client not available: %w", err)
 }
 
 func (g *Gateway) GetVolumeMountConfigMap() (map[consts.VolumeMountName]VolumeMountConfig, error) {
@@ -89,11 +108,11 @@ func (g *Gateway) DeleteChaosCRDsByLabel(ctx context.Context, labelKey, labelVal
 // resolution lists pods in a namespace that RestartPedestal hasn't created
 // yet. See github issue #91 item 1 / #92 item 1.
 func (g *Gateway) EnsureNamespace(ctx context.Context, name string) (bool, error) {
-	client := getK8sClient()
-	if client == nil {
-		return false, fmt.Errorf("kubernetes client not available")
+	client, err := getK8sClient()
+	if err != nil {
+		return false, k8sClientNotAvailableErr(err)
 	}
-	_, err := client.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+	_, err = client.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
 	if err == nil {
 		return false, nil
 	}
@@ -120,9 +139,9 @@ func (g *Gateway) EnsureNamespace(ctx context.Context, name string) (bool, error
 // listing would return empty and "app X not found" would surface to the
 // user. Callers treat (false, nil) as "skip this slot, try next".
 func (g *Gateway) NamespaceHasWorkload(ctx context.Context, namespace string) (bool, error) {
-	client := getK8sClient()
-	if client == nil {
-		return false, fmt.Errorf("kubernetes client not available")
+	client, err := getK8sClient()
+	if err != nil {
+		return false, k8sClientNotAvailableErr(err)
 	}
 	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{Limit: 1})
 	if err != nil {
@@ -135,15 +154,15 @@ func (g *Gateway) NamespaceHasWorkload(ctx context.Context, namespace string) (b
 }
 
 func (g *Gateway) CheckHealth(ctx context.Context) error {
-	if getK8sRestConfig() == nil {
-		return fmt.Errorf("kubernetes config not available")
+	if _, err := getK8sRestConfig(); err != nil {
+		return fmt.Errorf("kubernetes config not available: %w", err)
 	}
-	client := getK8sClient()
-	if client == nil {
-		return fmt.Errorf("kubernetes client not available")
+	client, err := getK8sClient()
+	if err != nil {
+		return k8sClientNotAvailableErr(err)
 	}
-	if getK8sDynamicClient() == nil {
-		return fmt.Errorf("kubernetes dynamic client not available")
+	if _, err := getK8sDynamicClient(); err != nil {
+		return fmt.Errorf("kubernetes dynamic client not available: %w", err)
 	}
 
 	if _, err := client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
@@ -157,9 +176,9 @@ func (g *Gateway) CheckHealth(ctx context.Context) error {
 // are ignored). The check requires at least one active pod to avoid a false
 // positive immediately after a helm release returns.
 func (g *Gateway) WaitForNamespacePodsReady(ctx context.Context, namespace string, timeout time.Duration) error {
-	client := getK8sClient()
-	if client == nil {
-		return fmt.Errorf("kubernetes client not available")
+	client, err := getK8sClient()
+	if err != nil {
+		return k8sClientNotAvailableErr(err)
 	}
 	if timeout <= 0 {
 		timeout = 10 * time.Minute
@@ -226,33 +245,58 @@ func isPodReady(conditions []corev1.PodCondition) bool {
 	return false
 }
 
-func getK8sClient() *kubernetes.Clientset {
+// getK8sClient lazily constructs the kubernetes clientset. On construction
+// failure it returns the error rather than calling logrus.Fatalf so request-
+// path callers (e.g. NamespaceHasWorkload on the auto-allocate submit path)
+// can surface a 5xx instead of crashing the backend process. See issue #193.
+func getK8sClient() (*kubernetes.Clientset, error) {
 	k8sClientOnce.Do(func() {
-		restConfig := getK8sRestConfig()
+		restConfig, err := getK8sRestConfig()
+		if err != nil {
+			k8sClientErr = err
+			return
+		}
 		clientset, err := kubernetes.NewForConfig(restConfig)
 		if err != nil {
-			logrus.Fatalf("failed to create Kubernetes clientset: %v", err)
+			k8sClientErr = fmt.Errorf("failed to create Kubernetes clientset: %w", err)
+			return
 		}
 
 		k8sClient = clientset
 	})
-	return k8sClient
+	if k8sClientErr != nil {
+		return nil, k8sClientErr
+	}
+	return k8sClient, nil
 }
 
-func getK8sDynamicClient() *dynamic.DynamicClient {
+// getK8sDynamicClient lazily constructs the dynamic client. See getK8sClient
+// for why errors are returned rather than fatal-logged.
+func getK8sDynamicClient() (*dynamic.DynamicClient, error) {
 	k8sDynamicClientOnce.Do(func() {
-		restConfig := getK8sRestConfig()
+		restConfig, err := getK8sRestConfig()
+		if err != nil {
+			k8sDynamicErr = err
+			return
+		}
 		dynamicClient, err := dynamic.NewForConfig(restConfig)
 		if err != nil {
-			logrus.Fatalf("failed to create Kubernetes dynamic client: %v", err)
+			k8sDynamicErr = fmt.Errorf("failed to create Kubernetes dynamic client: %w", err)
+			return
 		}
 
 		k8sDynamicClient = dynamicClient
 	})
-	return k8sDynamicClient
+	if k8sDynamicErr != nil {
+		return nil, k8sDynamicErr
+	}
+	return k8sDynamicClient, nil
 }
 
-func getK8sRestConfig() *rest.Config {
+// getK8sRestConfig lazily resolves the rest.Config (in-cluster preferred,
+// kubeconfig fallback). Errors are returned rather than fatal-logged so
+// callers can decide whether to fail the request or fail-fast at startup.
+func getK8sRestConfig() (*rest.Config, error) {
 	k8sRestConfigOnce.Do(func() {
 		restConfig, err := rest.InClusterConfig()
 		if err == nil {
@@ -266,20 +310,37 @@ func getK8sRestConfig() *rest.Config {
 		kubeconfig := filepath.Join(os.Getenv("HOME"), ".kube", "config")
 		config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 		if err != nil {
-			logrus.Fatalf("Failed to load Kubernetes config: %v", err)
+			k8sRestConfigErr = fmt.Errorf("failed to load Kubernetes config (neither in-cluster nor kubeconfig %q available): %w", kubeconfig, err)
+			return
 		}
 		if config == nil {
-			logrus.Fatalf("Failed to establish Kubernetes REST config: Neither In-Cluster nor external Kubeconfig available.")
+			k8sRestConfigErr = fmt.Errorf("failed to establish Kubernetes REST config: neither in-cluster nor external kubeconfig available")
+			return
 		}
 
 		k8sRestConfig = config
 	})
-	return k8sRestConfig
+	if k8sRestConfigErr != nil {
+		return nil, k8sRestConfigErr
+	}
+	return k8sRestConfig, nil
 }
 
-func getK8sController() *Controller {
+// k8sControllerErr captures a controller-init failure so repeated callers
+// see the same error rather than re-running construction (issue #193).
+var k8sControllerErr error
+
+func getK8sController() (*Controller, error) {
 	controllerOnce.Do(func() {
-		k8sController = newController()
+		ctrl, err := newController()
+		if err != nil {
+			k8sControllerErr = err
+			return
+		}
+		k8sController = ctrl
 	})
-	return k8sController
+	if k8sControllerErr != nil {
+		return nil, k8sControllerErr
+	}
+	return k8sController, nil
 }

--- a/AegisLab/src/infra/k8s/job.go
+++ b/AegisLab/src/infra/k8s/job.go
@@ -190,7 +190,13 @@ func createJob(ctx context.Context, jobConfig *JobConfig) error {
 			},
 		}
 
-		_, err := getK8sClient().BatchV1().Jobs(jobConfig.Namespace).Create(ctx, job, metav1.CreateOptions{})
+		client, err := getK8sClient()
+		if err != nil {
+			span.RecordError(err)
+			span.AddEvent("kubernetes client not available")
+			return fmt.Errorf("kubernetes client not available: %w", err)
+		}
+		_, err = client.BatchV1().Jobs(jobConfig.Namespace).Create(ctx, job, metav1.CreateOptions{})
 		if err != nil {
 			span.RecordError(err)
 			span.AddEvent("failed to create job")
@@ -249,8 +255,13 @@ func deleteJob(ctx context.Context, namespace, name string) error {
 
 	logEntry := logrus.WithField("namespace", namespace).WithField("name", name)
 
+	client, err := getK8sClient()
+	if err != nil {
+		return fmt.Errorf("kubernetes client not available: %w", err)
+	}
+
 	// 1. First check if Job exists and its status
-	job, err := getK8sClient().BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
+	job, err := client.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
@@ -265,7 +276,7 @@ func deleteJob(ctx context.Context, namespace, name string) error {
 	}
 
 	// 3. Execute deletion (idempotent operation)
-	err = getK8sClient().BatchV1().Jobs(namespace).Delete(ctx, name, deleteOptions)
+	err = client.BatchV1().Jobs(namespace).Delete(ctx, name, deleteOptions)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
@@ -278,7 +289,11 @@ func deleteJob(ctx context.Context, namespace, name string) error {
 }
 
 func getJob(ctx context.Context, namespace, jobName string) (*batchv1.Job, error) {
-	job, err := getK8sClient().BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
+	client, err := getK8sClient()
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes client not available: %w", err)
+	}
+	job, err := client.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get job: %v", err)
 	}
@@ -286,7 +301,11 @@ func getJob(ctx context.Context, namespace, jobName string) (*batchv1.Job, error
 }
 
 func getJobPodLogs(ctx context.Context, namespace, jobName string) (map[string][]string, error) {
-	podList, err := getK8sClient().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+	client, err := getK8sClient()
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes client not available: %w", err)
+	}
+	podList, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", consts.JobLabelName, jobName),
 	})
 	if err != nil {
@@ -303,7 +322,7 @@ func getJobPodLogs(ctx context.Context, namespace, jobName string) (map[string][
 			continue
 		}
 
-		req := getK8sClient().CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
+		req := client.CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{})
 		logStream, err := req.Stream(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get logs for pod %s: %v", pod.Name, err)
@@ -350,8 +369,13 @@ func waitForJobCompletion(ctx context.Context, namespace, jobName string) error 
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
 
+	client, err := getK8sClient()
+	if err != nil {
+		return fmt.Errorf("kubernetes client not available: %w", err)
+	}
+
 	for {
-		job, err := getK8sClient().BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
+		job, err := client.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to get job: %v", err)
 		}

--- a/AegisLab/src/infra/k8s/lazy_init_test.go
+++ b/AegisLab/src/infra/k8s/lazy_init_test.go
@@ -1,0 +1,125 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestK8sClientNotAvailableErrFormatting verifies the error wrapper used by
+// every request-path gateway method returns a stable user-visible prefix and
+// preserves the underlying cause via errors.Is/Unwrap. Issue #193.
+func TestK8sClientNotAvailableErrFormatting(t *testing.T) {
+	cause := errors.New("connection refused")
+	got := k8sClientNotAvailableErr(cause)
+	if got == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if !strings.Contains(got.Error(), "kubernetes client not available") {
+		t.Errorf("expected canonical prefix, got %q", got.Error())
+	}
+	if !errors.Is(got, cause) {
+		t.Errorf("expected wrapped cause to be retrievable via errors.Is, got %q", got.Error())
+	}
+
+	plain := k8sClientNotAvailableErr(nil)
+	if plain == nil || plain.Error() != "kubernetes client not available" {
+		t.Errorf("expected plain canonical message on nil cause, got %v", plain)
+	}
+}
+
+// withPoisonedClient temporarily forces every getK8sClient call to return the
+// given error so request-path tests can assert non-fatal propagation without
+// a live cluster. Restores the original sync.Once + cached state on cleanup.
+//
+// This is the key regression guard for issue #193: before the refactor a
+// poisoned init terminated the process via logrus.Fatalf; after the refactor
+// it must surface as a returned error to the caller.
+func withPoisonedClient(t *testing.T, cause error) {
+	t.Helper()
+
+	prevClient := k8sClient
+	prevErr := k8sClientErr
+
+	// Reset the Once to a fresh zero-value, then consume it with a
+	// no-op function. After this Do() completes, subsequent
+	// getK8sClient() calls will skip the init body and return the
+	// cached (k8sClient, k8sClientErr) pair we set below.
+	k8sClientOnce = sync.Once{}
+	k8sClient = nil
+	k8sClientErr = cause
+	k8sClientOnce.Do(func() {})
+
+	t.Cleanup(func() {
+		// Restore by zeroing the Once again and re-consuming it with
+		// the previously-cached pair. We avoid copying sync.Once
+		// values directly (which `go vet` flags as unsafe).
+		k8sClientOnce = sync.Once{}
+		k8sClient = prevClient
+		k8sClientErr = prevErr
+		k8sClientOnce.Do(func() {})
+	})
+}
+
+// TestNamespaceHasWorkloadPropagatesClientInitError covers the auto-allocate
+// submit hot path (#167). A transient client-construction failure must
+// surface as a (false, error) tuple to the caller instead of crashing the
+// process. Issue #193.
+func TestNamespaceHasWorkloadPropagatesClientInitError(t *testing.T) {
+	withPoisonedClient(t, errors.New("simulated apiserver outage"))
+
+	gw := &Gateway{}
+	ok, err := gw.NamespaceHasWorkload(context.Background(), "exp")
+	if err == nil {
+		t.Fatal("expected error when k8s client init fails, got nil")
+	}
+	if ok {
+		t.Errorf("expected ok=false on client init failure, got true")
+	}
+	if !strings.Contains(err.Error(), "kubernetes client not available") {
+		t.Errorf("expected canonical 'kubernetes client not available' prefix, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "simulated apiserver outage") {
+		t.Errorf("expected wrapped cause in error, got %q", err.Error())
+	}
+}
+
+// TestEnsureNamespacePropagatesClientInitError covers the prerequisite
+// namespace-creation path on the same hot path. Issue #193.
+func TestEnsureNamespacePropagatesClientInitError(t *testing.T) {
+	withPoisonedClient(t, errors.New("kubeconfig not found"))
+
+	gw := &Gateway{}
+	created, err := gw.EnsureNamespace(context.Background(), "exp")
+	if err == nil {
+		t.Fatal("expected error when k8s client init fails, got nil")
+	}
+	if created {
+		t.Errorf("expected created=false on client init failure, got true")
+	}
+	if !strings.Contains(err.Error(), "kubernetes client not available") {
+		t.Errorf("expected canonical prefix, got %q", err.Error())
+	}
+}
+
+// TestCheckHealthPropagatesClientInitError ensures the health probe surfaces
+// a non-fatal error rather than terminating the backend. Issue #193.
+func TestCheckHealthPropagatesClientInitError(t *testing.T) {
+	withPoisonedClient(t, errors.New("apiserver unreachable"))
+
+	gw := &Gateway{}
+	err := gw.CheckHealth(context.Background())
+	if err == nil {
+		t.Fatal("expected error when k8s client init fails, got nil")
+	}
+	// CheckHealth probes rest-config first, then client, then dynamic
+	// client. Any of those failing must surface as a non-fatal error
+	// — the assertion is "didn't crash and returned an error".
+	if !strings.Contains(err.Error(), "kubernetes client not available") &&
+		!strings.Contains(err.Error(), "kubernetes config not available") &&
+		!strings.Contains(err.Error(), "dynamic client not available") {
+		t.Errorf("expected one of the canonical not-available prefixes, got %q", err.Error())
+	}
+}

--- a/AegisLab/src/infra/k8s/module.go
+++ b/AegisLab/src/infra/k8s/module.go
@@ -12,10 +12,17 @@ var Module = fx.Module("k8s",
 	fx.Provide(ProvideRestConfig),
 )
 
-func ProvideController() *Controller {
+// ProvideController is a fx provider for the lazy-initialized k8s controller.
+// Returns an error so a transient API-server blip during startup surfaces as
+// an fx wire-up failure rather than a logrus.Fatalf process kill (issue #193).
+// fx will halt application startup on this error, which is the desired
+// fail-fast behavior for genuinely-broken bootstrap.
+func ProvideController() (*Controller, error) {
 	return getK8sController()
 }
 
-func ProvideRestConfig() *rest.Config {
+// ProvideRestConfig is a fx provider for the lazy-initialized rest.Config.
+// Returns an error for the same reason as ProvideController (issue #193).
+func ProvideRestConfig() (*rest.Config, error) {
 	return getK8sRestConfig()
 }


### PR DESCRIPTION
Closes #193.

## Background

Issue #193 surfaced as a Copilot follow-up on PR #167 review. Lazy-init getters
in `AegisLab/src/infra/k8s/` (notably `getK8sClient`, `getK8sDynamicClient`,
`getK8sRestConfig`) called `logrus.Fatalf` on construction failure, which
terminates the backend process. After PR #167 put `NamespaceHasWorkload` on the
auto-allocate submit hot path, a transient k8s API blip during a user submit
could crash the producer pod with `os.Exit(1)`.

## Getter signatures: before / after

| getter | before | after | file:line |
| --- | --- | --- | --- |
| `getK8sClient` | `() *kubernetes.Clientset` | `() (*kubernetes.Clientset, error)` | `infra/k8s/gateway.go:252` |
| `getK8sDynamicClient` | `() *dynamic.DynamicClient` | `() (*dynamic.DynamicClient, error)` | `infra/k8s/gateway.go:275` |
| `getK8sRestConfig` | `() *rest.Config` | `() (*rest.Config, error)` | `infra/k8s/gateway.go:299` |
| `getK8sController` | `() *Controller` | `() (*Controller, error)` | `infra/k8s/gateway.go:333` |
| `newController` | `() *Controller` | `() (*Controller, error)` | `infra/k8s/controller.go:81` |
| `ProvideController` (fx) | `() *Controller` | `() (*Controller, error)` | `infra/k8s/module.go:21` |
| `ProvideRestConfig` (fx) | `() *rest.Config` | `() (*rest.Config, error)` | `infra/k8s/module.go:27` |

The cached `(value, error)` pair is guarded by the existing `sync.Once`. Init
errors are sticky: every subsequent call returns the same error rather than
re-attempting construction (preserving the original fail-once-stay-failed
behavior, just non-fatally).

## Converted callers

### Request-path (now propagate the error to the caller)

All callers inside `infra/k8s/`:

- `gateway.go`: `EnsureNamespace`, `NamespaceHasWorkload`, `CheckHealth`,
  `WaitForNamespacePodsReady` — already returned `error`; now propagate
  init failure via the canonical `kubernetes client not available: %w`
  wrapper (`k8sClientNotAvailableErr`).
- `job.go`: `createJob`, `deleteJob`, `getJob`, `getJobPodLogs`,
  `waitForJobCompletion`.
- `crd.go`: `DeleteChaosCRDsByLabel`, `deleteCRD`.
- `controller.go`: `AddNamespaceInformers`, `checkRecoveryStatus` —
  return error to the caller (queue worker re-enqueues with rate limit).
- `controller.go`: `handlePodError` — logs and returns (best-effort
  diagnostic path; cannot meaningfully retry from here).

External callers (`module/injection`, `service/consumer`, etc.) are
unchanged — they call the public Gateway methods, which already returned
`error`. No request handler changes needed.

### Bootstrap-path (preserved fail-fast, made explicit)

- `Controller.Initialize` (`infra/k8s/controller.go:124`): kept fail-fast
  on `startJobAndPodInformers` failure but replaced `logrus.Fatalf` with
  an explicit `logrus.Errorf` + `os.Exit(1)` so the intent reads clearly
  in source.
- `ProvideController` / `ProvideRestConfig` (`infra/k8s/module.go`): fx
  providers now return errors. fx will halt application startup on a
  non-nil error during DI graph build. This is the same fail-fast effect
  as the previous `Fatalf`, but routed through the proper lifecycle
  channel rather than killing the process from arbitrary code.

No other `logrus.Fatalf` / `log.Fatalf` / `panic` calls remain in
`infra/k8s/` (verified by `grep -rn 'logrus.Fatalf\|log.Fatalf\|panic(' infra/k8s/`).

## Tests

Added `infra/k8s/lazy_init_test.go`:

- `TestK8sClientNotAvailableErrFormatting` — verifies the canonical error
  wrapper preserves the underlying cause through `errors.Is`.
- `TestNamespaceHasWorkloadPropagatesClientInitError` — exercises the
  exact code path from issue #193 (auto-allocate submit hot path). With
  a poisoned `sync.Once` state, asserts the gateway returns
  `(false, error)` instead of crashing the test process.
- `TestEnsureNamespacePropagatesClientInitError` — same guarantee for
  the prerequisite namespace-creation path.
- `TestCheckHealthPropagatesClientInitError` — health probe surfaces
  a non-fatal error.

The bootstrap `os.Exit(1)` branch in `Controller.Initialize` is not
unit-tested — exercising it would terminate the test runner. The fx-
provider error path is exercised implicitly by every existing test that
wires up the application (any startup-time client-init failure now fails
fx wireup with a real error message instead of `Fatalf`-ing the process).

## Verification

```
cd AegisLab/src
go build -tags duckdb_arrow ./...                    # green
go vet -tags duckdb_arrow ./infra/k8s/...            # green
go test -tags duckdb_arrow ./infra/k8s/... ./module/injection/... ./service/consumer/...
# ok  aegis/infra/k8s        0.041s
# ok  aegis/module/injection 3.735s
# ok  aegis/service/consumer 0.113s
```

Rebased onto `origin/main` after PR #192 merged; no conflicts (PR #192
touched `infra/redis/gateway.go` + `module/injection/alloc.go`, this PR
is `infra/k8s/*` only).

## Test plan

- [x] `go build -tags duckdb_arrow ./...` green from `AegisLab/src`
- [x] `go vet -tags duckdb_arrow ./infra/k8s/...` green
- [x] `go test ./infra/k8s/... ./module/injection/... ./service/consumer/...` green
- [x] No `logrus.Fatalf` / `log.Fatalf` / `panic(` remain in `infra/k8s/`
- [x] Rebased onto current `origin/main` (post-#192)