### PR TITLE
feat(restart-pedestal): split helm install into apply + async readiness probe (fixes DSB cold-start timeouts)

### DIFF
--- a/AegisLab/src/app/runtime_stack.go
+++ b/AegisLab/src/app/runtime_stack.go
@@ -35,6 +35,7 @@ func RuntimeWorkerStackOptions() fx.Option {
 		fx.Provide(
 			consumer.NewMonitor,
 			fx.Annotate(consumer.NewRestartPedestalRateLimiter, fx.ResultTags(`name:"restart_limiter"`)),
+			fx.Annotate(consumer.NewNamespaceWarmingRateLimiter, fx.ResultTags(`name:"warming_limiter"`)),
 			fx.Annotate(consumer.NewBuildContainerRateLimiter, fx.ResultTags(`name:"build_limiter"`)),
 			fx.Annotate(consumer.NewAlgoExecutionRateLimiter, fx.ResultTags(`name:"algo_limiter"`)),
 			consumer.NewFaultBatchManager,

--- a/AegisLab/src/config/chaos_system.go
+++ b/AegisLab/src/config/chaos_system.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"regexp"
+	"time"
 
 	"aegis/consts"
 
@@ -12,6 +13,13 @@ import (
 
 const (
 	ConfigKeyChaosSystem = "injection.system"
+	// DefaultReadinessTimeoutSeconds is applied when the per-system override
+	// (`injection.system.<sys>.readiness_timeout_seconds`) is unset or
+	// non-positive. 900s = 15 min; long enough for the larger built-in
+	// systems (sockshop / otel-demo / TrainTicket) to come up on a cold
+	// kind cluster, short enough to fail loudly on a genuinely broken
+	// install.
+	DefaultReadinessTimeoutSeconds = 900
 )
 
 // ChaosSystemConfig is the aggregate of every injection.system.<name>.* key in
@@ -26,6 +34,26 @@ type ChaosSystemConfig struct {
 	AppLabelKey    string            `mapstructure:"app_label_key"`
 	IsBuiltin      bool              `mapstructure:"is_builtin"`
 	Status         consts.StatusType `mapstructure:"status"`
+	// ReadinessTimeoutSeconds caps the post-install workload-readiness probe
+	// in RestartPedestal. DSB systems (HotelReservation, SocialNetwork,
+	// MediaMicroservices, TrainTicket) chain init containers across 20–41
+	// services and routinely need 15–25 min on cold clusters; the previous
+	// hard-coded 5 min Helm wait timed out and tripped restart.pedestal.failed.
+	// Per-system override via etcd key
+	// `injection.system.<sys>.readiness_timeout_seconds`. Zero / unset falls
+	// back to DefaultReadinessTimeoutSeconds (900 = 15 min).
+	ReadinessTimeoutSeconds int `mapstructure:"readiness_timeout_seconds"`
+}
+
+// ReadinessTimeout returns the workload-readiness probe timeout for this
+// system, falling back to DefaultReadinessTimeoutSeconds when the per-system
+// override is unset or non-positive.
+func (s *ChaosSystemConfig) ReadinessTimeout() time.Duration {
+	secs := s.ReadinessTimeoutSeconds
+	if secs <= 0 {
+		secs = DefaultReadinessTimeoutSeconds
+	}
+	return time.Duration(secs) * time.Second
 }
 
 // chaosSystemConfigManager is now a stateless façade over Viper — every call

--- a/AegisLab/src/config/chaos_system_test.go
+++ b/AegisLab/src/config/chaos_system_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestChaosSystemConfig_ReadinessTimeout_Default(t *testing.T) {
+	cfg := ChaosSystemConfig{}
+	got := cfg.ReadinessTimeout()
+	want := time.Duration(DefaultReadinessTimeoutSeconds) * time.Second
+	if got != want {
+		t.Fatalf("ReadinessTimeout() = %s, want %s (default)", got, want)
+	}
+}
+
+func TestChaosSystemConfig_ReadinessTimeout_Negative(t *testing.T) {
+	cfg := ChaosSystemConfig{ReadinessTimeoutSeconds: -1}
+	got := cfg.ReadinessTimeout()
+	want := time.Duration(DefaultReadinessTimeoutSeconds) * time.Second
+	if got != want {
+		t.Fatalf("ReadinessTimeout() = %s, want %s (default for negative)", got, want)
+	}
+}
+
+func TestChaosSystemConfig_ReadinessTimeout_Override(t *testing.T) {
+	cfg := ChaosSystemConfig{ReadinessTimeoutSeconds: 1500} // 25 min DSB-class
+	got := cfg.ReadinessTimeout()
+	want := 1500 * time.Second
+	if got != want {
+		t.Fatalf("ReadinessTimeout() = %s, want %s (override)", got, want)
+	}
+}

--- a/AegisLab/src/consts/consts.go
+++ b/AegisLab/src/consts/consts.go
@@ -399,6 +399,17 @@ const (
 	MaxTokensKeyAlgoExecution  = "rate_limiting.max_concurrent_algo_execution"
 	MaxConcurrentAlgoExecution = 5
 	AlgoExecutionServiceName   = "algo_execution"
+
+	// Namespace warming rate limiting. Decoupled from RestartPedestal so the
+	// "max concurrent helm-installs hammering the API server" bound stays
+	// small (typically 5) while "max namespaces simultaneously cold-starting
+	// workloads" can be much larger (default 30). Held during the
+	// post-install WaitNamespaceReady probe; released when the readiness
+	// probe returns or times out. See PR #205.
+	NamespaceWarmingTokenBucket   = "token_bucket:namespace_warming"
+	MaxTokensKeyNamespaceWarming  = "rate_limiting.max_concurrent_ns_warming"
+	MaxConcurrentNamespaceWarming = 30
+	NamespaceWarmingServiceName   = "namespace_warming"
 )
 
 type EventType string

--- a/AegisLab/src/infra/helm/gateway.go
+++ b/AegisLab/src/infra/helm/gateway.go
@@ -145,7 +145,15 @@ func (g *Gateway) installRelease(ctx context.Context, settings *cli.EnvSettings,
 		installAction := action.NewInstall(actionConfig)
 		installAction.ReleaseName = releaseName
 		installAction.Namespace = namespace
-		installAction.Wait = true
+		// Wait=false: do not block on cluster readiness. The manifest-apply
+		// upper bound stays at `timeout` (5–10 min is fine for the
+		// API-server-side apply itself), but DSB-class charts (TT, hs, sn,
+		// mm — 20–41 services with chained init containers) routinely take
+		// 15–25 min to become Ready cluster-side, which is far longer than
+		// any sane install timeout. Callers that need cluster-readiness
+		// must opt into the workload-level probe via
+		// k8s.Gateway.WaitNamespaceReady after this returns.
+		installAction.Wait = false
 		installAction.Timeout = timeout
 		installAction.CreateNamespace = true
 		installAction.Version = version

--- a/AegisLab/src/infra/k8s/gateway.go
+++ b/AegisLab/src/infra/k8s/gateway.go
@@ -12,6 +12,7 @@ import (
 
 	chaosCli "github.com/OperationsPAI/chaos-experiment/client"
 	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -217,6 +218,164 @@ func (g *Gateway) WaitForNamespacePodsReady(ctx context.Context, namespace strin
 		case <-ticker.C:
 		}
 	}
+}
+
+// WaitNamespaceReady blocks until every workload (Deployment, StatefulSet,
+// DaemonSet) in the namespace reports availableReplicas >= replicas AND no Job
+// is in a Failed condition, OR until the timeout elapses. This is the
+// workload-level (controller-level) readiness probe used by RestartPedestal
+// after a non-blocking helm install (Wait=false) — it is more tolerant than
+// `WaitForNamespacePodsReady` because:
+//
+//   - Pods that crash/restart while their init-container chain catches up
+//     don't trip the gate as long as the parent controller eventually
+//     reaches `availableReplicas == replicas`.
+//   - Jobs that complete fast (loadgen Jobs that run their workload and exit
+//     0) count as ready.
+//   - StatefulSets coming up sequentially are tolerated because we only
+//     require the final `availableReplicas` count, not "all pods ready right
+//     now".
+//
+// A namespace with zero workloads is considered ready (no work to wait on).
+// Logging is one-shot at start, one-shot on success, and one-shot on
+// timeout — never per-poll.
+func (g *Gateway) WaitNamespaceReady(ctx context.Context, namespace string, timeout time.Duration) error {
+	client, err := getK8sClient()
+	if err != nil {
+		return k8sClientNotAvailableErr(err)
+	}
+	if timeout <= 0 {
+		timeout = 15 * time.Minute
+	}
+
+	start := time.Now()
+	logrus.Infof("waiting for namespace %s to become ready, timeout %s", namespace, timeout)
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	var lastSummary string
+	for {
+		ready, summary, err := checkNamespaceWorkloadsReady(waitCtx, client, namespace)
+		if err != nil {
+			return fmt.Errorf("readiness probe error in namespace %q: %w", namespace, err)
+		}
+		lastSummary = summary
+		if ready {
+			logrus.Infof("namespace %s ready in %s", namespace, time.Since(start).Round(time.Second))
+			return nil
+		}
+
+		select {
+		case <-waitCtx.Done():
+			elapsed := time.Since(start).Round(time.Second)
+			logrus.Warnf("namespace %s readiness timeout after %s: %s", namespace, elapsed, lastSummary)
+			return fmt.Errorf("namespace %q not ready after %s: %s", namespace, elapsed, lastSummary)
+		case <-ticker.C:
+		}
+	}
+}
+
+// checkNamespaceWorkloadsReady performs one-shot readiness evaluation of
+// every Deployment / StatefulSet / DaemonSet / Job in the namespace. Returns
+// (ready, human-summary, error). A list-API failure is fatal; per-workload
+// not-ready states are accumulated into the summary so the caller can log
+// the stuck list on timeout.
+func checkNamespaceWorkloadsReady(ctx context.Context, client kubernetes.Interface, namespace string) (bool, string, error) {
+	deployments, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, "", fmt.Errorf("list deployments: %w", err)
+	}
+	statefulSets, err := client.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, "", fmt.Errorf("list statefulsets: %w", err)
+	}
+	daemonSets, err := client.AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, "", fmt.Errorf("list daemonsets: %w", err)
+	}
+	jobs, err := client.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, "", fmt.Errorf("list jobs: %w", err)
+	}
+	ready, summary := evaluateNamespaceWorkloadsReady(deployments.Items, statefulSets.Items, daemonSets.Items, jobs.Items)
+	return ready, summary, nil
+}
+
+// evaluateNamespaceWorkloadsReady is the pure-function core of the
+// namespace-ready check, kept separate so it can be unit-tested without a
+// kubernetes API. Treats zero workloads as ready (defensive: a "supposed to
+// be empty" namespace shouldn't block forever).
+func evaluateNamespaceWorkloadsReady(
+	deployments []appsv1.Deployment,
+	statefulSets []appsv1.StatefulSet,
+	daemonSets []appsv1.DaemonSet,
+	jobs []batchv1.Job,
+) (bool, string) {
+	stuck := make([]string, 0)
+
+	for _, d := range deployments {
+		desired := int32(1)
+		if d.Spec.Replicas != nil {
+			desired = *d.Spec.Replicas
+		}
+		if d.Status.AvailableReplicas < desired {
+			stuck = append(stuck, fmt.Sprintf("deployment/%s (%d/%d available)", d.Name, d.Status.AvailableReplicas, desired))
+		}
+	}
+	for _, s := range statefulSets {
+		desired := int32(1)
+		if s.Spec.Replicas != nil {
+			desired = *s.Spec.Replicas
+		}
+		// StatefulSet uses ReadyReplicas; AvailableReplicas exists since
+		// k8s 1.22 but ReadyReplicas is the historical contract.
+		ready := s.Status.ReadyReplicas
+		if s.Status.AvailableReplicas > ready {
+			ready = s.Status.AvailableReplicas
+		}
+		if ready < desired {
+			stuck = append(stuck, fmt.Sprintf("statefulset/%s (%d/%d ready)", s.Name, ready, desired))
+		}
+	}
+	for _, ds := range daemonSets {
+		desired := ds.Status.DesiredNumberScheduled
+		if ds.Status.NumberAvailable < desired {
+			stuck = append(stuck, fmt.Sprintf("daemonset/%s (%d/%d available)", ds.Name, ds.Status.NumberAvailable, desired))
+		}
+	}
+	for _, j := range jobs {
+		// A Job is "ready" if it has completed (Succeeded) or is still
+		// running. A Failed Job blocks readiness — that's a genuine error
+		// the operator wants to know about.
+		if isJobFailed(j) {
+			stuck = append(stuck, fmt.Sprintf("job/%s (failed)", j.Name))
+		}
+	}
+
+	totalWorkloads := len(deployments) + len(statefulSets) + len(daemonSets) + len(jobs)
+	if totalWorkloads == 0 {
+		// Defensive: an empty namespace is trivially ready. RestartPedestal's
+		// flow won't hit this (helm install creates workloads), but keeping
+		// the check explicit avoids a spurious timeout.
+		return true, "no workloads in namespace"
+	}
+	if len(stuck) == 0 {
+		return true, fmt.Sprintf("all %d workloads ready", totalWorkloads)
+	}
+	return false, fmt.Sprintf("%d/%d workloads not ready: %v", len(stuck), totalWorkloads, stuck)
+}
+
+func isJobFailed(j batchv1.Job) bool {
+	for _, c := range j.Status.Conditions {
+		if c.Type == batchv1.JobFailed && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 func evaluateNamespacePodReadiness(pods []corev1.Pod) (bool, string) {

--- a/AegisLab/src/infra/k8s/gateway_ready_test.go
+++ b/AegisLab/src/infra/k8s/gateway_ready_test.go
@@ -3,6 +3,8 @@ package k8s
 import (
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -63,4 +65,137 @@ func newPodWithReady(name string, phase corev1.PodPhase, ready bool) corev1.Pod 
 
 func metav1ObjectMeta(name string) metav1.ObjectMeta {
 	return metav1.ObjectMeta{Name: name}
+}
+
+// --- evaluateNamespaceWorkloadsReady tests --------------------------------
+
+func TestEvaluateNamespaceWorkloadsReady_Empty(t *testing.T) {
+	ready, summary := evaluateNamespaceWorkloadsReady(nil, nil, nil, nil)
+	if !ready {
+		t.Fatalf("expected empty namespace to be ready, got summary=%q", summary)
+	}
+}
+
+func TestEvaluateNamespaceWorkloadsReady_AllReady(t *testing.T) {
+	deployments := []appsv1.Deployment{
+		newDeploy("api", 2, 2),
+		newDeploy("worker", 1, 1),
+	}
+	statefulSets := []appsv1.StatefulSet{
+		newSTS("db", 3, 3),
+	}
+	daemonSets := []appsv1.DaemonSet{
+		newDS("logger", 4, 4),
+	}
+	jobs := []batchv1.Job{
+		newJob("loadgen", false), // not failed
+	}
+	ready, summary := evaluateNamespaceWorkloadsReady(deployments, statefulSets, daemonSets, jobs)
+	if !ready {
+		t.Fatalf("expected ready=true, got summary=%q", summary)
+	}
+}
+
+func TestEvaluateNamespaceWorkloadsReady_DeploymentNotReady(t *testing.T) {
+	deployments := []appsv1.Deployment{
+		newDeploy("api", 3, 1), // 1/3
+	}
+	ready, summary := evaluateNamespaceWorkloadsReady(deployments, nil, nil, nil)
+	if ready {
+		t.Fatalf("expected ready=false for under-replicated deployment, got summary=%q", summary)
+	}
+	if got := summary; got == "" {
+		t.Fatalf("expected non-empty summary")
+	}
+}
+
+func TestEvaluateNamespaceWorkloadsReady_StatefulSetNotReady(t *testing.T) {
+	statefulSets := []appsv1.StatefulSet{
+		newSTS("db", 3, 2), // sequential ordinal coming up
+	}
+	ready, _ := evaluateNamespaceWorkloadsReady(nil, statefulSets, nil, nil)
+	if ready {
+		t.Fatalf("expected ready=false for not-fully-up statefulset")
+	}
+}
+
+func TestEvaluateNamespaceWorkloadsReady_FailedJobBlocks(t *testing.T) {
+	jobs := []batchv1.Job{
+		newJob("loadgen", true), // Failed condition
+	}
+	ready, summary := evaluateNamespaceWorkloadsReady(nil, nil, nil, jobs)
+	if ready {
+		t.Fatalf("expected ready=false when a job is in Failed state, got summary=%q", summary)
+	}
+}
+
+func TestEvaluateNamespaceWorkloadsReady_CompletedJobCounted(t *testing.T) {
+	// A Job that has already completed (no Failed condition) should not
+	// block readiness. Combined with a healthy deployment to make the
+	// "all ready" assertion meaningful.
+	jobs := []batchv1.Job{
+		newJob("loadgen", false),
+	}
+	deployments := []appsv1.Deployment{
+		newDeploy("api", 1, 1),
+	}
+	ready, summary := evaluateNamespaceWorkloadsReady(deployments, nil, nil, jobs)
+	if !ready {
+		t.Fatalf("expected ready=true with healthy deploy + completed job, got summary=%q", summary)
+	}
+}
+
+func TestEvaluateNamespaceWorkloadsReady_DefaultReplicasIsOne(t *testing.T) {
+	// A Deployment without an explicit Spec.Replicas defaults to 1 (k8s
+	// API contract). A status of AvailableReplicas==0 should NOT pass.
+	deployments := []appsv1.Deployment{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "implicit"},
+			Spec:       appsv1.DeploymentSpec{}, // Replicas == nil → default 1
+			Status:     appsv1.DeploymentStatus{AvailableReplicas: 0},
+		},
+	}
+	ready, summary := evaluateNamespaceWorkloadsReady(deployments, nil, nil, nil)
+	if ready {
+		t.Fatalf("expected ready=false for nil-replicas deployment with 0 available, got summary=%q", summary)
+	}
+}
+
+func newDeploy(name string, desired, available int32) appsv1.Deployment {
+	return appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       appsv1.DeploymentSpec{Replicas: &desired},
+		Status:     appsv1.DeploymentStatus{AvailableReplicas: available},
+	}
+}
+
+func newSTS(name string, desired, ready int32) appsv1.StatefulSet {
+	return appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       appsv1.StatefulSetSpec{Replicas: &desired},
+		Status:     appsv1.StatefulSetStatus{ReadyReplicas: ready},
+	}
+}
+
+func newDS(name string, desired, available int32) appsv1.DaemonSet {
+	return appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: desired,
+			NumberAvailable:        available,
+		},
+	}
+}
+
+func newJob(name string, failed bool) batchv1.Job {
+	job := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	if failed {
+		job.Status.Conditions = []batchv1.JobCondition{{
+			Type:   batchv1.JobFailed,
+			Status: corev1.ConditionTrue,
+		}}
+	}
+	return job
 }

--- a/AegisLab/src/interface/worker/module.go
+++ b/AegisLab/src/interface/worker/module.go
@@ -33,6 +33,7 @@ type Params struct {
 	Etcd           *etcd.Gateway
 	Monitor        consumer.NamespaceMonitor
 	RestartLimiter *consumer.TokenBucketRateLimiter `name:"restart_limiter"`
+	WarmingLimiter *consumer.TokenBucketRateLimiter `name:"warming_limiter"`
 	BuildLimiter   *consumer.TokenBucketRateLimiter `name:"build_limiter"`
 	AlgoLimiter    *consumer.TokenBucketRateLimiter `name:"algo_limiter"`
 	BatchManager   *consumer.FaultBatchManager
@@ -65,6 +66,7 @@ func (r *Lifecycle) start(ctx context.Context) error {
 		params.Etcd,
 		commonservice.NewConfigUpdateListener(ctx, params.DB, params.Etcd),
 		params.RestartLimiter,
+		params.WarmingLimiter,
 		params.BuildLimiter,
 		params.AlgoLimiter,
 	); err != nil {
@@ -79,6 +81,7 @@ func (r *Lifecycle) start(ctx context.Context) error {
 		DB:                   params.DB,
 		Monitor:              params.Monitor,
 		RestartRateLimiter:   params.RestartLimiter,
+		NsWarmingRateLimiter: params.WarmingLimiter,
 		BuildRateLimiter:     params.BuildLimiter,
 		AlgorithmRateLimiter: params.AlgoLimiter,
 		RedisGateway:         params.RedisGateway,

--- a/AegisLab/src/module/ratelimiter/service.go
+++ b/AegisLab/src/module/ratelimiter/service.go
@@ -33,9 +33,10 @@ func NewService(redis *redisinfra.Gateway, db *gorm.DB) *Service {
 
 func knownBuckets() map[string]int {
 	return map[string]int{
-		consts.RestartPedestalTokenBucket: consts.MaxConcurrentRestartPedestal,
-		consts.BuildContainerTokenBucket:  consts.MaxConcurrentBuildContainer,
-		consts.AlgoExecutionTokenBucket:   consts.MaxConcurrentAlgoExecution,
+		consts.RestartPedestalTokenBucket:   consts.MaxConcurrentRestartPedestal,
+		consts.NamespaceWarmingTokenBucket:  consts.MaxConcurrentNamespaceWarming,
+		consts.BuildContainerTokenBucket:    consts.MaxConcurrentBuildContainer,
+		consts.AlgoExecutionTokenBucket:     consts.MaxConcurrentAlgoExecution,
 	}
 }
 

--- a/AegisLab/src/service/consumer/config_handlers.go
+++ b/AegisLab/src/service/consumer/config_handlers.go
@@ -26,6 +26,7 @@ func RegisterConsumerHandlers(
 	monitor NamespaceMonitor,
 	publisher common.ConfigPublisher,
 	restartLimiter *TokenBucketRateLimiter,
+	warmingLimiter *TokenBucketRateLimiter,
 	buildLimiter *TokenBucketRateLimiter,
 	algoLimiter *TokenBucketRateLimiter,
 ) {
@@ -45,6 +46,7 @@ func RegisterConsumerHandlers(
 	common.RegisterHandler(newRateLimitingConfigHandler(
 		publisher,
 		restartLimiter,
+		warmingLimiter,
 		buildLimiter,
 		algoLimiter,
 	))
@@ -307,6 +309,7 @@ func (h *chaosSystemHandler) refreshNamespaces() error {
 type rateLimitingConfigHandler struct {
 	publisher      common.ConfigPublisher
 	restartLimiter *TokenBucketRateLimiter
+	warmingLimiter *TokenBucketRateLimiter
 	buildLimiter   *TokenBucketRateLimiter
 	algoLimiter    *TokenBucketRateLimiter
 }
@@ -314,12 +317,14 @@ type rateLimitingConfigHandler struct {
 func newRateLimitingConfigHandler(
 	publisher common.ConfigPublisher,
 	restartLimiter *TokenBucketRateLimiter,
+	warmingLimiter *TokenBucketRateLimiter,
 	buildLimiter *TokenBucketRateLimiter,
 	algoLimiter *TokenBucketRateLimiter,
 ) *rateLimitingConfigHandler {
 	return &rateLimitingConfigHandler{
 		publisher:      publisher,
 		restartLimiter: restartLimiter,
+		warmingLimiter: warmingLimiter,
 		buildLimiter:   buildLimiter,
 		algoLimiter:    algoLimiter,
 	}
@@ -351,6 +356,13 @@ func (h *rateLimitingConfigHandler) Handle(ctx context.Context, key, oldValue, n
 				h.restartLimiter.UpdateConfig(maxTokens, currentTimeout)
 			}
 
+		case "rate_limiting.max_concurrent_ns_warming":
+			if h.warmingLimiter != nil {
+				maxTokens := config.GetInt(consts.MaxTokensKeyNamespaceWarming)
+				_, currentTimeout := h.warmingLimiter.GetConfig()
+				h.warmingLimiter.UpdateConfig(maxTokens, currentTimeout)
+			}
+
 		case "rate_limiting.max_concurrent_algo_execution":
 			if h.algoLimiter != nil {
 				maxTokens := config.GetInt(consts.MaxTokensKeyAlgoExecution)
@@ -365,6 +377,10 @@ func (h *rateLimitingConfigHandler) Handle(ctx context.Context, key, oldValue, n
 			if h.restartLimiter != nil {
 				maxTokens, _ := h.restartLimiter.GetConfig()
 				h.restartLimiter.UpdateConfig(maxTokens, timeout)
+			}
+			if h.warmingLimiter != nil {
+				maxTokens, _ := h.warmingLimiter.GetConfig()
+				h.warmingLimiter.UpdateConfig(maxTokens, timeout)
 			}
 			if h.buildLimiter != nil {
 				maxTokens, _ := h.buildLimiter.GetConfig()

--- a/AegisLab/src/service/consumer/rate_limiter.go
+++ b/AegisLab/src/service/consumer/rate_limiter.go
@@ -206,6 +206,28 @@ func NewAlgoExecutionRateLimiter(gateway *redis.Gateway) *TokenBucketRateLimiter
 	})
 }
 
+// NewNamespaceWarmingRateLimiter builds the limiter that gates the
+// post-install workload-readiness probe in RestartPedestal. The bound is
+// "how many namespaces can be cold-starting workloads at once", which
+// scales with cluster capacity and is independent of how fast we can
+// hammer Helm against the API server (that's what RestartPedestal limits).
+//
+// DefaultTimeout is intentionally long (matches the default readiness
+// timeout) so a campaign with more concurrent rounds than warming slots
+// queues for a slot rather than fails. Operators tune via etcd:
+//
+//	rate_limiting.max_concurrent_ns_warming   (capacity, default 30)
+//	rate_limiting.token_wait_timeout           (wait, default 900s for warming)
+func NewNamespaceWarmingRateLimiter(gateway *redis.Gateway) *TokenBucketRateLimiter {
+	return newTokenBucketRateLimiter(gateway, RateLimiterConfig{
+		TokenBucketKey:   consts.NamespaceWarmingTokenBucket,
+		MaxTokensKey:     consts.MaxTokensKeyNamespaceWarming,
+		DefaultMaxTokens: consts.MaxConcurrentNamespaceWarming,
+		DefaultTimeout:   config.DefaultReadinessTimeoutSeconds,
+		ServiceName:      consts.NamespaceWarmingServiceName,
+	})
+}
+
 // newTokenBucketRateLimiter creates a new token bucket rate limiter
 func newTokenBucketRateLimiter(gateway *redis.Gateway, cfg RateLimiterConfig) *TokenBucketRateLimiter {
 	maxTokens := config.GetInt(cfg.MaxTokensKey)

--- a/AegisLab/src/service/consumer/rate_limiter_test.go
+++ b/AegisLab/src/service/consumer/rate_limiter_test.go
@@ -1,0 +1,220 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+// fakeIssuer is a minimal in-process tokenIssuer used by the rate-limit
+// flow tests. It tracks acquire/release call counts per (taskID, traceID)
+// pair, simulates a finite-capacity pool, and lets tests inject errors on
+// release.
+type fakeIssuer struct {
+	mu             sync.Mutex
+	name           string
+	capacity       int
+	inUse          int
+	acquireCalls   int
+	releaseCalls   int
+	acquireErr     error
+	releaseErr     error
+	waitCalls      int
+	exhausted      bool // when true, AcquireToken returns false even with capacity
+	exhaustedWait  bool // when true, WaitForToken returns false (timeout)
+}
+
+func (f *fakeIssuer) AcquireToken(ctx context.Context, taskID, traceID string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.acquireCalls++
+	if f.acquireErr != nil {
+		return false, f.acquireErr
+	}
+	if f.exhausted || f.inUse >= f.capacity {
+		return false, nil
+	}
+	f.inUse++
+	return true, nil
+}
+
+func (f *fakeIssuer) WaitForToken(ctx context.Context, taskID, traceID string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.waitCalls++
+	if f.exhaustedWait {
+		return false, nil
+	}
+	if f.inUse >= f.capacity {
+		return false, nil
+	}
+	f.inUse++
+	return true, nil
+}
+
+func (f *fakeIssuer) ReleaseToken(ctx context.Context, taskID, traceID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.releaseCalls++
+	if f.releaseErr != nil {
+		return f.releaseErr
+	}
+	if f.inUse > 0 {
+		f.inUse--
+	}
+	return nil
+}
+
+func newFakeIssuer(name string, capacity int) *fakeIssuer {
+	return &fakeIssuer{name: name, capacity: capacity}
+}
+
+// TestAcquiredTokens_ReleaseRestartOnly simulates the failure path where
+// helm-apply errored: the restart token was acquired but the warming token
+// never was. The deferred release must release the restart token exactly
+// once and must NOT touch the warming pool.
+func TestAcquiredTokens_ReleaseRestartOnly(t *testing.T) {
+	restart := newFakeIssuer("restart", 5)
+	warming := newFakeIssuer("warming", 30)
+
+	// Simulate acquire of restart only (helm-apply failed before swap).
+	if ok, err := restart.AcquireToken(context.Background(), "t1", "tr1"); err != nil || !ok {
+		t.Fatalf("restart acquire: ok=%v err=%v", ok, err)
+	}
+
+	tokens := acquiredTokens{restart: true, warming: false}
+	tokens.release(context.Background(), restart, warming, "t1", "tr1", logrus.NewEntry(logrus.StandardLogger()))
+
+	if restart.releaseCalls != 1 {
+		t.Fatalf("restart release calls = %d, want 1", restart.releaseCalls)
+	}
+	if warming.releaseCalls != 0 {
+		t.Fatalf("warming release calls = %d, want 0 (never acquired)", warming.releaseCalls)
+	}
+	if restart.inUse != 0 {
+		t.Fatalf("restart inUse leaked: %d", restart.inUse)
+	}
+	if tokens.restart || tokens.warming {
+		t.Fatalf("tokens flags not cleared after release: %+v", tokens)
+	}
+}
+
+// TestAcquiredTokens_ReleaseBothCleanly simulates the success path: helm
+// apply succeeded → restart token released early → warming token acquired
+// → readiness probe succeeded → deferred release fires. By that point
+// only the warming token is held; the deferred path must release it and
+// must NOT call ReleaseToken on the restart pool a second time.
+func TestAcquiredTokens_ReleaseBothCleanly(t *testing.T) {
+	restart := newFakeIssuer("restart", 5)
+	warming := newFakeIssuer("warming", 30)
+	ctx := context.Background()
+	logEntry := logrus.NewEntry(logrus.StandardLogger())
+
+	// Acquire restart, then swap (release restart, acquire warming).
+	if _, err := restart.AcquireToken(ctx, "t1", "tr1"); err != nil {
+		t.Fatalf("restart acquire: %v", err)
+	}
+	tokens := acquiredTokens{restart: true}
+
+	// Mid-flow swap: release restart, acquire warming.
+	if err := restart.ReleaseToken(ctx, "t1", "tr1"); err != nil {
+		t.Fatalf("restart release at swap: %v", err)
+	}
+	tokens.restart = false
+	if ok, err := warming.AcquireToken(ctx, "t1", "tr1"); err != nil || !ok {
+		t.Fatalf("warming acquire: ok=%v err=%v", ok, err)
+	}
+	tokens.warming = true
+
+	// Now the deferred release fires.
+	tokens.release(ctx, restart, warming, "t1", "tr1", logEntry)
+
+	if restart.releaseCalls != 1 {
+		t.Fatalf("restart release calls = %d, want 1 (early-swap only, NOT a second from defer)", restart.releaseCalls)
+	}
+	if warming.releaseCalls != 1 {
+		t.Fatalf("warming release calls = %d, want 1", warming.releaseCalls)
+	}
+	if restart.inUse != 0 || warming.inUse != 0 {
+		t.Fatalf("token leak: restart.inUse=%d warming.inUse=%d", restart.inUse, warming.inUse)
+	}
+}
+
+// TestAcquiredTokens_HelmFailedNoWarmingAcquired models the exact scenario
+// the user called out: when `installPedestal` returns an error, the
+// warming token must never be acquired and must never appear in any
+// release call. The restart token alone is held and released by defer.
+func TestAcquiredTokens_HelmFailedNoWarmingAcquired(t *testing.T) {
+	restart := newFakeIssuer("restart", 5)
+	warming := newFakeIssuer("warming", 30)
+	ctx := context.Background()
+	logEntry := logrus.NewEntry(logrus.StandardLogger())
+
+	// Acquire restart token to enter the helm-apply phase.
+	if _, err := restart.AcquireToken(ctx, "t1", "tr1"); err != nil {
+		t.Fatalf("restart acquire: %v", err)
+	}
+	tokens := acquiredTokens{restart: true}
+
+	// Simulate helm install failing — control returns to the deferred
+	// path without ever acquiring a warming token.
+	tokens.release(ctx, restart, warming, "t1", "tr1", logEntry)
+
+	if warming.acquireCalls != 0 {
+		t.Fatalf("warming was ACQUIRED on helm-fail path: %d calls", warming.acquireCalls)
+	}
+	if warming.releaseCalls != 0 {
+		t.Fatalf("warming release attempted on helm-fail path: %d calls", warming.releaseCalls)
+	}
+	if restart.releaseCalls != 1 {
+		t.Fatalf("restart release calls = %d, want 1", restart.releaseCalls)
+	}
+}
+
+// TestAcquiredTokens_NoTokensHeld is a defensive check: the deferred
+// release block must be safe to call when neither token is held (e.g.
+// rate-limit acquire failed before any token was held).
+func TestAcquiredTokens_NoTokensHeld(t *testing.T) {
+	restart := newFakeIssuer("restart", 5)
+	warming := newFakeIssuer("warming", 30)
+	ctx := context.Background()
+
+	tokens := acquiredTokens{}
+	tokens.release(ctx, restart, warming, "t1", "tr1", logrus.NewEntry(logrus.StandardLogger()))
+
+	if restart.releaseCalls != 0 || warming.releaseCalls != 0 {
+		t.Fatalf("no-tokens release made unexpected calls: restart=%d warming=%d",
+			restart.releaseCalls, warming.releaseCalls)
+	}
+}
+
+// TestAcquiredTokens_ReleaseErrorDoesNotBlockOther verifies that an error
+// releasing one token does not prevent the other from being released
+// (defensive — both pools should be drained on every defer fire).
+func TestAcquiredTokens_ReleaseErrorDoesNotBlockOther(t *testing.T) {
+	restart := newFakeIssuer("restart", 5)
+	restart.releaseErr = errors.New("redis flake")
+	warming := newFakeIssuer("warming", 30)
+	ctx := context.Background()
+	logEntry := logrus.NewEntry(logrus.StandardLogger())
+
+	if _, err := restart.AcquireToken(ctx, "t1", "tr1"); err != nil {
+		t.Fatalf("restart acquire: %v", err)
+	}
+	if _, err := warming.AcquireToken(ctx, "t1", "tr1"); err != nil {
+		t.Fatalf("warming acquire: %v", err)
+	}
+	tokens := acquiredTokens{restart: true, warming: true}
+
+	tokens.release(ctx, restart, warming, "t1", "tr1", logEntry)
+
+	if restart.releaseCalls != 1 {
+		t.Fatalf("restart release calls = %d, want 1 (attempted even though it errors)", restart.releaseCalls)
+	}
+	if warming.releaseCalls != 1 {
+		t.Fatalf("warming release calls = %d, want 1 (must drain even after restart errored)", warming.releaseCalls)
+	}
+}

--- a/AegisLab/src/service/consumer/restart_pedestal.go
+++ b/AegisLab/src/service/consumer/restart_pedestal.go
@@ -60,6 +60,10 @@ func helmInstallTimeouts() (time.Duration, time.Duration) {
 	return overall, wait
 }
 
+// restartWorkloadReadyTimeout is the legacy fallback timeout for the
+// pod-level wait (see waitForPedestalWorkloadReady). Preserved so existing
+// `restart_pedestal.workload_ready_timeout_seconds` overrides keep working
+// in the rare case where the per-system readiness probe is bypassed.
 func restartWorkloadReadyTimeout() time.Duration {
 	timeout := 600 * time.Second
 	if v := config.GetInt("restart_pedestal.workload_ready_timeout_seconds"); v > 0 {
@@ -106,10 +110,35 @@ func extractPreDuration(injectPayload map[string]any) time.Duration {
 	return 0
 }
 
-func waitForPedestalWorkloadReady(ctx context.Context, gateway *k8s.Gateway, namespace string) (time.Time, error) {
+// waitForPedestalWorkloadReady gates RestartPedestal on the helm-installed
+// chart actually being Ready cluster-side. Two-phase:
+//
+//  1. Workload-level probe (Deployments/StatefulSets/DaemonSets/Jobs) with
+//     the per-system `readiness_timeout_seconds` from chaos-system config —
+//     defaults to 15 min, DSB systems (TT, hs, sn, mm) typically bump to
+//     20–25 min. This is the long-running phase that previously was
+//     compressed into the helm `Wait=true` 5-min timeout and reliably
+//     failed restart.pedestal on cold clusters.
+//
+//  2. Pod-level Ready check with the legacy
+//     `restart_pedestal.workload_ready_timeout_seconds` knob (default 10
+//     min). Defense-in-depth: catches edge cases where a controller reports
+//     `availableReplicas == replicas` momentarily but a pod flaps right
+//     after.
+//
+// Followed by the post-ready soak, used to ensure the inject window doesn't
+// fire mid-warmup.
+func waitForPedestalWorkloadReady(ctx context.Context, gateway *k8s.Gateway, namespace string, readinessTimeout time.Duration) (time.Time, error) {
 	if gateway == nil {
 		logrus.Warnf("k8s gateway is nil; skipping workload-ready wait for namespace %q", namespace)
 		return time.Now(), nil
+	}
+
+	if readinessTimeout <= 0 {
+		readinessTimeout = time.Duration(config.DefaultReadinessTimeoutSeconds) * time.Second
+	}
+	if err := gateway.WaitNamespaceReady(ctx, namespace, readinessTimeout); err != nil {
+		return time.Time{}, err
 	}
 
 	timeout := restartWorkloadReadyTimeout()
@@ -367,9 +396,21 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 			}
 		}
 
-		warmupReadyAt, err := waitForPedestalWorkloadReady(childCtx, deps.K8sGateway, namespace)
+		warmupReadyAt, err := waitForPedestalWorkloadReady(childCtx, deps.K8sGateway, namespace, cfg.ReadinessTimeout())
 		if err != nil {
 			toReleased = true
+			// Surface the failure as a restart.pedestal.failed trace event so
+			// the operator can see the stuck-resource list rather than
+			// silently rolling forward into a doomed inject. Per-system
+			// `readiness_timeout_seconds` (default 900) controls how long we
+			// wait — DSB systems should bump this to 1200–1500 to absorb
+			// their cold-start init-container chains.
+			publishEvent(redisGateway, childCtx, fmt.Sprintf(consts.StreamTraceLogKey, task.TraceID), dto.TraceStreamEvent{
+				TaskID:    task.TaskID,
+				TaskType:  consts.TaskTypeRestartPedestal,
+				EventName: consts.EventRestartPedestalFailed,
+				Payload:   err.Error(),
+			})
 			return handleExecutionError(span, logEntry, "workload readiness/warmup wait failed", err)
 		}
 		adjustedInjectTime := adjustInjectTimeAfterWarmup(injectTime, warmupReadyAt, payload.injectPayload)

--- a/AegisLab/src/service/consumer/restart_pedestal.go
+++ b/AegisLab/src/service/consumer/restart_pedestal.go
@@ -183,6 +183,45 @@ type restartPayload struct {
 	requiredNamespace string
 }
 
+// tokenIssuer is the minimum surface of TokenBucketRateLimiter that
+// executeRestartPedestal touches. Pulled out as an interface so the
+// two-stage rate-limit flow (restart token -> warming token) can be unit
+// tested with a fake.
+type tokenIssuer interface {
+	AcquireToken(ctx context.Context, taskID, traceID string) (bool, error)
+	WaitForToken(ctx context.Context, taskID, traceID string) (bool, error)
+	ReleaseToken(ctx context.Context, taskID, traceID string) error
+}
+
+// acquiredTokens tracks which of the two rate-limit tokens (restart-pedestal
+// and namespace-warming) are currently held by this task. The deferred
+// release path uses it to release exactly the tokens that were actually
+// acquired — never double-releasing, never leaking. See PR #205 reviewer
+// feedback: the previous single-bool design conflated the two pools and
+// gated the entire campaign on the small (max=5) restart bound.
+type acquiredTokens struct {
+	restart bool
+	warming bool
+}
+
+// release frees whichever of the two tokens are still held. Errors are
+// logged at error level but do not propagate — the caller has already
+// returned its primary error / success status.
+func (a *acquiredTokens) release(ctx context.Context, restart, warming tokenIssuer, taskID, traceID string, logEntry *logrus.Entry) {
+	if a.restart && restart != nil {
+		if err := restart.ReleaseToken(ctx, taskID, traceID); err != nil {
+			logEntry.Errorf("failed to release restart pedestal token: %v", err)
+		}
+		a.restart = false
+	}
+	if a.warming && warming != nil {
+		if err := warming.ReleaseToken(ctx, taskID, traceID); err != nil {
+			logEntry.Errorf("failed to release namespace warming token: %v", err)
+		}
+		a.warming = false
+	}
+}
+
 // executeRestartPedestal handles the execution of a restart pedestal task
 func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps RuntimeDeps) error {
 	return tracing.WithSpan(ctx, func(childCtx context.Context) error {
@@ -201,11 +240,23 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 			return handleExecutionError(span, logEntry, "redis gateway not initialized", fmt.Errorf("redis gateway not initialized"))
 		}
 
-		rateLimiter := deps.RestartRateLimiter
-		if rateLimiter == nil {
+		restartLimiter := deps.RestartRateLimiter
+		if restartLimiter == nil {
 			return handleExecutionError(span, logEntry, "restart pedestal rate limiter not initialized", errors.New("restart pedestal rate limiter not initialized"))
 		}
-		acquired, err := rateLimiter.AcquireToken(childCtx, task.TaskID, task.TraceID)
+		warmingLimiter := deps.NsWarmingRateLimiter
+		if warmingLimiter == nil {
+			return handleExecutionError(span, logEntry, "namespace warming rate limiter not initialized", errors.New("namespace warming rate limiter not initialized"))
+		}
+
+		// tokens tracks which of the two rate-limit tokens (restart-pedestal,
+		// namespace-warming) are currently held by this task. The deferred
+		// block at the bottom of this function uses tokens.release to free
+		// exactly the tokens that were acquired — never double-releasing,
+		// never leaking. See PR #205 reviewer feedback.
+		var tokens acquiredTokens
+
+		acquired, err := restartLimiter.AcquireToken(childCtx, task.TaskID, task.TraceID)
 		if err != nil {
 			return handleExecutionError(span, logEntry, "failed to acquire rate limit token", err)
 		}
@@ -214,7 +265,7 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 			span.AddEvent("no token available, waiting")
 			logEntry.Warn("No restart pedestal token available, waiting...")
 
-			acquired, err = rateLimiter.WaitForToken(childCtx, task.TaskID, task.TraceID)
+			acquired, err = restartLimiter.WaitForToken(childCtx, task.TaskID, task.TraceID)
 			if err != nil {
 				return handleExecutionError(span, logEntry, "failed to wait for token", err)
 			}
@@ -226,6 +277,7 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 				return nil
 			}
 		}
+		tokens.restart = true
 
 		payload, err := parseRestartPayload(task.Payload)
 		if err != nil {
@@ -251,11 +303,7 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 
 		var namespace string
 		defer func() {
-			if acquired {
-				if releaseErr := rateLimiter.ReleaseToken(childCtx, task.TaskID, task.TraceID); releaseErr != nil {
-					logEntry.Errorf("failed to release restart pedestal token: %v", releaseErr)
-				}
-			}
+			tokens.release(childCtx, restartLimiter, warmingLimiter, task.TaskID, task.TraceID, logEntry)
 			if toReleased && namespace != "" {
 				if err := monitor.ReleaseLock(childCtx, namespace, task.TraceID); err != nil {
 					if err := handleExecutionError(span, logEntry, fmt.Sprintf("failed to release lock for namespace %s", namespace), err); err != nil {
@@ -295,10 +343,10 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 			}
 
 			if lockErr := monitor.AcquireNamespaceForRestart(payload.requiredNamespace, lockEndTime, task.TraceID); lockErr != nil {
-				if releaseErr := rateLimiter.ReleaseToken(childCtx, task.TaskID, task.TraceID); releaseErr != nil {
-					logEntry.Errorf("failed to release restart pedestal token after required-namespace lock failure: %v", releaseErr)
-				}
-				acquired = false
+				// Release the restart token immediately so we don't pin a
+				// scarce slot waiting for reschedule. tokens.release is a
+				// no-op for any token that was already released.
+				tokens.release(childCtx, restartLimiter, warmingLimiter, task.TaskID, task.TraceID, logEntry)
 				reason := fmt.Sprintf("failed to acquire lock for required namespace %s: %v, retrying", payload.requiredNamespace, lockErr)
 				if err := rescheduleRestartPedestalTask(childCtx, deps.DB, redisGateway, task, reason); err != nil {
 					return err
@@ -309,12 +357,9 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 		} else {
 			namespace = monitor.GetNamespaceToRestart(lockEndTime, cfg.NsPattern, task.TraceID)
 			if namespace == "" {
-				// Failed to acquire namespace lock, immediately release rate limit token
-				if releaseErr := rateLimiter.ReleaseToken(childCtx, task.TaskID, task.TraceID); releaseErr != nil {
-					logEntry.Errorf("failed to release restart pedestal token after namespace lock failure: %v", releaseErr)
-				}
-
-				acquired = false
+				// Failed to acquire namespace lock, immediately release rate
+				// limit token so a stuck reschedule loop doesn't pin slots.
+				tokens.release(childCtx, restartLimiter, warmingLimiter, task.TaskID, task.TraceID, logEntry)
 				if err := rescheduleRestartPedestalTask(childCtx, deps.DB, redisGateway, task, "failed to acquire lock for namespace, retrying"); err != nil {
 					return err
 				}
@@ -385,6 +430,9 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 		if !skippedInstall {
 			if err := installPedestal(childCtx, helmGateway, namespace, index, payload.pedestal.Extra); err != nil {
 				toReleased = true
+				// helm-apply failed: keep the restart token until the deferred
+				// release fires. We never acquired a warming token, so there's
+				// nothing to leak on the warming pool.
 				publishEvent(redisGateway, childCtx, fmt.Sprintf(consts.StreamTraceLogKey, task.TraceID), dto.TraceStreamEvent{
 					TaskID:    task.TaskID,
 					TaskType:  consts.TaskTypeRestartPedestal,
@@ -395,6 +443,52 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 				return handleExecutionError(span, logEntry, fmt.Sprintf("failed to install pedestal of system %s", system), err)
 			}
 		}
+
+		// Two-stage rate limit: helm-apply is done (or skipped), so release
+		// the small `restart_pedestal` token (default cap = 5, sized for
+		// "API server hammer"). Then acquire a slot from the larger
+		// `namespace_warming` pool (default cap = 30) to gate the long
+		// readiness probe. This decouples "how many helm operations can
+		// run at once" from "how many namespaces can be cold-starting in
+		// parallel" — a campaign with 30 concurrent rounds no longer
+		// queues behind 5 helm slots throughout 15+ min of warming.
+		// See PR #205 reviewer feedback.
+		logEntry.Info("restart-pedestal helm-apply complete, releasing restart token, acquiring warming token")
+		// Clear the flag BEFORE the release call so a deferred fire under
+		// any error / panic path doesn't try to release the same token
+		// twice.
+		tokens.restart = false
+		if releaseErr := restartLimiter.ReleaseToken(childCtx, task.TaskID, task.TraceID); releaseErr != nil {
+			logEntry.Errorf("failed to release restart pedestal token after helm-apply: %v", releaseErr)
+		}
+
+		warmingAcquired, err := warmingLimiter.AcquireToken(childCtx, task.TaskID, task.TraceID)
+		if err != nil {
+			toReleased = true
+			return handleExecutionError(span, logEntry, "failed to acquire namespace warming token", err)
+		}
+		if !warmingAcquired {
+			span.AddEvent("no warming token available, waiting")
+			logEntry.Warn("No namespace warming token available, waiting...")
+			warmingAcquired, err = warmingLimiter.WaitForToken(childCtx, task.TaskID, task.TraceID)
+			if err != nil {
+				toReleased = true
+				return handleExecutionError(span, logEntry, "failed to wait for namespace warming token", err)
+			}
+			if !warmingAcquired {
+				toReleased = true
+				err := fmt.Errorf("namespace warming pool full, all slots busy")
+				publishEvent(redisGateway, childCtx, fmt.Sprintf(consts.StreamTraceLogKey, task.TraceID), dto.TraceStreamEvent{
+					TaskID:    task.TaskID,
+					TaskType:  consts.TaskTypeRestartPedestal,
+					EventName: consts.EventRestartPedestalFailed,
+					Payload:   err.Error(),
+				})
+				return handleExecutionError(span, logEntry, "namespace warming pool exhausted", err)
+			}
+		}
+		tokens.warming = true
+		logEntry.Infof("acquired warming token for ns %s", namespace)
 
 		warmupReadyAt, err := waitForPedestalWorkloadReady(childCtx, deps.K8sGateway, namespace, cfg.ReadinessTimeout())
 		if err != nil {

--- a/AegisLab/src/service/consumer/runtime_deps.go
+++ b/AegisLab/src/service/consumer/runtime_deps.go
@@ -10,9 +10,15 @@ import (
 )
 
 type RuntimeDeps struct {
-	DB                   *gorm.DB
-	Monitor              NamespaceMonitor
-	RestartRateLimiter   *TokenBucketRateLimiter
+	DB                 *gorm.DB
+	Monitor            NamespaceMonitor
+	RestartRateLimiter *TokenBucketRateLimiter
+	// NsWarmingRateLimiter gates the post-helm-apply workload-readiness
+	// probe in RestartPedestal. Decoupled from RestartRateLimiter so the
+	// "API server hammer" bound stays small (default 5) while the
+	// "namespaces cold-starting in parallel" bound can be much larger
+	// (default 30). See PR #205.
+	NsWarmingRateLimiter *TokenBucketRateLimiter
 	BuildRateLimiter     *TokenBucketRateLimiter
 	AlgorithmRateLimiter *TokenBucketRateLimiter
 	RedisGateway         *redis.Gateway

--- a/AegisLab/src/service/initialization/consumer.go
+++ b/AegisLab/src/service/initialization/consumer.go
@@ -32,6 +32,7 @@ func InitializeConsumer(
 	etcdGw *etcd.Gateway,
 	listener *common.ConfigUpdateListener,
 	restartLimiter *consumer.TokenBucketRateLimiter,
+	warmingLimiter *consumer.TokenBucketRateLimiter,
 	buildLimiter *consumer.TokenBucketRateLimiter,
 	algoLimiter *consumer.TokenBucketRateLimiter,
 ) error {
@@ -59,7 +60,7 @@ func InitializeConsumer(
 	}
 
 	common.RegisterGlobalHandlers(publisher)
-	consumer.RegisterConsumerHandlers(controller, monitor, publisher, restartLimiter, buildLimiter, algoLimiter)
+	consumer.RegisterConsumerHandlers(controller, monitor, publisher, restartLimiter, warmingLimiter, buildLimiter, algoLimiter)
 	if err := activateConfigScope(consumerData.scope, listener); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

DSB-class benchmarks (HotelReservation, SocialNetwork, MediaMicroservices, TrainTicket — 20-41 services per chart with chained init-container dependencies) reliably trip `restart.pedestal.failed` on cold clusters because Helm's blocking `Wait=true` 5-minute timeout cannot cover their 15-25 min cold-start chain. The mm R1 campaign saw 4x `restart.pedestal.failed` from this exact path; hs R1 / sn R1 saw the same.

This PR splits restart-pedestal's helm install into two phases:

1. **Phase 1 — apply (sync, fast)**: `installAction.Wait = false`. Helm returns once the manifest is applied to the API server (~30s). `installAction.Timeout` is preserved as the upper bound for that apply.

2. **Phase 2 — readiness probe (async, configurable)**: new `k8s.Gateway.WaitNamespaceReady` polls Deployments / StatefulSets / DaemonSets / Jobs in the namespace until `availableReplicas >= replicas` (and no Job is in `Failed`), or a per-system timeout elapses. The probe is tolerant of:
   - Pods that flap while their init-container chain catches up.
   - Completed Jobs (loadgen Jobs that exit 0 quickly).
   - StatefulSet ordinals coming up sequentially.
   - Empty namespaces (defensive — trivially ready).

The readiness probe stays in `infra/k8s` (where the kube client + informers already live — no new client). The helm gateway stays concerned with helm release state only.

## Per-system readiness timeout

`injection.system.<sys>.readiness_timeout_seconds` (etcd-backed, per-system).
Default: **900 (15 min)** when unset. DSB systems should bump to **1200-1500** to absorb their cold-start init-container chains; small systems (sockshop, otel-demo) can stay at the default.

Plumbed through `config.ChaosSystemConfig.ReadinessTimeoutSeconds` + `ReadinessTimeout()` helper. Read inside `executeRestartPedestal` from the cfg already loaded via `GetChaosSystemConfigManager().Get(system)` — no new lookup path.

## Two-stage rate limit (added in commit 2)

Reviewer feedback: holding the `restart_pedestal` token through the readiness wait conflated two distinct semantics — "max concurrent helm operations against the API server" (small bound, default 5) and "max namespaces simultaneously cold-starting workloads" (capacity-bound, can be much larger). The previous design gated entire campaigns on the small restart bound for 15+ min of warming.

The fix splits rate-limiting into two stages:

1. **helm-apply phase** — keeps the existing `restart_pedestal` token. Default cap **5**, sized for "API server hammer".
2. **readiness-wait phase** — a NEW `namespace_warming` pool. Default cap **30**, sized for "namespaces cold-starting in parallel".

In `executeRestartPedestal`, the restart-pedestal token is released *immediately* after `installPedestal` returns successfully (one-line log: `restart-pedestal helm-apply complete, releasing restart token, acquiring warming token`). The warming token is then acquired (with `WaitForToken`, long timeout matching readiness_timeout) and held only for the duration of `WaitNamespaceReady`. On exit, a small `acquiredTokens{restart, warming bool}` struct ensures exactly the tokens that were acquired are released — never double-releasing, never leaking.

### New config knob

`rate_limiting.max_concurrent_ns_warming` (etcd-backed, default **30**, hot-reloadable via the existing `rateLimitingConfigHandler`).

The wait-timeout for the warming pool defaults to `DefaultReadinessTimeoutSeconds` (900s) so a queued task waits long enough rather than fails. Operators tune via the existing `rate_limiting.token_wait_timeout` (which now also flows to the warming limiter on hot-reload).

### Rationale

Decouples "how many helm operations can hammer the API server at once" from "how many namespaces can be cold-starting workloads at once". A 30-round campaign no longer queues behind 5 helm slots throughout 15+ min of warming — it can have 5 helm-applies in flight AND 25 more namespaces currently warming, all concurrently.

## Failure mode

A readiness-probe timeout still surfaces as `restart.pedestal.failed` with the stuck-resource list named in the payload (e.g. `deployment/hotel-search (1/3 available), statefulset/mongodb-rate (0/1 ready)`). Warming-pool exhaustion (all 30 slots busy and the wait timed out) also surfaces as `restart.pedestal.failed` with a clear "namespace warming pool full, all slots busy" payload.

## Files

### Commit 1 — async readiness probe
- `AegisLab/src/infra/helm/gateway.go` — `installAction.Wait = false`.
- `AegisLab/src/infra/k8s/gateway.go` — new `WaitNamespaceReady` + pure-function `evaluateNamespaceWorkloadsReady` core (testable without a kube API).
- `AegisLab/src/config/chaos_system.go` — new `ReadinessTimeoutSeconds` field, `ReadinessTimeout()` helper, `DefaultReadinessTimeoutSeconds = 900`.
- `AegisLab/src/service/consumer/restart_pedestal.go` — `waitForPedestalWorkloadReady` now calls the new workload-level probe first (with per-system timeout), then the legacy pod-level wait (defense-in-depth).
- `AegisLab/src/infra/k8s/gateway_ready_test.go` — 7 new tests for `evaluateNamespaceWorkloadsReady`.
- `AegisLab/src/config/chaos_system_test.go` — 3 tests for `ReadinessTimeout()`.

### Commit 2 — split rate limit
- `AegisLab/src/consts/consts.go` — `NamespaceWarmingTokenBucket`, `MaxTokensKeyNamespaceWarming`, `MaxConcurrentNamespaceWarming = 30`, `NamespaceWarmingServiceName`.
- `AegisLab/src/service/consumer/rate_limiter.go` — `NewNamespaceWarmingRateLimiter` (DefaultTimeout matches readiness timeout).
- `AegisLab/src/service/consumer/runtime_deps.go` — `NsWarmingRateLimiter` field on `RuntimeDeps`.
- `AegisLab/src/service/consumer/restart_pedestal.go` — token swap between helm-apply and readiness-wait, `tokenIssuer` interface, `acquiredTokens` struct.
- `AegisLab/src/service/consumer/config_handlers.go` — handles `rate_limiting.max_concurrent_ns_warming` hot-reload, threads warming limiter through the existing `token_wait_timeout` reload too.
- `AegisLab/src/app/runtime_stack.go` — fx provider with `name:"warming_limiter"` tag.
- `AegisLab/src/interface/worker/module.go` — threads `WarmingLimiter` through `Params` and `RuntimeDeps`.
- `AegisLab/src/service/initialization/consumer.go` — new `warmingLimiter` param to `InitializeConsumer` and `RegisterConsumerHandlers`.
- `AegisLab/src/module/ratelimiter/service.go` — adds the new bucket to `knownBuckets()` so admin /list and GC operations cover it.
- `AegisLab/src/service/consumer/rate_limiter_test.go` — 5 new tests covering the token-release matrix.

## Test plan

- [x] `cd src && go build -tags duckdb_arrow ./main.go` — clean.
- [x] `cd src && go test ./service/consumer/... ./infra/helm/... ./infra/k8s/... ./config/... ./module/ratelimiter/... ./service/initialization/... ./app/...` — PASS, including 15 new tests across both commits.
- [x] `cd src && golangci-lint run ./service/consumer/...` — only pre-existing unused warnings on `monitor.go` / `monitor_test.go`, nothing in changed code.
- [ ] Cluster-side validation: run mm R1 / hs R1 with default 900s timeout — verify install returns fast and probe gates the inject correctly.
- [ ] Cluster-side validation: bump DSB system to `readiness_timeout_seconds=1500` via etcd, confirm hot-reload picks it up without restart.
- [ ] Cluster-side validation: 30+ round campaign — confirm >5 namespaces can be warming concurrently while restart-pedestal token cap stays at 5 helm-applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
