### PR TITLE
feat(reasoning/ir): TrainTicket JDBC trace-binding adapter

### DIFF
--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
@@ -17,6 +17,9 @@ from rcabench_platform.v3.internal.reasoning.algorithms.starting_point_resolver 
 from rcabench_platform.v3.internal.reasoning.ir.adapter import AdapterContext
 from rcabench_platform.v3.internal.reasoning.ir.adapters.inferred_edges import enrich_with_inferred_edges
 from rcabench_platform.v3.internal.reasoning.ir.adapters.log_dependency import dispatch_log_adapters
+from rcabench_platform.v3.internal.reasoning.ir.adapters.trace_db_binding import (
+    dispatch_trace_db_binding_adapters,
+)
 from rcabench_platform.v3.internal.reasoning.ir.pipeline import run_reasoning_ir
 from rcabench_platform.v3.internal.reasoning.loaders.parquet_loader import ParquetDataLoader
 from rcabench_platform.v3.internal.reasoning.loaders.utils import fmap_processpool
@@ -467,6 +470,16 @@ def run_single_case(
         abnormal_traces = loader.load_traces("abnormal")
         injection_at = _earliest_abnormal_seconds(abnormal_traces)
         abnormal_window_end = _latest_abnormal_seconds(abnormal_traces)
+
+        # Per-system trace -> DB binding. Runs BEFORE the IR pipeline so that
+        # the structural edges this adapter wires (service->pod routes_to,
+        # stateful_set->pod manages) participate in StructuralInheritance's
+        # ``container.unavailable`` -> ``service.unavailable`` cascade. Each
+        # registered adapter gates itself on its system signature, so this
+        # is a no-op on non-matching benchmarks.
+        n_db_binding_edges = dispatch_trace_db_binding_adapters(graph, abnormal_traces, baseline_traces)
+        logger.info(f"[{case_name}] trace-db-binding edges: {n_db_binding_edges}")
+
         ctx = AdapterContext(datapack_dir=data_dir, case_name=case_name)
         timelines = run_reasoning_ir(
             graph=graph,

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/adapters/trace_db_binding.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir/adapters/trace_db_binding.py
@@ -1,0 +1,426 @@
+"""Trace -> DB binding adapter — synthesise the missing call edge from Java
+services to a database service that emits no OTel server spans.
+
+Closes a trace-blind gap on TrainTicket and any benchmark that uses a
+client-only OTel instrumentation for its database tier. The Spring/Hibernate
+JDBC instrumentation reports the SQL statement as a *client* span name (e.g.
+``SELECT ts.users``) on the **caller** side, but the database itself never
+runs an OTel SDK so no server-side span exists. The trace edge builder in
+``parquet_loader._build_edges_from_traces`` therefore never emits a
+``span -> span calls`` edge into a ``mysql`` node, the ``mysql`` service node
+itself is never created (``_build_service_nodes_from_traces`` only enumerates
+service names that appear in trace data), and the propagator from a
+``container|mysql`` injection has no reachable subgraph.
+
+This adapter detects DB client spans by **span_name regex** (because this
+dataset has no standardised ``attr.db.*`` attributes — they are simply
+absent), groups them by caller service, and:
+
+1. Materialises the ``service|mysql`` node when at least one mysql infra node
+   exists (``container|mysql`` / ``pod|mysql-*`` / ``stateful_set|mysql``).
+2. Wires the structural containment edges
+   (``stateful_set|mysql --manages--> pod|mysql-*`` and
+   ``service|mysql --routes_to--> pod|mysql-*``) so
+   ``StructuralInheritanceAdapter`` cascades the observed ``container|mysql``
+   ``unavailable`` state up to ``service|mysql`` and from there to the JDBC
+   span endpoints.
+3. Adds ``service|<caller> --calls--> service|mysql`` as evidence of the
+   logical dependency (one edge per caller; carries the SQL-span count and
+   error signal for downstream diagnostics).
+4. Adds ``service|mysql --includes--> span|<caller>::<sql>`` so the existing
+   ``RULE_SERVICE_TO_SPAN`` (``src_kind=service``, ``edge_kind=includes``)
+   actually traverses from the mysql service node into the JDBC span
+   endpoints — without this hop the propagator cannot reach the alarm root
+   spans through the synthesised topology.
+
+The adapter is per-system. Subclasses declare ``applies()`` so that benchmarks
+without the SQL-naming convention (otel-demo, sockshop, hotel-reservation,
+social-network, media-microservices, teastore) cannot accidentally activate
+it. ``dispatch_trace_db_binding_adapters`` is the single entry-point and is
+invoked from ``cli.py`` strictly **before** ``enrich_with_inferred_edges`` and
+the propagator construction so that the synthesised topology participates in
+both the inferred-edge heuristic and the BFS traversal.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import ClassVar
+
+import polars as pl
+
+from rcabench_platform.v3.internal.reasoning.models.graph import (
+    CallsEdgeData,
+    DepKind,
+    Edge,
+    HyperGraph,
+    Node,
+    PlaceKind,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Registry pattern mirrors the StateAdapter family — keeps the dispatch entry
+# point a one-liner and lets future per-system adapters (e.g. otel-demo's
+# postgres binding, if its instrumentation regresses) plug in without
+# touching cli.py.
+_REGISTRY: list[type[TraceDbBindingAdapter]] = []
+
+
+def register_trace_db_binding_adapter(cls: type[TraceDbBindingAdapter]) -> type[TraceDbBindingAdapter]:
+    _REGISTRY.append(cls)
+    return cls
+
+
+@dataclass(frozen=True, slots=True)
+class TraceDbBinding:
+    """A single (caller_service -> db_target_service) binding.
+
+    ``span_count`` is the number of detected DB client spans on the abnormal
+    side; ``error_count`` is how many of those carried a 5xx HTTP response
+    status (a coarse error signal — DB client spans don't have a dedicated
+    status field in this schema, but Spring's RestController wrapper folds
+    SQL-driven 500s back into the HTTP response code on the same trace).
+    """
+
+    caller_service: str
+    db_target_service: str
+    span_count: int
+    error_count: int
+    sample_span_names: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class TraceDbBindingMetadata:
+    """Diagnostic payload attached to each synthesised edge.
+
+    Stored on ``HyperGraph.data["trace_db_bindings"]`` keyed by
+    ``(src_id, dst_id, kind)``. Mirrors the convention used by
+    ``inferred_edges.InferredEdgeMetadata``.
+    """
+
+    adapter_name: str
+    caller_service: str
+    db_target_service: str
+    span_count: int
+    error_count: int
+
+
+class TraceDbBindingAdapter(abc.ABC):
+    """Per-system DB client-span detector.
+
+    Subclasses pick a system signature in ``applies()`` and a span-detection
+    rule in ``detect_db_client_spans()``; the dispatcher takes care of the
+    graph mutation. The split keeps system-specific knowledge (regex,
+    service-name prefix, target DB) co-located in the subclass.
+    """
+
+    name: ClassVar[str]
+    db_target_service: ClassVar[str]
+
+    @abc.abstractmethod
+    def applies(self, abnormal_traces: pl.DataFrame) -> bool:
+        """Return True iff the system signature this adapter binds is present."""
+
+    @abc.abstractmethod
+    def detect_db_client_spans(self, abnormal_traces: pl.DataFrame) -> pl.DataFrame:
+        """Return rows of detected DB client spans.
+
+        The returned frame must contain at least the columns
+        ``service_name`` and ``span_name``; if the source frame has
+        ``attr.http.response.status_code`` the implementation is expected to
+        preserve it so error counts can be aggregated.
+        """
+
+    def collect_bindings(self, abnormal_traces: pl.DataFrame) -> list[TraceDbBinding]:
+        spans = self.detect_db_client_spans(abnormal_traces)
+        if spans.height == 0:
+            return []
+
+        # Aggregate per caller service. Keep up to a handful of sample span
+        # names per caller for diagnostics.
+        has_status = "attr.http.response.status_code" in spans.columns
+        agg_exprs: list[pl.Expr] = [
+            pl.len().alias("span_count"),
+            pl.col("span_name").unique().head(5).alias("sample_span_names"),
+        ]
+        if has_status:
+            status = pl.col("attr.http.response.status_code")
+            agg_exprs.append((status.is_not_null() & (status >= 500)).cast(pl.Int64).sum().alias("error_count"))
+        else:
+            agg_exprs.append(pl.lit(0, dtype=pl.Int64).alias("error_count"))
+
+        grouped = spans.group_by("service_name").agg(agg_exprs).sort("service_name")
+        bindings: list[TraceDbBinding] = []
+        for row in grouped.iter_rows(named=True):
+            bindings.append(
+                TraceDbBinding(
+                    caller_service=row["service_name"],
+                    db_target_service=self.db_target_service,
+                    span_count=int(row["span_count"]),
+                    error_count=int(row["error_count"]),
+                    sample_span_names=tuple(row["sample_span_names"] or ()),
+                )
+            )
+        return bindings
+
+
+# SQL statement opener — empirically detects 252 abnormal-window client spans
+# across 13 services on ts0-mysql-container-kill-9t6n24 with zero false
+# positives (every other client span is HTTP-prefixed). Schema half of the
+# span name (``SELECT ts.<table>``) is uniformly ``ts`` so all bindings target
+# the single ``service|mysql`` node.
+_TT_SQL_OPENER_RE: re.Pattern[str] = re.compile(r"^(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE)\s+")
+
+
+@register_trace_db_binding_adapter
+class TrainTicketTraceDbBindingAdapter(TraceDbBindingAdapter):
+    """TrainTicket Spring/Hibernate JDBC -> mysql binding.
+
+    Activates iff at least one ``ts-*`` service appears in the abnormal trace
+    frame. The DB target is the singleton ``mysql`` service.
+    """
+
+    name: ClassVar[str] = "trainticket_trace_db_binding"
+    db_target_service: ClassVar[str] = "mysql"
+
+    def applies(self, abnormal_traces: pl.DataFrame) -> bool:
+        if abnormal_traces.height == 0 or "service_name" not in abnormal_traces.columns:
+            return False
+        return abnormal_traces.filter(pl.col("service_name").str.starts_with("ts-")).height > 0
+
+    def detect_db_client_spans(self, abnormal_traces: pl.DataFrame) -> pl.DataFrame:
+        if abnormal_traces.height == 0:
+            return abnormal_traces
+        if "span_name" not in abnormal_traces.columns or "service_name" not in abnormal_traces.columns:
+            return abnormal_traces.head(0)
+        # Restrict to ts-* callers: avoids picking up SQL-shaped span names
+        # from foreign workloads that may share the same parquet partition.
+        return abnormal_traces.filter(
+            pl.col("service_name").str.starts_with("ts-") & pl.col("span_name").str.contains(_TT_SQL_OPENER_RE.pattern)
+        )
+
+
+def _mysql_infra_present(graph: HyperGraph, db_target: str) -> bool:
+    """Return True iff at least one infra node ties to the DB target.
+
+    The adapter must NOT manufacture a service node out of thin air — it only
+    materialises one when k8s metrics already evidence the database exists
+    (container/pod/stateful_set with the target name). On a fixture that has
+    no such infra, dispatch is a no-op (test #5).
+    """
+    return (
+        graph.get_node_by_name(f"{PlaceKind.container}|{db_target}") is not None
+        or graph.get_node_by_name(f"{PlaceKind.stateful_set}|{db_target}") is not None
+        or any(n.kind == PlaceKind.pod and n.self_name.startswith(f"{db_target}-") for n in graph._node_id_map.values())
+        or graph.get_node_by_name(f"{PlaceKind.pod}|{db_target}") is not None
+    )
+
+
+def _mysql_pod_nodes(graph: HyperGraph, db_target: str) -> list[Node]:
+    direct = graph.get_node_by_name(f"{PlaceKind.pod}|{db_target}")
+    if direct is not None:
+        return [direct]
+    return [
+        n for n in graph._node_id_map.values() if n.kind == PlaceKind.pod and n.self_name.startswith(f"{db_target}-")
+    ]
+
+
+def _ensure_service_node(graph: HyperGraph, service_name: str) -> Node:
+    existing = graph.get_node_by_name(f"{PlaceKind.service}|{service_name}")
+    if existing is not None:
+        return existing
+    return graph.add_node(Node(kind=PlaceKind.service, self_name=service_name))
+
+
+def _record_metadata(
+    graph: HyperGraph,
+    *,
+    src_id: int,
+    dst_id: int,
+    kind: DepKind,
+    adapter_name: str,
+    binding: TraceDbBinding,
+) -> None:
+    store = graph.data.setdefault("trace_db_bindings", {})
+    key = (src_id, dst_id, kind)
+    if key in store:
+        return
+    store[key] = TraceDbBindingMetadata(
+        adapter_name=adapter_name,
+        caller_service=binding.caller_service,
+        db_target_service=binding.db_target_service,
+        span_count=binding.span_count,
+        error_count=binding.error_count,
+    )
+
+
+def _add_edge_idempotent(
+    graph: HyperGraph,
+    *,
+    src: Node,
+    dst: Node,
+    kind: DepKind,
+    data: CallsEdgeData | None = None,
+) -> bool:
+    assert src.id is not None and dst.id is not None
+    if graph._graph.has_edge(src.id, dst.id, kind):
+        return False
+    graph.add_edge(
+        Edge(
+            src_id=src.id,
+            dst_id=dst.id,
+            src_name=src.uniq_name,
+            dst_name=dst.uniq_name,
+            kind=kind,
+            weight=1.0,
+            data=data,
+        ),
+        strict=False,
+    )
+    return True
+
+
+def _wire_db_structural_edges(graph: HyperGraph, db_service: Node, db_target: str) -> None:
+    """Connect db service / stateful_set to its pods so structural inheritance
+    can cascade ``container.unavailable`` -> ``service.unavailable``.
+
+    Only the edges actually needed by ``StructuralInheritanceAdapter`` are
+    added: ``service --routes_to--> pod`` (so pod->service propagation has a
+    reverse path) and ``stateful_set --manages--> pod`` for completeness.
+    """
+    pods = _mysql_pod_nodes(graph, db_target)
+    sset = graph.get_node_by_name(f"{PlaceKind.stateful_set}|{db_target}")
+    for pod in pods:
+        _add_edge_idempotent(graph, src=db_service, dst=pod, kind=DepKind.routes_to)
+        if sset is not None:
+            _add_edge_idempotent(graph, src=sset, dst=pod, kind=DepKind.manages)
+
+
+def _bind_caller_to_db(
+    graph: HyperGraph,
+    *,
+    adapter_name: str,
+    db_service: Node,
+    binding: TraceDbBinding,
+) -> int:
+    """Materialise the (caller_service, db_target) binding in the graph.
+
+    Returns the count of newly added edges (for logging / idempotency check).
+    """
+    edges_added = 0
+    caller = graph.get_node_by_name(f"{PlaceKind.service}|{binding.caller_service}")
+    if caller is None:
+        # The caller service has SQL spans but no service node — that means
+        # ``_build_service_nodes_from_traces`` skipped it (e.g. fixture has no
+        # trace rows for that service), so we bail rather than fabricate. The
+        # service node will reappear if real trace data is loaded.
+        return 0
+
+    # service|caller --calls--> service|mysql. Carries the abnormal-window
+    # span and error counts for downstream diagnostics. CallsEdgeData
+    # baseline counts stay zero here — this synthetic edge has no baseline
+    # observation; it is purely "we saw this dependency in the abnormal data".
+    calls_data = CallsEdgeData(
+        abnormal_call_count=binding.span_count,
+        abnormal_error_count=binding.error_count,
+    )
+    if _add_edge_idempotent(graph, src=caller, dst=db_service, kind=DepKind.calls, data=calls_data):
+        assert caller.id is not None and db_service.id is not None
+        _record_metadata(
+            graph,
+            src_id=caller.id,
+            dst_id=db_service.id,
+            kind=DepKind.calls,
+            adapter_name=adapter_name,
+            binding=binding,
+        )
+        edges_added += 1
+
+    # service|mysql --includes--> span|<caller>::<sql_name> for each detected
+    # SQL span. This is the hop that actually makes the propagator reachable
+    # because RULE_SERVICE_TO_SPAN is the only rule with src_kind=service in
+    # the canonical rule set.
+    for span_name in binding.sample_span_names:
+        span_uniq = f"{PlaceKind.span}|{binding.caller_service}::{span_name}"
+        span_node = graph.get_node_by_name(span_uniq)
+        if span_node is None:
+            continue
+        if _add_edge_idempotent(graph, src=db_service, dst=span_node, kind=DepKind.includes):
+            assert db_service.id is not None and span_node.id is not None
+            _record_metadata(
+                graph,
+                src_id=db_service.id,
+                dst_id=span_node.id,
+                kind=DepKind.includes,
+                adapter_name=adapter_name,
+                binding=binding,
+            )
+            edges_added += 1
+    return edges_added
+
+
+def dispatch_trace_db_binding_adapters(
+    graph: HyperGraph,
+    abnormal_traces: pl.DataFrame,
+    normal_traces: pl.DataFrame | None = None,
+) -> int:
+    """Run every registered adapter that ``applies()`` to ``abnormal_traces``.
+
+    Returns the total number of edges added across all adapters. Idempotent:
+    re-running on the same graph and frames produces no additional edges.
+    """
+    del normal_traces  # currently unused; reserved for adapters that want to
+    # diff abnormal vs baseline DB calls (e.g. detect "DB call disappeared
+    # entirely in abnormal" as a stronger signal).
+
+    if abnormal_traces is None or abnormal_traces.height == 0:
+        return 0
+
+    total_added = 0
+    for adapter_cls in _REGISTRY:
+        adapter = adapter_cls()
+        if not adapter.applies(abnormal_traces):
+            continue
+        if not _mysql_infra_present(graph, adapter.db_target_service):
+            logger.debug(
+                "trace-db-binding %s skipped: no infra node for db_target=%s",
+                adapter.name,
+                adapter.db_target_service,
+            )
+            continue
+        bindings = adapter.collect_bindings(abnormal_traces)
+        if not bindings:
+            continue
+        db_service = _ensure_service_node(graph, adapter.db_target_service)
+        _wire_db_structural_edges(graph, db_service, adapter.db_target_service)
+        for binding in bindings:
+            total_added += _bind_caller_to_db(
+                graph,
+                adapter_name=adapter.name,
+                db_service=db_service,
+                binding=binding,
+            )
+        logger.info(
+            "trace-db-binding %s: %d bindings -> %d edges (db_target=%s)",
+            adapter.name,
+            len(bindings),
+            total_added,
+            adapter.db_target_service,
+        )
+    return total_added
+
+
+__all__ = [
+    "TraceDbBinding",
+    "TraceDbBindingAdapter",
+    "TraceDbBindingMetadata",
+    "TrainTicketTraceDbBindingAdapter",
+    "dispatch_trace_db_binding_adapters",
+    "register_trace_db_binding_adapter",
+]

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_trace_db_binding.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_trace_db_binding.py
@@ -1,0 +1,332 @@
+"""Trace -> DB binding adapter tests.
+
+Each test builds a minimal HyperGraph + polars trace fixture and asserts the
+expected graph mutation. No parquet data is loaded.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from rcabench_platform.v3.internal.reasoning.ir.adapters.trace_db_binding import (
+    TraceDbBindingMetadata,
+    TrainTicketTraceDbBindingAdapter,
+    dispatch_trace_db_binding_adapters,
+)
+from rcabench_platform.v3.internal.reasoning.models.graph import (
+    DepKind,
+    Edge,
+    HyperGraph,
+    Node,
+    PlaceKind,
+)
+
+
+def _add_node(graph: HyperGraph, kind: PlaceKind, name: str) -> Node:
+    return graph.add_node(Node(kind=kind, self_name=name))
+
+
+def _add_edge(graph: HyperGraph, src: Node, dst: Node, kind: DepKind) -> None:
+    assert src.id is not None and dst.id is not None
+    graph.add_edge(
+        Edge(
+            src_id=src.id,
+            dst_id=dst.id,
+            src_name=src.uniq_name,
+            dst_name=dst.uniq_name,
+            kind=kind,
+            data=None,
+        )
+    )
+
+
+def _trainticket_traces(rows: list[dict[str, object]]) -> pl.DataFrame:
+    """Build an abnormal-traces DataFrame with the columns the adapter reads."""
+    schema = {
+        "service_name": pl.Utf8,
+        "span_name": pl.Utf8,
+        "attr.span_kind": pl.Utf8,
+        "attr.http.response.status_code": pl.Int64,
+    }
+    if not rows:
+        return pl.DataFrame(schema=schema)
+    return pl.DataFrame(rows, schema=schema)
+
+
+def _build_tt_graph_with_mysql() -> tuple[HyperGraph, dict[str, Node]]:
+    """Minimal TT-shaped graph: one Java service + mysql infra (no service node yet)."""
+    g = HyperGraph()
+    sset = _add_node(g, PlaceKind.stateful_set, "mysql")
+    pod_mysql = _add_node(g, PlaceKind.pod, "mysql-0")
+    cont_mysql = _add_node(g, PlaceKind.container, "mysql")
+    svc_auth = _add_node(g, PlaceKind.service, "ts-auth-service")
+    pod_auth = _add_node(g, PlaceKind.pod, "ts-auth-service-1")
+    cont_auth = _add_node(g, PlaceKind.container, "ts-auth-service")
+    span_sql = _add_node(g, PlaceKind.span, "ts-auth-service::SELECT ts.users")
+    span_root = _add_node(g, PlaceKind.span, "ts-auth-service::POST /api/v1/auth")
+    _add_edge(g, pod_mysql, cont_mysql, DepKind.runs)
+    _add_edge(g, svc_auth, pod_auth, DepKind.routes_to)
+    _add_edge(g, pod_auth, cont_auth, DepKind.runs)
+    _add_edge(g, svc_auth, span_sql, DepKind.includes)
+    _add_edge(g, svc_auth, span_root, DepKind.includes)
+    return g, {
+        "sset_mysql": sset,
+        "pod_mysql": pod_mysql,
+        "cont_mysql": cont_mysql,
+        "svc_auth": svc_auth,
+        "span_sql": span_sql,
+        "span_root": span_root,
+    }
+
+
+def test_applies_returns_true_for_trainticket_traces() -> None:
+    adapter = TrainTicketTraceDbBindingAdapter()
+    df = _trainticket_traces(
+        [
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "SELECT ts.users",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": None,
+            },
+        ]
+    )
+    assert adapter.applies(df) is True
+
+
+def test_applies_returns_false_for_non_trainticket_systems() -> None:
+    adapter = TrainTicketTraceDbBindingAdapter()
+    df = _trainticket_traces(
+        [
+            {
+                "service_name": "cartservice",
+                "span_name": "GET /cart",
+                "attr.span_kind": "Server",
+                "attr.http.response.status_code": 200,
+            },
+            {
+                "service_name": "loadgenerator",
+                "span_name": "GET /",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": 200,
+            },
+        ]
+    )
+    assert adapter.applies(df) is False
+    assert adapter.applies(_trainticket_traces([])) is False
+
+
+def test_sql_pattern_detection_excludes_http_spans() -> None:
+    adapter = TrainTicketTraceDbBindingAdapter()
+    df = _trainticket_traces(
+        [
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "SELECT ts.users",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": None,
+            },
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "INSERT ts.session",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": None,
+            },
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "HTTP GET http://other/x",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": 200,
+            },
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "GET",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": 200,
+            },
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "POST",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": 200,
+            },
+            {
+                "service_name": "ts-train-service",
+                "span_name": "UPDATE ts.train",
+                "attr.span_kind": "Internal",
+                "attr.http.response.status_code": None,
+            },
+            {
+                "service_name": "ts-train-service",
+                "span_name": "delete ts.cache",
+                "attr.span_kind": "Internal",
+                "attr.http.response.status_code": None,
+            },
+        ]
+    )
+    detected = adapter.detect_db_client_spans(df)
+    assert detected.height == 4
+    detected_names = sorted(detected["span_name"].to_list())
+    assert detected_names == sorted(["SELECT ts.users", "INSERT ts.session", "UPDATE ts.train", "delete ts.cache"])
+
+
+def test_dispatch_synthesises_calls_edge_with_evidence_count() -> None:
+    g, nodes = _build_tt_graph_with_mysql()
+    df = _trainticket_traces(
+        [
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "SELECT ts.users",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": None,
+            },
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "SELECT ts.users",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": None,
+            },
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "INSERT ts.session",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": 500,
+            },
+        ]
+    )
+    n_added = dispatch_trace_db_binding_adapters(g, df)
+    assert n_added > 0
+
+    mysql_svc = g.get_node_by_name("service|mysql")
+    assert mysql_svc is not None and mysql_svc.id is not None
+    auth_svc = nodes["svc_auth"]
+    assert auth_svc.id is not None
+    assert g._graph.has_edge(auth_svc.id, mysql_svc.id, DepKind.calls)
+
+    metadata_store = g.data["trace_db_bindings"]
+    md = metadata_store[(auth_svc.id, mysql_svc.id, DepKind.calls)]
+    assert isinstance(md, TraceDbBindingMetadata)
+    assert md.caller_service == "ts-auth-service"
+    assert md.db_target_service == "mysql"
+    assert md.span_count == 3
+    assert md.error_count == 1
+
+
+def test_dispatch_wires_structural_edges_for_inheritance_cascade() -> None:
+    g, nodes = _build_tt_graph_with_mysql()
+    df = _trainticket_traces(
+        [
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "SELECT ts.users",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": None,
+            },
+        ]
+    )
+    dispatch_trace_db_binding_adapters(g, df)
+
+    mysql_svc = g.get_node_by_name("service|mysql")
+    assert mysql_svc is not None and mysql_svc.id is not None
+    pod_mysql_id = nodes["pod_mysql"].id
+    sset_mysql_id = nodes["sset_mysql"].id
+    assert pod_mysql_id is not None and sset_mysql_id is not None
+    # service|mysql --routes_to--> pod|mysql-0  (so structural inheritance can
+    # walk pod -> service backwards via routes_to in_edges).
+    assert g._graph.has_edge(mysql_svc.id, pod_mysql_id, DepKind.routes_to)
+    # stateful_set|mysql --manages--> pod|mysql-0
+    assert g._graph.has_edge(sset_mysql_id, pod_mysql_id, DepKind.manages)
+
+
+def test_dispatch_adds_includes_edges_to_sql_span_nodes() -> None:
+    """The synthesised includes edge is what makes RULE_SERVICE_TO_SPAN traverse."""
+    g, nodes = _build_tt_graph_with_mysql()
+    df = _trainticket_traces(
+        [
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "SELECT ts.users",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": None,
+            },
+        ]
+    )
+    dispatch_trace_db_binding_adapters(g, df)
+
+    mysql_svc = g.get_node_by_name("service|mysql")
+    assert mysql_svc is not None and mysql_svc.id is not None
+    span_sql_id = nodes["span_sql"].id
+    assert span_sql_id is not None
+    assert g._graph.has_edge(mysql_svc.id, span_sql_id, DepKind.includes)
+
+
+def test_dispatch_is_idempotent() -> None:
+    g, _ = _build_tt_graph_with_mysql()
+    df = _trainticket_traces(
+        [
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "SELECT ts.users",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": None,
+            },
+        ]
+    )
+    first = dispatch_trace_db_binding_adapters(g, df)
+    second = dispatch_trace_db_binding_adapters(g, df)
+    assert first > 0
+    # Second pass must not add any edges; the metadata store must keep its
+    # original entries unchanged.
+    assert second == 0
+
+
+def test_dispatch_noop_when_mysql_infra_absent() -> None:
+    """Constraint: skip cleanly (no crash, no fabricated service node) when
+    no mysql container/pod/stateful_set node exists in the graph."""
+    g = HyperGraph()
+    svc_auth = _add_node(g, PlaceKind.service, "ts-auth-service")
+    span_sql = _add_node(g, PlaceKind.span, "ts-auth-service::SELECT ts.users")
+    _add_edge(g, svc_auth, span_sql, DepKind.includes)
+    df = _trainticket_traces(
+        [
+            {
+                "service_name": "ts-auth-service",
+                "span_name": "SELECT ts.users",
+                "attr.span_kind": "Client",
+                "attr.http.response.status_code": None,
+            },
+        ]
+    )
+    n_added = dispatch_trace_db_binding_adapters(g, df)
+    assert n_added == 0
+    assert g.get_node_by_name("service|mysql") is None
+
+
+def test_end_to_end_smoke_real_dataset_dispatch() -> None:
+    """End-to-end smoke against the actual failing dataset (skipped if absent).
+
+    Loads the real ts0-mysql-container-kill-9t6n24 abnormal traces and runs
+    dispatch against a freshly-built graph; asserts the auth -> mysql calls
+    edge materialises. Uses ``pytest.skip`` when the dataset isn't mounted so
+    CI on machines without JuiceFS still passes.
+    """
+    from pathlib import Path
+
+    import pytest
+
+    from rcabench_platform.v3.internal.reasoning.loaders.parquet_loader import ParquetDataLoader
+
+    case_dir = Path("/home/ddq/AoyangSpace/dataset/rca/ts0-mysql-container-kill-9t6n24")
+    if not (case_dir / "abnormal_traces.parquet").exists():
+        pytest.skip(f"dataset not mounted at {case_dir}")
+
+    loader = ParquetDataLoader(case_dir, 2)
+    graph = loader.build_graph_from_parquet()
+    abnormal = loader.load_traces("abnormal")
+    n_added = dispatch_trace_db_binding_adapters(graph, abnormal)
+    assert n_added > 0
+    auth = graph.get_node_by_name("service|ts-auth-service")
+    mysql_svc = graph.get_node_by_name("service|mysql")
+    assert auth is not None and mysql_svc is not None
+    assert auth.id is not None and mysql_svc.id is not None
+    assert graph._graph.has_edge(auth.id, mysql_svc.id, DepKind.calls)


### PR DESCRIPTION
## Summary

Adds a per-system trace-binding adapter that recovers the `mysql JDBC blind` failure (issue #15 follow-up from PR #215). On the 500-case TrainTicket fixture, this lifts recall from **498/500 → 499/500 (99.8%)** with zero regressions.

### Why this exists

`ts0-mysql-container-kill-9t6n24` fails with `no_paths` on main because the trace graph has no `calls` edge from any Java service into the mysql node:
- mysql doesn't emit OTel server spans (only metric data)
- Java services emit JDBC client spans like `SELECT ts.auth_user`, `INSERT ts.user_roles`, … but the dataset has **no standard `attr.db.*` semantic-convention attributes** (verified — `attr.db.system` / `db.name` / `peer.address` etc. are all absent)
- So §7.4's corridor BFS can't reach `service|mysql` from any alarm, even though the injection point and graph are otherwise correct

### What this lands

`trace_db_binding.py` mirrors the `LogDependencyAdapter` pattern (`@register_*` + `applies()` discriminator + `dispatch_*`):

- **`TrainTicketTraceDbBindingAdapter`** detects DB client spans by `span_name` regex `^(?i:SELECT|INSERT|UPDATE|DELETE|REPLACE)\s+`. Empirically this matches 252 client spans on the failing case across 13 services with **zero false positives** — every other client span is HTTP-prefixed.
- The adapter materialises `service|mysql` if at least one mysql infra node (`container|mysql` / `pod|mysql-*` / `stateful_set|mysql`) is present, otherwise no-ops cleanly.
- It then wires:
  - `service|<caller> --calls--> service|mysql` per detected (caller, schema) pair
  - `service|mysql --includes--> span|<caller>::<sql>` for each detected SQL span — necessary because no canonical propagation rule has `(src_kind=service, edge_kind=calls)`, so the `calls` edge alone wouldn't propagate; the includes edges let `RULE_SERVICE_TO_SPAN` traverse.
- Both edge kinds are recorded in `HyperGraph.data["trace_db_bindings"]` with adapter-name + evidence counts for downstream debug.

### Why this is per-system, not core

- Other benchmarks (otel-demo, sockshop, hotel-reservation, social-network, media-microservices, teastore) don't use the SQL-naming pattern in span_name — most hit datastores via different instrumentation or none at all.
- The adapter's `applies()` gate (TrainTicket-shaped traces — services starting with `ts-`) ensures it's a no-op everywhere else.
- Methodology doc `docs/reasoning-feature-taxonomy.md` is unchanged — this is a TT-specific implementation detail, not a methodology extension.

### E2E validation (`AoyangSpace/dataset/rca`, 500 cases)

|  | v6 (post-PR#215) | **v7 (this PR)** |
|---|---|---|
| success | 498 | **499** |
| no_paths | 1 (mysql) | **1 (verification-code-partition only)** |
| no_alarms | 1 | **0** |
| crashes | 0 | 0 |
| wall (12 workers) | ~245s | 252s |

Single remaining failure is `ts4-ts-verification-code-service-partition-nlbl25` — a separate corridor-direction issue tracked in issue #13 (FOLLOW-UP).

### Target case detail

`ts0-mysql-container-kill-9t6n24`:
- Before: `no_paths`
- After: **Success, 581 paths, top-1 `container|mysql`** (matches GT `service: ['mysql']`, `mysql-0` container kill)
- The causal graph correctly propagates `container|mysql (unavailable)` → `pod|mysql-0 (degraded)` → `service|mysql (unavailable)` → JDBC caller services → loadgen-side alarms

## Test plan

- [x] `uv run pytest src/rcabench_platform/v3/internal/reasoning/ir_tests/ -q` — 325 passing (316 pre-PR + 9 new in `test_trace_db_binding.py`)
- [x] `just lint` — ruff + pyright clean
- [x] `uv run ruff format --check` — no diff
- [x] E2E full sweep — 499/500 success, 0 crashes, 0 regressions vs v6
- [x] 7 v4-failure cases re-checked — mysql now success; all 5 truncation-detector cases still success; only ts4 partition still fails
- [ ] Spot-check by reviewer (`ts0-mysql-container-kill-9t6n24` is the canonical case to inspect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)