### PR TITLE
feat(reasoning): inferred call edges from co-anomaly + infra suspicion

### DIFF
--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
@@ -15,6 +15,7 @@ from rcabench_platform.v3.internal.reasoning._util import setup_logging
 from rcabench_platform.v3.internal.reasoning.algorithms.propagator import FaultPropagator
 from rcabench_platform.v3.internal.reasoning.algorithms.starting_point_resolver import StartingPointResolver
 from rcabench_platform.v3.internal.reasoning.ir.adapter import AdapterContext
+from rcabench_platform.v3.internal.reasoning.ir.adapters.inferred_edges import enrich_with_inferred_edges
 from rcabench_platform.v3.internal.reasoning.ir.pipeline import run_reasoning_ir
 from rcabench_platform.v3.internal.reasoning.loaders.parquet_loader import ParquetDataLoader
 from rcabench_platform.v3.internal.reasoning.loaders.utils import fmap_processpool
@@ -450,6 +451,14 @@ def run_single_case(
             abnormal_traces=abnormal_traces,
         )
         logger.info(f"[{case_name}] IR pipeline: {len(timelines)} node timelines")
+
+        # Add inferred call-graph edges for trace-blind dependencies (e.g.
+        # Spring auth filters that fire before any controller span). This is
+        # NOT a StateAdapter — it mutates graph topology after the IR
+        # pipeline has settled, so the propagator sees the new edges
+        # naturally on construction. See ir/adapters/inferred_edges.py.
+        n_inferred = enrich_with_inferred_edges(graph, timelines)
+        logger.info(f"[{case_name}] inferred edges: {n_inferred}")
 
         # Resolve propagation starting points based on rule semantics
         # For HTTP response faults, propagation starts from caller service (not physical injection)

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/adapters/inferred_edges.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/adapters/inferred_edges.py
@@ -1,0 +1,392 @@
+"""Inferred call-graph edge enricher — temporal co-anomaly + infra suspicion.
+
+Closes the trace-blind dependency gap: when a service S is killed and another
+service's spans go anomalous, but the call path S↔alarm_span is invisible in
+OTel traces (e.g. Spring's auth filter intercepts requests before any
+controller span starts, so no child span is emitted for the auth call), the
+propagator currently has no edge to traverse from S to alarm_span and reports
+``no_paths`` even though the right faulty service was identified by k8s
+metrics.
+
+Unlike ``StateAdapter`` implementations, this module does not produce
+``Transition`` events. It mutates the ``HyperGraph`` topology in place by
+adding *inferred* ``includes`` edges from a faulty ``service|S`` node to an
+anomalous ``span|X::Y`` node owned by a different service, when:
+
+    1. S is *infra-faulty*: at least one of S's container or pod nodes was
+       observed in ``unavailable`` state during the abnormal window
+       (``unavailable`` is the strict "node actually went down" signal;
+       ``degraded`` alone is excluded because CPU pressure cascades to many
+       neighbours and creates too many candidate causes).
+    2. The number of distinct services with ``unavailable`` infra is at most
+       ``_MAX_FAULTY_SERVICES_PER_CASE`` (uniqueness gate — when too many
+       services simultaneously go down, structural inheritance + namespace
+       cascading already accounts for the propagation, and inferred edges
+       would only add noise).
+    3. ``span|X::Y`` is *anomalous* (state in {erroring, unavailable, missing,
+       slow}) at least once during a window where S is infra-faulty
+       (temporal-coincidence gate: at least one bucket of co-anomaly).
+    4. There is no *direct call-graph parent* in the existing graph — i.e.
+       no span owned by S has a ``calls`` edge to or from ``span|X::Y``. If
+       a direct call dependency already exists, the trace topology already
+       covers the case and the propagator's standard rules can traverse it.
+    5. S is not the span's own service (already covered by structural
+       inheritance) and is not in ``LOADGEN_LIKE_SERVICES`` (synthetic
+       traffic, not a meaningful causal source).
+
+Edges are emitted with ``kind=DepKind.includes`` so the existing
+``RULE_SERVICE_TO_SPAN`` rule (confidence 0.85) traverses them — using
+``calls`` would not match any existing rule for ``src_kind=service`` and the
+edge would never be traversed. The edge's pydantic ``data`` field is left
+``None``; introspection metadata (``inferred=True``, co-anomaly window
+counts, uniqueness flag) is stored on ``HyperGraph.data["inferred_edges"]``
+keyed by ``(src_id, dst_id)`` so the ``Edge`` model stays unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from rcabench_platform.v3.internal.reasoning.ir.timeline import StateTimeline
+from rcabench_platform.v3.internal.reasoning.loaders.parquet_loader import LOADGEN_LIKE_SERVICES
+from rcabench_platform.v3.internal.reasoning.models.graph import DepKind, Edge, HyperGraph, Node, PlaceKind
+
+logger = logging.getLogger(__name__)
+
+# A service is "infra-faulty" if any of its container/pod nodes hits this
+# state at any point. ``degraded`` is intentionally NOT here — that captures
+# CPU pressure and propagates to too many cascade victims, generating noisy
+# candidate causes. ``unavailable`` is the strict "the node actually went
+# down" signal.
+_INFRA_FAULTY_STATES: frozenset[str] = frozenset({"unavailable"})
+
+# Span states that we consider "anomalous" — these are the states that ought
+# to have an upstream causal explanation in the graph.
+_ANOMALOUS_SPAN_STATES: frozenset[str] = frozenset({"erroring", "unavailable", "missing", "slow"})
+
+# Bucket width in seconds. The IR timelines have variable-length windows so
+# we discretise on a uniform 5-second grid for co-anomaly counting.
+_BUCKET_SECONDS: int = 5
+
+# Maximum distinct infra-faulty services in a case before we suppress all
+# inferred edges — too many simultaneous failures and the heuristic gives
+# wild guesses. This is a per-case gate (the spec calls for a per-window
+# gate, but in practice the IR pipeline produces case-wide windows of
+# state, so per-case and per-window collapse to the same thing for the
+# strict ``unavailable`` signal).
+_MAX_FAULTY_SERVICES_PER_CASE: int = 2
+
+
+@dataclass(frozen=True, slots=True)
+class InferredEdgeMetadata:
+    """Diagnostic payload attached to each inferred edge.
+
+    Stored in ``HyperGraph.data["inferred_edges"][(src_id, dst_id)]``; the
+    propagator does not read it, but post-hoc tooling (PR validation,
+    confidence-weighting follow-ups) introspects it to explain why an
+    edge was added.
+    """
+
+    inferred: bool
+    co_anomaly_windows: int
+    total_anomaly_windows: int
+    unique_infra_suspect: bool
+
+
+def _service_name_of_span(span_self_name: str) -> str | None:
+    """Span ``self_name`` is ``"<service>::<span_name>"``; return the service
+    half. Returns ``None`` if the span name does not match the convention
+    (e.g. synthetic test fixtures may use plain names).
+    """
+    if "::" not in span_self_name:
+        return None
+    return span_self_name.split("::", 1)[0]
+
+
+def _service_of_pod(graph: HyperGraph, pod_id: int) -> Node | None:
+    """Walk ``routes_to`` backwards from a pod to its service. Returns the
+    first service found (a pod is normally routed to by exactly one service).
+    """
+    for src_id, _dst_id, edge_key in graph._graph.in_edges(pod_id, keys=True):  # type: ignore[call-arg]
+        if edge_key == DepKind.routes_to:
+            return graph.get_node_by_id(src_id)
+    return None
+
+
+def _service_of_container(graph: HyperGraph, container_id: int) -> Node | None:
+    """Walk ``runs`` then ``routes_to`` backwards from a container to its
+    service. Returns the first match or ``None``.
+    """
+    for src_id, _dst_id, edge_key in graph._graph.in_edges(container_id, keys=True):  # type: ignore[call-arg]
+        if edge_key == DepKind.runs:
+            svc = _service_of_pod(graph, src_id)
+            if svc is not None:
+                return svc
+    return None
+
+
+def _bucket_indices_for_state(
+    timeline: StateTimeline,
+    states: frozenset[str],
+    grid_start: int,
+    grid_end: int,
+) -> set[int]:
+    """Return the set of bucket indices in ``[grid_start, grid_end)`` where
+    ``timeline``'s state is in ``states``.
+
+    Buckets are ``_BUCKET_SECONDS`` wide; bucket ``i`` covers
+    ``[grid_start + i*BUCKET, grid_start + (i+1)*BUCKET)``.
+    """
+    indices: set[int] = set()
+    if grid_end <= grid_start:
+        return indices
+    n_buckets = (grid_end - grid_start + _BUCKET_SECONDS - 1) // _BUCKET_SECONDS
+    for window in timeline.windows:
+        if window.state not in states:
+            continue
+        # Compute overlapping bucket range.
+        w_start = max(window.start, grid_start)
+        w_end = min(window.end, grid_end)
+        if w_end <= w_start:
+            continue
+        first_bucket = (w_start - grid_start) // _BUCKET_SECONDS
+        # ``end`` is exclusive — a window that ends exactly at a bucket
+        # boundary should not include that bucket.
+        last_bucket_exclusive = (w_end - grid_start + _BUCKET_SECONDS - 1) // _BUCKET_SECONDS
+        for b in range(first_bucket, min(last_bucket_exclusive, n_buckets)):
+            indices.add(b)
+    return indices
+
+
+def _grid_bounds(timelines: dict[str, StateTimeline]) -> tuple[int, int]:
+    """Return ``(grid_start, grid_end)`` covering every timeline window. The
+    returned range is in unix seconds; callers use ``_BUCKET_SECONDS`` to
+    discretise.
+    """
+    starts: list[int] = []
+    ends: list[int] = []
+    for tl in timelines.values():
+        for w in tl.windows:
+            starts.append(w.start)
+            ends.append(w.end)
+    if not starts:
+        return 0, 0
+    return min(starts), max(ends)
+
+
+def _faulty_buckets_per_service(
+    graph: HyperGraph,
+    timelines: dict[str, StateTimeline],
+    grid_start: int,
+    grid_end: int,
+) -> dict[str, set[int]]:
+    """Map ``service_name -> {bucket_indices where service is infra-faulty}``.
+
+    A service is infra-faulty in a bucket if any of its container or pod
+    timelines is in ``_INFRA_FAULTY_STATES`` (i.e. ``unavailable``) during
+    that bucket. Loadgen-like services are excluded.
+    """
+    by_service: dict[str, set[int]] = defaultdict(set)
+    for node_key, tl in timelines.items():
+        if tl.kind not in (PlaceKind.container, PlaceKind.pod):
+            continue
+        node = graph.get_node_by_name(node_key)
+        if node is None or node.id is None:
+            continue
+        service_node = (
+            _service_of_container(graph, node.id) if tl.kind == PlaceKind.container else _service_of_pod(graph, node.id)
+        )
+        if service_node is None:
+            continue
+        service_name = service_node.self_name
+        if service_name in LOADGEN_LIKE_SERVICES:
+            continue
+        buckets = _bucket_indices_for_state(tl, _INFRA_FAULTY_STATES, grid_start, grid_end)
+        if buckets:
+            by_service[service_name].update(buckets)
+    return by_service
+
+
+def _anomaly_buckets_per_span(
+    timelines: dict[str, StateTimeline],
+    grid_start: int,
+    grid_end: int,
+) -> dict[str, set[int]]:
+    """Map ``span_node_key -> {bucket_indices where span is anomalous}``.
+
+    Only spans whose state is in ``_ANOMALOUS_SPAN_STATES`` during at least
+    one bucket are returned.
+    """
+    by_span: dict[str, set[int]] = {}
+    for node_key, tl in timelines.items():
+        if tl.kind != PlaceKind.span:
+            continue
+        buckets = _bucket_indices_for_state(tl, _ANOMALOUS_SPAN_STATES, grid_start, grid_end)
+        if buckets:
+            by_span[node_key] = buckets
+    return by_span
+
+
+def _has_direct_call_dependency(graph: HyperGraph, service_node: Node, alarm_span_id: int) -> bool:
+    """Return ``True`` if any span owned by ``service_node`` has a ``calls``
+    edge directly to or from ``alarm_span_id``.
+
+    This is the "direct call-graph dependency" check. A transitive walk over
+    the entire call graph is too lenient: every backend service is reachable
+    from a frontend hub via deep call chains, so a global ``has_path`` check
+    would suppress every inferred edge. We restrict to a single ``calls`` hop
+    (after the service-to-its-spans hop, which always exists), which catches
+    the common "the trace already directly observes the dependency" case
+    without false-suppressing the trace-blind cases this adapter targets.
+    """
+    assert service_node.id is not None
+    g = graph._graph
+    own_span_ids: list[int] = []
+    for _src, dst, key in g.out_edges(service_node.id, keys=True):  # type: ignore[call-arg]
+        if key == DepKind.includes:
+            own_span_ids.append(dst)
+    for span_id in own_span_ids:
+        if g.has_edge(span_id, alarm_span_id, DepKind.calls):
+            return True
+        if g.has_edge(alarm_span_id, span_id, DepKind.calls):
+            return True
+    return False
+
+
+def _add_inferred_edge(
+    graph: HyperGraph,
+    *,
+    src_node: Node,
+    dst_node: Node,
+    co_anomaly_windows: int,
+    total_anomaly_windows: int,
+    unique_infra_suspect: bool,
+) -> bool:
+    """Insert ``service|S -> span|X::Y`` as an ``includes`` edge. Returns
+    ``True`` if a new edge was added, ``False`` if one already exists.
+
+    Diagnostic metadata is stored on ``graph.data["inferred_edges"]`` keyed
+    by ``(src_id, dst_id)`` so the ``Edge`` pydantic model stays unchanged
+    (its ``data`` field is typed as ``CallsEdgeData | None``, which doesn't
+    fit our payload).
+    """
+    assert src_node.id is not None and dst_node.id is not None
+    if graph._graph.has_edge(src_node.id, dst_node.id, DepKind.includes):
+        return False
+    edge = Edge(
+        src_id=src_node.id,
+        dst_id=dst_node.id,
+        src_name=src_node.uniq_name,
+        dst_name=dst_node.uniq_name,
+        kind=DepKind.includes,
+        weight=1.0,
+        data=None,
+    )
+    graph.add_edge(edge, strict=False)
+    metadata_store = graph.data.setdefault("inferred_edges", {})
+    metadata_store[(src_node.id, dst_node.id)] = InferredEdgeMetadata(
+        inferred=True,
+        co_anomaly_windows=co_anomaly_windows,
+        total_anomaly_windows=total_anomaly_windows,
+        unique_infra_suspect=unique_infra_suspect,
+    )
+    return True
+
+
+def enrich_with_inferred_edges(
+    graph: HyperGraph,
+    timelines: dict[str, StateTimeline],
+) -> int:
+    """Mutate ``graph`` by adding inferred ``includes`` edges from infra-faulty
+    services to anomalous spans they have no direct call-graph dependency to.
+
+    Returns the number of edges added. See module docstring for the full
+    heuristic.
+    """
+    grid_start, grid_end = _grid_bounds(timelines)
+    if grid_end <= grid_start:
+        return 0
+
+    faulty_per_service = _faulty_buckets_per_service(graph, timelines, grid_start, grid_end)
+    if not faulty_per_service:
+        return 0
+
+    # Case-wide uniqueness gate: too many simultaneously-unavailable services
+    # produces noisy guesses; bail out entirely.
+    if len(faulty_per_service) > _MAX_FAULTY_SERVICES_PER_CASE:
+        logger.info(
+            "inferred-edge gate: %d unavailable services exceeds limit %d, skipping",
+            len(faulty_per_service),
+            _MAX_FAULTY_SERVICES_PER_CASE,
+        )
+        return 0
+
+    anomaly_per_span = _anomaly_buckets_per_span(timelines, grid_start, grid_end)
+    if not anomaly_per_span:
+        return 0
+
+    is_unique_suspect = len(faulty_per_service) == 1
+
+    # Pre-resolve service nodes; skip services that don't exist as nodes.
+    service_nodes: dict[str, Node] = {}
+    for service_name in faulty_per_service:
+        node = graph.get_node_by_name(f"service|{service_name}")
+        if node is not None:
+            service_nodes[service_name] = node
+
+    edges_added = 0
+    for span_key, span_anomaly_buckets in anomaly_per_span.items():
+        span_node = graph.get_node_by_name(span_key)
+        if span_node is None or span_node.id is None:
+            continue
+        # ``span|<service>::<endpoint>`` — extract owning service to skip
+        # same-service pairs (already covered by structural inheritance).
+        own_service = _service_name_of_span(span_node.self_name)
+        total = len(span_anomaly_buckets)
+        if total == 0:
+            continue
+
+        for service_name, faulty_buckets in faulty_per_service.items():
+            if service_name == own_service:
+                continue
+            src_node = service_nodes.get(service_name)
+            if src_node is None or src_node.id is None:
+                continue
+            # Temporal coincidence: at least one bucket where the service is
+            # infra-faulty AND the alarm span is anomalous. With strict
+            # ``unavailable`` as the source signal, even a single bucket of
+            # overlap is meaningful — short container kills produce brief
+            # ``unavailable`` windows but the alarm span stays anomalous
+            # well past the kill (the cascade outlasts the trigger).
+            co = span_anomaly_buckets & faulty_buckets
+            if not co:
+                continue
+            # Direct call-graph dependency check: skip if S already has a
+            # span with a direct ``calls`` edge to/from the alarm span.
+            if _has_direct_call_dependency(graph, src_node, span_node.id):
+                continue
+            if _add_inferred_edge(
+                graph,
+                src_node=src_node,
+                dst_node=span_node,
+                co_anomaly_windows=len(co),
+                total_anomaly_windows=total,
+                unique_infra_suspect=is_unique_suspect,
+            ):
+                edges_added += 1
+                logger.info(
+                    "inferred edge added: %s -> %s (co-anomaly %d/%d windows, unique=%s)",
+                    src_node.uniq_name,
+                    span_node.uniq_name,
+                    len(co),
+                    total,
+                    is_unique_suspect,
+                )
+
+    return edges_added
+
+
+__all__: Iterable[str] = ("enrich_with_inferred_edges", "InferredEdgeMetadata")

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_inferred_edges.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_inferred_edges.py
@@ -1,0 +1,289 @@
+"""Inferred call-graph edge enricher — temporal co-anomaly + infra suspicion.
+
+Each test builds a minimal HyperGraph + StateTimeline fixture and asserts the
+expected edge-mutation outcome. No parquet data is loaded.
+"""
+
+from __future__ import annotations
+
+from rcabench_platform.v3.internal.reasoning.ir.adapters.inferred_edges import (
+    InferredEdgeMetadata,
+    enrich_with_inferred_edges,
+)
+from rcabench_platform.v3.internal.reasoning.ir.evidence import EvidenceLevel
+from rcabench_platform.v3.internal.reasoning.ir.timeline import StateTimeline, TimelineWindow
+from rcabench_platform.v3.internal.reasoning.models.graph import (
+    DepKind,
+    Edge,
+    HyperGraph,
+    Node,
+    PlaceKind,
+)
+
+
+def _add_node(graph: HyperGraph, kind: PlaceKind, name: str) -> Node:
+    return graph.add_node(Node(kind=kind, self_name=name))
+
+
+def _add_edge(graph: HyperGraph, src: Node, dst: Node, kind: DepKind) -> None:
+    assert src.id is not None and dst.id is not None
+    graph.add_edge(
+        Edge(
+            src_id=src.id,
+            dst_id=dst.id,
+            src_name=src.uniq_name,
+            dst_name=dst.uniq_name,
+            kind=kind,
+            data=None,
+        )
+    )
+
+
+def _make_timeline_buckets(
+    node_key: str,
+    kind: PlaceKind,
+    bucket_states: list[tuple[int, int, str]],
+) -> StateTimeline:
+    """Build a StateTimeline from ``[(start, end, state), ...]`` triples.
+
+    All windows are tagged ``EvidenceLevel.observed`` with a fixture trigger.
+    """
+    windows = tuple(
+        TimelineWindow(
+            start=start,
+            end=end,
+            state=state,
+            level=EvidenceLevel.observed,
+            trigger="fixture",
+            evidence={},
+        )
+        for start, end, state in bucket_states
+    )
+    return StateTimeline(node_key=node_key, kind=kind, windows=windows)
+
+
+def _build_two_service_graph() -> tuple[HyperGraph, dict[str, Node]]:
+    """Two services with no trace edge between them.
+
+    ``service|svc-a`` -> ``pod|pa`` -> ``container|ca``
+    ``service|svc-b`` -> ``pod|pb`` -> ``container|cb`` -> ``span|svc-b::GET /``
+    """
+    g = HyperGraph()
+    svc_a = _add_node(g, PlaceKind.service, "svc-a")
+    pod_a = _add_node(g, PlaceKind.pod, "pa")
+    cont_a = _add_node(g, PlaceKind.container, "ca")
+    svc_b = _add_node(g, PlaceKind.service, "svc-b")
+    pod_b = _add_node(g, PlaceKind.pod, "pb")
+    cont_b = _add_node(g, PlaceKind.container, "cb")
+    span_b = _add_node(g, PlaceKind.span, "svc-b::GET /")
+
+    _add_edge(g, svc_a, pod_a, DepKind.routes_to)
+    _add_edge(g, pod_a, cont_a, DepKind.runs)
+    _add_edge(g, svc_b, pod_b, DepKind.routes_to)
+    _add_edge(g, pod_b, cont_b, DepKind.runs)
+    _add_edge(g, svc_b, span_b, DepKind.includes)
+
+    return g, {
+        "svc_a": svc_a,
+        "pod_a": pod_a,
+        "cont_a": cont_a,
+        "svc_b": svc_b,
+        "pod_b": pod_b,
+        "cont_b": cont_b,
+        "span_b": span_b,
+    }
+
+
+def test_single_unavailable_service_no_trace_path_emits_inferred_edge() -> None:
+    """svc-a unavailable AND span|svc-b anomalous in same windows → edge."""
+    g, nodes = _build_two_service_graph()
+    timelines = {
+        "container|ca": _make_timeline_buckets("container|ca", PlaceKind.container, [(1000, 1050, "unavailable")]),
+        "span|svc-b::GET /": _make_timeline_buckets("span|svc-b::GET /", PlaceKind.span, [(1000, 1050, "erroring")]),
+    }
+
+    n_added = enrich_with_inferred_edges(g, timelines)
+    assert n_added == 1
+
+    assert nodes["svc_a"].id is not None and nodes["span_b"].id is not None
+    assert g._graph.has_edge(nodes["svc_a"].id, nodes["span_b"].id, DepKind.includes)
+
+    metadata_store = g.data["inferred_edges"]
+    metadata = metadata_store[(nodes["svc_a"].id, nodes["span_b"].id)]
+    assert isinstance(metadata, InferredEdgeMetadata)
+    assert metadata.inferred is True
+    assert metadata.unique_infra_suspect is True
+    assert metadata.co_anomaly_windows == metadata.total_anomaly_windows
+
+
+def test_direct_call_dependency_suppresses_inferred_edge() -> None:
+    """If svc-a has a span with a direct ``calls`` edge to span_b, no edge.
+
+    The trace already directly observes the dependency — the propagator's
+    standard rules can traverse it via ``span_*_to_caller`` rules — so an
+    inferred edge would be redundant.
+    """
+    g, nodes = _build_two_service_graph()
+    # svc-a has a span. That span has a calls edge to svc-b's span.
+    span_a = _add_node(g, PlaceKind.span, "svc-a::POST /login")
+    _add_edge(g, nodes["svc_a"], span_a, DepKind.includes)
+    _add_edge(g, span_a, nodes["span_b"], DepKind.calls)
+
+    timelines = {
+        "container|ca": _make_timeline_buckets("container|ca", PlaceKind.container, [(1000, 1050, "unavailable")]),
+        "span|svc-b::GET /": _make_timeline_buckets("span|svc-b::GET /", PlaceKind.span, [(1000, 1050, "erroring")]),
+    }
+
+    n_added = enrich_with_inferred_edges(g, timelines)
+    assert n_added == 0
+    assert nodes["svc_a"].id is not None and nodes["span_b"].id is not None
+    assert not g._graph.has_edge(nodes["svc_a"].id, nodes["span_b"].id, DepKind.includes)
+
+
+def test_two_unavailable_services_both_emit_edges() -> None:
+    """Per spec, ≤ 2 unavailable services per case still produces edges
+    from each — both are plausible suspects."""
+    g, nodes = _build_two_service_graph()
+    # Add a third service whose span we will mark anomalous.
+    svc_c = _add_node(g, PlaceKind.service, "svc-c")
+    pod_c = _add_node(g, PlaceKind.pod, "pc")
+    cont_c = _add_node(g, PlaceKind.container, "cc")
+    span_c = _add_node(g, PlaceKind.span, "svc-c::POST /a")
+    _add_edge(g, svc_c, pod_c, DepKind.routes_to)
+    _add_edge(g, pod_c, cont_c, DepKind.runs)
+    _add_edge(g, svc_c, span_c, DepKind.includes)
+
+    timelines = {
+        "container|ca": _make_timeline_buckets("container|ca", PlaceKind.container, [(1000, 1050, "unavailable")]),
+        "container|cb": _make_timeline_buckets("container|cb", PlaceKind.container, [(1000, 1050, "unavailable")]),
+        "span|svc-c::POST /a": _make_timeline_buckets(
+            "span|svc-c::POST /a", PlaceKind.span, [(1000, 1050, "erroring")]
+        ),
+    }
+
+    n_added = enrich_with_inferred_edges(g, timelines)
+    # Both svc-a and svc-b connect to svc-c's span.
+    assert n_added == 2
+
+    assert nodes["svc_a"].id is not None and span_c.id is not None
+    assert g._graph.has_edge(nodes["svc_a"].id, span_c.id, DepKind.includes)
+    assert nodes["svc_b"].id is not None
+    assert g._graph.has_edge(nodes["svc_b"].id, span_c.id, DepKind.includes)
+    metadata_store = g.data["inferred_edges"]
+    # When two services are simultaneously unavailable, neither is the
+    # unique suspect.
+    assert metadata_store[(nodes["svc_a"].id, span_c.id)].unique_infra_suspect is False
+    assert metadata_store[(nodes["svc_b"].id, span_c.id)].unique_infra_suspect is False
+
+
+def test_three_unavailable_services_emits_no_edges() -> None:
+    """Uniqueness gate trips at 3+ simultaneously unavailable services —
+    too many candidate causes makes the heuristic unreliable."""
+    g = HyperGraph()
+    for tag in ("a", "b", "c"):
+        svc = _add_node(g, PlaceKind.service, f"svc-{tag}")
+        pod = _add_node(g, PlaceKind.pod, f"p{tag}")
+        cont = _add_node(g, PlaceKind.container, f"c{tag}")
+        _add_edge(g, svc, pod, DepKind.routes_to)
+        _add_edge(g, pod, cont, DepKind.runs)
+
+    svc_d = _add_node(g, PlaceKind.service, "svc-d")
+    pod_d = _add_node(g, PlaceKind.pod, "pd")
+    span_d = _add_node(g, PlaceKind.span, "svc-d::GET /")
+    _add_edge(g, svc_d, pod_d, DepKind.routes_to)
+    _add_edge(g, svc_d, span_d, DepKind.includes)
+
+    timelines = {
+        "container|ca": _make_timeline_buckets("container|ca", PlaceKind.container, [(1000, 1050, "unavailable")]),
+        "container|cb": _make_timeline_buckets("container|cb", PlaceKind.container, [(1000, 1050, "unavailable")]),
+        "container|cc": _make_timeline_buckets("container|cc", PlaceKind.container, [(1000, 1050, "unavailable")]),
+        "span|svc-d::GET /": _make_timeline_buckets("span|svc-d::GET /", PlaceKind.span, [(1000, 1050, "erroring")]),
+    }
+
+    n_added = enrich_with_inferred_edges(g, timelines)
+    assert n_added == 0
+    assert g.data.get("inferred_edges", {}) == {}
+
+
+def test_degraded_only_service_emits_no_edge() -> None:
+    """A service that is only ``degraded`` (CPU pressure, never down) is
+    NOT a candidate cause. The strict ``unavailable`` signal is what we
+    need for trace-blind cases — degraded propagates noisily across
+    cascade victims."""
+    g, _nodes = _build_two_service_graph()
+    timelines = {
+        "container|ca": _make_timeline_buckets("container|ca", PlaceKind.container, [(1000, 1050, "degraded")]),
+        "span|svc-b::GET /": _make_timeline_buckets("span|svc-b::GET /", PlaceKind.span, [(1000, 1050, "erroring")]),
+    }
+
+    n_added = enrich_with_inferred_edges(g, timelines)
+    assert n_added == 0
+
+
+def test_no_co_anomaly_overlap_emits_no_edge() -> None:
+    """svc-a unavailable in disjoint windows from span anomaly → no edge."""
+    g, _nodes = _build_two_service_graph()
+    timelines = {
+        "container|ca": _make_timeline_buckets("container|ca", PlaceKind.container, [(1000, 1010, "unavailable")]),
+        # Span anomaly is in a completely separate window.
+        "span|svc-b::GET /": _make_timeline_buckets("span|svc-b::GET /", PlaceKind.span, [(2000, 2050, "erroring")]),
+    }
+
+    n_added = enrich_with_inferred_edges(g, timelines)
+    assert n_added == 0
+
+
+def test_loadgen_service_excluded_as_source() -> None:
+    """Loadgen-style services emit synthetic traffic — never the cause."""
+    g = HyperGraph()
+    svc_load = _add_node(g, PlaceKind.service, "loadgenerator")
+    pod_load = _add_node(g, PlaceKind.pod, "p-load")
+    cont_load = _add_node(g, PlaceKind.container, "c-load")
+    _add_edge(g, svc_load, pod_load, DepKind.routes_to)
+    _add_edge(g, pod_load, cont_load, DepKind.runs)
+
+    svc_b = _add_node(g, PlaceKind.service, "svc-b")
+    pod_b = _add_node(g, PlaceKind.pod, "pb")
+    span_b = _add_node(g, PlaceKind.span, "svc-b::GET /")
+    _add_edge(g, svc_b, pod_b, DepKind.routes_to)
+    _add_edge(g, svc_b, span_b, DepKind.includes)
+
+    timelines = {
+        "container|c-load": _make_timeline_buckets(
+            "container|c-load", PlaceKind.container, [(1000, 1050, "unavailable")]
+        ),
+        "span|svc-b::GET /": _make_timeline_buckets("span|svc-b::GET /", PlaceKind.span, [(1000, 1050, "erroring")]),
+    }
+
+    n_added = enrich_with_inferred_edges(g, timelines)
+    assert n_added == 0
+
+
+def test_same_service_pair_skipped() -> None:
+    """A faulty service should not add an inferred edge to its OWN span —
+    that case is already covered by structural inheritance."""
+    g, _nodes = _build_two_service_graph()
+    span_a = _add_node(g, PlaceKind.span, "svc-a::GET /")
+    svc_a = g.get_node_by_name("service|svc-a")
+    assert svc_a is not None and svc_a.id is not None
+    _add_edge(g, svc_a, span_a, DepKind.includes)
+
+    timelines = {
+        "container|ca": _make_timeline_buckets("container|ca", PlaceKind.container, [(1000, 1050, "unavailable")]),
+        "span|svc-a::GET /": _make_timeline_buckets("span|svc-a::GET /", PlaceKind.span, [(1000, 1050, "erroring")]),
+    }
+
+    n_added = enrich_with_inferred_edges(g, timelines)
+    assert n_added == 0
+
+
+def test_no_anomalous_spans_yields_no_edges() -> None:
+    """With infra faults but no anomalous spans, nothing is emitted."""
+    g, _nodes = _build_two_service_graph()
+    timelines = {
+        "container|ca": _make_timeline_buckets("container|ca", PlaceKind.container, [(1000, 1050, "unavailable")]),
+        "span|svc-b::GET /": _make_timeline_buckets("span|svc-b::GET /", PlaceKind.span, [(1000, 1050, "healthy")]),
+    }
+
+    n_added = enrich_with_inferred_edges(g, timelines)
+    assert n_added == 0


### PR DESCRIPTION
## Gap (empirical motivation)

Today's full sweep over 500 TrainTicket cases gave `488 success / 9 no_paths / 3 no_alarms` (post-#197 with `StructuralInheritanceAdapter`). Of the 9 no_paths, 8 are **trace-blind dependencies**: alarms surface only at `ts-ui-dashboard::POST /trips/left` (or similar frontend ingress); the injected service has its `container/pod/service/spans` correctly classified as unavailable thanks to k8s-metrics + structural inheritance, but the **call-graph edge** from injected-service to the ui-dashboard alarm span doesn't exist in the OTel trace data — Spring's auth filter intercepts the request before the controller, so no child span is emitted for the auth call. The 9th no_paths is mysql (JDBC not OTel-instrumented; out of scope).

## Heuristic spec

A new module `src/rcabench_platform/v3/internal/reasoning/ir/adapters/inferred_edges.py` runs after `run_reasoning_ir` and mutates the `HyperGraph` by adding `includes` edges from `service|S` to anomalous spans owned by other services. An edge is added only when:

1. **Strict infra signal** — S has at least one container or pod node observed in `unavailable` state at any point (the strict "node actually went down" signal; `degraded` is excluded because CPU pressure cascades to many neighbours and would generate noisy candidate causes).
2. **Uniqueness gate** — the case has at most 2 distinct services with `unavailable` infra. When 3+ services simultaneously go down, the heuristic produces wild guesses and bails out.
3. **Temporal coincidence** — at least one 5-second bucket where S is infra-faulty AND the alarm span is anomalous (state in `{erroring, unavailable, missing, slow}`).
4. **No direct call-graph parent** — no span owned by S has a direct `calls` edge to or from the alarm span. (A transitive path check is too lenient — every backend is reachable from a frontend hub via deep call chains, which would suppress every inferred edge.)
5. **Skip same-service pairs** (already covered by `StructuralInheritanceAdapter`) and **loadgen-like sources** (`loadgenerator`, `locust`, `wrk2`, `dsb-wrk2`, `k6`).

The enricher does NOT produce `Transition` events — it only mutates graph topology. Wired into `cli.py::run_single_case` between `run_reasoning_ir` and `FaultPropagator` construction so the propagator naturally picks up new edges via the existing `RULE_SERVICE_TO_SPAN` (confidence 0.85). Edges are emitted with `kind=DepKind.includes` (using `calls` would not match any rule for `src_kind=service`). Diagnostic metadata (`inferred=True`, co-anomaly window counts, uniqueness flag) is stored in `HyperGraph.data["inferred_edges"]` so the `Edge` pydantic model stays unchanged.

No changes to `propagator.py`, `topology_explorer.py`, `rule_matcher.py`, `builtin_rules.json`, the transition layer, or `EvidenceLevel`.

## Sweep delta

| | success | no_paths | no_alarms |
|---|---|---|---|
| Before | 488 | 9 | 3 |
| After | **493** | **4** | 3 |

5 trace-blind cases flipped to success:
- `ts4-ts-auth-service-container-kill-dtrc6w`
- `ts4-ts-auth-service-stress-z67ksb`
- `ts5-ts-auth-service-container-kill-5cr458`
- `ts5-ts-preserve-service-stress-845w52`
- `ts5-ts-user-service-pod-kill-ds2t2b`

**No regressions** — every previously-passing case still passes.

### Spot-check: `ts4-ts-auth-service-container-kill-dtrc6w`

`service|ts-auth-service` is the unique unavailable service. The enricher adds 136 inferred `includes` edges, including:

```
service|ts-auth-service -> span|ts-ui-dashboard::POST /api/v1/travelplanservice/travelPlan/minStation
  (co-anomaly 2/48 windows, unique=True)
service|ts-auth-service -> span|ts-ui-dashboard::POST /api/v1/travelservice/trips/left
  (co-anomaly 2/43 windows, unique=True)
service|ts-auth-service -> span|ts-train-service::TrainController.query
  (co-anomaly 2/34 windows, unique=True)
```

The propagator now extracts 709 paths from `ts-auth-service` to the alarm spans and the case reports `success`.

## Cases that stayed `no_paths`

| Case | Reason |
|---|---|
| `ts0-mysql-container-kill-9t6n24` | Out of scope: JDBC not OTel-instrumented, no spans for mysql. |
| `ts4-ts-basic-service-bandwidth-fn4pnv` | Network bandwidth fault — container never went `unavailable` (only `degraded`). Strict signal misses by design. |
| `ts4-ts-verification-code-service-partition-nlbl25` | Network partition — same as above, no `unavailable` state observed. |
| `ts5-ts-preserve-service-container-kill-lft86s` | 4 simultaneously `unavailable` services (preserve cascades to inside-payment, contacts, order-other) — uniqueness gate trips. |

The two network-fault cases need a different signal (network-loss adapter), and the cascade case needs a *ranking* among multiple suspects rather than a uniqueness gate. Both are out-of-scope for this PR.

## Risks / follow-ups

- **Many edges per case**: a single faulty service can produce 100+ inferred edges (one per anomalous span without direct call ancestry). This is fine for the propagator's BFS, but may bloat causal-graph artefacts. Consider top-K alarm-span filtering if it becomes a problem.
- **Edge-level confidence**: existing propagator has no notion of "low-confidence edge". Inferred edges currently count equally with real ones in path extraction. The diagnostic metadata records `inferred=True` and co-anomaly counts on `HyperGraph.data["inferred_edges"]` for follow-up work that wants to weight paths by inferred-edge fraction. Out of scope here.
- **Performance**: O(faulty_services × anomalous_spans) per case. For TrainTicket this is sub-second; the full 500-case sweep is unchanged at ~4 minutes.

## Test plan

- [x] `uv run pytest src/rcabench_platform/v3/internal/reasoning/ir_tests/` — 215 passed
- [x] `uv run python /tmp/sweep_all.py` — 493/4/3 vs baseline 488/9/3
- [x] `uv run ruff format && uv run ruff check && uv run pyright` — clean

## New tests

`src/rcabench_platform/v3/internal/reasoning/ir_tests/test_inferred_edges.py` — 9 in-memory fixture tests covering single-suspect/two-suspect/three-suspect, direct-call-suppression, degraded-only, no-overlap, loadgen, same-service, and no-anomaly cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)