### PR TITLE
rcabench(byte-cluster): add HPA to runtime-worker + api-gateway

### DIFF
--- a/AegisLab/helm/templates/deployment.yaml
+++ b/AegisLab/helm/templates/deployment.yaml
@@ -110,6 +110,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-auth
                   key: jwt_secret
+          {{- with .Values.microservices.apiGateway.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/rcabench/config.prod.toml
@@ -246,6 +250,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-auth
                   key: jwt_secret
+          {{- with .Values.microservices.runtimeWorkerService.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/rcabench/config.prod.toml

--- a/AegisLab/helm/templates/hpa.yaml
+++ b/AegisLab/helm/templates/hpa.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.microservices.apiGateway.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-api-gateway
+  labels:
+    app: {{ .Release.Name }}-api-gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-api-gateway
+  minReplicas: {{ .Values.microservices.apiGateway.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.microservices.apiGateway.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.microservices.apiGateway.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.microservices.apiGateway.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.microservices.apiGateway.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.microservices.apiGateway.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+{{- if .Values.microservices.runtimeWorkerService.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-runtime-worker-service
+  labels:
+    app: {{ .Release.Name }}-runtime-worker-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-runtime-worker-service
+  minReplicas: {{ .Values.microservices.runtimeWorkerService.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.microservices.runtimeWorkerService.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.microservices.runtimeWorkerService.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.microservices.runtimeWorkerService.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.microservices.runtimeWorkerService.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.microservices.runtimeWorkerService.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/AegisLab/helm/values.yaml
+++ b/AegisLab/helm/values.yaml
@@ -214,9 +214,28 @@ microservices:
     httpPort: 8082
     # Port for the runtime-intake gRPC server (runtime-worker -> api-gateway).
     intakeGrpcPort: 9096
+    # Pod resource requests/limits. HPA targetCPUUtilizationPercentage requires
+    # `requests.cpu` to be set; leave `resources: {}` to omit the block entirely.
+    resources: {}
+    # Horizontal Pod Autoscaler. Disabled by default; when enabled the chart
+    # emits an autoscaling/v2 HPA targeting this deployment. Requires
+    # metrics-server (or equivalent metrics.k8s.io provider) in the cluster.
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 4
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: 0
   runtimeWorkerService:
     replicaCount: 1
     grpcPort: 9094
+    resources: {}
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 8
+      targetCPUUtilizationPercentage: 70
+      targetMemoryUtilizationPercentage: 0
 
 persistence:
   # Global storage type setting - applies to containers, logs, and juicefs sections

--- a/AegisLab/manifests/byte-cluster/rcabench.values.yaml
+++ b/AegisLab/manifests/byte-cluster/rcabench.values.yaml
@@ -84,6 +84,32 @@ microservices:
   apiGateway:
     service:
       type: ClusterIP
+    # CPU requests are required for HPA targetCPUUtilizationPercentage to work.
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 4
+      targetCPUUtilizationPercentage: 70
+  runtimeWorkerService:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+    autoscaling:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 8
+      targetCPUUtilizationPercentage: 70
 
 persistence:
   storageType: volcengine


### PR DESCRIPTION
## Summary

When the inject-loop submits 30+ candidates concurrently, the bottleneck shifts from ClickHouse (now 2000 max_concurrent_queries via the in-flight clickstack PR) to the stateless consumer worker. This PR makes the two stateless rcabench services horizontally scalable on the byte-cluster so the load can spread across additional pod replicas instead of queueing on a single worker.

- New `helm/templates/hpa.yaml` emits an `autoscaling/v2` HorizontalPodAutoscaler for `api-gateway` and `runtime-worker-service`, each gated on `microservices.<svc>.autoscaling.enabled` (default `false`, back-compat).
- `deployment.yaml` now renders a `resources` block from `microservices.<svc>.resources` (default `{}`).
- byte-cluster values turn HPA on:
  - `api-gateway`: requests `cpu=200m mem=256Mi`, limits `cpu=1 mem=1Gi`, HPA `min=2 max=4 targetCPU=70%`.
  - `runtime-worker-service`: requests `cpu=500m mem=512Mi`, limits `cpu=2 mem=2Gi`, HPA `min=2 max=8 targetCPU=70%`.

CPU requests are set explicitly because `targetCPUUtilizationPercentage` needs them to compute % utilization. `metrics-server` is already part of the byte-cluster preflight (`kubectl get --raw /apis/metrics.k8s.io/v1beta1/nodes`).

Stateful workloads (clickhouse, mysql, redis, etcd, jaeger) deliberately left at fixed replicas — HPA on PVC-backed StatefulSets without sharding would lose data. ClickHouse read scale-out is tracked separately as a follow-up issue (replication via Keeper).

## Test plan

- [ ] `helm template rcabench ./helm -f ./manifests/byte-cluster/rcabench.values.yaml | grep -c HorizontalPodAutoscaler` returns `2`.
- [ ] `helm template rcabench ./helm` (no overrides) returns `0` HPAs — back-compat for non-byte deployments.
- [ ] After `helm upgrade`: `kubectl -n exp get hpa` shows both HPAs with `TARGETS` reading actual CPU%, not `<unknown>`.
- [ ] Both deployments now show `requests.cpu` set in `kubectl describe deployment`.
- [ ] Inject-loop with 30 concurrent candidates: `runtime-worker-service` scales beyond 2 replicas; `BuildDatapack` queue does not back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)