### PR TITLE
chore(seed): bump train-ticket chart 0.1.0 → 0.2.0 (OTel endpoint fix)

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -60,7 +60,7 @@ containers:
         github_link: OperationsPAI/train-ticket
         status: 1
         helm_config:
-          version: 0.1.0
+          version: 0.2.0
           chart_name: trainticket
           repo_name: train-ticket
           repo_url: https://operationspai.github.io/train-ticket

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -48,7 +48,7 @@ containers:
         github_link: OperationsPAI/train-ticket
         status: 1
         helm_config:
-          version: 0.1.0
+          version: 0.2.0
           chart_name: trainticket
           repo_name: train-ticket
           repo_url: https://operationspai.github.io/train-ticket

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -48,7 +48,7 @@ containers:
         github_link: OperationsPAI/train-ticket
         status: 1
         helm_config:
-          version: 0.1.0
+          version: 0.2.0
           chart_name: trainticket
           repo_name: train-ticket
           repo_url: https://operationspai.github.io/train-ticket


### PR DESCRIPTION
## What

Bumps train-ticket chart pin from `0.1.0` to `0.2.0` in three seed files:
- `data/initial_data/staging/data.yaml`
- `data/initial_data/prod/data.yaml`
- `manifests/byte-cluster/initial-data/data.yaml`

## Why

[OperationsPAI/train-ticket#22](https://github.com/OperationsPAI/train-ticket/pull/22) (merged) fixes the chart's OTel endpoint:

- Default endpoint now points at `opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317` (the always-listening deployment-collector ClusterIP) instead of `http://$(NODE_IP):4317` (which only worked when daemon-collector was on hostNetwork — byte-cluster's isn't).
- Replaces YAML block-scalar `value: \|` with inline-quoted to drop the trailing-newline that broke gRPC URL parsing in some Go OTel SDK versions.
- All 40+ service Deployments now consistently use the same endpoint as the loadgen pod.

## Operational symptom this unblocks

Every `ts*` namespace was emitting traces only from the `loadgen` pod (which had a separate, correctly-configured OTel value). The actual service pods (ts-payment-service, ts-train-service, ts-route-service, etc.) silently dropped all spans, so the detector ran on heavily incomplete telemetry. With this seed bump + the planned reseed/recycle, fresh `ts*` namespaces produce full per-service traces.

## Refs

- OperationsPAI/train-ticket#22 (chart change, merged)