### PR TITLE
chore(otel-collector): bump deployment-collector HPA max 18 → 40

### DIFF
--- a/AegisLab/manifests/byte-cluster/otel-kube-stack.values.yaml
+++ b/AegisLab/manifests/byte-cluster/otel-kube-stack.values.yaml
@@ -350,8 +350,11 @@ collectors:
     enabled: true
     replicas: 6
     autoscaler:
+      # Bumped maxReplicas 18 → 40 because under teastore firehose load the
+      # HPA pegged at 18 with memory at 170 %/60 %. With each replica at 8Gi
+      # mem limit we have headroom to scale up further before node pressure.
       minReplicas: 6
-      maxReplicas: 18
+      maxReplicas: 40
       targetCPUUtilization: 55
       targetMemoryUtilization: 60
     podDisruptionBudget:


### PR DESCRIPTION
## What

Bumps the deployment-collector HPA `maxReplicas` from 18 to 40 in `manifests/byte-cluster/otel-kube-stack.values.yaml`.

## Why

Under teastore (and other firehose-y) loadgen pressure the HPA pegged at the existing `maxReplicas: 18` with memory utilization at **170 % / 60 %** (target 60 %, actual ~170 % per pod). HPA wanted to scale further but was capped, so the per-pod memory headroom shrank and the collector started returning `data refused due to high memory usage` on incoming pushes — which then cascaded to `datapack.build.failed` for any system whose abnormal window crossed that period.

Live HPA snapshot during the incident (issue #216 root):
```
opentelemetry-kube-stack-deployment-collector
TARGETS: memory: 170%/60%, cpu: 37%/55%
MINPODS=6 MAXPODS=18 REPLICAS=18  ← max'd out
```

## Why 40 specifically

Each replica is at the chart's existing `8Gi` memory limit. The byte-cluster has 36 nodes; 40 replicas at 8 Gi limit = 320 Gi aggregate at saturation, which is well under cluster total memory and HPA only spends that headroom when memory utilization actually demands it (target 60 %).

## Already applied live

I hot-patched the live `OpenTelemetryCollector` CR (which owns the HPA via the operator) immediately so the loop could keep running. This PR persists that change in the byte-cluster values so future `helm upgrade opentelemetry-kube-stack` runs don't revert it.

## Refs

- #216 — teastore jmeter loadgen overload (the incident this came out of)
- #210 — BuildDatapack ingestion lag (related: when collector backs up, BuildDatapack races)