### PR TITLE
chore(seed): bump otel-demo-aegis 0.1.5 -> 0.1.6 (upstream 2.2.0)

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -83,11 +83,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.5
+      - name: 0.1.6
         github_link: open-telemetry/opentelemetry-demo
         status: 1
         helm_config:
-          version: 0.1.5
+          version: 0.1.6
           chart_name: otel-demo-aegis
           repo_name: opspai
           repo_url: oci://registry-1.docker.io/opspai

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -71,11 +71,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.5
+      - name: 0.1.6
         github_link: open-telemetry/opentelemetry-demo
         status: 1
         helm_config:
-          version: 0.1.5
+          version: 0.1.6
           chart_name: otel-demo-aegis
           repo_name: opspai
           repo_url: oci://registry-1.docker.io/opspai

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -71,11 +71,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.5
+      - name: 0.1.6
         github_link: open-telemetry/opentelemetry-demo
         status: 1
         helm_config:
-          version: 0.1.5
+          version: 0.1.6
           chart_name: otel-demo-aegis
           repo_name: opspai
           repo_url: oci://pair-cn-shanghai.cr.volces.com/opspai


### PR DESCRIPTION
## Summary
- benchmark-charts#3 republished `otel-demo-aegis` 0.1.6 (wraps upstream `opentelemetry-demo` 0.40.7 / appVersion 2.2.0).
- Bump seed in all three envs: byte-cluster + staging + prod.
- Pulls in upstream Kafka producer→consumer span_link propagation per OTel messaging semconv (aegis#236).

## Note
Closing the BFS gap from #236 also requires the aegis reasoning layer to **consume span_links as async edges**. That is a separate follow-up; this PR is necessary but not sufficient.

## Verified
- 0.1.6 published to OCI: \`registry-1.docker.io/opspai/otel-demo-aegis:0.1.6\` (sha256:deac1f7...)

## Test plan
- [ ] After merge, run otel-demo canary in byte-cluster: confirm chart 0.1.6 install + new \`product-reviews\`/\`llm\` upstream services come up
- [ ] Confirm Kafka producer→consumer span_link records appear in CH \`otel.otel_traces.Links\` columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)