### PR TITLE
feat(reasoning): structural inheritance adapter for infra->span states

### DIFF
--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
@@ -347,6 +347,29 @@ def _build_visualization_paths(
 # =============================================================================
 
 
+def _earliest_abnormal_seconds(abnormal_traces: pl.DataFrame) -> int:
+    """Earliest abnormal-trace timestamp normalized to unix seconds.
+
+    Mirrors ``ir/adapters/traces.py::_ts_seconds`` so the InjectionAdapter seed
+    lands on the same time axis as trace adapter transitions regardless of how
+    parquet stores ``time`` (Datetime[ns]/[us]/[ms], or int nanos/micros/secs).
+    """
+    if abnormal_traces.height == 0 or "time" not in abnormal_traces.columns:
+        return 0
+    raw = abnormal_traces["time"].min()
+    if raw is None:
+        return 0
+    if isinstance(raw, datetime):
+        return int(raw.timestamp())
+    if isinstance(raw, int):
+        if raw > 10**14:
+            return raw // 1_000_000_000
+        if raw > 10**11:
+            return raw // 1_000
+        return raw
+    return int(raw)  # type: ignore[arg-type]
+
+
 def run_single_case(
     data_dir: Path,
     max_hops: int,
@@ -416,9 +439,7 @@ def run_single_case(
         # at the start of the abnormal window).
         baseline_traces = loader.load_traces("normal")
         abnormal_traces = loader.load_traces("abnormal")
-        injection_at = (
-            int(abnormal_traces["time"].min()) if abnormal_traces.height > 0 else 0  # type: ignore[arg-type]
-        )
+        injection_at = _earliest_abnormal_seconds(abnormal_traces)
         ctx = AdapterContext(datapack_dir=data_dir, case_name=case_name)
         timelines = run_reasoning_ir(
             graph=graph,

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/adapters/structural_inheritance.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/adapters/structural_inheritance.py
@@ -1,0 +1,329 @@
+"""StructuralInheritanceAdapter — propagate infra availability down the containment hierarchy.
+
+Closes a state-detection gap on the trace adapter. ``TraceStateAdapter`` only
+rolls up service / span state from observed root-span anomalies, but in
+hierarchical benchmarks (e.g. TrainTicket) the only true roots belong to the
+load generator — non-loadgen services never get a service-level timeline, and
+when their pods/containers are killed the trace adapter additionally lacks
+baseline samples for those services so ``baseline_keys - seen_keys`` is empty
+too. The result: ``container|svc`` is correctly classified ``unavailable`` by
+``K8sMetricsAdapter`` while ``service|svc`` and ``span|svc::*`` have no
+timeline at all, and downstream rules (``container_unavailable_to_span``,
+``span_unavailable_to_caller``) cannot extract a path because their dst
+states are empty.
+
+This adapter expresses the structural invariant *if your container/pod/service
+is unavailable, the spans it would serve cannot be served either* directly at
+the IR layer, before the propagator runs. It walks the containment hierarchy
+implied by graph edges (``runs``, ``routes_to``, ``includes``) and emits
+``EvidenceLevel.inferred`` ``Transition`` events for the derived nodes that
+are weaker (or equal) in severity than what the upstream adapters already
+established. It only inherits the **availability** axis (``unavailable`` /
+``degraded``) — slow / erroring are causal claims that the propagator + rules
+should derive, not structural inheritance.
+
+The adapter is a regular ``StateAdapter`` but takes ``prior_timelines`` at
+construction so it can avoid emitting transitions that would be redundant
+(observed worst-or-equal already present) or contradictory (observed
+healthy-after-recovery later). The pipeline driver runs the observation
+adapters first, synthesises a phase-1 timeline dict, then constructs this
+adapter and re-synthesises with the combined transition stream.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from rcabench_platform.v3.internal.reasoning.ir.adapter import AdapterContext
+from rcabench_platform.v3.internal.reasoning.ir.evidence import EvidenceLevel
+from rcabench_platform.v3.internal.reasoning.ir.timeline import StateTimeline
+from rcabench_platform.v3.internal.reasoning.ir.transition import Transition
+from rcabench_platform.v3.internal.reasoning.models.graph import DepKind, HyperGraph, PlaceKind
+
+# Infrastructure-level states that trigger structural inheritance. Slow / erroring
+# are intentionally excluded — those are causal claims that should flow through
+# the propagator and rule matcher, not through containment.
+_INHERIT_SOURCE_STATES = frozenset({"unavailable", "degraded"})
+
+# Severity ranks for the availability axis only. Mirrors the canonical severity
+# table in ir/states.py but kept local so this adapter does not couple to states
+# the propagator might reorder later. ``missing`` and ``unavailable`` tie at the
+# top — both mean "the node is gone".
+_AVAILABILITY_SEVERITY: dict[str, int] = {
+    "unknown": 0,
+    "healthy": 1,
+    "slow": 2,
+    "degraded": 3,
+    "restarting": 3,
+    "erroring": 4,
+    "unavailable": 5,
+    "missing": 5,
+}
+
+
+def _is_weaker_or_equal(prior_state: str, candidate: str) -> bool:
+    return _AVAILABILITY_SEVERITY.get(prior_state, 0) >= _AVAILABILITY_SEVERITY.get(candidate, 0)
+
+
+def _last_state(timeline: StateTimeline | None) -> str:
+    if timeline is None or not timeline.windows:
+        return "healthy"
+    return timeline.windows[-1].state
+
+
+class StructuralInheritanceAdapter:
+    """Emit inferred transitions on derived nodes when infra is unavailable/degraded.
+
+    Inheritance map (derived state strictly within the containment edges'
+    ``possible_dst_states`` so propagator-side rule shapes stay consistent):
+
+    - ``container.unavailable`` -> parent ``pod.degraded``
+                                -> ``service.unavailable``
+                                -> every ``span|service::*``: ``missing``
+    - ``container.degraded``    -> ``service.degraded``
+                                (spans NOT inherited; degraded infra does not
+                                imply spans degrade — that should come from
+                                the trace adapter as an observable)
+    - ``pod.unavailable``       -> ``service.unavailable``
+                                -> every ``span|service::*``: ``missing``
+    - ``pod.degraded``          -> ``service.degraded``
+    - ``service.unavailable``   -> every ``span|service::*``: ``missing``
+    """
+
+    name = "structural_inheritance"
+
+    def __init__(
+        self,
+        *,
+        graph: HyperGraph,
+        prior_timelines: dict[str, StateTimeline],
+    ) -> None:
+        self._graph = graph
+        self._prior_timelines = prior_timelines
+
+    def emit(self, ctx: AdapterContext) -> Iterable[Transition]:
+        return list(self._emit_all())
+
+    def _emit_all(self) -> Iterable[Transition]:
+        # Track derived-node last-emitted state so we collapse contiguous source
+        # windows into a single transition (mirrors the other adapters' shape).
+        derived_last: dict[str, str] = {}
+
+        for source_node_key, timeline in self._prior_timelines.items():
+            if timeline.kind not in (PlaceKind.container, PlaceKind.pod, PlaceKind.service):
+                continue
+            for window in timeline.windows:
+                if window.state not in _INHERIT_SOURCE_STATES:
+                    continue
+                yield from self._emit_inheritance(
+                    source_node_key=source_node_key,
+                    source_kind=timeline.kind,
+                    source_state=window.state,
+                    at=window.start,
+                    derived_last=derived_last,
+                )
+
+    def _emit_inheritance(
+        self,
+        *,
+        source_node_key: str,
+        source_kind: PlaceKind,
+        source_state: str,
+        at: int,
+        derived_last: dict[str, str],
+    ) -> Iterable[Transition]:
+        if source_kind == PlaceKind.container:
+            yield from self._from_container(source_node_key, source_state, at, derived_last)
+        elif source_kind == PlaceKind.pod:
+            yield from self._from_pod(source_node_key, source_state, at, derived_last)
+        elif source_kind == PlaceKind.service:
+            if source_state == "unavailable":
+                yield from self._propagate_to_spans(source_node_key, source_state, at, derived_last)
+
+    def _from_container(
+        self,
+        container_key: str,
+        source_state: str,
+        at: int,
+        derived_last: dict[str, str],
+    ) -> Iterable[Transition]:
+        container_node = self._graph.get_node_by_name(container_key)
+        if container_node is None or container_node.id is None:
+            return
+
+        pod_ids = [
+            src_id
+            for src_id, _dst_id, edge_key in self._graph._graph.in_edges(container_node.id, keys=True)  # type: ignore[call-arg]
+            if edge_key == DepKind.runs
+        ]
+
+        if source_state == "unavailable":
+            for pod_id in pod_ids:
+                pod_node = self._graph.get_node_by_id(pod_id)
+                yield from self._maybe_emit(
+                    derived_node_key=pod_node.uniq_name,
+                    derived_kind=PlaceKind.pod,
+                    derived_state="degraded",
+                    at=at,
+                    source_node_key=container_key,
+                    source_state=source_state,
+                    derived_last=derived_last,
+                )
+                yield from self._propagate_pod_to_service_and_spans(
+                    pod_node_id=pod_id,
+                    derived_service_state="unavailable",
+                    propagate_spans=True,
+                    at=at,
+                    source_node_key=container_key,
+                    source_state=source_state,
+                    derived_last=derived_last,
+                )
+        elif source_state == "degraded":
+            for pod_id in pod_ids:
+                yield from self._propagate_pod_to_service_and_spans(
+                    pod_node_id=pod_id,
+                    derived_service_state="degraded",
+                    propagate_spans=False,
+                    at=at,
+                    source_node_key=container_key,
+                    source_state=source_state,
+                    derived_last=derived_last,
+                )
+
+    def _from_pod(
+        self,
+        pod_key: str,
+        source_state: str,
+        at: int,
+        derived_last: dict[str, str],
+    ) -> Iterable[Transition]:
+        pod_node = self._graph.get_node_by_name(pod_key)
+        if pod_node is None or pod_node.id is None:
+            return
+        if source_state == "unavailable":
+            yield from self._propagate_pod_to_service_and_spans(
+                pod_node_id=pod_node.id,
+                derived_service_state="unavailable",
+                propagate_spans=True,
+                at=at,
+                source_node_key=pod_key,
+                source_state=source_state,
+                derived_last=derived_last,
+            )
+        elif source_state == "degraded":
+            yield from self._propagate_pod_to_service_and_spans(
+                pod_node_id=pod_node.id,
+                derived_service_state="degraded",
+                propagate_spans=False,
+                at=at,
+                source_node_key=pod_key,
+                source_state=source_state,
+                derived_last=derived_last,
+            )
+
+    def _propagate_pod_to_service_and_spans(
+        self,
+        *,
+        pod_node_id: int,
+        derived_service_state: str,
+        propagate_spans: bool,
+        at: int,
+        source_node_key: str,
+        source_state: str,
+        derived_last: dict[str, str],
+    ) -> Iterable[Transition]:
+        service_ids = [
+            src_id
+            for src_id, _dst_id, edge_key in self._graph._graph.in_edges(pod_node_id, keys=True)  # type: ignore[call-arg]
+            if edge_key == DepKind.routes_to
+        ]
+        for service_id in service_ids:
+            service_node = self._graph.get_node_by_id(service_id)
+            yield from self._maybe_emit(
+                derived_node_key=service_node.uniq_name,
+                derived_kind=PlaceKind.service,
+                derived_state=derived_service_state,
+                at=at,
+                source_node_key=source_node_key,
+                source_state=source_state,
+                derived_last=derived_last,
+            )
+            if propagate_spans:
+                yield from self._propagate_to_spans(
+                    service_node.uniq_name,
+                    source_state,
+                    at,
+                    derived_last,
+                    source_node_key_override=source_node_key,
+                )
+
+    def _propagate_to_spans(
+        self,
+        service_key: str,
+        source_state: str,
+        at: int,
+        derived_last: dict[str, str],
+        *,
+        source_node_key_override: str | None = None,
+    ) -> Iterable[Transition]:
+        service_node = self._graph.get_node_by_name(service_key)
+        if service_node is None or service_node.id is None:
+            return
+        source_for_evidence = source_node_key_override or service_key
+        for _src_id, dst_id, edge_key in self._graph._graph.out_edges(service_node.id, keys=True):  # type: ignore[call-arg]
+            if edge_key != DepKind.includes:
+                continue
+            span_node = self._graph.get_node_by_id(dst_id)
+            if span_node.kind != PlaceKind.span:
+                continue
+            yield from self._maybe_emit(
+                derived_node_key=span_node.uniq_name,
+                derived_kind=PlaceKind.span,
+                derived_state="missing",
+                at=at,
+                source_node_key=source_for_evidence,
+                source_state=source_state,
+                derived_last=derived_last,
+            )
+
+    def _maybe_emit(
+        self,
+        *,
+        derived_node_key: str,
+        derived_kind: PlaceKind,
+        derived_state: str,
+        at: int,
+        source_node_key: str,
+        source_state: str,
+        derived_last: dict[str, str],
+    ) -> Iterable[Transition]:
+        prior = self._prior_timelines.get(derived_node_key)
+        prior_state = _last_state(prior)
+        # Skip when an observed signal already classified this node at least
+        # as severely as our structural claim — emitting would only add a
+        # weaker, redundant transition.
+        if prior is not None and _is_weaker_or_equal(prior_state, derived_state):
+            return
+        last_emitted = derived_last.get(derived_node_key)
+        if last_emitted == derived_state:
+            return
+        from_state = last_emitted if last_emitted is not None else prior_state
+        yield Transition(
+            node_key=derived_node_key,
+            kind=derived_kind,
+            at=at,
+            from_state=from_state,
+            to_state=derived_state,
+            trigger="structural_inheritance",
+            level=EvidenceLevel.inferred,
+            evidence={
+                "trigger_metric": "structural_inheritance",
+                "specialization_labels": frozenset(
+                    {f"inherited_from:{source_node_key}", f"source_state:{source_state}"}
+                ),
+            },
+        )
+        derived_last[derived_node_key] = derived_state
+
+
+__all__ = ["StructuralInheritanceAdapter"]

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/pipeline.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/pipeline.py
@@ -1,11 +1,27 @@
 """IR pipeline driver: assemble adapters, synth timelines, run inference fixpoint.
 
-Phase 2 entry point. Constructs the standard adapter trio (Injection +
-Traces + K8sMetrics) explicitly and feeds their transition stream into
-``synth_timelines`` + ``run_fixpoint``. The ``@register_adapter`` registry
-is preserved for future plug-in style assembly; this driver wires the
-core trio manually so that callers don't need to know which adapter
-classes are registered.
+Phase 2 entry point. Constructs the standard adapter set (Injection +
+Traces + K8sMetrics + JVM) explicitly and feeds their transition stream
+into ``synth_timelines`` + ``run_fixpoint``. The ``@register_adapter``
+registry is preserved for future plug-in style assembly; this driver
+wires the core set manually so that callers don't need to know which
+adapter classes are registered.
+
+Execution is two-phase:
+
+1. The observation adapters (Injection, Traces, K8sMetrics, JVM, plus any
+   ``extra_adapters``) emit transitions, which are synthesised into a first
+   pass of timelines.
+2. ``StructuralInheritanceAdapter`` is then constructed with those phase-1
+   timelines and the graph, and emits inferred transitions for derived
+   nodes (pod / service / span) when an infra-level node went unavailable
+   or degraded but its derived nodes have no observation. The combined
+   transition stream is synthesised once more so the final timelines
+   reflect both observed and inherited state.
+
+The structural pass is the only place where containment-driven state is
+expressed at the IR layer; rule matching and propagation continue to run
+unchanged downstream of synth.
 """
 
 from __future__ import annotations
@@ -16,6 +32,9 @@ from rcabench_platform.v3.internal.reasoning.ir.adapter import AdapterContext, S
 from rcabench_platform.v3.internal.reasoning.ir.adapters.injection import InjectionAdapter
 from rcabench_platform.v3.internal.reasoning.ir.adapters.jvm import JvmAugmenterAdapter
 from rcabench_platform.v3.internal.reasoning.ir.adapters.k8s_metrics import K8sMetricsAdapter
+from rcabench_platform.v3.internal.reasoning.ir.adapters.structural_inheritance import (
+    StructuralInheritanceAdapter,
+)
 from rcabench_platform.v3.internal.reasoning.ir.adapters.traces import TraceStateAdapter
 from rcabench_platform.v3.internal.reasoning.ir.inference import InferenceRule, run_fixpoint
 from rcabench_platform.v3.internal.reasoning.ir.synth import synth_timelines
@@ -49,14 +68,14 @@ def run_reasoning_ir(
         baseline_traces / abnormal_traces: polars DataFrames; passed
             untyped because polars is an optional import path elsewhere
             and this signature is shared with tests that pass mocks.
-        extra_adapters: optional adapters appended to the standard trio
+        extra_adapters: optional adapters appended to the standard set
             (e.g. JVM augmenter once it exists).
         inference_rules: rules for the post-synth fixpoint pass; default
             is empty (no rules).
         observation_start / observation_end: pinned observation bounds
             forwarded to ``synth_timelines``.
     """
-    adapters: list[StateAdapter] = [
+    observation_adapters: list[StateAdapter] = [
         InjectionAdapter(resolved=resolved, injection_at=injection_at),
         TraceStateAdapter(baseline_traces=baseline_traces, abnormal_traces=abnormal_traces),  # type: ignore[arg-type]
         K8sMetricsAdapter(graph=graph),
@@ -65,11 +84,20 @@ def run_reasoning_ir(
         JvmAugmenterAdapter(graph=graph),
     ]
     if extra_adapters:
-        adapters.extend(extra_adapters)
+        observation_adapters.extend(extra_adapters)
 
     transitions: list[Transition] = []
-    for adapter in adapters:
+    for adapter in observation_adapters:
         transitions.extend(adapter.emit(ctx))
+
+    phase1_timelines = synth_timelines(
+        transitions,
+        observation_start=observation_start,
+        observation_end=observation_end,
+    )
+
+    structural = StructuralInheritanceAdapter(graph=graph, prior_timelines=phase1_timelines)
+    transitions.extend(structural.emit(ctx))
 
     timelines = synth_timelines(
         transitions,

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_structural_inheritance_adapter.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_structural_inheritance_adapter.py
@@ -1,0 +1,213 @@
+"""StructuralInheritanceAdapter — containment-driven state inference."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rcabench_platform.v3.internal.reasoning.ir.adapter import AdapterContext
+from rcabench_platform.v3.internal.reasoning.ir.adapters.structural_inheritance import (
+    StructuralInheritanceAdapter,
+)
+from rcabench_platform.v3.internal.reasoning.ir.evidence import EvidenceLevel
+from rcabench_platform.v3.internal.reasoning.ir.synth import synth_timelines
+from rcabench_platform.v3.internal.reasoning.ir.timeline import StateTimeline, TimelineWindow
+from rcabench_platform.v3.internal.reasoning.ir.transition import Transition
+from rcabench_platform.v3.internal.reasoning.models.graph import (
+    DepKind,
+    Edge,
+    HyperGraph,
+    Node,
+    PlaceKind,
+)
+
+CTX = AdapterContext(datapack_dir=Path("/tmp/not-used"), case_name="structural-fixture")
+
+
+def _add_node(graph: HyperGraph, kind: PlaceKind, name: str) -> Node:
+    return graph.add_node(Node(kind=kind, self_name=name))
+
+
+def _add_edge(graph: HyperGraph, src: Node, dst: Node, kind: DepKind) -> None:
+    assert src.id is not None and dst.id is not None
+    graph.add_edge(
+        Edge(
+            src_id=src.id,
+            dst_id=dst.id,
+            src_name=src.uniq_name,
+            dst_name=dst.uniq_name,
+            kind=kind,
+            data=None,
+        )
+    )
+
+
+def _make_timeline(node_key: str, kind: PlaceKind, state: str, *, level: EvidenceLevel) -> StateTimeline:
+    return StateTimeline(
+        node_key=node_key,
+        kind=kind,
+        windows=(
+            TimelineWindow(
+                start=2000,
+                end=2030,
+                state=state,
+                level=level,
+                trigger="fixture",
+                evidence={},
+            ),
+        ),
+    )
+
+
+def _build_basic_graph() -> tuple[HyperGraph, dict[str, Node]]:
+    """service|svc -> pod|p -> container|c, plus span|svc::GET / and span|svc::POST /."""
+    g = HyperGraph()
+    svc = _add_node(g, PlaceKind.service, "svc")
+    pod = _add_node(g, PlaceKind.pod, "p")
+    cont = _add_node(g, PlaceKind.container, "c")
+    span_a = _add_node(g, PlaceKind.span, "svc::GET /")
+    span_b = _add_node(g, PlaceKind.span, "svc::POST /")
+    _add_edge(g, pod, cont, DepKind.runs)
+    _add_edge(g, svc, pod, DepKind.routes_to)
+    _add_edge(g, svc, span_a, DepKind.includes)
+    _add_edge(g, svc, span_b, DepKind.includes)
+    return g, {"svc": svc, "pod": pod, "cont": cont, "span_a": span_a, "span_b": span_b}
+
+
+def test_container_unavailable_emits_pod_degraded() -> None:
+    g, _ = _build_basic_graph()
+    prior = {
+        "container|c": _make_timeline("container|c", PlaceKind.container, "unavailable", level=EvidenceLevel.observed),
+    }
+    events = list(StructuralInheritanceAdapter(graph=g, prior_timelines=prior).emit(CTX))
+    pod_events = [e for e in events if e.node_key == "pod|p"]
+    assert pod_events, f"expected pod transition, got {events}"
+    assert pod_events[0].to_state == "degraded"
+    assert pod_events[0].level == EvidenceLevel.inferred
+    assert pod_events[0].trigger == "structural_inheritance"
+
+
+def test_container_unavailable_propagates_to_service_and_spans() -> None:
+    g, _ = _build_basic_graph()
+    prior = {
+        "container|c": _make_timeline("container|c", PlaceKind.container, "unavailable", level=EvidenceLevel.observed),
+    }
+    events = list(StructuralInheritanceAdapter(graph=g, prior_timelines=prior).emit(CTX))
+
+    svc_events = [e for e in events if e.node_key == "service|svc"]
+    assert svc_events
+    assert svc_events[0].to_state == "unavailable"
+
+    span_a_events = [e for e in events if e.node_key == "span|svc::GET /"]
+    span_b_events = [e for e in events if e.node_key == "span|svc::POST /"]
+    assert span_a_events and span_b_events
+    assert span_a_events[0].to_state == "missing"
+    assert span_b_events[0].to_state == "missing"
+    for e in svc_events + span_a_events + span_b_events:
+        assert e.level == EvidenceLevel.inferred
+
+
+def test_no_emit_when_prior_already_worse_or_equal() -> None:
+    g, _ = _build_basic_graph()
+    prior = {
+        "container|c": _make_timeline("container|c", PlaceKind.container, "unavailable", level=EvidenceLevel.observed),
+        # Service already observed at unavailable — structural would be
+        # redundant; one of the spans already missing — same.
+        "service|svc": _make_timeline("service|svc", PlaceKind.service, "unavailable", level=EvidenceLevel.observed),
+        "span|svc::GET /": _make_timeline("span|svc::GET /", PlaceKind.span, "missing", level=EvidenceLevel.observed),
+    }
+    events = list(StructuralInheritanceAdapter(graph=g, prior_timelines=prior).emit(CTX))
+    # service redundant -> not emitted; span_a redundant -> not emitted
+    assert not [e for e in events if e.node_key == "service|svc"]
+    assert not [e for e in events if e.node_key == "span|svc::GET /"]
+    # span_b had no prior -> still emitted
+    assert [e for e in events if e.node_key == "span|svc::POST /"]
+
+
+def test_does_not_inherit_slow_or_erroring() -> None:
+    g, _ = _build_basic_graph()
+    prior = {
+        "container|c": _make_timeline("container|c", PlaceKind.container, "erroring", level=EvidenceLevel.observed),
+        "pod|p": _make_timeline("pod|p", PlaceKind.pod, "erroring", level=EvidenceLevel.observed),
+    }
+    events = list(StructuralInheritanceAdapter(graph=g, prior_timelines=prior).emit(CTX))
+    assert events == [], f"adapter must ignore non-availability axes, got {events}"
+
+
+def test_one_container_unavailable_others_healthy_yields_pod_degraded() -> None:
+    """Multi-container service convention: a single container.unavailable degrades
+    the pod (matches RULE_CONTAINER_UNAVAILABLE_TO_POD) and renders the spans
+    served by that pod missing. Documented convention: ANY container unavailable
+    suffices to mark the pod degraded; the propagator + rules continue to handle
+    fan-out from there."""
+    g = HyperGraph()
+    svc = _add_node(g, PlaceKind.service, "svc")
+    pod = _add_node(g, PlaceKind.pod, "p")
+    cont_bad = _add_node(g, PlaceKind.container, "bad")
+    cont_ok = _add_node(g, PlaceKind.container, "ok")
+    span = _add_node(g, PlaceKind.span, "svc::GET /")
+    _add_edge(g, pod, cont_bad, DepKind.runs)
+    _add_edge(g, pod, cont_ok, DepKind.runs)
+    _add_edge(g, svc, pod, DepKind.routes_to)
+    _add_edge(g, svc, span, DepKind.includes)
+
+    prior = {
+        "container|bad": _make_timeline(
+            "container|bad", PlaceKind.container, "unavailable", level=EvidenceLevel.observed
+        ),
+        "container|ok": _make_timeline("container|ok", PlaceKind.container, "healthy", level=EvidenceLevel.observed),
+    }
+    events = list(StructuralInheritanceAdapter(graph=g, prior_timelines=prior).emit(CTX))
+
+    pod_events = [e for e in events if e.node_key == "pod|p"]
+    svc_events = [e for e in events if e.node_key == "service|svc"]
+    span_events = [e for e in events if e.node_key == "span|svc::GET /"]
+    assert pod_events and pod_events[0].to_state == "degraded"
+    assert svc_events and svc_events[0].to_state == "unavailable"
+    assert span_events and span_events[0].to_state == "missing"
+
+
+def test_empty_prior_timelines_yields_no_transitions() -> None:
+    g, _ = _build_basic_graph()
+    events = list(StructuralInheritanceAdapter(graph=g, prior_timelines={}).emit(CTX))
+    assert events == []
+
+
+def test_pod_unavailable_directly_propagates_to_service_and_spans() -> None:
+    """The pod-killed path (no container observation) still propagates."""
+    g, _ = _build_basic_graph()
+    prior = {
+        "pod|p": _make_timeline("pod|p", PlaceKind.pod, "unavailable", level=EvidenceLevel.observed),
+    }
+    events = list(StructuralInheritanceAdapter(graph=g, prior_timelines=prior).emit(CTX))
+    svc_events = [e for e in events if e.node_key == "service|svc"]
+    span_events = [e for e in events if e.node_key.startswith("span|")]
+    assert svc_events and svc_events[0].to_state == "unavailable"
+    assert len(span_events) == 2
+    assert all(e.to_state == "missing" for e in span_events)
+
+
+def test_synth_combines_observed_and_inferred_into_single_timeline() -> None:
+    """End-to-end: feeding observed transitions through phase-1 synth and the
+    structural adapter through phase-2 synth produces one combined timeline
+    per derived node, with the observation winning where both fired."""
+    g, _ = _build_basic_graph()
+    observed = [
+        Transition(
+            node_key="container|c",
+            kind=PlaceKind.container,
+            at=2000,
+            from_state="healthy",
+            to_state="unavailable",
+            trigger="k8s.container.restarts",
+            level=EvidenceLevel.observed,
+            evidence={},
+        ),
+    ]
+    phase1 = synth_timelines(observed)
+    inferred = list(StructuralInheritanceAdapter(graph=g, prior_timelines=phase1).emit(CTX))
+    combined = synth_timelines([*observed, *inferred])
+    assert "service|svc" in combined
+    assert "pod|p" in combined
+    assert "span|svc::GET /" in combined
+    span_states = {w.state for w in combined["span|svc::GET /"].windows}
+    assert "missing" in span_states

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/loaders/parquet_loader.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/loaders/parquet_loader.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -160,6 +161,35 @@ CALLER_LIKE_SERVICES: set[str] = LOADGEN_LIKE_SERVICES | {
 
 def _is_caller_like(service_name: str) -> bool:
     return service_name.lower() in CALLER_LIKE_SERVICES
+
+
+def _ts_to_int_seconds(values) -> np.ndarray:
+    """Coerce a per-pod/container timestamp list to int64 unix-seconds.
+
+    Real OTel parquet emits ``time`` as ``Datetime[ns]``; after a groupby agg the
+    list contains ``datetime.datetime`` objects, so a naive ``np.array(...)`` gives
+    dtype=object which crashes every downstream ``int(np.min(ts))`` /
+    ``range(ts_min, ts_max+1)`` site in the IR adapters. Normalize once at the
+    boundary so consumers never have to know what shape the parquet stored.
+    """
+    arr = np.asarray(values)
+    if arr.dtype == np.int64 or arr.dtype == np.int32:
+        return arr.astype(np.int64, copy=False)
+    if arr.dtype.kind == "M":  # numpy datetime64
+        return arr.astype("datetime64[s]").astype(np.int64)
+    if arr.dtype == object and arr.size > 0 and isinstance(arr.flat[0], datetime):
+        return np.fromiter((int(x.timestamp()) for x in arr), dtype=np.int64, count=arr.size)
+    if arr.dtype.kind == "i":
+        x = arr.astype(np.int64, copy=False)
+        # Heuristic match to ir/adapters/traces._ts_seconds: detect ns/μs/s ints
+        if x.size > 0:
+            sample = int(x.flat[0])
+            if sample > 10**14:
+                return x // 1_000_000_000
+            if sample > 10**11:
+                return x // 1_000
+        return x
+    return arr.astype(np.int64, copy=False)
 
 
 def _resolve_span_service(span_name: str, service_names: list[str]) -> str | None:
@@ -461,8 +491,13 @@ class ParquetDataLoader:
         loadgens = list(LOADGEN_LIKE_SERVICES)
 
         def filter_root_spans(df: pl.DataFrame) -> pl.DataFrame:
+            # Backend "root" = first server-side span the request hits, regardless of whether
+            # an instrumented loadgen produced an outer client/root span above it. Using
+            # parent_span_id=="" alone breaks on TrainTicket-style data where 100% of true
+            # roots belong to the loadgenerator and the actual frontend (ts-ui-dashboard)
+            # only ever appears as a Server-kind child.
             return df.filter(
-                (pl.col("parent_span_id") == "") & (~pl.col("service_name").str.to_lowercase().is_in(loadgens))
+                (pl.col("attr.span_kind") == "Server") & (~pl.col("service_name").str.to_lowercase().is_in(loadgens))
             )
 
         baseline_root = filter_root_spans(baseline_traces)
@@ -1492,7 +1527,7 @@ class ParquetDataLoader:
                         result[entity] = ({}, {})
 
                     abnormal_metrics = result[entity][1]
-                    abnormal_metrics[metric] = (np.array(row["timestamps"]), np.array(row["values"]))
+                    abnormal_metrics[metric] = (_ts_to_int_seconds(row["timestamps"]), np.array(row["values"]))
 
             if len(baseline_gauge) > 0:
                 baseline_grouped = baseline_gauge.group_by([entity_col, "metric"]).agg(
@@ -1507,7 +1542,7 @@ class ParquetDataLoader:
                         result[entity] = ({}, {})
 
                     baseline_metrics = result[entity][0]
-                    baseline_metrics[metric] = (np.array(row["timestamps"]), np.array(row["values"]))
+                    baseline_metrics[metric] = (_ts_to_int_seconds(row["timestamps"]), np.array(row["values"]))
 
         # Process histogram metrics - optimized with group_by
         if hist_metrics:
@@ -1537,7 +1572,10 @@ class ParquetDataLoader:
                             result[entity] = ({}, {})
 
                         abnormal_metrics = result[entity][1]
-                        abnormal_metrics[f"{metric}{suffix}"] = (np.array(row["timestamps"]), np.array(row["values"]))
+                        abnormal_metrics[f"{metric}{suffix}"] = (
+                            _ts_to_int_seconds(row["timestamps"]),
+                            np.array(row["values"]),
+                        )
 
                 # Baseline period
                 if len(baseline_hist) > 0 and stat_col in baseline_hist.columns:
@@ -1553,7 +1591,10 @@ class ParquetDataLoader:
                             result[entity] = ({}, {})
 
                         baseline_metrics = result[entity][0]
-                        baseline_metrics[f"{metric}{suffix}"] = (np.array(row["timestamps"]), np.array(row["values"]))
+                        baseline_metrics[f"{metric}{suffix}"] = (
+                            _ts_to_int_seconds(row["timestamps"]),
+                            np.array(row["values"]),
+                        )
 
         # Process sum metrics - optimized with group_by
         if sum_metrics_list:
@@ -1575,7 +1616,7 @@ class ParquetDataLoader:
                         result[entity] = ({}, {})
 
                     abnormal_metrics = result[entity][1]
-                    abnormal_metrics[metric] = (np.array(row["timestamps"]), np.array(row["values"]))
+                    abnormal_metrics[metric] = (_ts_to_int_seconds(row["timestamps"]), np.array(row["values"]))
 
             # Baseline period
             if len(baseline_sum) > 0:
@@ -1591,7 +1632,7 @@ class ParquetDataLoader:
                         result[entity] = ({}, {})
 
                     baseline_metrics = result[entity][0]
-                    baseline_metrics[metric] = (np.array(row["timestamps"]), np.array(row["values"]))
+                    baseline_metrics[metric] = (_ts_to_int_seconds(row["timestamps"]), np.array(row["values"]))
 
         return result
 
@@ -1746,7 +1787,7 @@ class ParquetDataLoader:
                     .sort("time")
                     .select(["time", "value"])
                 )
-                baseline_timestamps = baseline_data.select("time").to_series().to_numpy()
+                baseline_timestamps = _ts_to_int_seconds(baseline_data.select("time").to_series().to_list())
                 baseline_values = baseline_data.select("value").to_series().to_numpy()
 
                 # Get abnormal gauge data
@@ -1757,7 +1798,7 @@ class ParquetDataLoader:
                     .sort("time")
                     .select(["time", "value"])
                 )
-                abnormal_timestamps = abnormal_data.select("time").to_series().to_numpy()
+                abnormal_timestamps = _ts_to_int_seconds(abnormal_data.select("time").to_series().to_list())
                 abnormal_values = abnormal_data.select("value").to_series().to_numpy()
 
                 if len(abnormal_values) == 0:


### PR DESCRIPTION
## Summary

Closes a state-detection gap in the reasoning pipeline. `K8sMetricsAdapter` correctly classifies `container|X` as `unavailable` (and `pod` as `degraded`/`healthy`), but `TraceStateAdapter` only rolls up service/span state from loadgen-rooted spans, and non-root services with no baseline samples never enter any timeline. With no `service|X` or `span|X::*` timeline, downstream rules (`container_unavailable_to_span`, `span_unavailable_to_caller`) find empty `dst_states` and cannot extract a path even though the alarms are graph-reachable.

This PR adds `StructuralInheritanceAdapter`, a new IR adapter that expresses the structural invariant *"if your infra is dead, your spans cannot be served"* at the adapter layer (not via propagator hacks or namespace fallbacks). It walks the containment hierarchy via the `runs` / `routes_to` / `includes` edges already in the graph and emits `EvidenceLevel.inferred` transitions for derived nodes when an upstream adapter has classified a container/pod/service as `unavailable` or `degraded`.

Inheritance is restricted to the availability axis only:
- `container.unavailable` -> parent `pod.degraded`, `service.unavailable`, every `span|service::*` becomes `missing`
- `container.degraded` -> `service.degraded` (spans NOT inherited)
- `pod.unavailable` -> `service.unavailable` + spans `missing`
- `pod.degraded` -> `service.degraded`
- `service.unavailable` -> spans `missing`

`slow` / `erroring` are intentionally NOT inherited — those are causal claims that the propagator + rules should derive. The adapter also skips emission when the prior timeline already classifies the derived node at least as severely (no redundant transitions).

The pipeline driver now executes in two phases: observation adapters (Injection, Traces, K8sMetrics, JVM) emit transitions and synth phase-1 timelines, then `StructuralInheritanceAdapter` is constructed with those timelines and emits inferred transitions; the combined stream synthesises once more.

## Sweep delta

500 TrainTicket cases:
- before: 487 success / 10 no_paths / 3 no_alarms
- after:  488 success /  9 no_paths / 3 no_alarms

Case that flipped to success: `ts9-ts-payment-service-container-kill-mnvc8v` — the canonical example for this bug (per the prompt).

Cases that stayed `no_paths` and why this adapter is not the right fix for them:
- `ts0-mysql-container-kill-9t6n24`, `ts9` mysql cases — mysql has no traces at all (JDBC trace-blind).
- `ts4`/`ts5` `auth/preserve/user/basic/verification` cases — alarms surface only at the loadgen-rooted ts-ui-dashboard ingress; the gap is alarm-distance/edge-graph not infra-inheritance.
- `ts4-ts-auth-service-stress`, `ts4-ts-basic-service-bandwidth`, `ts5-ts-preserve-service-stress` — non-availability faults (cpu/network); not in scope.

The 3 no_alarms cases are unchanged (no signal to chain off of).

## Test plan

- [x] `uv run pytest src/rcabench_platform/v3/internal/reasoning/ir_tests/test_structural_inheritance_adapter.py -xvs` (8/8 pass)
- [x] `uv run pytest src/rcabench_platform/v3/internal/reasoning/ir_tests/` (206/206 pass — no regressions)
- [x] `uv run ruff format` and `uv run ruff check` clean
- [x] `uv run pyright` clean on changed files and on the full reasoning module
- [x] `uv run python /tmp/sweep_all.py` — 488/500 success vs 487/500 baseline