### PR TITLE
clickstack(byte-cluster): pin Keeper + HyperDX image to volces opspai mirror

### DIFF
--- a/AegisLab/manifests/byte-cluster/clickstack.values.yaml
+++ b/AegisLab/manifests/byte-cluster/clickstack.values.yaml
@@ -28,7 +28,10 @@ hyperdx:
     type: ClusterIP
   deployment:
     image:
-      repository: pair-diag-cn-guangzhou.cr.volces.com/pair/hyperdx
+      # auto-mirrored from docker.io/opspai/hyperdx:2.23.0 (pushed locally;
+      # the pair-diag project does not have 2.23.0 — only old 2.8.0)
+      repository: pair-cn-shanghai.cr.volces.com/opspai/hyperdx
+      tag: "2.23.0"
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -76,6 +79,13 @@ clickhouse:
   keeper:
     spec:
       replicas: 3
+      # Keeper image: chart default `clickhouse/clickhouse-keeper:latest` is
+      # unreachable from byte-cluster (docker.io egress flake). Pinned to a
+      # specific 25.7 alpine and routed through the volces docker.io mirror.
+      containerTemplate:
+        image:
+          repository: pair-cn-shanghai.cr.volces.com/opspai/clickhouse-keeper
+          tag: "25.7-alpine"
       dataVolumeClaimSpec:
         accessModes:
           - ReadWriteOnce


### PR DESCRIPTION
## What

Override two image references in `clickstack.values.yaml` so the operator-managed CH cluster can actually pull its components on byte-cluster:

- **Keeper**: chart 2.1.1 hardcodes `docker.io/clickhouse/clickhouse-keeper:latest` (no values key to override in chart). byte-cluster nodes can't reach docker.io directly. Add `clickhouse.keeper.spec.containerTemplate.image` (passthrough into the KeeperCluster CR) → `pair-cn-shanghai.cr.volces.com/opspai/clickhouse-keeper:25.7-alpine`.
- **HyperDX**: was `pair-diag-cn-guangzhou.cr.volces.com/pair/hyperdx:<chart-appVersion=2.23.0>`. The pair-diag project never received the 2.23.0 build (only 2.8.0). Switch to `pair-cn-shanghai.cr.volces.com/opspai/hyperdx:2.23.0`.

## How the new tags exist

Both images were pulled from upstream and pushed to docker.io/opspai/*, where they auto-mirror to `pair-cn-shanghai.cr.volces.com/opspai/*` (see `reference_volces_mirror`):

- `docker.io/opspai/clickhouse-keeper:25.7-alpine` ← `clickhouse/clickhouse-keeper:25.7-alpine`
- `docker.io/opspai/hyperdx:2.23.0` ← `docker.hyperdx.io/hyperdx/hyperdx:2.23.0`

## Verification

After this override + helm upgrade on byte-cluster:
- `kubectl get keepercluster clickstack-keeper -n monitoring` → `READY: True / 3 ready replicas`
- `kubectl get clickhousecluster clickstack-clickhouse -n monitoring` → `READY: True / All shards are ready`
- `clickhouse-client --query "SELECT name,value FROM system.server_settings WHERE name='max_concurrent_queries'"` → `2000`
- `SHOW DATABASES` includes `otel`
- HyperDX UI loads at the chart-managed Service

Follow-up to PR #211 (which landed the chart vendor + base values rewrite). Both lift PR #208 (CH replication) from "tracking-only" to "shipped on byte-cluster".