### PR TITLE
feat(pedestal): hot-reseed helm_configs values from CLI (closes #201)

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/pedestal.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/pedestal.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"aegis/cmd/aegisctl/client"
 	"aegis/cmd/aegisctl/output"
@@ -59,7 +61,13 @@ Typical workflow for fixing a bad repo URL without touching MySQL directly:
 
   aegisctl pedestal helm get    --container-version-id 42
   aegisctl pedestal helm set    --container-version-id 42 --repo-url https://...
-  aegisctl pedestal helm verify --container-version-id 42`,
+  aegisctl pedestal helm verify --container-version-id 42
+
+To propagate a data.yaml chart bump (with new override values) to a running
+cluster without raw SQL — the issue #201 use case — use:
+
+  aegisctl pedestal helm reseed --container-version-id 42            # dry-run
+  aegisctl pedestal helm reseed --container-version-id 42 --apply    # commit`,
 }
 
 // --- shared flags ---
@@ -196,9 +204,176 @@ var pedestalHelmVerifyCmd = &cobra.Command{
 	},
 }
 
+// --- reseed ---
+//
+// `aegisctl pedestal helm reseed` is the hot-reseed counterpart to `set`.
+// `set` only mutates chart-level fields on `helm_configs`; reseed also
+// reconciles the linked `parameter_configs` + `helm_config_values` rows from
+// the seed YAML so a chart bump that adds new override keys (issue #201,
+// teastore 0.1.1 -> 0.1.2 + jmeter.waitForRegistryImage.* values) takes
+// effect on a running cluster without raw SQL.
+//
+// Defaults to dry-run (server side, mirrors `aegisctl system reseed`). Pass
+// --apply to actually write. --prune drops links whose key disappeared
+// from the seed.
+var (
+	pedestalHelmReseedEnv      string
+	pedestalHelmReseedDataPath string
+	pedestalHelmReseedApply    bool
+	pedestalHelmReseedPrune    bool
+)
+
+type pedestalHelmReseedReq struct {
+	Env      string `json:"env,omitempty"`
+	DataPath string `json:"data_path,omitempty"`
+	Apply    bool   `json:"apply"`
+	Prune    bool   `json:"prune,omitempty"`
+}
+
+type pedestalHelmReseedAction struct {
+	Layer    string `json:"layer"`
+	System   string `json:"system"`
+	Key      string `json:"key"`
+	OldValue string `json:"old_value"`
+	NewValue string `json:"new_value"`
+	Note     string `json:"note"`
+	Applied  bool   `json:"applied"`
+}
+
+type pedestalHelmReseedResp struct {
+	DryRun       bool                       `json:"dry_run"`
+	SystemFilter string                     `json:"system_filter"`
+	SeedPath     string                     `json:"seed_path"`
+	Actions      []pedestalHelmReseedAction `json:"actions"`
+}
+
+var pedestalHelmReseedCmd = &cobra.Command{
+	Use:   "reseed",
+	Short: "Hot-reseed helm_configs + values for one container_version from data.yaml",
+	Long: `Reconcile the helm_configs row and its linked parameter_configs +
+helm_config_values for a pedestal container_version against the seed YAML.
+Use this to propagate a data.yaml chart-version bump (and any new overridable
+values) to a running cluster without raw SQL — e.g. issue #201's teastore
+0.1.1 -> 0.1.2 + jmeter.waitForRegistryImage.* values.
+
+Defaults to DRY-RUN for safety. Pass --apply to actually write.
+
+Conflict semantics:
+  - Existing parameter_configs.default_value is NEVER overwritten (warning
+    logged + reported as a skipped action). Operators who want to clobber
+    drift must edit the row directly.
+  - New parameter_configs / helm_config_values rows ARE inserted.
+  - --prune removes helm_config_values links whose key disappeared from the
+    seed; off by default to avoid surprising deletions.
+
+Idempotent: a re-run with no upstream change yields zero applied actions.`,
+	Example: `  aegisctl pedestal helm reseed --container-version-id 62
+  aegisctl pedestal helm reseed --container-version-id 62 --apply
+  aegisctl pedestal helm reseed --container-version-id 62 --apply --prune
+  aegisctl pedestal helm reseed --container-version-id 62 --env staging`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if pedestalHelmVersionID <= 0 {
+			return fmt.Errorf("--container-version-id is required and must be > 0")
+		}
+		body := pedestalHelmReseedReq{
+			Env:      strings.TrimSpace(pedestalHelmReseedEnv),
+			DataPath: strings.TrimSpace(pedestalHelmReseedDataPath),
+			Apply:    pedestalHelmReseedApply,
+			Prune:    pedestalHelmReseedPrune,
+		}
+		path := fmt.Sprintf("/api/v2/pedestal/helm/%d/reseed", pedestalHelmVersionID)
+		if flagDryRun {
+			plan := map[string]any{
+				"dry_run":              true,
+				"operation":            "pedestal_helm_reseed",
+				"container_version_id": pedestalHelmVersionID,
+				"method":               "POST",
+				"path":                 path,
+				"body":                 body,
+			}
+			if output.OutputFormat(flagOutput) == output.FormatJSON {
+				output.PrintJSON(plan)
+			} else {
+				output.PrintInfo(fmt.Sprintf("Dry run: POST %s apply=%v prune=%v", path, body.Apply, body.Prune))
+			}
+			return nil
+		}
+		c := newClient()
+		var resp client.APIResponse[pedestalHelmReseedResp]
+		if err := c.Post(path, body, &resp); err != nil {
+			return fmt.Errorf("reseed: %w (hint: retry without --apply to diff without writing; check backend logs for which subsystem failed)", err)
+		}
+		if output.OutputFormat(flagOutput) == output.FormatJSON {
+			output.PrintJSON(resp.Data)
+			return nil
+		}
+		printPedestalHelmReseedReport(&resp.Data)
+		return nil
+	},
+}
+
+func printPedestalHelmReseedReport(r *pedestalHelmReseedResp) {
+	mode := "APPLY"
+	if r.DryRun {
+		mode = "DRY-RUN"
+	}
+	suffix := ""
+	if r.SystemFilter != "" {
+		suffix = " filter=" + r.SystemFilter
+	}
+	output.PrintInfo(fmt.Sprintf("pedestal helm reseed %s (seed=%s%s)", mode, r.SeedPath, suffix))
+
+	if len(r.Actions) == 0 {
+		output.PrintInfo("No drift — DB already in sync with data.yaml for this container_version.")
+		return
+	}
+
+	actions := append([]pedestalHelmReseedAction(nil), r.Actions...)
+	sort.SliceStable(actions, func(i, j int) bool {
+		if actions[i].Layer != actions[j].Layer {
+			return actions[i].Layer < actions[j].Layer
+		}
+		return actions[i].Key < actions[j].Key
+	})
+
+	rows := make([][]string, 0, len(actions))
+	for _, a := range actions {
+		status := "plan"
+		if a.Applied {
+			status = "applied"
+		} else if r.DryRun {
+			status = "would-apply"
+		} else if strings.Contains(a.Note, "preserved") || strings.Contains(a.Note, "drift on existing parameter_config") {
+			status = "preserved"
+		}
+		rows = append(rows, []string{
+			a.Layer,
+			truncCell(a.Key, 48),
+			truncCell(a.OldValue, 28),
+			truncCell(a.NewValue, 28),
+			status,
+			truncCell(a.Note, 48),
+		})
+	}
+	output.PrintTable([]string{"Layer", "Key", "Old", "New", "Status", "Note"}, rows)
+
+	if r.DryRun {
+		output.PrintInfo("Re-run with --apply to write the planned changes.")
+	}
+	preserved := 0
+	for _, a := range actions {
+		if !a.Applied && (strings.Contains(a.Note, "preserved") || strings.Contains(a.Note, "drift on existing parameter_config")) {
+			preserved++
+		}
+	}
+	if preserved > 0 {
+		output.PrintInfo(fmt.Sprintf("%d parameter_config default_value drift(s) preserved; edit the row directly if you want to clobber.", preserved))
+	}
+}
+
 func init() {
-	// Shared flag across all three subcommands.
-	for _, c := range []*cobra.Command{pedestalHelmGetCmd, pedestalHelmSetCmd, pedestalHelmVerifyCmd} {
+	// Shared flag across all four subcommands.
+	for _, c := range []*cobra.Command{pedestalHelmGetCmd, pedestalHelmSetCmd, pedestalHelmVerifyCmd, pedestalHelmReseedCmd} {
 		c.Flags().IntVar(&pedestalHelmVersionID, "container-version-id", 0, "Container version ID (required)")
 		_ = c.MarkFlagRequired("container-version-id")
 	}
@@ -210,9 +385,15 @@ func init() {
 	pedestalHelmSetCmd.Flags().StringVar(&pedestalHelmSetValues, "values-file", "", "Path to the values YAML file (optional)")
 	pedestalHelmSetCmd.Flags().StringVar(&pedestalHelmSetLocal, "local-path", "", "Local chart fallback path (optional)")
 
+	pedestalHelmReseedCmd.Flags().StringVar(&pedestalHelmReseedEnv, "env", "", "Environment selector ('prod' / 'staging') for the server-side seed root")
+	pedestalHelmReseedCmd.Flags().StringVar(&pedestalHelmReseedDataPath, "data-path", "", "Override server-side initialization.data_path (advanced)")
+	pedestalHelmReseedCmd.Flags().BoolVar(&pedestalHelmReseedApply, "apply", false, "Actually write changes (default is dry-run)")
+	pedestalHelmReseedCmd.Flags().BoolVar(&pedestalHelmReseedPrune, "prune", false, "Delete helm_config_values links whose key disappeared from the seed")
+
 	pedestalHelmCmd.AddCommand(pedestalHelmGetCmd)
 	pedestalHelmCmd.AddCommand(pedestalHelmSetCmd)
 	pedestalHelmCmd.AddCommand(pedestalHelmVerifyCmd)
+	pedestalHelmCmd.AddCommand(pedestalHelmReseedCmd)
 
 	pedestalCmd.AddCommand(pedestalHelmCmd)
 }

--- a/AegisLab/src/module/pedestal/api_types.go
+++ b/AegisLab/src/module/pedestal/api_types.go
@@ -37,3 +37,48 @@ type PedestalHelmVerifyResp struct {
 	OK     bool                      `json:"ok"`
 	Checks []PedestalHelmVerifyCheck `json:"checks"`
 }
+
+// ---------------------- Pedestal Helm Reseed DTOs ----------------------
+
+// ReseedHelmConfigReq is the body for POST
+// /api/v2/pedestal/helm/{container_version_id}/reseed.
+//
+// Defaults: Apply=false (the server runs a dry-run unless Apply=true). This
+// mirrors `aegisctl system reseed` so a misfired POST never writes.
+type ReseedHelmConfigReq struct {
+	// Env selects prod / staging when the server-side initialization.data_path
+	// points at the initial_data root. Empty falls back to whatever the file
+	// at DataPath (or `initialization.data_path`) contains.
+	Env string `json:"env,omitempty"`
+	// DataPath optionally overrides server-side initialization.data_path
+	// (e.g. for one-off file paths produced by aegisctl). Server-side admins
+	// only — the handler still resolves this against ResolveSeedPath.
+	DataPath string `json:"data_path,omitempty"`
+	// Apply: when false, the response is a dry-run plan. When true, mutations
+	// are committed to the DB.
+	Apply bool `json:"apply"`
+	// Prune: when true, helm_config_values links whose key disappeared from
+	// the seed are removed. Default false to avoid surprising deletions.
+	Prune bool `json:"prune,omitempty"`
+}
+
+// ReseedActionResp mirrors initialization.ReseedAction without forcing the
+// CLI / external clients to depend on the initialization package.
+type ReseedActionResp struct {
+	Layer    string `json:"layer"`
+	System   string `json:"system"`
+	Key      string `json:"key"`
+	OldValue string `json:"old_value"`
+	NewValue string `json:"new_value"`
+	Note     string `json:"note"`
+	Applied  bool   `json:"applied"`
+}
+
+// ReseedHelmConfigResp is the aggregated reseed report returned by the
+// pedestal helm reseed endpoint.
+type ReseedHelmConfigResp struct {
+	DryRun       bool               `json:"dry_run"`
+	SystemFilter string             `json:"system_filter"`
+	SeedPath     string             `json:"seed_path"`
+	Actions      []ReseedActionResp `json:"actions"`
+}

--- a/AegisLab/src/module/pedestal/handler.go
+++ b/AegisLab/src/module/pedestal/handler.go
@@ -8,6 +8,7 @@ import (
 	"aegis/dto"
 	"aegis/middleware"
 	"aegis/model"
+	"aegis/service/initialization"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -142,6 +143,89 @@ func (h *Handler) VerifyPedestalHelmConfig(c *gin.Context) {
 		resp.Checks[i] = PedestalHelmVerifyCheck{Name: chk.Name, OK: chk.OK, Detail: chk.Detail}
 	}
 	dto.SuccessResponse(c, resp)
+}
+
+// ReseedPedestalHelmConfig hot-reseeds the helm_configs row + linked
+// parameter_configs / helm_config_values for a single container_version
+// from the seed YAML. Closes #201: lets operators propagate a chart-version
+// bump (and any new overridable values) to a running cluster without raw
+// SQL.
+//
+//	@Summary		Reseed pedestal helm config from data.yaml
+//	@Description	Reconcile the helm_configs row and its linked parameter_configs / helm_config_values for a pedestal container version against the seed YAML. Defaults to dry-run unless apply=true. Idempotent: a re-run with no upstream change yields zero applied actions.
+//	@Tags			Pedestal
+//	@ID				reseed_pedestal_helm_config
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			container_version_id	path	int						true	"Container version ID"
+//	@Param			request					body	ReseedHelmConfigReq		false	"Reseed request"
+//	@Success		200	{object}	dto.GenericResponse[ReseedHelmConfigResp]
+//	@Router			/api/v2/pedestal/helm/{container_version_id}/reseed [post]
+//	@x-api-type		{"sdk":"true"}
+func (h *Handler) ReseedPedestalHelmConfig(c *gin.Context) {
+	if _, ok := middleware.GetCurrentUserID(c); !ok {
+		dto.ErrorResponse(c, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+	versionID, ok := parseVersionID(c)
+	if !ok {
+		return
+	}
+	// Body is optional — an empty POST runs a dry-run with the server-side
+	// default seed path. We tolerate "EOF" for an empty body.
+	var req ReseedHelmConfigReq
+	if c.Request.ContentLength > 0 {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			dto.ErrorResponse(c, http.StatusBadRequest, "Invalid request format: "+err.Error())
+			return
+		}
+	}
+	report, err := h.service.ReseedHelmConfig(c.Request.Context(), ReseedHelmConfigInput{
+		ContainerVersionID: versionID,
+		Env:                req.Env,
+		DataPath:           req.DataPath,
+		Apply:              req.Apply,
+		Prune:              req.Prune,
+	})
+	if err != nil {
+		// Map gorm.ErrRecordNotFound to 404 — caller asked for a version_id
+		// that doesn't exist.
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			dto.ErrorResponse(c, http.StatusNotFound, "Container version not found: "+err.Error())
+			return
+		}
+		dto.ErrorResponse(c, http.StatusInternalServerError, "Failed to reseed helm config: "+err.Error())
+		return
+	}
+	dto.SuccessResponse(c, toReseedResp(report))
+}
+
+// toReseedResp adapts the internal initialization.ReseedReport to the public
+// API DTO so the report shape stays stable for SDK consumers even if internal
+// fields drift.
+func toReseedResp(r *initialization.ReseedReport) ReseedHelmConfigResp {
+	if r == nil {
+		return ReseedHelmConfigResp{}
+	}
+	out := ReseedHelmConfigResp{
+		DryRun:       r.DryRun,
+		SystemFilter: r.SystemFilter,
+		SeedPath:     r.SeedPath,
+		Actions:      make([]ReseedActionResp, 0, len(r.Actions)),
+	}
+	for _, a := range r.Actions {
+		out.Actions = append(out.Actions, ReseedActionResp{
+			Layer:    a.Layer,
+			System:   a.System,
+			Key:      a.Key,
+			OldValue: a.OldValue,
+			NewValue: a.NewValue,
+			Note:     a.Note,
+			Applied:  a.Applied,
+		})
+	}
+	return out
 }
 
 func parseVersionID(c *gin.Context) (int, bool) {

--- a/AegisLab/src/module/pedestal/handler_service.go
+++ b/AegisLab/src/module/pedestal/handler_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"aegis/model"
+	"aegis/service/initialization"
 )
 
 // HandlerService captures the pedestal operations consumed by the HTTP handler.
@@ -11,6 +12,17 @@ type HandlerService interface {
 	GetHelmConfig(context.Context, int) (*model.HelmConfig, error)
 	UpsertHelmConfig(context.Context, int, *model.HelmConfig) (*model.HelmConfig, error)
 	VerifyHelmConfig(context.Context, int) (*Result, error)
+	ReseedHelmConfig(context.Context, ReseedHelmConfigInput) (*initialization.ReseedReport, error)
+}
+
+// ReseedHelmConfigInput is the service-layer call shape for the reseed flow.
+// Distinct from the HTTP DTO so the service stays free of gin / JSON tags.
+type ReseedHelmConfigInput struct {
+	ContainerVersionID int
+	Env                string
+	DataPath           string
+	Apply              bool
+	Prune              bool
 }
 
 func AsHandlerService(service *Service) HandlerService {

--- a/AegisLab/src/module/pedestal/routes.go
+++ b/AegisLab/src/module/pedestal/routes.go
@@ -21,6 +21,11 @@ func Routes(handler *Handler) framework.RouteRegistrar {
 					helm.GET("/:container_version_id", handler.GetPedestalHelmConfig)
 					helm.POST("/:container_version_id/verify", handler.VerifyPedestalHelmConfig)
 					helm.PUT("/:container_version_id", middleware.RequireContainerVersionUpload, handler.UpsertPedestalHelmConfig)
+					// Hot-reseed helm_configs values from data.yaml for one
+					// container_version (issue #201). Same upload permission as
+					// PUT — only operators with write access to container
+					// versions can trigger a write reseed.
+					helm.POST("/:container_version_id/reseed", middleware.RequireContainerVersionUpload, handler.ReseedPedestalHelmConfig)
 				}
 			}
 		},

--- a/AegisLab/src/module/pedestal/service.go
+++ b/AegisLab/src/module/pedestal/service.go
@@ -2,8 +2,13 @@ package pedestal
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	"aegis/config"
+	"aegis/consts"
 	"aegis/model"
+	"aegis/service/initialization"
 )
 
 // Service is the pedestal module's application-layer facade. It keeps the
@@ -40,4 +45,35 @@ func (s *Service) VerifyHelmConfig(ctx context.Context, versionID int) (*Result,
 		ValueFile: cfg.ValueFile,
 	}, VerifyValueFile)
 	return &result, nil
+}
+
+// ReseedHelmConfig propagates a data.yaml chart-version / values bump to the
+// running DB for one container_version. This is the targeted hot-reseed
+// counterpart to `aegisctl system reseed` and is keyed by container_version_id
+// rather than system name. See issue #201 for motivation.
+//
+// The service layer here keeps two responsibilities:
+//   - Resolve the seed file path against the same `initialization.data_path`
+//     config key used by the first-boot loader so reseed and seed always read
+//     the same file.
+//   - Default Apply=false to dry-run for safety, matching the chaossystem
+//     reseed contract.
+func (s *Service) ReseedHelmConfig(ctx context.Context, in ReseedHelmConfigInput) (*initialization.ReseedReport, error) {
+	if in.ContainerVersionID <= 0 {
+		return nil, fmt.Errorf("container_version_id is required and must be > 0: %w", consts.ErrBadRequest)
+	}
+	basePath := strings.TrimSpace(in.DataPath)
+	if basePath == "" {
+		basePath = config.GetString("initialization.data_path")
+	}
+	seedPath, err := initialization.ResolveSeedPath(basePath, strings.TrimSpace(in.Env))
+	if err != nil {
+		return nil, fmt.Errorf("resolve seed path: %w: %w", err, consts.ErrBadRequest)
+	}
+	return initialization.ReseedHelmConfigForVersion(ctx, s.repo.db, initialization.ReseedHelmConfigForVersionRequest{
+		DataPath:           seedPath,
+		ContainerVersionID: in.ContainerVersionID,
+		DryRun:             !in.Apply,
+		Prune:              in.Prune,
+	})
 }

--- a/AegisLab/src/service/initialization/reseed.go
+++ b/AegisLab/src/service/initialization/reseed.go
@@ -656,6 +656,348 @@ func systemLabelFromKey(key string) string {
 	return ""
 }
 
+// ReseedHelmConfigForVersionRequest drives a per-container_version reseed of
+// the helm_configs row + its linked parameter_configs / helm_config_values
+// tables. Unlike ReseedFromDataFile, which is keyed by system name and
+// honors the "history-preservation" contract (never UPDATE an existing
+// (container_id, version_name) row), this entry point is keyed by an
+// explicit container_version_id and IS allowed to mutate the chart-level
+// fields (chart_name / version / repo_url / repo_name / value_file /
+// local_path) of the bound helm_configs row in place.
+//
+// This is the targeted "fix-up" path used by aegisctl pedestal helm reseed
+// to propagate a seed-YAML chart bump to a running cluster without forcing
+// re-allocation of every namespace bound to the old version_id (issue #201).
+type ReseedHelmConfigForVersionRequest struct {
+	DataPath           string // absolute path to data.yaml (resolved upstream from env/base)
+	ContainerVersionID int    // required: which container_version's helm_configs row to reseed
+	DryRun             bool   // default safety: don't write
+	Prune              bool   // when true, delete helm_config_values links whose key disappeared from the seed
+}
+
+// ReseedHelmConfigForVersion is the entry point for a single-version helm
+// reseed. The contract:
+//
+//   - Looks up the container_version row by ID. Returns gorm.ErrRecordNotFound
+//     when absent so callers can map to HTTP 404.
+//   - Walks data.yaml looking for a `versions[].name` that matches the row's
+//     name on the same container. If absent, returns an error so the caller
+//     knows the seed has no entry to reconcile against.
+//   - UPSERTs the helm_configs row (chart_name / version / repo* / value_file /
+//     local_path). Existing local_path / value_file are preserved when the seed
+//     entry omits them so an operator-set local-fallback isn't clobbered.
+//   - Walks the seed's helm_config.values list and: (a) inserts missing
+//     parameter_configs rows (looked up by (config_key, type, category));
+//     (b) inserts missing helm_config_values links; (c) when an existing
+//     parameter_config row's default_value differs from the seed default,
+//     LOGS A WARNING and leaves the DB row untouched (protects manual edits).
+//   - With Prune=true, also deletes helm_config_values rows whose
+//     parameter_config key is no longer in the seed. Parameter_configs rows
+//     themselves are left in place because they may be shared across multiple
+//     helm_configs.
+//   - Idempotent: a second invocation with the same seed yields zero applied
+//     actions.
+func ReseedHelmConfigForVersion(ctx context.Context, db *gorm.DB, req ReseedHelmConfigForVersionRequest) (*ReseedReport, error) {
+	if db == nil {
+		return nil, errors.New("reseed: db is required")
+	}
+	if req.ContainerVersionID <= 0 {
+		return nil, errors.New("reseed: container_version_id is required and must be > 0")
+	}
+	if strings.TrimSpace(req.DataPath) == "" {
+		return nil, errors.New("reseed: data_path is required")
+	}
+
+	// Look up the version row + parent container. We need the container.Name
+	// to find the matching block in data.yaml.
+	var version model.ContainerVersion
+	if err := db.Where("id = ?", req.ContainerVersionID).First(&version).Error; err != nil {
+		return nil, err
+	}
+	var container model.Container
+	if err := db.Where("id = ?", version.ContainerID).First(&container).Error; err != nil {
+		return nil, fmt.Errorf("lookup parent container for version_id=%d: %w", req.ContainerVersionID, err)
+	}
+
+	data, err := loadInitialDataFromFile(req.DataPath)
+	if err != nil {
+		return nil, fmt.Errorf("reseed: load %s: %w", req.DataPath, err)
+	}
+
+	// Locate the seed entry for this container + version.
+	var seedContainer *InitialDataContainer
+	for i := range data.Containers {
+		c := &data.Containers[i]
+		if c.Name == container.Name && c.Type == container.Type {
+			seedContainer = c
+			break
+		}
+	}
+	if seedContainer == nil {
+		return nil, fmt.Errorf("reseed: data.yaml has no container entry for name=%s type=%d", container.Name, container.Type)
+	}
+	var seedVersion *InitialContainerVersion
+	for i := range seedContainer.Versions {
+		if seedContainer.Versions[i].Name == version.Name {
+			seedVersion = &seedContainer.Versions[i]
+			break
+		}
+	}
+	if seedVersion == nil {
+		return nil, fmt.Errorf("reseed: data.yaml has no versions[] entry for %s@%s", container.Name, version.Name)
+	}
+	if seedVersion.HelmConfig == nil {
+		return nil, fmt.Errorf("reseed: data.yaml entry for %s@%s has no helm_config block", container.Name, version.Name)
+	}
+
+	report := &ReseedReport{
+		Env:          "",
+		DryRun:       req.DryRun,
+		SystemFilter: container.Name,
+		SeedPath:     req.DataPath,
+	}
+
+	// --- helm_configs row upsert ------------------------------------------
+	helm, err := upsertHelmConfigForReseed(db, &version, seedVersion.HelmConfig, container.Name, req.DryRun, report)
+	if err != nil {
+		return report, fmt.Errorf("reseed helm_configs for %s@%s: %w", container.Name, version.Name, err)
+	}
+	if helm == nil {
+		// Dry-run path with no existing row: synthesize a placeholder so the
+		// values walk below still produces "would-apply" entries against the
+		// seed's chart fields.
+		helm = seedVersion.HelmConfig.ConvertToDBHelmConfig()
+		helm.ContainerVersionID = version.ID
+	}
+
+	// --- helm_config_values reconcile -------------------------------------
+	// backfillHelmConfigValues only inserts MISSING links/parameter_configs;
+	// it never overwrites an existing parameter_config.default_value. The
+	// drift-warning case is handled by warnHelmValueDefaultDrift below.
+	if err := warnHelmValueDefaultDrift(db, helm, version.Name, seedVersion.HelmConfig, container.Name, report); err != nil {
+		return report, err
+	}
+	// Only do the insert pass when the helm_configs row actually exists in DB
+	// (i.e. not a dry-run for a brand-new container_version). For dry-run we
+	// still want to surface what WOULD be added, so reuse the existing
+	// backfill in dry-run mode against the seed's helm_configs id.
+	if helm.ID != 0 || req.DryRun {
+		if err := backfillHelmConfigValues(db, helm, version.Name, seedVersion.HelmConfig, container.Name, req.DryRun, "reseed: new helm value", report); err != nil {
+			return report, err
+		}
+	}
+
+	// --- prune ------------------------------------------------------------
+	if req.Prune && helm.ID != 0 {
+		if err := pruneHelmConfigValues(db, helm, version.Name, seedVersion.HelmConfig, container.Name, req.DryRun, report); err != nil {
+			return report, err
+		}
+	}
+
+	return report, nil
+}
+
+// upsertHelmConfigForReseed mutates the helm_configs row bound to the given
+// container_version. Unlike compareHelmConfigDrift, this DOES write
+// chart-level fields back to DB (the whole point of issue #201's targeted
+// reseed). value_file and local_path are preserved when the seed omits them.
+func upsertHelmConfigForReseed(db *gorm.DB, version *model.ContainerVersion, seed *InitialHelmConfig, systemName string, dryRun bool, report *ReseedReport) (*model.HelmConfig, error) {
+	var existing model.HelmConfig
+	err := db.Where("container_version_id = ?", version.ID).First(&existing).Error
+	switch {
+	case err == nil:
+		drifts := []string{}
+		if existing.ChartName != seed.ChartName {
+			drifts = append(drifts, fmt.Sprintf("chart_name %s -> %s", existing.ChartName, seed.ChartName))
+		}
+		if existing.Version != seed.Version {
+			drifts = append(drifts, fmt.Sprintf("version %s -> %s", existing.Version, seed.Version))
+		}
+		if existing.RepoURL != seed.RepoURL {
+			drifts = append(drifts, fmt.Sprintf("repo_url %s -> %s", existing.RepoURL, seed.RepoURL))
+		}
+		if existing.RepoName != seed.RepoName {
+			drifts = append(drifts, fmt.Sprintf("repo_name %s -> %s", existing.RepoName, seed.RepoName))
+		}
+		if len(drifts) == 0 {
+			return &existing, nil
+		}
+		act := ReseedAction{
+			Layer:    "helm_configs",
+			System:   systemName,
+			Key:      version.Name,
+			OldValue: fmt.Sprintf("chart=%s version=%s repo=%s url=%s", existing.ChartName, existing.Version, existing.RepoName, existing.RepoURL),
+			NewValue: fmt.Sprintf("chart=%s version=%s repo=%s url=%s", seed.ChartName, seed.Version, seed.RepoName, seed.RepoURL),
+			Note:     "in-place chart upsert: " + strings.Join(drifts, ", "),
+		}
+		if dryRun {
+			report.Actions = append(report.Actions, act)
+			return &existing, nil
+		}
+		existing.ChartName = seed.ChartName
+		existing.Version = seed.Version
+		existing.RepoURL = seed.RepoURL
+		existing.RepoName = seed.RepoName
+		// Preserve operator-set value_file / local_path when the seed omits
+		// them; otherwise the seed wins.
+		// Note: InitialHelmConfig has no value_file / local_path fields today,
+		// so this branch is intentionally future-proofing.
+		if err := db.Save(&existing).Error; err != nil {
+			return nil, fmt.Errorf("update helm_configs row id=%d: %w", existing.ID, err)
+		}
+		act.Applied = true
+		report.Actions = append(report.Actions, act)
+		logrus.Infof("reseed %s: updated helm_configs id=%d for version=%s (%s)", systemName, existing.ID, version.Name, strings.Join(drifts, ", "))
+		return &existing, nil
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		// No helm_configs row yet — INSERT. This is the same path as
+		// compareHelmConfigDrift's "missing" branch, but expressed inline so
+		// the value-link reconcile below can use the freshly-created row.
+		helm := seed.ConvertToDBHelmConfig()
+		helm.ContainerVersionID = version.ID
+		act := ReseedAction{
+			Layer:    "helm_configs",
+			System:   systemName,
+			Key:      version.Name,
+			NewValue: fmt.Sprintf("chart=%s version=%s repo=%s url=%s", seed.ChartName, seed.Version, seed.RepoName, seed.RepoURL),
+			Note:     "create helm_configs row for existing container_version",
+		}
+		if dryRun {
+			report.Actions = append(report.Actions, act)
+			return nil, nil
+		}
+		if err := db.Create(helm).Error; err != nil {
+			return nil, fmt.Errorf("insert helm_configs for version_id=%d: %w", version.ID, err)
+		}
+		act.Applied = true
+		report.Actions = append(report.Actions, act)
+		logrus.Infof("reseed %s: inserted helm_configs id=%d for version=%s", systemName, helm.ID, version.Name)
+		return helm, nil
+	default:
+		return nil, fmt.Errorf("lookup helm_configs for version_id=%d: %w", version.ID, err)
+	}
+}
+
+// warnHelmValueDefaultDrift logs and reports (without applying) cases where
+// an existing parameter_configs row already linked to this helm_config has a
+// different default_value than the seed. This protects manually-edited
+// overrides per the issue #201 conflict semantics.
+func warnHelmValueDefaultDrift(db *gorm.DB, helm *model.HelmConfig, versionName string, seed *InitialHelmConfig, systemName string, report *ReseedReport) error {
+	if helm == nil || seed == nil || len(seed.Values) == 0 || helm.ID == 0 {
+		return nil
+	}
+	// Pull the parameter_configs that this helm_config currently points at.
+	var existing []model.ParameterConfig
+	if err := db.Table("parameter_configs").
+		Joins("JOIN helm_config_values ON helm_config_values.parameter_config_id = parameter_configs.id").
+		Where("helm_config_values.helm_config_id = ? AND parameter_configs.category = ?", helm.ID, consts.ParameterCategoryHelmValues).
+		Find(&existing).Error; err != nil {
+		return fmt.Errorf("list helm values for %s@%s: %w", systemName, versionName, err)
+	}
+	have := make(map[string]*model.ParameterConfig, len(existing))
+	for i := range existing {
+		have[parameterConfigIdentity(&existing[i])] = &existing[i]
+	}
+	for _, vs := range seed.Values {
+		want := vs.ConvertToDBParameterConfig()
+		key := parameterConfigIdentity(want)
+		got, ok := have[key]
+		if !ok {
+			continue
+		}
+		if defaultValuesEqual(got.DefaultValue, want.DefaultValue) {
+			continue
+		}
+		oldVal := "<nil>"
+		if got.DefaultValue != nil {
+			oldVal = *got.DefaultValue
+		}
+		newVal := "<nil>"
+		if want.DefaultValue != nil {
+			newVal = *want.DefaultValue
+		}
+		report.Actions = append(report.Actions, ReseedAction{
+			Layer:    "parameter_configs",
+			System:   systemName,
+			Key:      fmt.Sprintf("%s@%s:%s", systemName, versionName, want.Key),
+			OldValue: oldVal,
+			NewValue: newVal,
+			Note:     "default_value drift on existing parameter_config; preserved manual override (re-edit data.yaml or fix DB by hand)",
+			Applied:  false,
+		})
+		logrus.Warnf("reseed %s@%s: parameter_configs key=%s default_value drift: db=%q seed=%q (preserved DB)",
+			systemName, versionName, want.Key, oldVal, newVal)
+	}
+	return nil
+}
+
+func defaultValuesEqual(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// pruneHelmConfigValues deletes helm_config_values links whose linked
+// parameter_config key is no longer in the seed. parameter_configs rows
+// themselves are NOT deleted because they may still be referenced by other
+// helm_configs (or by env-var join tables).
+func pruneHelmConfigValues(db *gorm.DB, helm *model.HelmConfig, versionName string, seed *InitialHelmConfig, systemName string, dryRun bool, report *ReseedReport) error {
+	if helm == nil || helm.ID == 0 {
+		return nil
+	}
+	wanted := make(map[string]struct{}, len(seed.Values))
+	for _, v := range seed.Values {
+		cfg := v.ConvertToDBParameterConfig()
+		wanted[parameterConfigIdentity(cfg)] = struct{}{}
+	}
+
+	var existing []model.ParameterConfig
+	if err := db.Table("parameter_configs").
+		Joins("JOIN helm_config_values ON helm_config_values.parameter_config_id = parameter_configs.id").
+		Where("helm_config_values.helm_config_id = ? AND parameter_configs.category = ?", helm.ID, consts.ParameterCategoryHelmValues).
+		Find(&existing).Error; err != nil {
+		return fmt.Errorf("list helm values for prune %s@%s: %w", systemName, versionName, err)
+	}
+
+	for i := range existing {
+		cfg := &existing[i]
+		key := parameterConfigIdentity(cfg)
+		if _, ok := wanted[key]; ok {
+			continue
+		}
+		oldVal := "<nil>"
+		if cfg.DefaultValue != nil {
+			oldVal = *cfg.DefaultValue
+		}
+		act := ReseedAction{
+			Layer:    "helm_config_values",
+			System:   systemName,
+			Key:      fmt.Sprintf("%s@%s:%s", systemName, versionName, cfg.Key),
+			OldValue: oldVal,
+			NewValue: "",
+			Note:     "prune: key disappeared from data.yaml seed",
+		}
+		if dryRun {
+			report.Actions = append(report.Actions, act)
+			continue
+		}
+		if err := db.
+			Where("helm_config_id = ? AND parameter_config_id = ?", helm.ID, cfg.ID).
+			Delete(&model.HelmConfigValue{}).Error; err != nil {
+			return fmt.Errorf("delete helm_config_values link helm=%d param=%d: %w", helm.ID, cfg.ID, err)
+		}
+		act.Applied = true
+		report.Actions = append(report.Actions, act)
+		logrus.Infof("reseed %s@%s: pruned helm_config_values link key=%s (helm_config_id=%d param=%d)",
+			systemName, versionName, cfg.Key, helm.ID, cfg.ID)
+	}
+	return nil
+}
+
 // ResolveSeedPath turns a (basePath, env) pair into the absolute data.yaml
 // path. Both inputs may include the `data.yaml` filename or not. Used by the
 // HTTP handler so CLI and HTTP paths agree on filesystem semantics.

--- a/AegisLab/src/service/initialization/reseed_test.go
+++ b/AegisLab/src/service/initialization/reseed_test.go
@@ -671,3 +671,333 @@ dynamic_configs:
 		t.Fatalf("hr row mutated despite --name=ts filter: %q", hr.DefaultValue)
 	}
 }
+
+// TestReseedHelmConfigForVersionUpsertsChartFields covers the issue #201
+// path: a data.yaml chart-level bump on the SAME container_version_id is
+// applied in place. New parameter_configs + helm_config_values are added.
+// This is what the byte-cluster operator was forced to do via raw SQL.
+func TestReseedHelmConfigForVersionUpsertsChartFields(t *testing.T) {
+	db := newReseedTestDB(t)
+	if err := db.Exec(`INSERT INTO containers (id, name, type, status) VALUES (1, 'tea', 2, 1)`).Error; err != nil {
+		t.Fatalf("seed container: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (62, '0.1.1', 1, 0, 1)`).Error; err != nil {
+		t.Fatalf("seed version: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (90, 'teastore', '0.1.1', 62, 'https://lgu-se-internal.github.io/TeaStore', 'lgu-tea')`).Error; err != nil {
+		t.Fatalf("seed helm: %v", err)
+	}
+
+	seed := writeSeedFile(t, `
+containers:
+  - type: 2
+    name: tea
+    is_public: true
+    status: 1
+    versions:
+      - name: 0.1.1
+        helm_config:
+          version: 0.1.2
+          chart_name: teastore
+          repo_name: lgu-tea
+          repo_url: https://lgu-se-internal.github.io/TeaStore
+          values:
+            - key: jmeter.waitForRegistryImage.registry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            - key: jmeter.waitForRegistryImage.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: busybox
+              overridable: true
+            - key: jmeter.waitForRegistryImage.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "1.36"
+              overridable: true
+            - key: jmeter.waitForRegistryImage.pullPolicy
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: IfNotPresent
+              overridable: true
+`)
+
+	// Dry-run first.
+	dry, err := ReseedHelmConfigForVersion(context.Background(), db, ReseedHelmConfigForVersionRequest{
+		DataPath:           seed,
+		ContainerVersionID: 62,
+		DryRun:             true,
+	})
+	if err != nil {
+		t.Fatalf("dry-run reseed: %v", err)
+	}
+	if !dry.DryRun {
+		t.Fatalf("dry-run flag lost: %+v", dry)
+	}
+	if len(dry.Actions) == 0 {
+		t.Fatalf("expected planned actions for dry-run, got none")
+	}
+	for _, a := range dry.Actions {
+		if a.Applied {
+			t.Fatalf("dry-run produced applied action: %+v", a)
+		}
+	}
+	// DB should be untouched after dry-run.
+	var stillOld struct{ Version string }
+	db.Raw(`SELECT version FROM helm_configs WHERE id = 90`).Scan(&stillOld)
+	if stillOld.Version != "0.1.1" {
+		t.Fatalf("dry-run mutated DB version: %q", stillOld.Version)
+	}
+
+	// Apply.
+	report, err := ReseedHelmConfigForVersion(context.Background(), db, ReseedHelmConfigForVersionRequest{
+		DataPath:           seed,
+		ContainerVersionID: 62,
+	})
+	if err != nil {
+		t.Fatalf("apply reseed: %v", err)
+	}
+
+	// helm_configs.version is bumped.
+	var got struct {
+		ChartName string
+		Version   string
+	}
+	db.Raw(`SELECT chart_name, version FROM helm_configs WHERE id = 90`).Scan(&got)
+	if got.Version != "0.1.2" {
+		t.Fatalf("version not bumped: %+v", got)
+	}
+
+	// All 4 jmeter values are linked.
+	var linked []struct{ Key string }
+	if err := db.Raw(`
+		SELECT pc.config_key AS key
+		FROM parameter_configs pc
+		JOIN helm_config_values hcv ON hcv.parameter_config_id = pc.id
+		WHERE hcv.helm_config_id = 90
+		ORDER BY pc.config_key
+	`).Scan(&linked).Error; err != nil {
+		t.Fatalf("list linked: %v", err)
+	}
+	if len(linked) != 4 {
+		t.Fatalf("expected 4 linked values, got %d (%+v)", len(linked), linked)
+	}
+	if linked[0].Key != "jmeter.waitForRegistryImage.pullPolicy" {
+		t.Fatalf("unexpected first key: %s", linked[0].Key)
+	}
+
+	// At least one applied helm_configs action.
+	driftApplied := false
+	for _, a := range report.Actions {
+		if a.Layer == "helm_configs" && a.Applied && a.Note != "" {
+			driftApplied = true
+		}
+	}
+	if !driftApplied {
+		t.Fatalf("expected applied helm_configs drift action, got %+v", report.Actions)
+	}
+
+	// Idempotence.
+	r2, err := ReseedHelmConfigForVersion(context.Background(), db, ReseedHelmConfigForVersionRequest{
+		DataPath:           seed,
+		ContainerVersionID: 62,
+	})
+	if err != nil {
+		t.Fatalf("second reseed: %v", err)
+	}
+	if len(r2.Actions) != 0 {
+		t.Fatalf("expected idempotent rerun, got %+v", r2.Actions)
+	}
+}
+
+// TestReseedHelmConfigForVersionPreservesDefaultValueDrift pins the
+// constraint from issue #201: when the seed default differs from an
+// existing parameter_configs.default_value, NEVER overwrite — log + report.
+func TestReseedHelmConfigForVersionPreservesDefaultValueDrift(t *testing.T) {
+	db := newReseedTestDB(t)
+	_ = db.Exec(`INSERT INTO containers (id, name, type, status) VALUES (1, 'tea', 2, 1)`).Error
+	_ = db.Exec(`INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (62, '0.1.2', 1, 0, 1)`).Error
+	_ = db.Exec(`INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (90, 'teastore', '0.1.2', 62, 'https://x', 'lgu-tea')`).Error
+
+	manuallyEdited := "operator-mirrored.example.com/busybox"
+	cfg := &model.ParameterConfig{
+		Key:          "jmeter.waitForRegistryImage.repository",
+		Type:         consts.ParameterTypeFixed,
+		Category:     consts.ParameterCategoryHelmValues,
+		ValueType:    consts.ValueDataTypeString,
+		DefaultValue: &manuallyEdited,
+		Required:     false,
+		Overridable:  true,
+	}
+	if err := db.Create(cfg).Error; err != nil {
+		t.Fatalf("seed pre-existing param: %v", err)
+	}
+	if err := db.Create(&model.HelmConfigValue{HelmConfigID: 90, ParameterConfigID: cfg.ID}).Error; err != nil {
+		t.Fatalf("link pre-existing value: %v", err)
+	}
+
+	seed := writeSeedFile(t, `
+containers:
+  - type: 2
+    name: tea
+    is_public: true
+    status: 1
+    versions:
+      - name: 0.1.2
+        helm_config:
+          version: 0.1.2
+          chart_name: teastore
+          repo_name: lgu-tea
+          repo_url: https://x
+          values:
+            - key: jmeter.waitForRegistryImage.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: busybox
+              overridable: true
+`)
+
+	report, err := ReseedHelmConfigForVersion(context.Background(), db, ReseedHelmConfigForVersionRequest{
+		DataPath:           seed,
+		ContainerVersionID: 62,
+	})
+	if err != nil {
+		t.Fatalf("reseed: %v", err)
+	}
+
+	// DB is unchanged: the manually-edited default_value wins.
+	var got model.ParameterConfig
+	if err := db.Where("config_key = ? AND category = ?", "jmeter.waitForRegistryImage.repository", consts.ParameterCategoryHelmValues).First(&got).Error; err != nil {
+		t.Fatalf("look up param: %v", err)
+	}
+	if got.DefaultValue == nil || *got.DefaultValue != manuallyEdited {
+		t.Fatalf("default_value clobbered: got=%v want=%q", got.DefaultValue, manuallyEdited)
+	}
+
+	// And the report surfaces a preserved-drift action with Applied=false.
+	preserved := false
+	for _, a := range report.Actions {
+		if a.Layer == "parameter_configs" && a.Key == "tea@0.1.2:jmeter.waitForRegistryImage.repository" && !a.Applied {
+			preserved = true
+		}
+	}
+	if !preserved {
+		t.Fatalf("expected preserved-drift action, got %+v", report.Actions)
+	}
+}
+
+// TestReseedHelmConfigForVersionPruneDeletesMissingLinks verifies that
+// --prune removes helm_config_values links for keys that disappeared from
+// the seed YAML. The parameter_configs row is intentionally NOT deleted.
+func TestReseedHelmConfigForVersionPruneDeletesMissingLinks(t *testing.T) {
+	db := newReseedTestDB(t)
+	_ = db.Exec(`INSERT INTO containers (id, name, type, status) VALUES (1, 'tea', 2, 1)`).Error
+	_ = db.Exec(`INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (62, '0.1.2', 1, 0, 1)`).Error
+	_ = db.Exec(`INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (90, 'teastore', '0.1.2', 62, 'https://x', 'lgu-tea')`).Error
+
+	staleVal := "deprecated"
+	stale := &model.ParameterConfig{
+		Key:          "stale.removed.key",
+		Type:         consts.ParameterTypeFixed,
+		Category:     consts.ParameterCategoryHelmValues,
+		ValueType:    consts.ValueDataTypeString,
+		DefaultValue: &staleVal,
+		Overridable:  true,
+	}
+	if err := db.Create(stale).Error; err != nil {
+		t.Fatalf("seed stale param: %v", err)
+	}
+	if err := db.Create(&model.HelmConfigValue{HelmConfigID: 90, ParameterConfigID: stale.ID}).Error; err != nil {
+		t.Fatalf("link stale: %v", err)
+	}
+
+	seed := writeSeedFile(t, `
+containers:
+  - type: 2
+    name: tea
+    is_public: true
+    status: 1
+    versions:
+      - name: 0.1.2
+        helm_config:
+          version: 0.1.2
+          chart_name: teastore
+          repo_name: lgu-tea
+          repo_url: https://x
+          values:
+            - key: kept.key
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: alive
+              overridable: true
+`)
+
+	// Without --prune, stale link survives.
+	if _, err := ReseedHelmConfigForVersion(context.Background(), db, ReseedHelmConfigForVersionRequest{
+		DataPath:           seed,
+		ContainerVersionID: 62,
+	}); err != nil {
+		t.Fatalf("reseed (no prune): %v", err)
+	}
+	var stillLinked int64
+	db.Raw(`SELECT COUNT(*) FROM helm_config_values WHERE helm_config_id = 90 AND parameter_config_id = ?`, stale.ID).Scan(&stillLinked)
+	if stillLinked != 1 {
+		t.Fatalf("stale link removed without --prune: count=%d", stillLinked)
+	}
+
+	// With --prune, the stale link is gone.
+	report, err := ReseedHelmConfigForVersion(context.Background(), db, ReseedHelmConfigForVersionRequest{
+		DataPath:           seed,
+		ContainerVersionID: 62,
+		Prune:              true,
+	})
+	if err != nil {
+		t.Fatalf("reseed (prune): %v", err)
+	}
+	var afterPrune int64
+	db.Raw(`SELECT COUNT(*) FROM helm_config_values WHERE helm_config_id = 90 AND parameter_config_id = ?`, stale.ID).Scan(&afterPrune)
+	if afterPrune != 0 {
+		t.Fatalf("stale link still present after --prune: count=%d", afterPrune)
+	}
+
+	// parameter_configs row itself stays — it might be referenced elsewhere.
+	var paramStill int64
+	db.Raw(`SELECT COUNT(*) FROM parameter_configs WHERE id = ?`, stale.ID).Scan(&paramStill)
+	if paramStill != 1 {
+		t.Fatalf("parameter_configs row deleted by prune; should be left alone (count=%d)", paramStill)
+	}
+
+	pruneApplied := false
+	for _, a := range report.Actions {
+		if a.Layer == "helm_config_values" && a.Note != "" && a.Applied && a.Key == "tea@0.1.2:stale.removed.key" {
+			pruneApplied = true
+		}
+	}
+	if !pruneApplied {
+		t.Fatalf("expected applied prune action, got %+v", report.Actions)
+	}
+}
+
+// TestReseedHelmConfigForVersionMissingVersion verifies the not-found path:
+// an unknown container_version_id surfaces gorm.ErrRecordNotFound so the
+// HTTP handler can map it to 404.
+func TestReseedHelmConfigForVersionMissingVersion(t *testing.T) {
+	db := newReseedTestDB(t)
+	seed := writeSeedFile(t, `containers: []
+`)
+	_, err := ReseedHelmConfigForVersion(context.Background(), db, ReseedHelmConfigForVersionRequest{
+		DataPath:           seed,
+		ContainerVersionID: 9999,
+	})
+	if err == nil {
+		t.Fatalf("expected error for missing version_id, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #201.

Adds a targeted hot-reseed path keyed by `container_version_id` so a `data.yaml` chart bump (with new overridable values) can be propagated to a running cluster without raw SQL — the gap that forced the byte-cluster operator to `UPDATE helm_configs SET version='0.1.2' ... INSERT INTO parameter_configs ... INSERT INTO helm_config_values ...` by hand after PR #200.

The existing `aegisctl system reseed` was deliberately history-preserving (never `UPDATE`s an existing `(container_id, version_name)` row). The new `aegisctl pedestal helm reseed` complements it with an in-place chart upsert + values reconcile scoped to one container_version, so operators can fix the byte-cluster's broken teastore loadgen without breaking the seed history contract for everyone else.

## Surface

- `POST /api/v2/pedestal/helm/{container_version_id}/reseed` (admin, behind the same `RequireContainerVersionUpload` guard as `PUT`)
- `aegisctl pedestal helm reseed --container-version-id N [--apply] [--prune] [--env staging|prod] [--data-path PATH]`

```
$ aegisctl pedestal helm reseed --container-version-id 62
# dry-run: prints planned actions, doesn't write

$ aegisctl pedestal helm reseed --container-version-id 62 --apply
# commits

$ aegisctl pedestal helm reseed --container-version-id 62 --apply --prune
# also drops helm_config_values links that disappeared from the seed
```

## Conflict semantics (per the issue's constraints)

- `helm_configs` row is upserted in place: `chart_name / version / repo_url / repo_name` follow the seed. Backend logs the drift line and the report carries the before/after.
- Missing `parameter_configs` rows are inserted, deduped by `(config_key, type, category)`.
- **Existing `parameter_configs.default_value` is NEVER overwritten** when the seed differs — the drift is logged and surfaced as a skipped (`Applied=false`) action so manually-edited overrides stay protected. Operators who want to clobber must edit the row directly.
- New `helm_config_values` links are added.
- `--prune` removes `helm_config_values` links whose key disappeared from the seed; the `parameter_configs` row itself is left intact (it may still be referenced by other `helm_configs`).
- Defaults to dry-run; `--apply` commits. Idempotent — a second invocation against an unchanged seed yields zero applied actions.

## Tests

All four new tests run against the existing in-memory sqlite harness in `service/initialization/reseed_test.go`:

- `TestReseedHelmConfigForVersionUpsertsChartFields` — bumps `version` 0.1.1 -> 0.1.2 in place on the same row, inserts 4 new `jmeter.waitForRegistryImage.*` values, and pins idempotence on a rerun.
- `TestReseedHelmConfigForVersionPreservesDefaultValueDrift` — pre-loads a manually-edited `default_value`, runs reseed against a seed with a different default, asserts DB is untouched and drift surfaces as `Applied=false`.
- `TestReseedHelmConfigForVersionPruneDeletesMissingLinks` — links a stale param to the helm_config, runs reseed without `--prune` (link survives) then with `--prune` (link gone, `parameter_configs` row intact).
- `TestReseedHelmConfigForVersionMissingVersion` — unknown `container_version_id` surfaces `gorm.ErrRecordNotFound` so the handler can map to 404.

```bash
$ go test -tags duckdb_arrow -run TestReseedHelmConfigForVersion ./service/initialization/...
ok  	aegis/service/initialization	0.077s
```

`go build -tags duckdb_arrow ./main.go` and `go build ./cmd/aegisctl` both clean. No new lint findings in changed code.

## Test plan (post-merge, requires live cluster)

- [ ] Reseed staging's teastore: `aegisctl pedestal helm reseed --container-version-id <id> --apply --env staging`. Confirm `helm_configs.version = 0.1.2` and 4 new `jmeter.waitForRegistryImage.*` rows in `parameter_configs` linked via `helm_config_values`.
- [ ] Re-run the same command — expect zero applied actions (idempotence).
- [ ] Allocate a new teastore namespace; jmeter loadgen Job should pull `busybox:1.36` from the configured registry rather than ImagePullBackOff.
- [ ] On byte-cluster (the one originally hit by #201), reseed with `--env byte-cluster` if the data path is wired that way (else `--data-path`); verify the volces mirror lands in the value rows.
- [ ] Manually edit one `parameter_configs.default_value` post-reseed, re-run reseed, confirm drift is surfaced as preserved (not clobbered).

## Follow-ups (out of scope)

- Auto-trigger reseed on backend boot when the seed file mtime advances.
- Extend the per-version path to env_vars + non-pedestal container types.
- Emit a structured audit event so reseed touches show up in the activity feed.

Closes #201