### PR TITLE
chore(seed): bump sn 0.1.3→0.1.4 + media 0.1.3→0.1.4 to pickup OTel chart fix (#53)

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -225,11 +225,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.3
+      - name: 0.1.4
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
-          version: 0.1.3
+          version: 0.1.4
           chart_name: social-network
           repo_name: lgu-dsb
           repo_url: https://lgu-se-internal.github.io/DeathStarBench
@@ -264,11 +264,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.3
+      - name: 0.1.4
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
-          version: 0.1.3
+          version: 0.1.4
           chart_name: media-microservices
           repo_name: lgu-dsb
           repo_url: https://lgu-se-internal.github.io/DeathStarBench


### PR DESCRIPTION
## What

Bumps two DSB chart pins in `manifests/byte-cluster/initial-data/data.yaml`:

- `sn` (social-network): 0.1.3 → 0.1.4
- `media` (media-microservices): 0.1.3 → 0.1.4

`hs` (hotel-reservation) is already pinned at 0.1.3, no change needed — the helm repo just received a NEW 0.1.3 with the OTel fix in [LGU-SE-Internal/DeathStarBench#53](https://github.com/LGU-SE-Internal/DeathStarBench/pull/53).

## Why

PR LGU#53 fixes the chart-side OTel endpoint double-prepend bug documented in #221: `_baseDeploymentServices.tpl` no longer auto-prepends `http://` when the seed value is already a host:port. After this seed lands + reseed + ns recycle, hs/sn/mm pods receive the OTLP endpoint env verbatim, spans actually reach the collector, and the chronic `datapack.build.failed` (empty abnormal_traces.parquet) failure mode disappears for these systems.

## Refs

- LGU-SE-Internal/DeathStarBench#53 (chart fix, merged)
- #221 (the chronic hs failure this unblocks)