### PR TITLE
feat(aegisctl): enforce --force and --dry-run on write commands (#237)

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/cluster.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/cluster.go
@@ -51,12 +51,10 @@ development cluster needs before guided local end-to-end validation.
 
 By default the command previews intended changes without writing. Pass
 --apply (or the alias --fix) to perform the actual writes. --dry-run can be
-used explicitly to force a no-write preview, and --output json returns a
+used explicitly to force a no-write preview, --non-interactive is treated
+as an explicit apply request, and --output json returns a
 stable machine-readable summary with create/update/skip outcomes.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if clusterPrepareApply && flagDryRun {
-			return fmt.Errorf("--apply/--fix cannot be combined with --dry-run")
-		}
 		if clusterPrepareTimeout <= 0 {
 			return fmt.Errorf("--timeout must be greater than 0")
 		}
@@ -74,7 +72,7 @@ stable machine-readable summary with create/update/skip outcomes.`,
 		ctx, cancel := context.WithTimeout(cmd.Context(), time.Duration(clusterPrepareTimeout)*time.Second)
 		defer cancel()
 
-		apply := clusterPrepareApply && !flagDryRun
+		apply := shouldApplyClusterPrepareLocalE2E()
 		results, err := runner.Run(ctx, env, apply)
 		if err != nil {
 			return err
@@ -94,6 +92,10 @@ stable machine-readable summary with create/update/skip outcomes.`,
 		cluster.RenderPrepareTable(os.Stdout, results)
 		return nil
 	},
+}
+
+func shouldApplyClusterPrepareLocalE2E() bool {
+	return (clusterPrepareApply || flagNonInteractive) && !flagDryRun
 }
 
 var clusterPreflightCmd = &cobra.Command{
@@ -153,6 +155,9 @@ func init() {
 	clusterPrepareLocalE2ECmd.Flags().BoolVar(&clusterPrepareApply, "fix", false, "Alias for --apply")
 	clusterPrepareLocalE2ECmd.Flags().StringVar(&clusterPrepareConfig, "config", "", "Path to a specific config TOML (defaults to config.$ENV_MODE.toml in cwd)")
 	clusterPrepareLocalE2ECmd.Flags().IntVar(&clusterPrepareTimeout, "timeout", 30, "Overall timeout for the local/e2e preparation run in seconds")
+	cobra.OnInitialize(func() {
+		markDryRunSupported(clusterPrepareLocalE2ECmd)
+	})
 
 	clusterCmd.AddCommand(clusterPreflightCmd)
 	clusterPrepareCmd.AddCommand(clusterPrepareLocalE2ECmd)

--- a/AegisLab/src/cmd/aegisctl/cmd/cluster_prepare_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/cluster_prepare_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import "testing"
+
+func TestShouldApplyClusterPrepareLocalE2E(t *testing.T) {
+	t.Cleanup(func() {
+		clusterPrepareApply = false
+		flagNonInteractive = false
+		flagDryRun = false
+	})
+
+	cases := []struct {
+		name           string
+		clusterApply   bool
+		nonInteractive bool
+		dryRun         bool
+		wantApply      bool
+	}{
+		{name: "default", clusterApply: false, nonInteractive: false, dryRun: false, wantApply: false},
+		{name: "explicit apply", clusterApply: true, nonInteractive: false, dryRun: false, wantApply: true},
+		{name: "non-interactive", clusterApply: false, nonInteractive: true, dryRun: false, wantApply: true},
+		{name: "explicit apply + non-interactive", clusterApply: true, nonInteractive: true, dryRun: false, wantApply: true},
+		{name: "dry-run suppresses default", clusterApply: false, nonInteractive: false, dryRun: true, wantApply: false},
+		{name: "dry-run suppresses non-interactive", clusterApply: false, nonInteractive: true, dryRun: true, wantApply: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clusterPrepareApply = tc.clusterApply
+			flagNonInteractive = tc.nonInteractive
+			flagDryRun = tc.dryRun
+			if got := shouldApplyClusterPrepareLocalE2E(); got != tc.wantApply {
+				t.Fatalf("shouldApplyClusterPrepareLocalE2E() = %v, want %v", got, tc.wantApply)
+			}
+		})
+	}
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/container.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/container.go
@@ -432,17 +432,26 @@ var containerResolveCmd = &cobra.Command{
 
 // --- container build ---
 
-var containerBuildVersion string
+var (
+	containerBuildVersion string
+	containerBuildForce   bool
+)
 
 var containerBuildCmd = &cobra.Command{
 	Use:   "build <name>",
 	Short: "Trigger a container build",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		if !containerBuildForce || flagDryRun {
+			printContainerBuildPlan(name, containerBuildVersion)
+			return nil
+		}
+
 		c := newClient()
 
 		body := map[string]string{
-			"name": args[0],
+			"name": name,
 		}
 		if containerBuildVersion != "" {
 			body["version"] = containerBuildVersion
@@ -458,15 +467,40 @@ var containerBuildCmd = &cobra.Command{
 			return nil
 		}
 
-		output.PrintInfo(fmt.Sprintf("Build triggered for container %q", args[0]))
+		output.PrintInfo(fmt.Sprintf("Build triggered for container %q", name))
 		return nil
 	},
+}
+
+func printContainerBuildPlan(name, version string) {
+	if output.OutputFormat(flagOutput) == output.FormatJSON {
+		payload := map[string]any{
+			"dry_run": true,
+			"name":    name,
+		}
+		if version != "" {
+			payload["version"] = version
+		}
+		output.PrintJSON(payload)
+		return
+	}
+
+	if flagNonInteractive && !containerBuildForce {
+		output.PrintInfo("Refusing to build without --force in non-interactive mode")
+		return
+	}
+	fmt.Fprintf(os.Stdout, "Build preview for container %q\n", name)
+	if version != "" {
+		fmt.Fprintf(os.Stdout, "  version: %s\n", version)
+	}
+	output.PrintInfo("Run --force to execute the build")
 }
 
 func init() {
 	containerListCmd.Flags().StringVar(&containerListType, "type", "", "Filter by type: algorithm|benchmark|pedestal")
 
 	containerBuildCmd.Flags().StringVar(&containerBuildVersion, "version", "", "Version tag for the build")
+	containerBuildCmd.Flags().BoolVar(&containerBuildForce, "force", false, "Required to actually trigger the build")
 
 	containerDeleteCmd.Flags().BoolVar(&containerDeleteYes, "yes", false, "Skip confirmation prompt")
 	containerDeleteCmd.Flags().BoolVar(&containerDeleteYes, "force", false, "Alias for --yes")
@@ -479,6 +513,7 @@ func init() {
 	containerCmd.AddCommand(containerResolveCmd)
 
 	cobra.OnInitialize(func() {
+		markDryRunSupported(containerBuildCmd)
 		markDryRunSupported(containerDeleteCmd)
 	})
 

--- a/AegisLab/src/cmd/aegisctl/cmd/container_build_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/container_build_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestContainerBuildNonInteractiveDoesNotTriggerBuildWithoutForce(t *testing.T) {
+	requestCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v2/containers/build" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"code":    200,
+				"message": "ok",
+				"data":    map[string]any{"status": "triggered"},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	res := runCLI(t, "container", "build", "worker", "--non-interactive", "--server", srv.URL, "--token", "tok")
+	if res.code != ExitCodeSuccess {
+		t.Fatalf("exit = %d, want %d", res.code, ExitCodeSuccess)
+	}
+	if requestCount != 0 {
+		t.Fatalf("expected no request, got %d", requestCount)
+	}
+	if !strings.Contains(res.stderr, "Refusing to build without --force in non-interactive mode") {
+		t.Fatalf("stderr missing non-interactive refusal; got %q", res.stderr)
+	}
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/rate_limiter.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/rate_limiter.go
@@ -113,6 +113,7 @@ var (
 	rlResetBucket string
 	rlResetForce  bool
 )
+var rlGCForce bool
 
 var rateLimiterResetCmd = &cobra.Command{
 	Use:   "reset",
@@ -139,10 +140,41 @@ var rateLimiterGCCmd = &cobra.Command{
 	Short: "Release tokens held by terminal-state tasks across all buckets",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c := newClient()
+		doMutation := rlGCForce && !flagDryRun
+
+		var listResp client.APIResponse[rlListResp]
+		if err := c.Get("/api/v2/rate-limiters", &listResp); err != nil {
+			return err
+		}
+		leaked := leakedRateLimiterBuckets(listResp.Data.Items)
+		if len(leaked) == 0 && !doMutation {
+			if output.OutputFormat(flagOutput) == output.FormatJSON {
+				output.PrintJSON(map[string]any{"dry_run": true, "items": []rlItem{}, "count": 0})
+				return nil
+			}
+			output.PrintInfo("No terminal-state buckets to clean")
+			output.PrintInfo("Use --force to execute cleanup")
+			return nil
+		}
+
+		if !doMutation {
+			if output.OutputFormat(flagOutput) == output.FormatJSON {
+				output.PrintJSON(map[string]any{
+					"dry_run": true,
+					"items":   leaked,
+					"count":   len(leaked),
+				})
+				return nil
+			}
+			printRateLimiterGCPlan(leaked)
+			return nil
+		}
+
 		var resp client.APIResponse[rlGCResp]
 		if err := c.Post("/api/v2/rate-limiters/gc", nil, &resp); err != nil {
 			return err
 		}
+
 		if output.OutputFormat(flagOutput) == output.FormatJSON {
 			output.PrintJSON(resp.Data)
 			return nil
@@ -153,11 +185,59 @@ var rateLimiterGCCmd = &cobra.Command{
 	},
 }
 
+func leakedRateLimiterBuckets(items []rlItem) []rlItem {
+	out := make([]rlItem, 0, len(items))
+	for _, item := range items {
+		leakedHolders := make([]rlHolder, 0, len(item.Holders))
+		for _, holder := range item.Holders {
+			if holder.IsTerminal {
+				leakedHolders = append(leakedHolders, holder)
+			}
+		}
+		if len(leakedHolders) == 0 {
+			continue
+		}
+		filtered := item
+		filtered.Holders = leakedHolders
+		out = append(out, filtered)
+	}
+	return out
+}
+
+func printRateLimiterGCPlan(leaks []rlItem) {
+	if len(leaks) == 0 {
+		fmt.Println("No terminal-state buckets to clean")
+		output.PrintInfo("Use --force to execute cleanup")
+		return
+	}
+
+	fmt.Println("The following buckets have terminal-state holders and would be cleaned:")
+	headers := []string{"BUCKET", "HELD/CAP", "TERMINAL HOLDERS"}
+	rows := make([][]string, 0, len(leaks))
+	for _, item := range leaks {
+		holders := make([]string, 0, len(item.Holders))
+		for _, holder := range item.Holders {
+			holders = append(holders, fmt.Sprintf("%s[%s]", holder.TaskID, holder.TaskState))
+		}
+		rows = append(rows, []string{
+			item.Bucket,
+			fmt.Sprintf("%d/%d", item.Held, item.Capacity),
+			strings.Join(holders, ", "),
+		})
+	}
+	output.PrintTable(headers, rows)
+	output.PrintInfo("Use --force to execute cleanup")
+}
+
 func init() {
 	rateLimiterResetCmd.Flags().StringVar(&rlResetBucket, "bucket", "", "Bucket short name, e.g. restart_service")
 	rateLimiterResetCmd.Flags().BoolVar(&rlResetForce, "force", false, "Required to actually perform the reset")
+	rateLimiterGCCmd.Flags().BoolVar(&rlGCForce, "force", false, "Required to actually perform cleanup")
 	rateLimiterCmd.AddCommand(rateLimiterStatusCmd)
 	rateLimiterCmd.AddCommand(rateLimiterResetCmd)
 	rateLimiterCmd.AddCommand(rateLimiterGCCmd)
+	cobra.OnInitialize(func() {
+		markDryRunSupported(rateLimiterGCCmd)
+	})
 	rootCmd.AddCommand(rateLimiterCmd)
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/rate_limiter_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/rate_limiter_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRateLimiterGCDryRunBehaviorWithoutForce(t *testing.T) {
+	requested := make([]string, 0, 4)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.Method+" "+r.URL.Path)
+		switch r.URL.Path {
+		case "/api/v2/rate-limiters":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"code":    200,
+				"message": "ok",
+				"data": map[string]any{
+					"items": []map[string]any{
+						{
+							"bucket":   "restart_service",
+							"key":      "token_bucket:restart_service",
+							"capacity": 8,
+							"held":     2,
+							"holders": []map[string]any{
+								{"task_id": "t1", "task_state": "terminal", "is_terminal": true},
+							},
+						},
+					},
+				},
+			})
+		case "/api/v2/rate-limiters/gc":
+			t.Fatalf("unexpected mutation request: %s %s", r.Method, r.URL.Path)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	cases := [][]string{
+		{"rate-limiter", "gc", "--server", srv.URL, "--token", "tok"},
+		{"rate-limiter", "gc", "--dry-run", "--server", srv.URL, "--token", "tok"},
+	}
+
+	for _, args := range cases {
+		requested = requested[:0]
+		res := runCLI(t, args...)
+		if res.code != ExitCodeSuccess {
+			t.Fatalf("exit = %d, want %d", res.code, ExitCodeSuccess)
+		}
+		for _, req := range requested {
+			if req == "POST /api/v2/rate-limiters/gc" {
+				t.Fatalf("mutation request observed without --force")
+			}
+		}
+		if !strings.Contains(res.stdout, "restart_service") {
+			t.Fatalf("stdout missing bucket preview; got %q", res.stdout)
+		}
+		if !strings.Contains(res.stderr, "Use --force to execute cleanup") {
+			t.Fatalf("stderr missing plan hint; got %q", res.stderr)
+		}
+	}
+}

--- a/scripts/review-reports/issue-249-review.md
+++ b/scripts/review-reports/issue-249-review.md
@@ -1,0 +1,60 @@
+# Review for issue #249 — PR #252
+
+## Cascade preconditions
+| submodule | remote branch | SHA match | FF-able |
+|-----------|---------------|-----------|---------|
+| (none)    | N/A           | N/A       | N/A     |
+
+No submodule pointers were changed in this branch diff (`git diff --raw origin/main..HEAD` had no `160000` submodule entries).
+
+## Per-AC verdicts
+### AC 1: `aegisctl rate-limiter gc` 在无 `--force` 时打印将被清理的 bucket 列表后退出（EXIT=0），需 `--force` 才执行；新增 `--dry-run` 同义于无 `--force`。
+**verdict**: PASS
+**command**: ``cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestRateLimiterGCDryRunBehaviorWithoutForce -count=1``
+**exit**: 0
+**stdout** (first 20 lines):
+```
+ok   	aegis/cmd/aegisctl/cmd	0.034s
+```
+
+### AC 2: `aegisctl container build` 新增 `--force` 与 `--dry-run`，无 `--force` 且 `--non-interactive` 时不发起 build。
+**verdict**: PASS
+**command**: ``cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestContainerBuildNonInteractiveDoesNotTriggerBuildWithoutForce -count=1``
+**exit**: 0
+**stdout** (first 20 lines):
+```
+ok   	aegis/cmd/aegisctl/cmd	0.019s
+```
+
+### AC 3: `aegisctl cluster prepare local-e2e` 默认行为等价 `--dry-run`，仅打印计划；显式 `--apply` 才执行 mutation；`--non-interactive` 隐式等价 `--force`。
+**verdict**: PASS
+**command**: ``cd AegisLab/src && go test ./cmd/aegisctl/cluster ./cmd/aegisctl/cmd -run 'TestLocalE2EPrepareRunner_DryRunDoesNotMutate|TestLocalE2EPrepareRunner_ApplyIsIdempotent' -count=1``
+**exit**: 0
+**stdout** (first 20 lines):
+```
+ok   	aegis/cmd/aegisctl/cluster	0.013s
+ok   	aegis/cmd/aegisctl/cmd	0.037s [no tests to run]
+```
+
+### AC 4: `--non-interactive` + `--apply` 时不再 prompt（agent-friendly）。
+**verdict**: PASS
+**command**: ``cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestShouldApplyClusterPrepareLocalE2E -count=1``
+**exit**: 0
+**stdout** (first 20 lines):
+```
+ok   	aegis/cmd/aegisctl/cmd	0.019s
+```
+
+### AC 5: 一个 integration test（仅一个）：对 `rate-limiter gc` 在无 `--force` 模式下断言 server 没有收到 mutation 请求（mock server 计数）。
+**verdict**: PASS
+**command**: ``cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestRateLimiterGCDryRunBehaviorWithoutForce -count=1``
+**exit**: 0
+**stdout** (first 20 lines):
+```
+ok   	aegis/cmd/aegisctl/cmd	0.034s
+```
+
+## Overall
+- PASS: 5 / 5
+- FAIL: none
+- UNVERIFIABLE: none


### PR DESCRIPTION
## Summary
- add --force/--dry-run and server-safety preview flow for rate-limiter gc
- add --force + dry-run semantics for container build and keep non-interactive on dry-run path
- make cluster prepare local-e2e default to preview mode and treat --non-interactive as explicit apply

## Subtask results
- subtask-1 (rate-limiter gc semantics) — DONE
  - verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestRateLimiterGCDryRunBehaviorWithoutForce` -> exit 0, command prints leaked bucket preview and skips mutation endpoint
- subtask-2 (container build force/dry-run) — DONE
  - verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestContainerBuildNonInteractiveDoesNotTriggerBuildWithoutForce` -> exit 0, no POST /api/v2/containers/build without --force
- subtask-3 (cluster local-e2e defaults) — DONE
  - verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestShouldApplyClusterPrepareLocalE2E` and `cd AegisLab/src && go test ./cmd/aegisctl/cluster -run TestLocalE2EPrepare` -> exit 0

## Submodule changes
- AegisLab: updated `src/cmd/aegisctl/cmd/rate_limiter.go`, `src/cmd/aegisctl/cmd/container.go`, `src/cmd/aegisctl/cmd/cluster.go` and added coverage in `src/cmd/aegisctl/cmd/*_test.go`
- AegisLab-frontend: — not modified
- chaos-experiment: — not modified
- rcabench-platform: — not modified

## Workspace-level changes
- none

## Known gaps / blockers
- none

Fixes #249
