### PR TITLE
feat(restart-pedestal): clean up stale chaos-mesh CRDs in target namespace before helm restart

### DIFF
--- a/AegisLab/src/infra/k8s/chaos_cleanup.go
+++ b/AegisLab/src/infra/k8s/chaos_cleanup.go
@@ -1,0 +1,250 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+)
+
+// ChaosMeshAPIGroup is the API group owning every chaos resource we care
+// about (HTTPChaos, NetworkChaos, PodHttpChaos, …). Used as the scope filter
+// when stripping finalizers — we must NEVER patch a resource outside this
+// group.
+const ChaosMeshAPIGroup = "chaos-mesh.org"
+
+// chaosResourceLister abstracts the discovery surface so unit tests can stub
+// the namespaced GVR list without standing up an apiserver.
+type chaosResourceLister interface {
+	NamespacedChaosGVRs(ctx context.Context) ([]schema.GroupVersionResource, error)
+}
+
+// discoveryChaosLister discovers namespaced chaos-mesh.org resources via the
+// kube discovery API. Subresources (containing "/" in Name) and cluster-
+// scoped kinds (Schedule/Workflow/RemoteCluster as of v2.7) are skipped.
+type discoveryChaosLister struct {
+	client discovery.DiscoveryInterface
+}
+
+func (d *discoveryChaosLister) NamespacedChaosGVRs(ctx context.Context) ([]schema.GroupVersionResource, error) {
+	if d == nil || d.client == nil {
+		return nil, fmt.Errorf("discovery client not available")
+	}
+	groups, err := d.client.ServerGroups()
+	if err != nil {
+		return nil, fmt.Errorf("list api groups: %w", err)
+	}
+
+	var versions []string
+	for i := range groups.Groups {
+		g := groups.Groups[i]
+		if g.Name != ChaosMeshAPIGroup {
+			continue
+		}
+		for _, v := range g.Versions {
+			versions = append(versions, v.GroupVersion)
+		}
+	}
+	if len(versions) == 0 {
+		return nil, nil
+	}
+
+	seen := make(map[schema.GroupVersionResource]struct{})
+	var out []schema.GroupVersionResource
+	for _, gv := range versions {
+		parsed, perr := schema.ParseGroupVersion(gv)
+		if perr != nil {
+			continue
+		}
+		rl, err := d.client.ServerResourcesForGroupVersion(gv)
+		if err != nil {
+			// One bad version shouldn't bring the whole cleanup down — chaos
+			// CRDs are sometimes mid-rollout when discovery races install.
+			logrus.WithError(err).Warnf("chaos-cleanup: discovery for %s failed; skipping", gv)
+			continue
+		}
+		for _, r := range rl.APIResources {
+			if !r.Namespaced {
+				continue
+			}
+			// Skip subresources like "httpchaos/status" — those are not
+			// directly listable/deletable through the dynamic client.
+			if strings.Contains(r.Name, "/") {
+				continue
+			}
+			if !verbsContain(r.Verbs, "list") || !verbsContain(r.Verbs, "delete") {
+				continue
+			}
+			gvr := schema.GroupVersionResource{
+				Group:    parsed.Group,
+				Version:  parsed.Version,
+				Resource: r.Name,
+			}
+			if _, ok := seen[gvr]; ok {
+				continue
+			}
+			seen[gvr] = struct{}{}
+			out = append(out, gvr)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Resource < out[j].Resource })
+	return out, nil
+}
+
+func verbsContain(verbs metav1.Verbs, target string) bool {
+	for _, v := range verbs {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}
+
+// CleanupNamespaceChaosResources reaps every chaos-mesh.org namespaced CR
+// that lives in `namespace`. For each instance: finalizers are merge-patched
+// to [] (so a stuck reconciler can never block deletion) and the object is
+// then force-deleted with GracePeriodSeconds=0.
+//
+// This is the namespace-scoped pre-helm cleanup invoked from RestartPedestal:
+// any zombie HTTPChaos / PodHttpChaos / etc. left behind by an earlier round
+// would otherwise re-attach to (or interfere with) freshly-created pods. The
+// implementation is deliberately scoped to the chaos-mesh.org API group so
+// that no other CRD's finalizers are ever touched.
+//
+// Returns a per-resource reap count and a (possibly empty) slice of warnings
+// — callers should treat warnings as best-effort: chaos-CR cleanup MUST NOT
+// block helm restart.
+func CleanupNamespaceChaosResources(ctx context.Context, namespace string) (map[string]int, []error) {
+	client, err := getK8sClient()
+	if err != nil {
+		return nil, []error{k8sClientNotAvailableErr(err)}
+	}
+	dyn, err := getK8sDynamicClient()
+	if err != nil {
+		return nil, []error{fmt.Errorf("kubernetes dynamic client not available: %w", err)}
+	}
+	return cleanupNamespaceChaosResourcesWith(ctx, &discoveryChaosLister{client: client.Discovery()}, dyn, namespace)
+}
+
+// cleanupNamespaceChaosResourcesWith is the test-injectable core. The lister
+// and dynamic client come in as parameters so tests can drive the logic
+// against an in-memory fake; the production path wires them from the lazy
+// gateway state.
+func cleanupNamespaceChaosResourcesWith(
+	ctx context.Context,
+	lister chaosResourceLister,
+	dyn dynamic.Interface,
+	namespace string,
+) (map[string]int, []error) {
+	if namespace == "" {
+		return nil, []error{fmt.Errorf("namespace must be non-empty")}
+	}
+	if lister == nil || dyn == nil {
+		return nil, []error{fmt.Errorf("chaos cleanup misconfigured: lister or dynamic client nil")}
+	}
+
+	gvrs, err := lister.NamespacedChaosGVRs(ctx)
+	if err != nil {
+		return nil, []error{fmt.Errorf("discover chaos-mesh CRDs: %w", err)}
+	}
+	if len(gvrs) == 0 {
+		// chaos-mesh not installed (or not yet discovered) — nothing to do.
+		return map[string]int{}, nil
+	}
+
+	summary := make(map[string]int, len(gvrs))
+	var warnings []error
+	for _, gvr := range gvrs {
+		// Defense-in-depth: refuse to touch anything outside chaos-mesh.org.
+		if gvr.Group != ChaosMeshAPIGroup {
+			warnings = append(warnings, fmt.Errorf("refusing to clean non-chaos GVR %s", gvr.String()))
+			continue
+		}
+
+		list, err := dyn.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
+			warnings = append(warnings, fmt.Errorf("list %s in %s: %w", gvr.Resource, namespace, err))
+			continue
+		}
+
+		for idx := range list.Items {
+			item := list.Items[idx]
+			if err := stripFinalizersAndDelete(ctx, dyn, gvr, namespace, item.GetName(), item.GetFinalizers()); err != nil {
+				warnings = append(warnings, fmt.Errorf("clean %s/%s/%s: %w", gvr.Resource, namespace, item.GetName(), err))
+				continue
+			}
+			summary[gvr.Resource]++
+		}
+	}
+	return summary, warnings
+}
+
+// stripFinalizersAndDelete patches finalizers to [] (only when non-empty —
+// avoids unnecessary writes against a healthy CR) and then issues a
+// foreground-propagation Delete with GracePeriodSeconds=0. Both calls
+// tolerate NotFound so concurrent reconciler-driven deletion is harmless.
+func stripFinalizersAndDelete(
+	ctx context.Context,
+	dyn dynamic.Interface,
+	gvr schema.GroupVersionResource,
+	namespace, name string,
+	existingFinalizers []string,
+) error {
+	if gvr.Group != ChaosMeshAPIGroup {
+		return fmt.Errorf("stripFinalizersAndDelete: refusing GVR outside %s: %s", ChaosMeshAPIGroup, gvr.String())
+	}
+
+	if len(existingFinalizers) > 0 {
+		_, err := dyn.Resource(gvr).Namespace(namespace).Patch(
+			ctx,
+			name,
+			types.MergePatchType,
+			[]byte(`{"metadata":{"finalizers":[]}}`),
+			metav1.PatchOptions{},
+		)
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("strip finalizers: %w", err)
+		}
+	}
+
+	zero := int64(0)
+	prop := metav1.DeletePropagationForeground
+	delErr := dyn.Resource(gvr).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{
+		GracePeriodSeconds: &zero,
+		PropagationPolicy:  &prop,
+	})
+	if delErr != nil && !k8serrors.IsNotFound(delErr) {
+		return fmt.Errorf("delete: %w", delErr)
+	}
+	return nil
+}
+
+// SummarizeChaosCleanup renders a single-line, alphabetised description of
+// what was reaped, suitable for a logrus.Info call. Empty summary returns
+// the empty string so the caller can short-circuit logging.
+func SummarizeChaosCleanup(summary map[string]int) string {
+	if len(summary) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(summary))
+	for k := range summary {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%d %s", summary[k], k))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/AegisLab/src/infra/k8s/chaos_cleanup_test.go
+++ b/AegisLab/src/infra/k8s/chaos_cleanup_test.go
@@ -1,0 +1,259 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// stubLister returns a fixed list of namespaced chaos GVRs and pretends the
+// discovery surface is healthy. Lets the test exercise the
+// list/strip-finalizers/delete loop without an apiserver.
+type stubLister struct {
+	gvrs []schema.GroupVersionResource
+	err  error
+}
+
+func (s *stubLister) NamespacedChaosGVRs(ctx context.Context) ([]schema.GroupVersionResource, error) {
+	return s.gvrs, s.err
+}
+
+func chaosGVR(resource string) schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    ChaosMeshAPIGroup,
+		Version:  "v1alpha1",
+		Resource: resource,
+	}
+}
+
+func newChaosCR(resource, namespace, name string, finalizers []string) *unstructured.Unstructured {
+	// Map dynamic-resource plural to a Kind suitable for the fake registry.
+	kindByResource := map[string]string{
+		"httpchaos":      "HTTPChaos",
+		"networkchaos":   "NetworkChaos",
+		"podchaos":       "PodChaos",
+		"podhttpchaos":   "PodHttpChaos",
+		"jvmchaos":       "JVMChaos",
+		"stresschaos":    "StressChaos",
+		"timechaos":      "TimeChaos",
+		"iochaos":        "IOChaos",
+		"podiochaos":     "PodIOChaos",
+		"podnetworkchaos": "PodNetworkChaos",
+		"dnschaos":       "DNSChaos",
+		"blockchaos":     "BlockChaos",
+	}
+	kind := kindByResource[resource]
+	if kind == "" {
+		kind = "Generic"
+	}
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   ChaosMeshAPIGroup,
+		Version: "v1alpha1",
+		Kind:    kind,
+	})
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	if len(finalizers) > 0 {
+		u.SetFinalizers(finalizers)
+	}
+	return u
+}
+
+// chaosResourceKinds is the resource→kind mapping the tests need. Chaos-mesh
+// plurals like `httpchaos` are already plural, so we cannot rely on the
+// fake client's `UnsafeGuessKindToResource` heuristic (which would store
+// items under `httpchaoses`).
+var chaosResourceKinds = []struct {
+	Resource string
+	Kind     string
+}{
+	{"httpchaos", "HTTPChaos"},
+	{"networkchaos", "NetworkChaos"},
+	{"podchaos", "PodChaos"},
+	{"podhttpchaos", "PodHttpChaos"},
+	{"jvmchaos", "JVMChaos"},
+	{"stresschaos", "StressChaos"},
+	{"timechaos", "TimeChaos"},
+	{"iochaos", "IOChaos"},
+	{"podiochaos", "PodIOChaos"},
+	{"podnetworkchaos", "PodNetworkChaos"},
+	{"dnschaos", "DNSChaos"},
+	{"blockchaos", "BlockChaos"},
+}
+
+// newFakeDynamicClient builds a fake dynamic client whose object tracker
+// stores `objs` under the *exact* chaos GVRs (e.g. `httpchaos`, not
+// `httpchaoses`). Items are inserted via Create against an explicit GVR
+// rather than the constructor's seeding path so the tracker doesn't
+// auto-pluralise.
+func newFakeDynamicClient(t *testing.T, objs ...*unstructured.Unstructured) dynamic.Interface {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	listKinds := make(map[schema.GroupVersionResource]string, len(chaosResourceKinds))
+	for _, r := range chaosResourceKinds {
+		gvk := schema.GroupVersionKind{Group: ChaosMeshAPIGroup, Version: "v1alpha1", Kind: r.Kind}
+		scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		listGVK := gvk
+		listGVK.Kind += "List"
+		scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+		listKinds[chaosGVR(r.Resource)] = r.Kind + "List"
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	for _, obj := range objs {
+		gvk := obj.GroupVersionKind()
+		// Find the matching plural for this kind from our static table.
+		var resource string
+		for _, r := range chaosResourceKinds {
+			if r.Kind == gvk.Kind {
+				resource = r.Resource
+				break
+			}
+		}
+		if resource == "" {
+			t.Fatalf("test fixture has unknown chaos kind %s; add it to chaosResourceKinds", gvk.Kind)
+		}
+		gvr := chaosGVR(resource)
+		if _, err := dyn.Resource(gvr).Namespace(obj.GetNamespace()).Create(context.Background(), obj, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("seed fake dynamic client: %v", err)
+		}
+	}
+	return dyn
+}
+
+func TestCleanupNamespaceChaosResources_ReapsZombiesAndStripsFinalizers(t *testing.T) {
+	ctx := context.Background()
+
+	zombieFinalizers := []string{"chaos-mesh/finalizers"}
+	objs := []*unstructured.Unstructured{
+		// otel-demo1 zombies (analogous to the byte-cluster evidence).
+		newChaosCR("httpchaos", "otel-demo1", "stuck-http-1", zombieFinalizers),
+		newChaosCR("httpchaos", "otel-demo1", "stuck-http-2", zombieFinalizers),
+		newChaosCR("podhttpchaos", "otel-demo1", "intermediate-1", zombieFinalizers),
+		// Different namespace — must NOT be touched by an otel-demo1 cleanup.
+		newChaosCR("httpchaos", "ts0", "another-stuck", zombieFinalizers),
+	}
+
+	dyn := newFakeDynamicClient(t, objs...)
+	lister := &stubLister{gvrs: []schema.GroupVersionResource{
+		chaosGVR("httpchaos"),
+		chaosGVR("networkchaos"),
+		chaosGVR("podhttpchaos"),
+	}}
+
+	summary, warnings := cleanupNamespaceChaosResourcesWith(ctx, lister, dyn, "otel-demo1")
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+
+	if got := summary["httpchaos"]; got != 2 {
+		t.Errorf("httpchaos reap count: got %d, want 2", got)
+	}
+	if got := summary["podhttpchaos"]; got != 1 {
+		t.Errorf("podhttpchaos reap count: got %d, want 1", got)
+	}
+	// `networkchaos` was discovered but had no instances — by design the
+	// summary omits zero-reap entries to keep the production log line short.
+	if _, present := summary["networkchaos"]; present {
+		t.Errorf("networkchaos should be absent from summary (no zombies), got %v", summary)
+	}
+
+	// Verify cross-namespace scoping: ts0's CR survives.
+	survivor, err := dyn.Resource(chaosGVR("httpchaos")).Namespace("ts0").Get(ctx, "another-stuck", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("ts0 zombie got reaped by otel-demo1 cleanup: %v", err)
+	}
+	if survivor.GetName() != "another-stuck" {
+		t.Fatalf("unexpected survivor: %v", survivor)
+	}
+
+	// And verify the otel-demo1 zombies are actually gone.
+	gone, err := dyn.Resource(chaosGVR("httpchaos")).Namespace("otel-demo1").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("post-cleanup list otel-demo1 httpchaos: %v", err)
+	}
+	if len(gone.Items) != 0 {
+		t.Errorf("expected 0 surviving httpchaos in otel-demo1, got %d", len(gone.Items))
+	}
+
+	// Summarizer should produce a stable, alphabetised line.
+	line := SummarizeChaosCleanup(summary)
+	want := "2 httpchaos, 1 podhttpchaos"
+	if line != want {
+		t.Errorf("summary line:\n got  %q\n want %q", line, want)
+	}
+
+	// Assert that finalizers were merge-patched to []. Without the patch,
+	// real-cluster deletes would hang on the chaos finalizer; the fake
+	// client doesn't enforce that, so we instead verify the patch action
+	// occurred and was scoped to chaos-mesh.org.
+	fake, ok := dyn.(*dynamicfake.FakeDynamicClient)
+	if !ok {
+		t.Fatalf("dyn is not a FakeDynamicClient: %T", dyn)
+	}
+	patchCount := 0
+	for _, act := range fake.Actions() {
+		patch, ok := act.(clienttesting.PatchAction)
+		if !ok {
+			continue
+		}
+		if patch.GetResource().Group != ChaosMeshAPIGroup {
+			t.Errorf("patch scoped to non-chaos group: %v", patch.GetResource())
+		}
+		if patch.GetNamespace() != "otel-demo1" {
+			t.Errorf("patch hit wrong namespace: %s", patch.GetNamespace())
+		}
+		if got := string(patch.GetPatch()); got != `{"metadata":{"finalizers":[]}}` {
+			t.Errorf("unexpected patch body: %s", got)
+		}
+		patchCount++
+	}
+	if patchCount != 3 {
+		t.Errorf("expected 3 finalizer-strip patches (2 httpchaos + 1 podhttpchaos in otel-demo1), got %d", patchCount)
+	}
+}
+
+func TestCleanupNamespaceChaosResources_RefusesNonChaosGVR(t *testing.T) {
+	ctx := context.Background()
+	dyn := newFakeDynamicClient(t)
+	// A malicious/buggy lister returning a non-chaos-mesh.org GVR must be
+	// rejected with a warning rather than silently patched — the whole
+	// purpose of the group filter is to never strip finalizers off
+	// unrelated CRDs.
+	lister := &stubLister{gvrs: []schema.GroupVersionResource{
+		{Group: "apps", Version: "v1", Resource: "deployments"},
+	}}
+
+	summary, warnings := cleanupNamespaceChaosResourcesWith(ctx, lister, dyn, "otel-demo1")
+	if len(summary) != 0 {
+		t.Errorf("expected empty summary, got %v", summary)
+	}
+	if len(warnings) == 0 {
+		t.Fatalf("expected a refusal warning for non-chaos GVR, got none")
+	}
+}
+
+func TestCleanupNamespaceChaosResources_NoChaosMeshInstalled(t *testing.T) {
+	// chaos-mesh isn't installed — discovery returns an empty GVR list. The
+	// cleanup must be a no-op (empty summary, no warnings, no panic) so
+	// RestartPedestal proceeds normally on clusters without chaos-mesh.
+	ctx := context.Background()
+	dyn := newFakeDynamicClient(t)
+	lister := &stubLister{gvrs: nil}
+
+	summary, warnings := cleanupNamespaceChaosResourcesWith(ctx, lister, dyn, "otel-demo1")
+	if len(summary) != 0 {
+		t.Errorf("expected empty summary, got %v", summary)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+}
+

--- a/AegisLab/src/infra/k8s/gateway.go
+++ b/AegisLab/src/infra/k8s/gateway.go
@@ -101,6 +101,14 @@ func (g *Gateway) DeleteChaosCRDsByLabel(ctx context.Context, labelKey, labelVal
 	return DeleteChaosCRDsByLabel(ctx, chaosGVRs, labelKey, labelValue)
 }
 
+// CleanupNamespaceChaosResources reaps zombie chaos-mesh.org CRs in a single
+// namespace before a helm restart. Best-effort; see
+// CleanupNamespaceChaosResources for semantics. Callers should NOT fail the
+// task on returned warnings — chaos-CR cleanup is advisory.
+func (g *Gateway) CleanupNamespaceChaosResources(ctx context.Context, namespace string) (map[string]int, []error) {
+	return CleanupNamespaceChaosResources(ctx, namespace)
+}
+
 // EnsureNamespace creates the namespace if it doesn't exist. Returns
 // (created, err). Harmless on existing namespaces — AlreadyExists is treated
 // as success. Breaks the submit→restart-pedestal chicken-and-egg: a first-run

--- a/AegisLab/src/service/consumer/restart_pedestal.go
+++ b/AegisLab/src/service/consumer/restart_pedestal.go
@@ -325,6 +325,15 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 			return handleExecutionError(span, logEntry, "missing extra info in pedestal item", fmt.Errorf("missing extra info in pedestal item"))
 		}
 
+		// Best-effort: reap any zombie chaos-mesh.org CRs left behind in this
+		// namespace by an earlier round (e.g. an HTTPChaos whose finalizer
+		// can't complete because PodHttpChaos was never created — common when
+		// the targeted pod was helm-uninstalled before duration expired).
+		// Stripping finalizers + force-delete here gives the next round a
+		// clean slate. Any failure is logged and ignored — chaos-CR cleanup
+		// MUST NOT block the helm restart.
+		reapNamespaceChaosResources(childCtx, deps.K8sGateway, namespace, logEntry)
+
 		// Skip the helm install when the caller has pre-installed the chart
 		// out-of-band (e.g. `aegisctl pedestal chart install` +
 		// wait-for-ready) and the release is already deployed. Namespace
@@ -616,4 +625,22 @@ func installPedestal(ctx context.Context, gateway *helm.Gateway, releaseName str
 
 		return fmt.Errorf("no chart source configured (neither remote nor local)")
 	})
+}
+
+// reapNamespaceChaosResources is the best-effort wrapper around the k8s
+// gateway's namespace-scoped chaos cleanup. Wrapped here (instead of called
+// inline in executeRestartPedestal) so the call site stays readable and so
+// every error path lands on a single Warn — never a task failure.
+func reapNamespaceChaosResources(ctx context.Context, gateway *k8s.Gateway, namespace string, logEntry *logrus.Entry) {
+	if gateway == nil {
+		logEntry.Debugf("k8s gateway nil; skipping chaos-CR cleanup for namespace %q", namespace)
+		return
+	}
+	summary, warnings := gateway.CleanupNamespaceChaosResources(ctx, namespace)
+	if line := k8s.SummarizeChaosCleanup(summary); line != "" {
+		logEntry.Infof("chaos cleanup before helm restart: cleaned %s in %s", line, namespace)
+	}
+	for _, w := range warnings {
+		logEntry.Warnf("chaos cleanup warning in %s: %v", namespace, w)
+	}
 }


### PR DESCRIPTION
## The zombie chaos-mesh CRD problem

When the inject-loop runs many rounds, chaos-mesh CRs (HTTPChaos, NetworkChaos, PodChaos, IOChaos, JVMChaos, StressChaos, DNSChaos, TimeChaos, BlockChaos, plus per-pod intermediates PodHttpChaos / PodIOChaos / PodNetworkChaos) accumulate as zombies in workload namespaces. The dominant case is HTTPChaos:

1. `duration` expires → chaos-controller sets `deletionTimestamp` on the CR.
2. The finalizer can never complete because some prerequisite (e.g. the per-pod `PodHttpChaos`) was never created — common when the targeted pod was helm-uninstalled before duration ended.
3. The CR sits forever in `Terminating`. chaos-controller-manager keeps reconciling it every ~12s and logs `PodHttpChaos … not found` failure events.
4. On the next round, the namespace re-allocation hits interference from old CRs even after pods are recreated.

**Concrete byte-cluster evidence** (taken right before this PR was opened): `kubectl get httpchaos -A` lists live CRs in `otel-demo1`-`otel-demo4`, `sockshop5`-`sockshop6`, `ts0`-`ts3` from rounds run 12+ hours ago. All have `phase: "Not Injected/Wait"`, `injectedCount: 0`, `deletionTimestamp` set, and 100+ failure events. The pods they targeted are long gone (those releases were `helm uninstall`ed).

## What this PR changes

When `RestartPedestal` runs against a namespace, **before invoking helm install/upgrade**, force-delete any chaos-mesh CRs that exist in that namespace. Strip finalizers if needed so deletion actually completes.

### Design

- **Namespace-scoped, not cluster-wide.** Each `RestartPedestal` cleans only its own target namespace.
- **Dynamic discovery** via the discovery API on group `chaos-mesh.org`. No hardcoded GVR list — future chaos-mesh versions adding new chaos types are picked up automatically. We also filter out subresources (`<resource>/status`) and require list+delete verbs.
- **Namespaced only.** Cluster-scoped resources (Workflow / Schedule / RemoteCluster as of v2.7) are skipped — they don't live in workload namespaces.
- **Group-scoped patch.** Finalizers are merge-patched only on `chaos-mesh.org` resources; defense-in-depth check refuses any GVR outside the group.
- **Force delete.** `GracePeriodSeconds=0` + foreground propagation so a stuck reconciler can't block.
- **Best-effort.** Any error during cleanup logs a Warn but does NOT fail the RestartPedestal task. Chaos-CR cleanup is advisory; we'd rather over-aggressively-not-break than block restart.
- **Single-line summary log** per namespace: `chaos cleanup before helm restart: cleaned 2 httpchaos, 1 podhttpchaos in otel-demo1`.

### Where the change lives

- New file `AegisLab/src/infra/k8s/chaos_cleanup.go` holds the discovery + reap logic, behind a small `chaosResourceLister` interface so tests can stub the discovery surface.
- `Gateway.CleanupNamespaceChaosResources` exposes it through the existing K8s gateway plumbing.
- `executeRestartPedestal` calls a thin `reapNamespaceChaosResources` wrapper after `pedestal.Extra` validation and before the `skipInstall` branch, so cleanup runs on both install and skip-install paths. The token-release / lock-release / span-lifecycle deferred logic in `executeRestartPedestal` is unchanged.

### Follow-ups (intentionally not in this PR)

- Cluster-scoped chaos resources (`Schedule`, `Workflow`) are skipped on purpose because they don't sit in workload namespaces. If those start zombieing too, a separate cluster-scoped sweep can be added later.
- No metrics yet — if zombie volume becomes worth tracking we should add a Prom counter per CRD kind.

## Test plan

- [x] `cd src && go build -tags duckdb_arrow ./main.go` — passes
- [x] `cd src && go build ./cmd/aegisctl` — passes
- [x] `cd src && go test ./infra/k8s/... ./service/consumer/...` — passes (3 new unit tests)
- [x] `cd src && golangci-lint run ./infra/k8s/...` — 0 issues
- [ ] Smoke-validate against the byte-cluster: trigger RestartPedestal on `otel-demo1` and confirm the pre-existing zombie HTTPChaos is reaped before the new helm install runs.
- [ ] Watch a multi-round inject-loop and confirm zombie count stays at 0 between rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)