### PR TITLE
chore(seed): bump teastore chart 0.1.3 → 0.1.4 for throttled jmeter defaults

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -292,11 +292,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.3
+      - name: 0.1.4
         github_link: LGU-SE-Internal/TeaStore
         status: 1
         helm_config:
-          version: 0.1.3
+          version: 0.1.4
           chart_name: teastore
           repo_name: lgu-tea
           repo_url: https://lgu-se-internal.github.io/TeaStore

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -266,11 +266,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.3
+      - name: 0.1.4
         github_link: LGU-SE-Internal/TeaStore
         status: 1
         helm_config:
-          version: 0.1.3
+          version: 0.1.4
           chart_name: teastore
           repo_name: lgu-tea
           repo_url: https://lgu-se-internal.github.io/TeaStore

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -303,11 +303,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.3
+      - name: 0.1.4
         github_link: LGU-SE-Internal/TeaStore
         status: 1
         helm_config:
-          version: 0.1.3
+          version: 0.1.4
           chart_name: teastore
           repo_name: lgu-tea
           repo_url: https://lgu-se-internal.github.io/TeaStore


### PR DESCRIPTION
## What

Bumps teastore helm chart pin in the three seed files from `0.1.3` to `0.1.4`:

- `data/initial_data/staging/data.yaml` (system: `tea`)
- `data/initial_data/prod/data.yaml` (system: `teastore`)
- `manifests/byte-cluster/initial-data/data.yaml` (system: `teastore`)

## Why

[LGU-SE-Internal/TeaStore#10](https://github.com/LGU-SE-Internal/TeaStore/pull/10) (merged) caps the chart's jmeter loadgen throughput:

- `jmeter.numUsers: 10 → 2`
- `jmeter.duration: 300 → 120`

That's roughly a 12× reduction in spans/sec per namespace, which matches what aegis-byte-cluster has been hot-overriding live for the past day. After this seed lands + a `helm upgrade rcabench` (or runtime-worker re-seed) on the live cluster, newly allocated `tea*` namespaces will use 0.1.4 directly without per-cluster overrides.

## Migration caveat

Existing `tea*` namespaces deployed with 0.1.3 keep their old throughput until they're recycled. StatefulSet `spec.selector.matchLabels` is immutable across the 0.1.3→0.1.4 boundary (chart 0.1.4 doesn't change selectors but the version label propagates onto new ReplicaSets), so to migrate a specific running tea ns operators must `helm uninstall && helm install`. The autonomous inject-loop already recycles tea ns on each round, so by the next round that ns is using 0.1.4.

## Refs

- LGU-SE-Internal/TeaStore#10 (chart change, merged)
- #216 (the cluster-wide overload incident this fixes at source)
- #218 (the OTel collector HPA bump that compensated for it on the consume side)