### PR TITLE
fix(consumer): freshness probe must use native CH port (regression from #222)

### DIFF
--- a/AegisLab/src/service/consumer/freshness.go
+++ b/AegisLab/src/service/consumer/freshness.go
@@ -53,15 +53,7 @@ func (p *clickHouseFreshnessProbe) MaxTraceTimestamp(ctx context.Context, namesp
 	if p.cfg == nil || p.cfg.Host == "" {
 		return time.Time{}, false, fmt.Errorf("clickhouse host not configured")
 	}
-	conn, err := chdriver.Open(&chdriver.Options{
-		Addr: []string{net.JoinHostPort(p.cfg.Host, strconv.Itoa(p.cfg.Port))},
-		Auth: chdriver.Auth{
-			Database: orDefaultStr(p.cfg.Database, "otel"),
-			Username: p.cfg.User,
-			Password: p.cfg.Password,
-		},
-		DialTimeout: 3 * time.Second,
-	})
+	conn, err := chdriver.Open(freshnessProbeOptions(p.cfg))
 	if err != nil {
 		return time.Time{}, false, fmt.Errorf("clickhouse open: %w", err)
 	}
@@ -88,6 +80,32 @@ func (p *clickHouseFreshnessProbe) MaxTraceTimestamp(ctx context.Context, namesp
 		return time.Time{}, false, nil
 	}
 	return ts, true, nil
+}
+
+// freshnessProbeOptions builds the clickhouse-go/v2 driver options used by
+// the freshness probe.
+//
+// Why HTTP: the dynamic etcd config (`database.clickhouse.port`) holds the
+// HTTP listener (8123) — the same port the BuildDatapack Job env vars and
+// clickstack tooling target. clickhouse-go/v2 defaults to the native binary
+// protocol (port 9000); speaking native bytes at 8123 yields
+// `unexpected packet [72] from server` (the 'H' of "HTTP/1.1"), which broke
+// every BuildDatapack run after the freshness pre-flight landed (#222) and
+// is the regression tracked in #226. Pinning Protocol=HTTP here keeps the
+// probe consistent with the configured port without introducing a new etcd
+// key. Extracted as a pure helper so unit tests can assert the choice
+// without opening a network connection.
+func freshnessProbeOptions(cfg *db.DatabaseConfig) *chdriver.Options {
+	return &chdriver.Options{
+		Addr: []string{net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))},
+		Auth: chdriver.Auth{
+			Database: orDefaultStr(cfg.Database, "otel"),
+			Username: cfg.User,
+			Password: cfg.Password,
+		},
+		Protocol:    chdriver.HTTP,
+		DialTimeout: 3 * time.Second,
+	}
 }
 
 func orDefaultStr(s, def string) string {

--- a/AegisLab/src/service/consumer/freshness_test.go
+++ b/AegisLab/src/service/consumer/freshness_test.go
@@ -1,0 +1,86 @@
+package consumer
+
+import (
+	"testing"
+
+	chdriver "github.com/ClickHouse/clickhouse-go/v2"
+
+	db "aegis/infra/db"
+)
+
+// TestFreshnessProbeOptions_UsesHTTPProtocol pins the regression fix for
+// issue #226: the freshness probe MUST speak HTTP, because the etcd
+// `database.clickhouse.port` config key holds the HTTP listener port
+// (8123) — not the native binary protocol port (9000). Speaking native
+// bytes at 8123 yields `unexpected packet [72] from server` and breaks
+// every BuildDatapack run.
+//
+// This test is a static config-shape assertion; it does not open a
+// network connection.
+func TestFreshnessProbeOptions_UsesHTTPProtocol(t *testing.T) {
+	cfg := &db.DatabaseConfig{
+		Host:     "clickhouse.observability.svc",
+		Port:     8123, // HTTP listener — what etcd is actually configured with
+		Database: "otel",
+		User:     "default",
+		Password: "secret",
+	}
+
+	opts := freshnessProbeOptions(cfg)
+
+	if opts.Protocol != chdriver.HTTP {
+		t.Fatalf("freshnessProbeOptions Protocol = %v, want chdriver.HTTP (regression #226: native protocol at port 8123 yields packet [72] error)", opts.Protocol)
+	}
+	if got, want := len(opts.Addr), 1; got != want {
+		t.Fatalf("Addr length = %d, want %d", got, want)
+	}
+	if got, want := opts.Addr[0], "clickhouse.observability.svc:8123"; got != want {
+		t.Fatalf("Addr[0] = %q, want %q (port must come from db.DatabaseConfig.Port, not a hardcoded 9000)", got, want)
+	}
+	if got, want := opts.Auth.Database, "otel"; got != want {
+		t.Fatalf("Auth.Database = %q, want %q", got, want)
+	}
+	if got, want := opts.Auth.Username, "default"; got != want {
+		t.Fatalf("Auth.Username = %q, want %q", got, want)
+	}
+	if got, want := opts.Auth.Password, "secret"; got != want {
+		t.Fatalf("Auth.Password = %q, want %q", got, want)
+	}
+}
+
+// TestFreshnessProbeOptions_DefaultsDatabaseToOtel covers the back-compat
+// behaviour preserved from the original implementation: when the config
+// block omits `database.clickhouse.db`, the probe falls back to "otel"
+// (the database name where otel-collector writes otel_traces).
+func TestFreshnessProbeOptions_DefaultsDatabaseToOtel(t *testing.T) {
+	cfg := &db.DatabaseConfig{
+		Host: "ch",
+		Port: 8123,
+	}
+
+	opts := freshnessProbeOptions(cfg)
+
+	if got, want := opts.Auth.Database, "otel"; got != want {
+		t.Fatalf("Auth.Database = %q, want %q (default fallback when cfg.Database is empty)", got, want)
+	}
+}
+
+// TestFreshnessProbeOptions_HonoursCustomPort proves the helper does NOT
+// hardcode 8123 — it just reads whatever the etcd config says. If a future
+// deploy moves the HTTP listener to a non-standard port, the probe still
+// works.
+func TestFreshnessProbeOptions_HonoursCustomPort(t *testing.T) {
+	cfg := &db.DatabaseConfig{
+		Host: "ch",
+		Port: 18123, // hypothetical alternate HTTP listener
+	}
+
+	opts := freshnessProbeOptions(cfg)
+
+	if got, want := opts.Addr[0], "ch:18123"; got != want {
+		t.Fatalf("Addr[0] = %q, want %q", got, want)
+	}
+	if opts.Protocol != chdriver.HTTP {
+		t.Fatalf("Protocol must remain HTTP regardless of port; got %v", opts.Protocol)
+	}
+}


### PR DESCRIPTION
Refs: #226 (regression), #222 (origin), #210 (original feature)

## Root cause (one line)

The clickhouse-go/v2 freshness probe added in #222 defaults to the native binary protocol, but reads its address from the etcd key `database.clickhouse.port` which holds the HTTP listener (8123). Speaking native bytes at 8123 makes the server reply with `HTTP/1.1 ...`, whose first byte `H == 0x48 == 72` becomes the `unexpected packet [72] from server` error that broke every BuildDatapack run on the deployed cluster.

## Fix

Path **(b)** from the issue: pin `Protocol: chdriver.HTTP` on the driver `Options` so the probe speaks the wire format the configured port expects. No new etcd key, no hardcoded 9000, and consistent with the rest of the platform — the BuildDatapack Job env vars and clickstack tooling all target 8123 already.

The driver-options builder is extracted into a pure helper `freshnessProbeOptions(*db.DatabaseConfig)` so unit tests can statically assert `Protocol == HTTP` and address composition without opening a network connection.

## Verification (locally)

```
cd src && go build -tags duckdb_arrow -o /dev/null ./main.go        # clean
cd src && go test ./service/consumer/... -v                          # all green incl. 3 new
cd src && golangci-lint run --new-from-rev=origin/main               # 0 issues
```

New tests in `src/service/consumer/freshness_test.go`:
- `TestFreshnessProbeOptions_UsesHTTPProtocol` — pins the regression: Protocol must be `chdriver.HTTP`, address must use the configured port (not 9000).
- `TestFreshnessProbeOptions_DefaultsDatabaseToOtel` — preserves the back-compat default DB name.
- `TestFreshnessProbeOptions_HonoursCustomPort` — proves the helper does not hardcode 8123 either; future deploys remain free to relocate the HTTP listener.

## Image

Built and pushed:
```
docker.io/opspai/rcabench:loop-20260427b
sha256:dce68da203fcd315d2015694925a0a7c49e56ad49c9949a54e8fefa95ae9f4da
```

The volces shanghai mirror auto-syncs from docker.io.

## Post-merge redeploy (operator)

After review, redeploy in `exp` with:

```
kubectl set image deploy/rcabench-api-gateway      api-gateway=docker.io/opspai/rcabench:loop-20260427b      -n exp
kubectl set image deploy/rcabench-runtime-worker-service runtime-worker-service=docker.io/opspai/rcabench:loop-20260427b -n exp
```

Then re-trigger any datapacks that errored out with `unexpected packet [72] from server`.

## Constraints honoured

- No deploy performed by this PR.
- Touched only `src/service/consumer/freshness.go` + new `freshness_test.go` — no `experiments/`, `.claude/`, `.codex/`, `vendor/`, or `manifests/byte-cluster/clickstack.values.yaml`.