### PR TITLE
fix(reasoning): resolve network partition to all GT services in graph

### DIFF
--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_resolve_network_partition.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/ir_tests/test_resolve_network_partition.py
@@ -1,0 +1,73 @@
+"""Resolver behavior for network faults with multi-service ground truth.
+
+A NetworkPartition cuts traffic between two services and the GT lists both;
+returning only one endpoint strands the corridor's forward BFS on whichever
+side has fewer outgoing edges. The resolver therefore returns *all* GT
+services that exist in the graph when GT is multi-service. Single-service
+GT (typical of NetworkDelay/Loss/Bandwidth) keeps the existing
+source-perceives-fault resolution.
+"""
+
+from __future__ import annotations
+
+import json
+
+from rcabench_platform.v3.internal.reasoning.models.graph import HyperGraph, Node, PlaceKind
+from rcabench_platform.v3.internal.reasoning.models.injection import InjectionNodeResolver
+
+
+def _graph_with(services: list[str]) -> HyperGraph:
+    g = HyperGraph()
+    for svc in services:
+        g.add_node(Node(kind=PlaceKind.service, self_name=svc))
+    return g
+
+
+def _injection(
+    fault_type_name: str,
+    source: str,
+    target: str,
+    *,
+    gt: list[str] | None = None,
+    direction: str = "from",
+) -> dict:
+    return {
+        "fault_type": fault_type_name,
+        "display_config": json.dumps(
+            {
+                "injection_point": {
+                    "source_service": source,
+                    "target_service": target,
+                },
+                "direction": direction,
+            }
+        ),
+        "ground_truth": {"service": gt if gt is not None else [source, target]},
+    }
+
+
+def test_partition_returns_all_gt_services_when_all_in_graph() -> None:
+    g = _graph_with(["ts-verification-code-service", "ts-ui-dashboard"])
+    resolver = InjectionNodeResolver(g, jvm_method_mapping=None)
+    resolved = resolver.resolve(_injection("NetworkPartition", "ts-verification-code-service", "ts-ui-dashboard"))
+    assert set(resolved.injection_nodes) == {
+        "service|ts-verification-code-service",
+        "service|ts-ui-dashboard",
+    }
+    assert resolved.resolution_method.startswith("network_ground_truth_")
+
+
+def test_partition_falls_back_to_source_when_only_one_gt_in_graph() -> None:
+    g = _graph_with(["ts-verification-code-service"])
+    resolver = InjectionNodeResolver(g, jvm_method_mapping=None)
+    resolved = resolver.resolve(_injection("NetworkPartition", "ts-verification-code-service", "ts-missing"))
+    assert resolved.injection_nodes == ["service|ts-verification-code-service"]
+    assert resolved.resolution_method.startswith("network_source_")
+
+
+def test_single_gt_keeps_source_resolution() -> None:
+    g = _graph_with(["ts-a", "ts-b"])
+    resolver = InjectionNodeResolver(g, jvm_method_mapping=None)
+    resolved = resolver.resolve(_injection("NetworkDelay", "ts-a", "ts-b", gt=["ts-a"]))
+    assert resolved.injection_nodes == ["service|ts-a"]
+    assert resolved.resolution_method.startswith("network_source_")

--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/injection.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/models/injection.py
@@ -726,6 +726,21 @@ class InjectionNodeResolver:
         # For 'from' direction: fault on incoming to source -> source perceives
         # For 'both': both directions affected -> source perceives
 
+        # Network faults frequently involve more than one service in the GT
+        # (partition, asymmetric loss between two endpoints, …). When the GT
+        # lists multiple services and all of them resolve in the graph, take
+        # them all as the injection_set — any single endpoint can leave the
+        # corridor's forward BFS stranded on whichever side has fewer
+        # outgoing edges (e.g. a callee whose primary out-edges are k8s
+        # structural rather than ``calls``). The other end provides the
+        # caller-perceptible expansion surface.
+        gt_services = [s for s in metadata.ground_truth_services if self.graph.get_node_by_name(f"service|{s}")]
+        if len(gt_services) >= 2:
+            return (
+                [f"service|{s}" for s in gt_services],
+                f"network_ground_truth_{direction or 'unknown'}",
+            )
+
         # Check if source exists in graph
         if source:
             source_node = self.graph.get_node_by_name(f"service|{source}")


### PR DESCRIPTION
## Summary

Recovers `ts4-ts-verification-code-service-partition-nlbl25` (issue #13 follow-up from PR #215) — the last failing case on the 500-case TrainTicket fixture. Lifts recall from **499/500 (99.8%) → 500/500 (100%)** with zero regressions and no measurable perf change.

### Why this exists

NetworkPartition cuts traffic between two services and the GT lists both. The current resolver returns only `source_service` as the injection_set, but for a partition the source side is often a callee whose primary out-edges are k8s structural (`routes_to`, `owns`, `runs`) rather than `calls`. Forward BFS from a callee-side service with few outgoing `calls` cannot reach the alarms — the corridor degenerates.

For ts4 specifically:
- GT: `['ts-verification-code-service', 'ts-ui-dashboard']`
- Old resolver returned `[service|ts-verification-code-service]` only
- Forward BFS from VC: 7 nodes, 0 reachable alarms (VC has 1 routes_to + 2 includes; spans only fan out internally)
- Backward BFS from alarms: 302 nodes
- Intersection ≈ ∅ → `no_paths`

### What this lands

Tiny surgical change in `_resolve_network`: when GT has 2+ services and all of them resolve in the graph, return them all as `injection_set`. Falls through to the existing source/target/fallback chain otherwise.

```python
gt_services = [s for s in metadata.ground_truth_services
               if self.graph.get_node_by_name(f"service|{s}")]
if len(gt_services) >= 2:
    return ([f"service|{s}" for s in gt_services],
            f"network_ground_truth_{direction or 'unknown'}")
```

The branch is on **GT shape (multi-service AND all in graph)**, not on the fault_type index. fault_type values aren't stable across schema revisions — the GT is the authoritative description of which services participate in the fault. NetworkDelay/Loss/Duplicate/Corrupt/Bandwidth typically have single-service GT and keep the existing source-only resolution.

### E2E validation (`AoyangSpace/dataset/rca`, 500 cases)

|  | v7 (post-PR#217) | **v8 (this PR)** |
|---|---|---|
| success | 499 | **500** |
| no_paths | 1 (ts4 partition) | **0** |
| no_alarms | 0 | 0 |
| crashes | 0 | 0 |
| wall (12 workers) | 251.7s | 263.9s |
| p95 latency | 8.0s | 8.3s |
| max latency | ~92s | 24.8s |

### Target case detail

`ts4-ts-verification-code-service-partition-nlbl25`:
- Before: `no_paths`, forward BFS 7 nodes
- After: **Success, 12 paths**, forward BFS reaches the alarm side via `service|ts-ui-dashboard`'s outgoing edges
- Top-K answer correctly includes both `ts-verification-code-service` and `ts-ui-dashboard`

## Test plan

- [x] 3 new unit tests in `test_resolve_network_partition.py`:
  - Partition with both GT in graph → both endpoints returned
  - Partition with only one GT in graph → falls through to source-only
  - NetworkDelay with single-service GT → keeps source-only
- [x] `uv run pytest src/rcabench_platform/v3/internal/reasoning/ir_tests/ -q` — 328 passing (325 + 3 new)
- [x] `just lint` — ruff + pyright clean
- [x] `uv run ruff format --check` — no diff
- [x] E2E full sweep — **500/500 success**, 0 crashes, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)