### PR TITLE
chore(seed): ts global.otelcollector override (chart 0.2.0)

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -71,6 +71,12 @@ containers:
               value_type: 1
               template_string: 31%03d
               overridable: false
+            - key: global.otelcollector
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317
+              overridable: true
           status: 1
   - type: 2
     name: otel-demo

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -59,6 +59,12 @@ containers:
               value_type: 1
               template_string: 31%03d
               overridable: false
+            - key: global.otelcollector
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317
+              overridable: true
           status: 1
   - type: 2
     name: otel-demo

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -59,6 +59,12 @@ containers:
               value_type: 1
               template_string: 31%03d
               overridable: false
+            - key: global.otelcollector
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317
+              overridable: true
           status: 1
   - type: 2
     name: otel-demo


### PR DESCRIPTION
## Summary
- TT chart 0.2.0 made the OTel endpoint value-driven (`{{ .Values.global.otelcollector | default "http://\$(NODE_IP):4317" }}`); without an override, the chart falls back to the broken `\$(NODE_IP)` block-scalar and only loadgen pods (separate endpoint) reach the collector.
- Mirror the DSB-side `global.otel.endpoint` pattern: add a `global.otelcollector` parameter pointing at `opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317` to all three seed files.
- Already hot-fixed live byte-cluster mysql (parameter_configs id=62 + helm_config_values link to id=47); this PR ensures the override survives reseed.

## Test plan
- [x] Canary `ts0` install with chart 0.2.0 + override: `OTEL_EXPORTER_OTLP_ENDPOINT=http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317` confirmed on `ts-station-service`
- [ ] Trace volume in ClickHouse confirms multi-service emission (not just loadgen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)