### PR TITLE
fix(inject): allocator hole-fills deleted slots before bootstrapping (#227)

### DIFF
--- a/AegisLab/scripts/reconcile-ns-count.sh
+++ b/AegisLab/scripts/reconcile-ns-count.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# reconcile-ns-count.sh — operator-triggered hot-fix for issue #227.
+#
+# The auto-allocator (#166) walks the per-system namespace pool 0..count-1
+# and skips slots whose namespace was deleted (probe returns "no workload").
+# Until the Pass 1.5 hole-fill fix lands and propagates, every campaign
+# round that deletes namespaces leaks one count slot. After 50+ rounds the
+# count drifts far above what's actually live and eventually trips the
+# dynamic_configs.max_value ceiling.
+#
+# This script reads live <sys>* namespaces from kubectl, computes the
+# minimal count that still covers them (max(idx)+1), and rewrites
+# /rcabench/config/global/injection.system.<sys>.count in etcd. Slots are
+# NOT actually freed — bootstrap still extends the pool — but the count
+# stops climbing past the live high-water mark, which is enough to keep a
+# running campaign from hitting max_value.
+#
+# USAGE
+#   ./scripts/reconcile-ns-count.sh [--dry-run] sys1 sys2 ...
+#   ./scripts/reconcile-ns-count.sh --dry-run hs sn mm teastore
+#
+# REQUIREMENTS
+#   - kubectl pointed at the target cluster (used to enumerate <sys><N> ns)
+#   - etcdctl + ETCDCTL_ENDPOINTS exported pointing at the aegis etcd cluster
+#     (aegisctl currently has no `chaos-system update count` subcommand —
+#      see memory note feedback_aegisctl_ownership; we go straight to etcd)
+#   - jq (for parsing etcd JSON values)
+#
+# SAFETY
+#   - --dry-run prints the target counts and the raw etcd put commands but
+#     writes nothing.
+#   - Without --dry-run, rewrites only the `count` field of the etcd value
+#     at /rcabench/config/global/injection.system.<sys>.count.
+#   - Bumps count UP when the live max exceeds it; refuses to silently shrink
+#     when the live max is lower (operator must --force-shrink to confirm —
+#     the backend's allocator may be holding locks at higher indices that we
+#     can't see from kubectl).
+#
+# REFERENCE: issue #227, memory note project_issue166_plan,
+# feedback_aegisctl_ownership.
+
+set -euo pipefail
+
+DRY_RUN=0
+FORCE_SHRINK=0
+SYSTEMS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --force-shrink) FORCE_SHRINK=1; shift ;;
+        --help|-h)
+            sed -n '2,40p' "$0"
+            exit 0
+            ;;
+        *) SYSTEMS+=("$1"); shift ;;
+    esac
+done
+
+if [[ ${#SYSTEMS[@]} -eq 0 ]]; then
+    echo "error: no systems specified" >&2
+    echo "usage: $0 [--dry-run] [--force-shrink] sys1 sys2 ..." >&2
+    exit 2
+fi
+
+for bin in kubectl etcdctl jq; do
+    if ! command -v "$bin" >/dev/null 2>&1; then
+        echo "error: $bin not found in PATH" >&2
+        exit 2
+    fi
+done
+
+if [[ -z "${ETCDCTL_ENDPOINTS:-}" ]]; then
+    echo "error: ETCDCTL_ENDPOINTS not exported (e.g. export ETCDCTL_ENDPOINTS=http://etcd:2379)" >&2
+    exit 2
+fi
+
+ETCD_KEY_PREFIX="/rcabench/config/global/injection.system."
+
+# extract the highest <sys><N> index in the cluster (-1 if none live).
+highest_live_index() {
+    local sys="$1"
+    kubectl get ns -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+        | grep -E "^${sys}[0-9]+$" \
+        | sed -E "s/^${sys}([0-9]+)$/\1/" \
+        | sort -n \
+        | tail -1 \
+        || true
+}
+
+# read current count value JSON from etcd. The dynamic_config payload is a
+# JSON blob with the field `default_value` (string) holding the count.
+read_count_value() {
+    local sys="$1"
+    etcdctl get --print-value-only "${ETCD_KEY_PREFIX}${sys}.count" 2>/dev/null || true
+}
+
+# rewrite the JSON blob preserving every field except default_value.
+patch_count_value() {
+    local raw="$1" newcount="$2"
+    echo "$raw" | jq --arg c "$newcount" '.default_value = $c'
+}
+
+exit_code=0
+for sys in "${SYSTEMS[@]}"; do
+    high="$(highest_live_index "$sys" || true)"
+    if [[ -z "$high" ]]; then
+        target=0
+    else
+        target=$((high + 1))
+    fi
+
+    raw="$(read_count_value "$sys")"
+    if [[ -z "$raw" ]]; then
+        echo "warn: system ${sys} has no count key in etcd at ${ETCD_KEY_PREFIX}${sys}.count; skipping" >&2
+        continue
+    fi
+
+    cur="$(echo "$raw" | jq -r '.default_value // empty')"
+    if [[ -z "$cur" ]]; then
+        echo "warn: system ${sys} count value has no default_value field; skipping (raw=$raw)" >&2
+        continue
+    fi
+
+    if [[ "$cur" -eq "$target" ]]; then
+        printf "%-12s count=%-4s OK (live max=%s)\n" "$sys" "$cur" "${high:-none}"
+        continue
+    fi
+
+    if [[ "$cur" -lt "$target" ]]; then
+        printf "%-12s count=%-4s -> %-4s (live max=%s; BEHIND reality, will bump up)\n" \
+            "$sys" "$cur" "$target" "${high:-none}"
+    else
+        printf "%-12s count=%-4s -> %-4s (live max=%s; AHEAD of reality, would shrink)\n" \
+            "$sys" "$cur" "$target" "${high:-none}"
+        if [[ "$FORCE_SHRINK" -ne 1 ]]; then
+            echo "  refusing to shrink without --force-shrink (backend may hold locks at higher indices)" >&2
+            continue
+        fi
+    fi
+
+    new_raw="$(patch_count_value "$raw" "$target")"
+    printf "  etcdctl put %s%s.count <patched-json>\n" "$ETCD_KEY_PREFIX" "$sys"
+
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        continue
+    fi
+
+    if ! etcdctl put "${ETCD_KEY_PREFIX}${sys}.count" "$new_raw" >/dev/null; then
+        echo "error: etcdctl put failed for ${sys}" >&2
+        exit_code=1
+    fi
+done
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo
+    echo "(dry-run: re-run without --dry-run to apply; backend will pick up changes via its etcd watcher)"
+fi
+
+exit "$exit_code"

--- a/AegisLab/src/module/injection/alloc.go
+++ b/AegisLab/src/module/injection/alloc.go
@@ -178,7 +178,14 @@ func AllocateNamespaceForRestart(
 
 	now := time.Now()
 
-	// Pass 1: hole-fill. Walk existing slots lowest-index first.
+	// Pass 1: hole-fill. Walk existing slots lowest-index first. Prefer
+	// slots that already have a workload (cheap reuse — RestartPedestal
+	// can helm-upgrade in place). Track the lowest-index unlocked-but-
+	// empty slot so Pass 1.5 can recycle it when the operator deleted the
+	// underlying namespace between rounds. Without this fallback, deleted
+	// slots looked identical to never-existed ones and the allocator
+	// always grew the pool via Pass 2; see #227.
+	emptySlotIdx := -1
 	for idx := 0; idx < cfg.Count; idx++ {
 		ns := fmt.Sprintf(template, idx)
 
@@ -196,6 +203,12 @@ func AllocateNamespaceForRestart(
 				return AllocateResult{}, fmt.Errorf("probe workload in %s: %w", ns, probeErr)
 			}
 			if !hasWorkload {
+				// Remember the lowest-index empty hole; Pass 1.5
+				// will fill it (treated as Fresh) after the
+				// workload-bearing scan completes.
+				if opts.AllowBootstrap && emptySlotIdx == -1 {
+					emptySlotIdx = idx
+				}
 				continue
 			}
 		}
@@ -212,6 +225,26 @@ func AllocateNamespaceForRestart(
 			return AllocateResult{}, fmt.Errorf("acquire ns lock for %s: %w", ns, err)
 		}
 		return AllocateResult{Namespace: ns, Fresh: false}, nil
+	}
+
+	// Pass 1.5: hole-fill into a deleted-but-counted slot before extending
+	// the pool. This is the fix for #227: an operator who deletes
+	// namespaces between rounds (autonomous inject-loop campaign) used to
+	// see count grow monotonically because every freed slot fell through
+	// to Pass 2 instead of being reused. Treated as Fresh because the
+	// caller must helm-install before BuildInjection can list pods —
+	// identical post-conditions to Pass 2.
+	if emptySlotIdx >= 0 {
+		ns := fmt.Sprintf(template, emptySlotIdx)
+		if err := nsLockAcquireFn(ctx, redis, ns, endTime, traceID, now); err != nil {
+			if !errors.Is(err, ErrNamespaceLocked) {
+				return AllocateResult{}, fmt.Errorf("recycle empty slot %s: %w", ns, err)
+			}
+			// Race: a peer allocator grabbed the empty slot between
+			// our scan and our lock. Fall through to bootstrap.
+		} else {
+			return AllocateResult{Namespace: ns, Fresh: true}, nil
+		}
 	}
 
 	// Pass 2: bootstrap a fresh slot at index = count, if allowed.

--- a/AegisLab/src/module/injection/alloc_test.go
+++ b/AegisLab/src/module/injection/alloc_test.go
@@ -245,6 +245,144 @@ func TestAllocateReleaseUsesCompareAndDelete(t *testing.T) {
 	}
 }
 
+// fakeCountWriter records EnsureCountForNamespace invocations for
+// hole-fill regression tests (#227). The bumped flag tracks whether the
+// call was forwarded — Pass 1.5 must NOT bump count when reusing a deleted
+// slot inside the existing range.
+type fakeCountWriter struct {
+	calls []string
+}
+
+func (f *fakeCountWriter) EnsureCountForNamespace(ctx context.Context, system, ns string) (bool, error) {
+	f.calls = append(f.calls, ns)
+	return true, nil
+}
+
+// TestAllocateRecyclesDeletedSlotBeforeBootstrapping is the regression test
+// for #227: when an operator deletes namespaces between rounds (autonomous
+// inject-loop campaign), the workload probe returns false for the freed
+// indices. Without Pass 1.5 those slots get skipped and the allocator
+// always extends the pool via Pass 2, growing count monotonically. With
+// Pass 1.5, the lowest-index empty slot is recycled (Fresh=true) before
+// bootstrapping at the high-water mark.
+func TestAllocateRecyclesDeletedSlotBeforeBootstrapping(t *testing.T) {
+	const system = "allochole"
+	cleanup := seedSockshopSystemInViper(t, system, 4)
+	defer cleanup()
+
+	// Slots 0..3 exist in count, but 0 and 1 are deleted (no workload),
+	// 2 has workload but is locked by another trace, 3 has workload and
+	// is free. Without Pass 1.5 the allocator would walk past 0/1 (no
+	// workload), skip 2 (locked), pick 3, leaving count alone — that's
+	// fine. To exercise the bug we make every workload-bearing slot
+	// locked too, so only the deleted slots remain available.
+	withAllocSeams(t,
+		func(ctx context.Context, r *redisinfra.Gateway, key, val string, ttl time.Duration) (bool, error) {
+			return true, nil
+		},
+		func(ctx context.Context, r *redisinfra.Gateway, key, val string) (int64, error) {
+			return 1, nil
+		},
+		func(ctx context.Context, r *redisinfra.Gateway, ns string, now time.Time) (bool, error) {
+			// hole2 / hole3 are workload-bearing but lock-active.
+			if ns == fmt.Sprintf("%s2", system) || ns == fmt.Sprintf("%s3", system) {
+				return true, nil
+			}
+			return false, nil
+		},
+		func(ctx context.Context, r *redisinfra.Gateway, ns string, endTime time.Time, traceID string, now time.Time) error {
+			return nil
+		},
+	)
+
+	probe := func(ctx context.Context, ns string) (bool, error) {
+		// hole0 / hole1 were deleted by the operator — no pods.
+		if ns == fmt.Sprintf("%s0", system) || ns == fmt.Sprintf("%s1", system) {
+			return false, nil
+		}
+		return true, nil
+	}
+
+	writer := &fakeCountWriter{}
+	res, err := AllocateNamespaceForRestart(
+		context.Background(),
+		&redisinfra.Gateway{},
+		system,
+		time.Now().Add(time.Hour),
+		"trace-hole",
+		probe,
+		AllocateOptions{AllowBootstrap: true, CountWriter: writer},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := fmt.Sprintf("%s0", system)
+	if res.Namespace != want {
+		t.Fatalf("namespace = %q, want %q (must hole-fill lowest deleted index, not bootstrap)", res.Namespace, want)
+	}
+	if !res.Fresh {
+		t.Fatalf("Fresh = false, want true (recycled empty slot needs RestartPedestal helm-install)")
+	}
+	if len(writer.calls) != 0 {
+		t.Fatalf("EnsureCountForNamespace called %v; Pass 1.5 must not bump count when reusing an in-range slot", writer.calls)
+	}
+}
+
+// TestAllocateBootstrapsWhenNoEmptySlotAvailable pins that Pass 1.5 only
+// kicks in when there's actually a deleted slot to recycle — if every
+// in-range slot has a workload (just contended), the allocator still falls
+// through to Pass 2 and bumps count. This is what the #166 design intended.
+func TestAllocateBootstrapsWhenNoEmptySlotAvailable(t *testing.T) {
+	const system = "allocnohole"
+	cleanup := seedSockshopSystemInViper(t, system, 2)
+	defer cleanup()
+
+	withAllocSeams(t,
+		func(ctx context.Context, r *redisinfra.Gateway, key, val string, ttl time.Duration) (bool, error) {
+			return true, nil
+		},
+		func(ctx context.Context, r *redisinfra.Gateway, key, val string) (int64, error) {
+			return 1, nil
+		},
+		// Every slot lock-active.
+		func(ctx context.Context, r *redisinfra.Gateway, ns string, now time.Time) (bool, error) {
+			if ns == fmt.Sprintf("%s2", system) {
+				return false, nil // bootstrap target free
+			}
+			return true, nil
+		},
+		func(ctx context.Context, r *redisinfra.Gateway, ns string, endTime time.Time, traceID string, now time.Time) error {
+			return nil
+		},
+	)
+
+	probe := func(ctx context.Context, ns string) (bool, error) { return true, nil }
+
+	writer := &fakeCountWriter{}
+	res, err := AllocateNamespaceForRestart(
+		context.Background(),
+		&redisinfra.Gateway{},
+		system,
+		time.Now().Add(time.Hour),
+		"trace-nohole",
+		probe,
+		AllocateOptions{AllowBootstrap: true, CountWriter: writer},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := fmt.Sprintf("%s2", system)
+	if res.Namespace != want {
+		t.Fatalf("namespace = %q, want bootstrap target %q", res.Namespace, want)
+	}
+	if !res.Fresh {
+		t.Fatalf("Fresh = false, want true (bootstrap path)")
+	}
+	if len(writer.calls) != 1 || writer.calls[0] != want {
+		t.Fatalf("EnsureCountForNamespace calls = %v, want [%s] (bootstrap must bump count)", writer.calls, want)
+	}
+}
+
 // TestAllocLockTTLCoversWorstCase pins the TTL contract — bumped from 10s
 // to >=60s after the #167 review. The previous 10s value let real-world
 // allocations cross the TTL when etcd writes or k8s API hiccuped.


### PR DESCRIPTION
Closes #227.

## Summary

- Pass 1.5 in `AllocateNamespaceForRestart`: when `AllowBootstrap=true` and the workload-bearing scan finds nothing fillable, recycle the lowest-index unlocked-but-empty slot (surfaced as `Fresh=true`) before extending the pool. Stops the count from climbing every round when the operator deletes namespaces between campaign rounds.
- New `scripts/reconcile-ns-count.sh`: operator-triggered hot-fix that reads live `<sys>*` namespaces from kubectl and rewrites the etcd `default_value` for `injection.system.<sys>.count` to `max(idx)+1`. Lets a running campaign with already-drifted counts recover without redeploying.
- Two new regression tests: `TestAllocateRecyclesDeletedSlotBeforeBootstrapping` (the actual bug — every workload-bearing slot is contended, only deleted slots remain; allocator must reuse hs0 instead of bumping count to 4) and `TestAllocateBootstrapsWhenNoEmptySlotAvailable` (the negative case — when no deleted slot exists, bootstrap path still kicks in).

## Diagnosis

Hole-fill was implemented in #166 but its workload-presence gate (`probe(ns) returns false → skip`) defeated the intent for the autonomous inject-loop usage pattern. The operator's `kubectl delete ns` between rounds left freed slots looking identical to never-existed slots, so they were always skipped and Pass 2 extended the pool. After 50+ rounds the per-system counts climbed past the originally-configured max_value=20 (had to be bumped to 50 mid-campaign), and continued climbing 1/round.

The smallest viable change is to remember the lowest empty slot during the existing scan and reuse it instead of bootstrapping when nothing else is fillable. Keeps the `Fresh=true` post-condition so the caller's RestartPedestal path is unchanged.

## Test plan

- [x] `go build -tags duckdb_arrow ./...`
- [x] `go test ./module/injection/`
- [x] new regression test exercises the deleted-ns scenario from #227
- [ ] `--dry-run` reconcile script on byte-cluster, then apply (operator-triggered, NOT done from this PR)
- [ ] post-merge: confirm next inject-loop round on hs/sn/mm reuses the lowest deleted index instead of bumping count

🤖 Generated with [Claude Code](https://claude.com/claude-code)