### PR TITLE
chore(seed): bump teastore chart 0.1.1 → 0.1.2 + jmeter busybox override

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -292,11 +292,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.1
+      - name: 0.1.2
         github_link: LGU-SE-Internal/TeaStore
         status: 1
         helm_config:
-          version: 0.1.1
+          version: 0.1.2
           chart_name: teastore
           repo_name: lgu-tea
           repo_url: https://lgu-se-internal.github.io/TeaStore
@@ -333,6 +333,33 @@ containers:
               category: 1
               value_type: 0
               default_value: otel-kube-stack
+              overridable: true
+            # 0.1.2 makes the busybox image used by jmeter's wait-for-registry
+            # init container configurable (LGU-SE-Internal/TeaStore#8). Empty
+            # registry preserves the upstream `busybox:1.36` (docker.io) default.
+            - key: jmeter.waitForRegistryImage.registry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: ""
+              overridable: true
+            - key: jmeter.waitForRegistryImage.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: busybox
+              overridable: true
+            - key: jmeter.waitForRegistryImage.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "1.36"
+              overridable: true
+            - key: jmeter.waitForRegistryImage.pullPolicy
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: IfNotPresent
               overridable: true
           status: 1
 datasets:

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -266,11 +266,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.0
+      - name: 0.1.2
         github_link: LGU-SE-Internal/TeaStore
         status: 1
         helm_config:
-          version: 0.1.0
+          version: 0.1.2
           chart_name: teastore
           repo_name: lgu-tea
           repo_url: https://lgu-se-internal.github.io/TeaStore
@@ -292,6 +292,33 @@ containers:
               category: 1
               value_type: 0
               default_value: http://otel-collector.otel.svc.cluster.local:4317
+              overridable: true
+            # 0.1.2 makes the busybox image used by jmeter's wait-for-registry
+            # init container configurable (LGU-SE-Internal/TeaStore#8). Empty
+            # registry preserves the upstream `busybox:1.36` (docker.io) default.
+            - key: jmeter.waitForRegistryImage.registry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: ""
+              overridable: true
+            - key: jmeter.waitForRegistryImage.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: busybox
+              overridable: true
+            - key: jmeter.waitForRegistryImage.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "1.36"
+              overridable: true
+            - key: jmeter.waitForRegistryImage.pullPolicy
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: IfNotPresent
               overridable: true
           status: 1
 datasets:

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -303,11 +303,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.1
+      - name: 0.1.2
         github_link: LGU-SE-Internal/TeaStore
         status: 1
         helm_config:
-          version: 0.1.1
+          version: 0.1.2
           chart_name: teastore
           repo_name: lgu-tea
           repo_url: https://lgu-se-internal.github.io/TeaStore
@@ -344,6 +344,33 @@ containers:
               category: 1
               value_type: 0
               default_value: opentelemetry-kube-stack
+              overridable: true
+            # 0.1.2 makes the busybox image used by jmeter's wait-for-registry
+            # init container configurable (LGU-SE-Internal/TeaStore#8). The Byte
+            # cluster cannot reach docker.io, so default to the volces mirror.
+            - key: jmeter.waitForRegistryImage.registry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            - key: jmeter.waitForRegistryImage.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: busybox
+              overridable: true
+            - key: jmeter.waitForRegistryImage.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "1.36"
+              overridable: true
+            - key: jmeter.waitForRegistryImage.pullPolicy
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: IfNotPresent
               overridable: true
           status: 1
 datasets:


### PR DESCRIPTION
## Summary

Bump the seeded teastore Helm pedestal from chart `0.1.1` to `0.1.2`, and wire the new `jmeter.waitForRegistryImage` value tree that the upstream chart added in [LGU-SE-Internal/TeaStore#8](https://github.com/LGU-SE-Internal/TeaStore/pull/8).

Upstream `0.1.2` makes the busybox image used by the jmeter loadgen Job's `wait-for-registry` init container configurable. Clusters that can't reach `docker.io` (notably **byte-cluster**, which has been hitting `Init:ImagePullBackOff` on `busybox:1.36`) can now point the init container at a mirrored registry instead.

## Changes

Three seed files updated, all under `containers[name in {teastore, tea}].versions[].helm_config`:

| File | Old chart version | New chart version | `jmeter.waitForRegistryImage.registry` default |
|---|---|---|---|
| `AegisLab/data/initial_data/prod/data.yaml` | 0.1.1 | 0.1.2 | `""` (upstream docker.io) |
| `AegisLab/data/initial_data/staging/data.yaml` | 0.1.0 | 0.1.2 | `""` (upstream docker.io) |
| `AegisLab/manifests/byte-cluster/initial-data/data.yaml` | 0.1.1 | 0.1.2 | `pair-cn-shanghai.cr.volces.com/opspai` |

The four new value entries added per file:
- `jmeter.waitForRegistryImage.registry`
- `jmeter.waitForRegistryImage.repository` (default `busybox`)
- `jmeter.waitForRegistryImage.tag` (default `"1.36"`)
- `jmeter.waitForRegistryImage.pullPolicy` (default `IfNotPresent`)

All four are `overridable: true` so per-environment override at deploy time still works.

**Defaults preserved**: prod/staging seed an empty `registry` so they continue producing the upstream `busybox:1.36` from docker.io — no behavior change for those environments. Only byte-cluster's default actively switches the registry to the volces mirror, which is the cluster that needs it.

The existing `global.image.*` and `opentelemetry.*` entries are untouched.

## Test plan

- [ ] YAML syntax: each file parses with `python3 -c "import yaml; yaml.safe_load(open('<f>'))"` — verified locally on all three.
- [ ] After re-seed on the byte-cluster, deploying a `tea` system now resolves chart `0.1.2` from `https://lgu-se-internal.github.io/TeaStore` and the jmeter Job's `wait-for-registry` init container pulls from the volces mirror instead of docker.io.
- [ ] On prod/staging clusters, deploying tea continues to pull `busybox:1.36` from docker.io (empty registry default → upstream behavior).