### PR TITLE
consumer: rate-limit BuildDatapack tasks (fix CH overload)

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -931,6 +931,15 @@ dynamic_configs:
     is_secret: false
     min_value: 1
     max_value: 20
+  - key: rate_limiting.max_concurrent_build_datapack
+    default_value: '8'
+    value_type: 2
+    scope: 1
+    category: rate_limiting
+    description: Maximum number of concurrent BuildDatapack jobs (caps ClickHouse query fan-out)
+    is_secret: false
+    min_value: 1
+    max_value: 50
   - key: rate_limiting.max_concurrent_restarts
     default_value: '5'
     value_type: 2

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -859,6 +859,15 @@ dynamic_configs:
     is_secret: false
     min_value: 1
     max_value: 20
+  - key: rate_limiting.max_concurrent_build_datapack
+    default_value: '8'
+    value_type: 2
+    scope: 1
+    category: rate_limiting
+    description: Maximum number of concurrent BuildDatapack jobs (caps ClickHouse query fan-out)
+    is_secret: false
+    min_value: 1
+    max_value: 50
   - key: rate_limiting.max_concurrent_restarts
     default_value: '2'
     value_type: 2

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -883,6 +883,15 @@ dynamic_configs:
     is_secret: false
     min_value: 1
     max_value: 20
+  - key: rate_limiting.max_concurrent_build_datapack
+    default_value: '8'
+    value_type: 2
+    scope: 1
+    category: rate_limiting
+    description: Maximum number of concurrent BuildDatapack jobs (caps ClickHouse query fan-out)
+    is_secret: false
+    min_value: 1
+    max_value: 50
   - key: rate_limiting.max_concurrent_restarts
     default_value: '5'
     value_type: 2

--- a/AegisLab/src/app/runtime_stack.go
+++ b/AegisLab/src/app/runtime_stack.go
@@ -37,6 +37,7 @@ func RuntimeWorkerStackOptions() fx.Option {
 			fx.Annotate(consumer.NewRestartPedestalRateLimiter, fx.ResultTags(`name:"restart_limiter"`)),
 			fx.Annotate(consumer.NewNamespaceWarmingRateLimiter, fx.ResultTags(`name:"warming_limiter"`)),
 			fx.Annotate(consumer.NewBuildContainerRateLimiter, fx.ResultTags(`name:"build_limiter"`)),
+			fx.Annotate(consumer.NewBuildDatapackRateLimiter, fx.ResultTags(`name:"build_datapack_limiter"`)),
 			fx.Annotate(consumer.NewAlgoExecutionRateLimiter, fx.ResultTags(`name:"algo_limiter"`)),
 			consumer.NewFaultBatchManager,
 			consumer.NewExecutionOwner,

--- a/AegisLab/src/cmd/aegisctl/cluster/prepare.go
+++ b/AegisLab/src/cmd/aegisctl/cluster/prepare.go
@@ -171,6 +171,7 @@ func LocalE2EEtcdActions() []PrepareAction {
 		"/rcabench/config/consumer/injection.system.otel-demo.extract_pattern":  `^(otel-demo)(\d+)$`,
 		"/rcabench/config/consumer/rate_limiting.max_concurrent_restarts":       "5",
 		"/rcabench/config/consumer/rate_limiting.max_concurrent_builds":         "3",
+		"/rcabench/config/consumer/rate_limiting.max_concurrent_build_datapack": "8",
 		"/rcabench/config/consumer/rate_limiting.max_concurrent_algo_execution": "5",
 		"/rcabench/config/consumer/rate_limiting.token_wait_timeout":            "10",
 	}

--- a/AegisLab/src/consts/consts.go
+++ b/AegisLab/src/consts/consts.go
@@ -389,10 +389,26 @@ const (
 	MaxConcurrentRestartPedestal = 2
 	RestartPedestalServiceName   = "restart_pedestal"
 
-	BuildContainerTokenBucket   = "token_bucket:build_container"
-	MaxTokensKeyBuildContainer  = "rate_limiting.max_concurrent_build_container"
+	BuildContainerTokenBucket = "token_bucket:build_container"
+	// MaxTokensKeyBuildContainer reads the same etcd key that the
+	// rate_limiting config handler watches (rate_limiting.max_concurrent_builds).
+	// Earlier this was "rate_limiting.max_concurrent_build_container" which
+	// disagreed with the watched key, so reload would silently no-op against
+	// the operator-set value. The Go symbol stays BuildContainerKey* to keep
+	// the BuildContainer / BuildDatapack / Algo / Restart triples symmetric.
+	MaxTokensKeyBuildContainer  = "rate_limiting.max_concurrent_builds"
 	MaxConcurrentBuildContainer = 3
 	BuildContainerServiceName   = "build_container"
+
+	// BuildDatapack rate limiting. Gates the BuildDatapack task type which
+	// fans out a Kubernetes Job that issues ~30 ClickHouse queries per
+	// invocation; without this cap the autonomous inject-loop has crossed
+	// ClickHouse's max_concurrent_queries=500 default and triggered
+	// "Code 202: Too many simultaneous queries" cascades.
+	BuildDatapackTokenBucket   = "token_bucket:build_datapack"
+	MaxTokensKeyBuildDatapack  = "rate_limiting.max_concurrent_build_datapack"
+	MaxConcurrentBuildDatapack = 8
+	BuildDatapackServiceName   = "build_datapack"
 
 	// Algorithm execution rate limiting
 	AlgoExecutionTokenBucket   = "token_bucket:algo_execution"

--- a/AegisLab/src/interface/controller/module.go
+++ b/AegisLab/src/interface/controller/module.go
@@ -23,15 +23,16 @@ var Module = fx.Module("controller",
 type Params struct {
 	fx.In
 
-	Controller     *k8s.Controller
-	K8sGateway     *k8s.Gateway
-	RedisGateway   *redis.Gateway
-	DB             *gorm.DB
-	Monitor        consumer.NamespaceMonitor
-	AlgoLimiter    *consumer.TokenBucketRateLimiter `name:"algo_limiter"`
-	BatchManager   *consumer.FaultBatchManager
-	ExecutionOwner consumer.ExecutionOwner
-	InjectionOwner consumer.InjectionOwner
+	Controller           *k8s.Controller
+	K8sGateway           *k8s.Gateway
+	RedisGateway         *redis.Gateway
+	DB                   *gorm.DB
+	Monitor              consumer.NamespaceMonitor
+	AlgoLimiter          *consumer.TokenBucketRateLimiter `name:"algo_limiter"`
+	BuildDatapackLimiter *consumer.TokenBucketRateLimiter `name:"build_datapack_limiter"`
+	BatchManager         *consumer.FaultBatchManager
+	ExecutionOwner       consumer.ExecutionOwner
+	InjectionOwner       consumer.InjectionOwner
 }
 
 type Lifecycle struct {
@@ -56,6 +57,7 @@ func (r *Lifecycle) start(ctx context.Context, cancel context.CancelFunc) error 
 			r.params.DB,
 			r.params.Monitor,
 			r.params.AlgoLimiter,
+			r.params.BuildDatapackLimiter,
 			r.params.K8sGateway,
 			r.params.RedisGateway,
 			r.params.BatchManager,

--- a/AegisLab/src/interface/worker/module.go
+++ b/AegisLab/src/interface/worker/module.go
@@ -24,18 +24,19 @@ var Module = fx.Module("worker",
 type Params struct {
 	fx.In
 
-	DB             *gorm.DB
-	RedisGateway   *redis.Gateway
-	BuildKit       *buildkit.Gateway
-	Helm           *helm.Gateway
-	K8sGateway     *k8s.Gateway
-	Controller     *k8s.Controller
-	Etcd           *etcd.Gateway
-	Monitor        consumer.NamespaceMonitor
-	RestartLimiter *consumer.TokenBucketRateLimiter `name:"restart_limiter"`
-	WarmingLimiter *consumer.TokenBucketRateLimiter `name:"warming_limiter"`
-	BuildLimiter   *consumer.TokenBucketRateLimiter `name:"build_limiter"`
-	AlgoLimiter    *consumer.TokenBucketRateLimiter `name:"algo_limiter"`
+	DB                   *gorm.DB
+	RedisGateway         *redis.Gateway
+	BuildKit             *buildkit.Gateway
+	Helm                 *helm.Gateway
+	K8sGateway           *k8s.Gateway
+	Controller           *k8s.Controller
+	Etcd                 *etcd.Gateway
+	Monitor              consumer.NamespaceMonitor
+	RestartLimiter       *consumer.TokenBucketRateLimiter `name:"restart_limiter"`
+	WarmingLimiter       *consumer.TokenBucketRateLimiter `name:"warming_limiter"`
+	BuildLimiter         *consumer.TokenBucketRateLimiter `name:"build_limiter"`
+	BuildDatapackLimiter *consumer.TokenBucketRateLimiter `name:"build_datapack_limiter"`
+	AlgoLimiter          *consumer.TokenBucketRateLimiter `name:"algo_limiter"`
 	BatchManager   *consumer.FaultBatchManager
 	ExecutionOwner consumer.ExecutionOwner
 	InjectionOwner consumer.InjectionOwner
@@ -68,6 +69,7 @@ func (r *Lifecycle) start(ctx context.Context) error {
 		params.RestartLimiter,
 		params.WarmingLimiter,
 		params.BuildLimiter,
+		params.BuildDatapackLimiter,
 		params.AlgoLimiter,
 	); err != nil {
 		return err
@@ -78,20 +80,21 @@ func (r *Lifecycle) start(ctx context.Context) error {
 
 	go consumer.StartScheduler(ctx, params.RedisGateway)
 	go consumer.ConsumeTasks(ctx, consumer.RuntimeDeps{
-		DB:                   params.DB,
-		Monitor:              params.Monitor,
-		RestartRateLimiter:   params.RestartLimiter,
-		NsWarmingRateLimiter: params.WarmingLimiter,
-		BuildRateLimiter:     params.BuildLimiter,
-		AlgorithmRateLimiter: params.AlgoLimiter,
-		RedisGateway:         params.RedisGateway,
-		K8sGateway:           params.K8sGateway,
-		BuildKitGateway:      params.BuildKit,
-		HelmGateway:          params.Helm,
-		FaultBatchManager:    params.BatchManager,
-		ExecutionOwner:       params.ExecutionOwner,
-		InjectionOwner:       params.InjectionOwner,
-		TaskRegistry:         params.TaskRegistry,
+		DB:                       params.DB,
+		Monitor:                  params.Monitor,
+		RestartRateLimiter:       params.RestartLimiter,
+		NsWarmingRateLimiter:     params.WarmingLimiter,
+		BuildRateLimiter:         params.BuildLimiter,
+		BuildDatapackRateLimiter: params.BuildDatapackLimiter,
+		AlgorithmRateLimiter:     params.AlgoLimiter,
+		RedisGateway:             params.RedisGateway,
+		K8sGateway:               params.K8sGateway,
+		BuildKitGateway:          params.BuildKit,
+		HelmGateway:              params.Helm,
+		FaultBatchManager:        params.BatchManager,
+		ExecutionOwner:           params.ExecutionOwner,
+		InjectionOwner:           params.InjectionOwner,
+		TaskRegistry:             params.TaskRegistry,
 	})
 	return nil
 }

--- a/AegisLab/src/service/consumer/build_datapack.go
+++ b/AegisLab/src/service/consumer/build_datapack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/trace"
+	"gorm.io/gorm"
 	corev1 "k8s.io/api/core/v1"
 
 	"aegis/config"
@@ -18,6 +20,8 @@ import (
 	"aegis/dto"
 	db "aegis/infra/db"
 	k8s "aegis/infra/k8s"
+	redis "aegis/infra/redis"
+	"aegis/service/common"
 	"aegis/tracing"
 	"aegis/utils"
 )
@@ -59,6 +63,51 @@ func executeBuildDatapackWithDeps(ctx context.Context, task *dto.UnifiedTask, de
 		if k8sGateway == nil {
 			return handleExecutionError(span, logEntry, "k8s gateway not initialized", fmt.Errorf("k8s gateway not initialized"))
 		}
+		redisGateway := deps.RedisGateway
+		if redisGateway == nil {
+			return handleExecutionError(span, logEntry, "redis gateway not initialized", fmt.Errorf("redis gateway not initialized"))
+		}
+
+		// Gate the BuildDatapack fan-out behind a token bucket. Each Job
+		// fires ~30 ClickHouse queries via rcabench-platform's
+		// prepare_inputs.py; without this gate, the autonomous inject-loop
+		// has crossed ClickHouse's max_concurrent_queries ceiling and
+		// triggered "Code 202: Too many simultaneous queries" cascades.
+		// Mirrors the BuildContainer / AlgoExecution guards exactly so
+		// retry / wait / reschedule semantics are uniform across task
+		// types. The token is held for the lifetime of the K8s Job and
+		// released by the job-callback path in k8s_handler.go.
+		rateLimiter := deps.BuildDatapackRateLimiter
+		if rateLimiter == nil {
+			return handleExecutionError(span, logEntry, "build datapack rate limiter not initialized", fmt.Errorf("build datapack rate limiter not initialized"))
+		}
+		acquired, err := acquireBuildDatapackToken(childCtx, rateLimiter, task, logEntry)
+		if err != nil {
+			return handleExecutionError(span, logEntry, "failed to acquire rate limit token", err)
+		}
+		if !acquired {
+			if err := rescheduleBuildDatapackTask(childCtx, deps.DB, redisGateway, task, "failed to acquire build datapack token within timeout, retrying later"); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		// Job-creation success "transfers ownership" of the token to the
+		// K8s Job; the job-callback path in k8s_handler.go releases it on
+		// success or failure of the Job. Any error path BEFORE the Job is
+		// successfully created must release the token here, otherwise the
+		// bucket slowly leaks on malformed payloads or transient gateway
+		// errors and eventually wedges every BuildDatapack task at "no
+		// token available".
+		jobLaunched := false
+		defer func() {
+			if jobLaunched {
+				return
+			}
+			if releaseErr := rateLimiter.ReleaseToken(childCtx, task.TaskID, task.TraceID); releaseErr != nil {
+				logEntry.WithError(releaseErr).Warn("failed to release build datapack token after pre-launch failure")
+			}
+		}()
 
 		payload, err := parseDatapackPayload(task.Payload)
 		if err != nil {
@@ -93,7 +142,11 @@ func executeBuildDatapackWithDeps(ctx context.Context, task *dto.UnifiedTask, de
 			payload:     payload,
 			dbConfig:    db.NewDatabaseConfig("clickhouse"),
 		}
-		return createDatapackJob(childCtx, k8sGateway, params)
+		if err := createDatapackJob(childCtx, k8sGateway, params); err != nil {
+			return err
+		}
+		jobLaunched = true
+		return nil
 	})
 }
 
@@ -217,4 +270,70 @@ func getDatapackJobEnvVars(taskID string, datapackPathPrefix string, payload *da
 	}
 
 	return jobEnvVars, nil
+}
+
+// acquireBuildDatapackToken runs the standard "acquire-or-wait" two-stage
+// token grab: try AcquireToken first; if the bucket is full, fall through
+// to WaitForToken; if that times out (returns false, nil) the caller is
+// expected to reschedule the task. Pulled out of executeBuildDatapackWithDeps
+// so the surge-cap behavior can be unit tested with a fakeIssuer instead of
+// requiring a live Redis Gateway.
+func acquireBuildDatapackToken(ctx context.Context, issuer tokenIssuer, task *dto.UnifiedTask, logEntry *logrus.Entry) (bool, error) {
+	span := trace.SpanFromContext(ctx)
+	acquired, err := issuer.AcquireToken(ctx, task.TaskID, task.TraceID)
+	if err != nil {
+		return false, err
+	}
+	if acquired {
+		return true, nil
+	}
+	span.AddEvent("no token available, waiting")
+	logEntry.Info("No build datapack token available, waiting...")
+	acquired, err = issuer.WaitForToken(ctx, task.TaskID, task.TraceID)
+	if err != nil {
+		return false, err
+	}
+	return acquired, nil
+}
+
+// rescheduleBuildDatapackTask reschedules a BuildDatapack task with a random
+// delay between 1 and 5 minutes when the rate-limit token wait timed out.
+// Mirrors rescheduleContainerBuildingTask / rescheduleAlgoExecutionTask so
+// the three task types behave consistently under sustained load.
+func rescheduleBuildDatapackTask(ctx context.Context, dbConn *gorm.DB, redisGateway *redis.Gateway, task *dto.UnifiedTask, reason string) error {
+	return tracing.WithSpan(ctx, func(childCtx context.Context) error {
+		span := trace.SpanFromContext(childCtx)
+
+		randomDelayMinutes := minDelayMinutes + rand.Intn(maxDelayMinutes-minDelayMinutes+1)
+		executeTime := time.Now().Add(time.Duration(randomDelayMinutes) * time.Minute)
+
+		span.AddEvent(fmt.Sprintf("rescheduling build datapack task: %s", reason))
+		logrus.WithFields(logrus.Fields{
+			"task_id":     task.TaskID,
+			"trace_id":    task.TraceID,
+			"delay_mins":  randomDelayMinutes,
+			"retry_count": task.ReStartNum + 1,
+		}).Warnf("%s: scheduled for %s", reason, executeTime.Format(time.DateTime))
+
+		tracing.SetSpanAttribute(childCtx, consts.TaskStateKey, consts.GetTaskStateName(consts.TaskRescheduled))
+
+		updateTaskState(childCtx,
+			newTaskStateUpdate(
+				task.TraceID,
+				task.TaskID,
+				consts.TaskTypeBuildDatapack,
+				consts.TaskRescheduled,
+				reason,
+			).withEvent(consts.EventNoTokenAvailable, executeTime.String()).withDB(dbConn).withRedis(redisGateway),
+		)
+
+		task.Reschedule(executeTime)
+		if err := common.SubmitTaskWithDB(childCtx, dbConn, redisGateway, task); err != nil {
+			span.RecordError(err)
+			span.AddEvent("failed to submit rescheduled task")
+			return fmt.Errorf("failed to submit rescheduled build datapack task: %w", err)
+		}
+
+		return nil
+	})
 }

--- a/AegisLab/src/service/consumer/build_datapack_test.go
+++ b/AegisLab/src/service/consumer/build_datapack_test.go
@@ -1,0 +1,115 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"aegis/dto"
+
+	"github.com/sirupsen/logrus"
+)
+
+// TestAcquireBuildDatapackToken_AcquiresOnFirstTry covers the happy path:
+// when the bucket has capacity, AcquireToken returns (true, nil) and we
+// never fall through to WaitForToken.
+func TestAcquireBuildDatapackToken_AcquiresOnFirstTry(t *testing.T) {
+	issuer := newFakeIssuer("build_datapack", 8)
+	task := &dto.UnifiedTask{TaskID: "tid-1", TraceID: "trc-1"}
+	logEntry := logrus.NewEntry(logrus.StandardLogger())
+
+	acquired, err := acquireBuildDatapackToken(context.Background(), issuer, task, logEntry)
+	if err != nil {
+		t.Fatalf("acquireBuildDatapackToken: %v", err)
+	}
+	if !acquired {
+		t.Fatalf("expected acquired=true on empty bucket, got false")
+	}
+	if issuer.acquireCalls != 1 {
+		t.Fatalf("AcquireToken calls = %d, want 1", issuer.acquireCalls)
+	}
+	if issuer.waitCalls != 0 {
+		t.Fatalf("WaitForToken calls = %d, want 0 (only used when bucket is full)", issuer.waitCalls)
+	}
+	if issuer.inUse != 1 {
+		t.Fatalf("inUse = %d, want 1 after successful acquire", issuer.inUse)
+	}
+}
+
+// TestAcquireBuildDatapackToken_FallsThroughToWait covers the surge path:
+// AcquireToken returns (false, nil) when the bucket is exhausted, which
+// must trigger a WaitForToken poll. If wait succeeds, the caller proceeds.
+func TestAcquireBuildDatapackToken_FallsThroughToWait(t *testing.T) {
+	issuer := newFakeIssuer("build_datapack", 8)
+	issuer.exhausted = true // first AcquireToken call returns false
+	task := &dto.UnifiedTask{TaskID: "tid-2", TraceID: "trc-2"}
+	logEntry := logrus.NewEntry(logrus.StandardLogger())
+
+	// Lift the exhausted flag inside WaitForToken's check by leaving
+	// exhaustedWait false; fakeIssuer only blocks WaitForToken via inUse>=cap.
+	acquired, err := acquireBuildDatapackToken(context.Background(), issuer, task, logEntry)
+	if err != nil {
+		t.Fatalf("acquireBuildDatapackToken: %v", err)
+	}
+	if !acquired {
+		t.Fatalf("expected acquired=true after wait succeeds, got false")
+	}
+	if issuer.acquireCalls != 1 {
+		t.Fatalf("AcquireToken calls = %d, want 1", issuer.acquireCalls)
+	}
+	if issuer.waitCalls != 1 {
+		t.Fatalf("WaitForToken calls = %d, want 1 (bucket was full)", issuer.waitCalls)
+	}
+}
+
+// TestAcquireBuildDatapackToken_ReschedulesOnTimeout is the critical test
+// for the inject-loop overload bug: when both AcquireToken and WaitForToken
+// return (false, nil), the helper must report acquired=false so the caller
+// can reschedule the task instead of barreling into createDatapackJob and
+// hammering ClickHouse beyond its concurrent-query ceiling.
+func TestAcquireBuildDatapackToken_ReschedulesOnTimeout(t *testing.T) {
+	issuer := newFakeIssuer("build_datapack", 8)
+	issuer.exhausted = true
+	issuer.exhaustedWait = true
+	task := &dto.UnifiedTask{TaskID: "tid-3", TraceID: "trc-3"}
+	logEntry := logrus.NewEntry(logrus.StandardLogger())
+
+	acquired, err := acquireBuildDatapackToken(context.Background(), issuer, task, logEntry)
+	if err != nil {
+		t.Fatalf("acquireBuildDatapackToken: %v", err)
+	}
+	if acquired {
+		t.Fatalf("expected acquired=false when wait times out, got true")
+	}
+	if issuer.acquireCalls != 1 {
+		t.Fatalf("AcquireToken calls = %d, want 1", issuer.acquireCalls)
+	}
+	if issuer.waitCalls != 1 {
+		t.Fatalf("WaitForToken calls = %d, want 1", issuer.waitCalls)
+	}
+	if issuer.inUse != 0 {
+		t.Fatalf("inUse = %d, want 0 (no token actually acquired)", issuer.inUse)
+	}
+}
+
+// TestAcquireBuildDatapackToken_PropagatesAcquireError ensures a Redis
+// connection flake on AcquireToken bubbles up to the caller (which then
+// handleExecutionError-marks the task), instead of silently falling
+// through to WaitForToken on a degraded backend.
+func TestAcquireBuildDatapackToken_PropagatesAcquireError(t *testing.T) {
+	issuer := newFakeIssuer("build_datapack", 8)
+	issuer.acquireErr = errors.New("redis: connection refused")
+	task := &dto.UnifiedTask{TaskID: "tid-4", TraceID: "trc-4"}
+	logEntry := logrus.NewEntry(logrus.StandardLogger())
+
+	acquired, err := acquireBuildDatapackToken(context.Background(), issuer, task, logEntry)
+	if err == nil {
+		t.Fatalf("expected acquire error to propagate, got nil")
+	}
+	if acquired {
+		t.Fatalf("expected acquired=false on acquire error, got true")
+	}
+	if issuer.waitCalls != 0 {
+		t.Fatalf("WaitForToken should not be called when AcquireToken errors: %d calls", issuer.waitCalls)
+	}
+}

--- a/AegisLab/src/service/consumer/config_handlers.go
+++ b/AegisLab/src/service/consumer/config_handlers.go
@@ -28,6 +28,7 @@ func RegisterConsumerHandlers(
 	restartLimiter *TokenBucketRateLimiter,
 	warmingLimiter *TokenBucketRateLimiter,
 	buildLimiter *TokenBucketRateLimiter,
+	buildDatapackLimiter *TokenBucketRateLimiter,
 	algoLimiter *TokenBucketRateLimiter,
 ) {
 	// Wire the controller as the monitor's NamespaceActivator so a successful
@@ -48,6 +49,7 @@ func RegisterConsumerHandlers(
 		restartLimiter,
 		warmingLimiter,
 		buildLimiter,
+		buildDatapackLimiter,
 		algoLimiter,
 	))
 	consumerScope := consts.ConfigScopeConsumer
@@ -307,11 +309,12 @@ func (h *chaosSystemHandler) refreshNamespaces() error {
 // =====================================================================
 
 type rateLimitingConfigHandler struct {
-	publisher      common.ConfigPublisher
-	restartLimiter *TokenBucketRateLimiter
-	warmingLimiter *TokenBucketRateLimiter
-	buildLimiter   *TokenBucketRateLimiter
-	algoLimiter    *TokenBucketRateLimiter
+	publisher            common.ConfigPublisher
+	restartLimiter       *TokenBucketRateLimiter
+	warmingLimiter       *TokenBucketRateLimiter
+	buildLimiter         *TokenBucketRateLimiter
+	buildDatapackLimiter *TokenBucketRateLimiter
+	algoLimiter          *TokenBucketRateLimiter
 }
 
 func newRateLimitingConfigHandler(
@@ -319,14 +322,16 @@ func newRateLimitingConfigHandler(
 	restartLimiter *TokenBucketRateLimiter,
 	warmingLimiter *TokenBucketRateLimiter,
 	buildLimiter *TokenBucketRateLimiter,
+	buildDatapackLimiter *TokenBucketRateLimiter,
 	algoLimiter *TokenBucketRateLimiter,
 ) *rateLimitingConfigHandler {
 	return &rateLimitingConfigHandler{
-		publisher:      publisher,
-		restartLimiter: restartLimiter,
-		warmingLimiter: warmingLimiter,
-		buildLimiter:   buildLimiter,
-		algoLimiter:    algoLimiter,
+		publisher:            publisher,
+		restartLimiter:       restartLimiter,
+		warmingLimiter:       warmingLimiter,
+		buildLimiter:         buildLimiter,
+		buildDatapackLimiter: buildDatapackLimiter,
+		algoLimiter:          algoLimiter,
 	}
 }
 
@@ -343,10 +348,21 @@ func (h *rateLimitingConfigHandler) Handle(ctx context.Context, key, oldValue, n
 
 		switch key {
 		case "rate_limiting.max_concurrent_builds":
+			// consts.MaxTokensKeyBuildContainer now points at the same
+			// "rate_limiting.max_concurrent_builds" key the watcher fires
+			// on; previously they disagreed and the operator-set value was
+			// silently ignored on reload.
 			if h.buildLimiter != nil {
 				maxTokens := config.GetInt(consts.MaxTokensKeyBuildContainer)
 				_, currentTimeout := h.buildLimiter.GetConfig()
 				h.buildLimiter.UpdateConfig(maxTokens, currentTimeout)
+			}
+
+		case "rate_limiting.max_concurrent_build_datapack":
+			if h.buildDatapackLimiter != nil {
+				maxTokens := config.GetInt(consts.MaxTokensKeyBuildDatapack)
+				_, currentTimeout := h.buildDatapackLimiter.GetConfig()
+				h.buildDatapackLimiter.UpdateConfig(maxTokens, currentTimeout)
 			}
 
 		case "rate_limiting.max_concurrent_restarts":
@@ -385,6 +401,10 @@ func (h *rateLimitingConfigHandler) Handle(ctx context.Context, key, oldValue, n
 			if h.buildLimiter != nil {
 				maxTokens, _ := h.buildLimiter.GetConfig()
 				h.buildLimiter.UpdateConfig(maxTokens, timeout)
+			}
+			if h.buildDatapackLimiter != nil {
+				maxTokens, _ := h.buildDatapackLimiter.GetConfig()
+				h.buildDatapackLimiter.UpdateConfig(maxTokens, timeout)
 			}
 			if h.algoLimiter != nil {
 				maxTokens, _ := h.algoLimiter.GetConfig()

--- a/AegisLab/src/service/consumer/config_handlers_test.go
+++ b/AegisLab/src/service/consumer/config_handlers_test.go
@@ -226,3 +226,43 @@ func TestChaosSystemReloadDoesNotHitDB(t *testing.T) {
 		t.Fatalf("reconcile: %v", err)
 	}
 }
+
+// TestRateLimitingConfigHandlerCategory pins the consumer-scope category so a
+// future refactor that drops it from RegisterConsumerHandlers' watcher set
+// would break this test rather than silently stop reload from firing.
+func TestRateLimitingConfigHandlerCategory(t *testing.T) {
+	h := newRateLimitingConfigHandler(nil, nil, nil, nil, nil, nil)
+	if got := h.Category(); got != "rate_limiting" {
+		t.Fatalf("Category() = %q, want %q", got, "rate_limiting")
+	}
+	if got := h.Scope(); got != consts.ConfigScopeConsumer {
+		t.Fatalf("Scope() = %v, want %v", got, consts.ConfigScopeConsumer)
+	}
+}
+
+// TestRateLimitingConfigHandlerHandlesBuildDatapackKey covers the new
+// "rate_limiting.max_concurrent_build_datapack" switch case. With a nil
+// limiter the handler must remain a no-op (no panic), and unknown keys
+// must hit the default branch without erroring.
+func TestRateLimitingConfigHandlerHandlesBuildDatapackKey(t *testing.T) {
+	h := newRateLimitingConfigHandler(nil, nil, nil, nil, nil, nil)
+	if err := h.Handle(context.Background(), "rate_limiting.max_concurrent_build_datapack", "8", "12"); err != nil {
+		t.Fatalf("handle build_datapack key: %v", err)
+	}
+	if err := h.Handle(context.Background(), "rate_limiting.unknown_key", "", ""); err != nil {
+		t.Fatalf("handle unknown key (must default-no-op): %v", err)
+	}
+}
+
+// TestRateLimitingConfigKeyAlignsWithBuildContainerConst guards against the
+// historical mismatch between the watched key (max_concurrent_builds) and the
+// const the reload reads (previously max_concurrent_build_container, which
+// was never present in etcd). If they ever drift again, the watcher fires
+// and the reload silently no-ops against a default value.
+func TestRateLimitingConfigKeyAlignsWithBuildContainerConst(t *testing.T) {
+	const watchedKey = "rate_limiting.max_concurrent_builds"
+	if consts.MaxTokensKeyBuildContainer != watchedKey {
+		t.Fatalf("MaxTokensKeyBuildContainer = %q, want %q (must match the key the rate_limiting handler watches)",
+			consts.MaxTokensKeyBuildContainer, watchedKey)
+	}
+}

--- a/AegisLab/src/service/consumer/k8s_handler.go
+++ b/AegisLab/src/service/consumer/k8s_handler.go
@@ -127,24 +127,26 @@ type jobLabels struct {
 }
 
 type k8sHandler struct {
-	db           *gorm.DB
-	store        *stateStore
-	monitor      NamespaceMonitor
-	algoLimiter  *TokenBucketRateLimiter
-	k8sGateway   *k8s.Gateway
-	redisGateway *redis.Gateway
-	batchManager *FaultBatchManager
+	db                   *gorm.DB
+	store                *stateStore
+	monitor              NamespaceMonitor
+	algoLimiter          *TokenBucketRateLimiter
+	buildDatapackLimiter *TokenBucketRateLimiter
+	k8sGateway           *k8s.Gateway
+	redisGateway         *redis.Gateway
+	batchManager         *FaultBatchManager
 }
 
-func NewHandler(db *gorm.DB, monitor NamespaceMonitor, algoLimiter *TokenBucketRateLimiter, k8sGateway *k8s.Gateway, redisGateway *redis.Gateway, batchManager *FaultBatchManager, execution ExecutionOwner, injection InjectionOwner) *k8sHandler {
+func NewHandler(db *gorm.DB, monitor NamespaceMonitor, algoLimiter *TokenBucketRateLimiter, buildDatapackLimiter *TokenBucketRateLimiter, k8sGateway *k8s.Gateway, redisGateway *redis.Gateway, batchManager *FaultBatchManager, execution ExecutionOwner, injection InjectionOwner) *k8sHandler {
 	return &k8sHandler{
-		db:           db,
-		store:        newStateStore(execution, injection),
-		monitor:      monitor,
-		algoLimiter:  algoLimiter,
-		k8sGateway:   k8sGateway,
-		redisGateway: redisGateway,
-		batchManager: batchManager,
+		db:                   db,
+		store:                newStateStore(execution, injection),
+		monitor:              monitor,
+		algoLimiter:          algoLimiter,
+		buildDatapackLimiter: buildDatapackLimiter,
+		k8sGateway:           k8sGateway,
+		redisGateway:         redisGateway,
+		batchManager:         batchManager,
 	}
 }
 
@@ -473,6 +475,20 @@ func (h *k8sHandler) HandleJobFailed(job *batchv1.Job, annotations map[string]st
 	var payload any
 	switch parsedLabels.taskType {
 	case consts.TaskTypeBuildDatapack:
+		// Release the BuildDatapack token first so a flood of failures
+		// does not wedge the bucket. Release-on-failure mirrors the
+		// algorithm path below.
+		if rateLimiter := h.buildDatapackLimiter; rateLimiter != nil {
+			if releaseErr := rateLimiter.ReleaseToken(taskCtx, parsedLabels.taskID, parsedLabels.traceID); releaseErr != nil {
+				errCtx.Warn(nil, "failed to release build datapack token on job failure", releaseErr)
+			} else {
+				logEntry.Info("successfully released build datapack token on job failure")
+				taskSpan.AddEvent("successfully released build datapack token on job failure")
+			}
+		} else {
+			errCtx.Warn(nil, "build datapack rate limiter not initialized on job failure", fmt.Errorf("build datapack rate limiter not initialized"))
+		}
+
 		logEntry.Error("datapack build failed")
 		taskSpan.AddEvent("datapack build failed")
 
@@ -583,6 +599,20 @@ func (h *k8sHandler) HandleJobSucceeded(job *batchv1.Job, annotations map[string
 
 	switch parsedLabels.taskType {
 	case consts.TaskTypeBuildDatapack:
+		// Release the BuildDatapack token now that the job has finished;
+		// holding it any longer would slow-leak the bucket. Mirrors the
+		// release-on-success of the algorithm path below.
+		if rateLimiter := h.buildDatapackLimiter; rateLimiter != nil {
+			if releaseErr := rateLimiter.ReleaseToken(taskCtx, parsedLabels.taskID, parsedLabels.traceID); releaseErr != nil {
+				errCtx.Warn(nil, "failed to release build datapack token on job success", releaseErr)
+			} else {
+				logEntry.Info("successfully released build datapack token on job success")
+				taskSpan.AddEvent("successfully released build datapack token on job success")
+			}
+		} else {
+			errCtx.Warn(nil, "build datapack rate limiter not initialized on job success", fmt.Errorf("build datapack rate limiter not initialized"))
+		}
+
 		logEntry.Info("datapack build successfully")
 		taskSpan.AddEvent("datapack build successfully")
 

--- a/AegisLab/src/service/consumer/rate_limiter.go
+++ b/AegisLab/src/service/consumer/rate_limiter.go
@@ -196,6 +196,22 @@ func NewBuildContainerRateLimiter(gateway *redis.Gateway) *TokenBucketRateLimite
 	})
 }
 
+// NewBuildDatapackRateLimiter builds the limiter that gates BuildDatapack
+// tasks. Each BuildDatapack run launches a Kubernetes Job that issues ~30
+// ClickHouse queries via rcabench-platform's prepare_inputs.py; without
+// this cap the autonomous inject-loop fans out enough jobs at once to
+// cross ClickHouse's `max_concurrent_queries` ceiling and trigger
+// "Code 202: Too many simultaneous queries" cascades.
+func NewBuildDatapackRateLimiter(gateway *redis.Gateway) *TokenBucketRateLimiter {
+	return newTokenBucketRateLimiter(gateway, RateLimiterConfig{
+		TokenBucketKey:   consts.BuildDatapackTokenBucket,
+		MaxTokensKey:     consts.MaxTokensKeyBuildDatapack,
+		DefaultMaxTokens: consts.MaxConcurrentBuildDatapack,
+		DefaultTimeout:   consts.TokenWaitTimeout,
+		ServiceName:      consts.BuildDatapackServiceName,
+	})
+}
+
 func NewAlgoExecutionRateLimiter(gateway *redis.Gateway) *TokenBucketRateLimiter {
 	return newTokenBucketRateLimiter(gateway, RateLimiterConfig{
 		TokenBucketKey:   consts.AlgoExecutionTokenBucket,

--- a/AegisLab/src/service/consumer/runtime_deps.go
+++ b/AegisLab/src/service/consumer/runtime_deps.go
@@ -20,7 +20,14 @@ type RuntimeDeps struct {
 	// (default 30). See PR #205.
 	NsWarmingRateLimiter *TokenBucketRateLimiter
 	BuildRateLimiter     *TokenBucketRateLimiter
-	AlgorithmRateLimiter *TokenBucketRateLimiter
+	// BuildDatapackRateLimiter caps concurrent BuildDatapack tasks. Each
+	// BuildDatapack Job issues ~30 ClickHouse queries; without this cap
+	// the inject-loop fan-out has overrun ClickHouse's max_concurrent_queries
+	// ceiling. Default 8 is a conservative bound (~240 concurrent CH queries)
+	// that fits inside the bumped 2000 ceiling with plenty of headroom for
+	// other consumers. See also rate_limiting.max_concurrent_build_datapack.
+	BuildDatapackRateLimiter *TokenBucketRateLimiter
+	AlgorithmRateLimiter     *TokenBucketRateLimiter
 	RedisGateway         *redis.Gateway
 	K8sGateway           *k8s.Gateway
 	BuildKitGateway      *buildkit.Gateway

--- a/AegisLab/src/service/initialization/consumer.go
+++ b/AegisLab/src/service/initialization/consumer.go
@@ -34,6 +34,7 @@ func InitializeConsumer(
 	restartLimiter *consumer.TokenBucketRateLimiter,
 	warmingLimiter *consumer.TokenBucketRateLimiter,
 	buildLimiter *consumer.TokenBucketRateLimiter,
+	buildDatapackLimiter *consumer.TokenBucketRateLimiter,
 	algoLimiter *consumer.TokenBucketRateLimiter,
 ) error {
 	consumerData, err := newConfigDataWithDB(db, consts.ConfigScopeConsumer)
@@ -60,7 +61,7 @@ func InitializeConsumer(
 	}
 
 	common.RegisterGlobalHandlers(publisher)
-	consumer.RegisterConsumerHandlers(controller, monitor, publisher, restartLimiter, warmingLimiter, buildLimiter, algoLimiter)
+	consumer.RegisterConsumerHandlers(controller, monitor, publisher, restartLimiter, warmingLimiter, buildLimiter, buildDatapackLimiter, algoLimiter)
 	if err := activateConfigScope(consumerData.scope, listener); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why

`executeBuildDatapackWithDeps` was the only of the four task-type executors that jumped straight into `createDatapackJob` with no token-bucket gate (RestartPedestal / BuildContainer / AlgoExecution all guard with `rateLimiter.AcquireToken` first). The autonomous inject-loop submits ~30 candidates across 4 systems at once, each spawning a BuildDatapack Job that fires ~30 ClickHouse queries via rcabench-platform's `prepare_inputs.py`. 30 builds x 30 queries = ~900 concurrent CH queries which crosses ClickHouse's `max_concurrent_queries=500` default and fails every build with `Code 202: Too many simultaneous queries`.

This PR caps the BuildDatapack fan-out at the backend so future surges never reach the ClickHouse ceiling — independent of whatever `max_concurrent_queries` the operator has set. The chart-side persistence of the live `max_concurrent_queries=2000` bump is a separate PR.

## Key cleanup

There was a long-standing mismatch between the etcd key the rate_limiting handler watched (`rate_limiting.max_concurrent_builds`) and the key the reload read on update (`consts.MaxTokensKeyBuildContainer = \"rate_limiting.max_concurrent_build_container\"`). Result: setting `max_concurrent_builds` in etcd fired the watcher, but the reload then read a different, never-set key and silently fell back to `MaxConcurrentBuildContainer=3`.

I went with **option (b) from the issue: keep the public name `rate_limiting.max_concurrent_builds` and fix the const string to match**. This is zero-data-migration on the live cluster — every existing seed (`data.yaml` prod/staging/byte-cluster, `aegisctl cluster prepare`, legacy DB-migration tests, dynamic_configs rows) keeps working unchanged.

A new regression test (`TestRateLimitingConfigKeyAlignsWithBuildContainerConst`) breaks the build immediately if the watched key and the const string drift apart again.

## Changes

- `consts/consts.go`: add BuildDatapack* triple (default cap = 8, ~240 concurrent CH queries with headroom inside even a 500 ceiling) and re-point `MaxTokensKeyBuildContainer` at the watched key.
- `consumer/rate_limiter.go`: `NewBuildDatapackRateLimiter` factory.
- `consumer/runtime_deps.go`: `BuildDatapackRateLimiter` field.
- `consumer/build_datapack.go`: gate `executeBuildDatapackWithDeps` on Acquire / Wait / reschedule, with a deferred release on every pre-launch failure so the bucket cannot slow-leak. Acquire helper factored out as `acquireBuildDatapackToken` for unit testing with the existing `fakeIssuer`. Added `rescheduleBuildDatapackTask` mirroring the BuildContainer / AlgoExecution shape.
- `consumer/config_handlers.go`: thread the new limiter through, add the `rate_limiting.max_concurrent_build_datapack` switch case, include in the `token_wait_timeout` fan-out.
- `consumer/k8s_handler.go`: release the BuildDatapack token in both HandleJobSucceeded and HandleJobFailed for `TaskTypeBuildDatapack`, parallel to how the algorithm-execution token is released today.
- `interface/worker` + `interface/controller` + `app/runtime_stack`: wire the new fx dependency through the same lattice the other limiters use (`name:\"build_datapack_limiter\"`).
- `cmd/aegisctl/cluster/prepare.go` LocalE2EEtcdActions: seed `\"rate_limiting.max_concurrent_build_datapack\" = \"8\"`.
- `data/initial_data/{prod,staging}/data.yaml` + `manifests/byte-cluster/initial-data/data.yaml`: seed the new dynamic_config row so a fresh backend boot lands the value in etcd via the existing `publishSeededConfigsToEtcd` path.

## Tests

- `service/consumer/build_datapack_test.go` (new): 4 cases — happy acquire, fall-through to wait, **reschedule-on-timeout** (the critical test that proves the loop cannot hammer CH past the cap), acquire error propagation.
- `service/consumer/config_handlers_test.go`: 3 new tests covering the new switch case + the key-alignment regression guard.

## Gates

- [x] `cd src && go build -tags duckdb_arrow -o /dev/null ./...`
- [x] `cd src && go test ./service/consumer/... ./service/initialization/... ./utils/...`
- [x] `cd src && golangci-lint run --new-from-rev=origin/main ./...` → 0 issues

## Test plan

- [ ] Roll out the worker pod with this image; verify it boots (no fx wiring panic).
- [ ] `kubectl exec -n exp deploy/rcabench-runtime-worker-service -- env | grep -i datapack` (sanity: container started).
- [ ] Submit a fresh inject-loop round of ~30 candidates; confirm in logs the consumer logs `\"No build datapack token available, waiting...\"` once the bucket fills, instead of all jobs racing into CH.
- [ ] Set `etcdctl put /rcabench/config/consumer/rate_limiting.max_concurrent_build_datapack 12` and verify the watcher logs `\"Rate limiting configuration updated\"` for the new key and subsequent submissions respect the new bound.
- [ ] After the run, `redis-cli SCARD token_bucket:build_datapack` returns 0 (no leaked tokens).

## Operator notes

Live-cluster etcd seed to apply alongside this rollout (only one new key — the rest stay as they are):

```
etcdctl put /rcabench/config/consumer/rate_limiting.max_concurrent_build_datapack 8
```

The existing `rate_limiting.max_concurrent_builds` key is unchanged and will now correctly drive `BuildContainer` reloads (it never did before).

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>