### PR TITLE
chore(seed): bump hs / sn / mm DSB chart 0.1.2 → 0.1.3 (byte-cluster)

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -186,11 +186,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.2
+      - name: 0.1.3
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
-          version: 0.1.2
+          version: 0.1.3
           chart_name: hotel-reservation
           repo_name: lgu-dsb
           repo_url: https://lgu-se-internal.github.io/DeathStarBench
@@ -225,11 +225,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.2
+      - name: 0.1.3
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
-          version: 0.1.2
+          version: 0.1.3
           chart_name: social-network
           repo_name: lgu-dsb
           repo_url: https://lgu-se-internal.github.io/DeathStarBench
@@ -264,11 +264,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.2
+      - name: 0.1.3
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
-          version: 0.1.2
+          version: 0.1.3
           chart_name: media-microservices
           repo_name: lgu-dsb
           repo_url: https://lgu-se-internal.github.io/DeathStarBench


### PR DESCRIPTION
## What

Bumps the byte-cluster seed for the three DSB systems from chart `0.1.2` to `0.1.3`:

- system `hs` (hotel-reservation)
- system `sn` (social-network)
- system `media` (media-microservices)

Touches only `manifests/byte-cluster/initial-data/data.yaml` (3 hits replaced with 0.1.3 each, both the `versions[].name` and the `helm_config.version` fields).

## Why

[LGU-SE-Internal/DeathStarBench#51](https://github.com/LGU-SE-Internal/DeathStarBench/pull/51) (merged) replaces the load-generator's `fetch-datasets` init container — which used to `git clone https://github.com/delimitrou/DeathStarBench.git` on every pod restart — with a pre-baked dataset image (`deathstarbench/loader-datasets`). Bumps:

- `social-network` 0.1.2 → 0.1.3 ✅
- `media-microservices` 0.1.2 → 0.1.3 ✅
- `hotel-reservation` unchanged (its loadgen never had the git-clone init)

## Operational impact

The autonomous inject-loop on byte-cluster has been losing 30 %+ of sn/mm rounds to `restart.pedestal.failed` because the load-generator's init container hit GitHub egress timeouts during `git clone`. After this seed lands + a one-shot `aegisctl reseed` on the live cluster, newly allocated `sn*` / `mm*` namespaces will use 0.1.3 charts and no longer depend on external GitHub for dataset assets.

## Out of scope

`data/initial_data/{staging,prod}/data.yaml` are left at their existing 0.1.0 pins — those tracks don't run on byte-cluster. Bump those separately if those environments later want to inherit the same fix.

## Refs

- LGU-SE-Internal/DeathStarBench#51 (chart change, merged, image build kicked off)
- Companion PR #212 (teastore 0.1.2 → 0.1.3, same shape)