### PR TITLE
feat(aegisctl): add schema diff gate and ansi pipe regression test

### DIFF
--- a/.github/workflows/aegisctl-schema-diff.yml
+++ b/.github/workflows/aegisctl-schema-diff.yml
@@ -1,0 +1,129 @@
+name: aegisctl schema diff gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "AegisLab/**"
+      - ".github/workflows/aegisctl-schema-diff.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  schema-diff-gate:
+    name: schema gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "AegisLab/src/go.mod"
+
+      - name: Generate schema and enforce acknowledged diff policy
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          workdir="$RUNNER_TEMP/aegisctl-schema-diff"
+          base_repo="$workdir/base-repo"
+          mkdir -p "$workdir"
+
+          current_json="$workdir/current-schema.json"
+          base_json="$workdir/base-schema.json"
+          diff_file="$workdir/schema.diff"
+          comment_file="$workdir/comment.md"
+          build_bin="$workdir/aegisctl-schema-dump"
+
+          build_schema() {
+            local repo_root=$1
+            local out_file=$2
+
+            (cd "$repo_root/AegisLab" && go build -o "$build_bin" ./src/cmd/aegisctl)
+            (cd "$repo_root/AegisLab/src" && "$build_bin" schema dump > "$out_file")
+          }
+
+          cleanup() {
+            if [ -d "$base_repo" ]; then
+              git worktree remove --force "$base_repo" || true
+            fi
+            rm -f "$build_bin"
+          }
+          trap cleanup EXIT
+
+          # Current head schema (this PR version).
+          build_schema "$GITHUB_WORKSPACE" "$current_json"
+
+          # Base schema from PR base sha.
+          git worktree add --detach "$base_repo" "$BASE_SHA"
+          build_schema "$base_repo" "$base_json"
+
+          if ! diff -u "$base_json" "$current_json" > "$diff_file"; then
+            :
+          fi
+
+          has_changes=0
+          if [ -s "$diff_file" ]; then
+            has_changes=1
+          fi
+
+          pr_body="$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")"
+          acked="false"
+          if printf '%s' "$pr_body" | grep -Eq '(^|[[:space:]])schema-changes-acknowledged:[[:space:]]*true([[:space:]]|$)'; then
+            acked="true"
+          fi
+
+          {
+            echo "## aegisctl schema diff"
+            echo
+            echo "- PR: #$PR_NUMBER"
+            echo "- Base: $BASE_SHA"
+            echo "- Head: $HEAD_SHA"
+            echo
+
+            if [ "$has_changes" -eq 0 ]; then
+            echo "No schema changes were detected."
+            echo
+            echo "Gate result: PASS"
+            echo
+            echo "No action required from schema-gate policy."
+            else
+              echo "Schema changed in this PR."
+              echo
+              echo "PR description must include: \\`schema-changes-acknowledged: true\\`."
+              echo "PR body acknowledgement: \\`$acked\\`"
+              echo
+              echo "### Diff (truncated to first 400 lines)"
+              echo '```diff'
+              if [ "$(wc -l < "$diff_file")" -gt 400 ]; then
+                sed -n '1,400p' "$diff_file"
+                echo '...'
+                echo '... truncated to first 400 lines ...'
+              else
+                cat "$diff_file"
+              fi
+              echo '```'
+              echo
+              if [ "$acked" = "true" ]; then
+                echo "Gate result: PASS (acknowledged)"
+              else
+                echo "Gate result: FAIL (missing acknowledgement)"
+              fi
+            fi
+          } > "$comment_file"
+
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$comment_file"
+
+          if [ "$has_changes" -eq 1 ] && [ "$acked" != "true" ]; then
+            echo "::error::aegisctl schema changed but PR body does not include 'schema-changes-acknowledged: true'."
+            exit 1
+          fi

--- a/AegisLab/src/cmd/aegisctl/cmd/contract_expansion_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/contract_expansion_test.go
@@ -27,8 +27,8 @@ func TestSchemaDumpEmitsValidJSON(t *testing.T) {
 		t.Fatalf("exit code = %d, want %d; stderr=%q", res.code, ExitCodeSuccess, res.stderr)
 	}
 	var doc struct {
-		Version   string `json:"version"`
-		Commands  []struct {
+		Version  string `json:"version"`
+		Commands []struct {
 			Path string `json:"path"`
 		} `json:"commands"`
 		ExitCodes map[string]string `json:"exit_codes"`
@@ -54,5 +54,70 @@ func TestSchemaDumpEmitsValidJSON(t *testing.T) {
 	}
 	if _, ok := doc.ExitCodes["7"]; !ok {
 		t.Fatalf("schema document missing exit code 7 entry")
+	}
+}
+
+func TestSchemaDumpFlagMetadataContainsTypeDefaultRequiredEnumValues(t *testing.T) {
+	res := runCLI(t, "schema", "dump")
+	if res.code != ExitCodeSuccess {
+		t.Fatalf("exit code = %d, want %d; stderr=%q", res.code, ExitCodeSuccess, res.stderr)
+	}
+
+	type schemaCommandDump struct {
+		Path  string            `json:"path"`
+		Flags []json.RawMessage `json:"flags"`
+	}
+	var doc struct {
+		Commands []schemaCommandDump `json:"commands"`
+	}
+	if err := json.Unmarshal([]byte(res.stdout), &doc); err != nil {
+		t.Fatalf("schema JSON decode failed: %v\nstdout=%q", err, res.stdout)
+	}
+	if len(doc.Commands) == 0 {
+		t.Fatalf("schema dump missing commands")
+	}
+
+	var outputSeen bool
+	var outputEnumValues []string
+	for _, c := range doc.Commands {
+		for _, flagRaw := range c.Flags {
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal(flagRaw, &raw); err != nil {
+				t.Fatalf("invalid flag object in schema dump: %v", err)
+			}
+			for _, key := range []string{"type", "default", "required", "enum_values", "name"} {
+				if _, ok := raw[key]; !ok {
+					t.Fatalf("schema flag missing %q in command %q", key, c.Path)
+				}
+			}
+			type flagMeta struct {
+				Name       string   `json:"name"`
+				Type       string   `json:"type"`
+				Default    string   `json:"default"`
+				Required   bool     `json:"required"`
+				EnumValues []string `json:"enum_values"`
+			}
+			var meta flagMeta
+			if err := json.Unmarshal(flagRaw, &meta); err != nil {
+				t.Fatalf("decode schema flag: %v", err)
+			}
+			if meta.Type == "" {
+				t.Fatalf("schema flag %q in command %q missing type", meta.Name, c.Path)
+			}
+			if meta.Required && meta.Name == "" {
+				t.Fatalf("schema flag in command %q has required=true with missing name", c.Path)
+			}
+			if c.Path == "aegisctl" && meta.Name == "output" {
+				outputSeen = true
+				outputEnumValues = append(outputEnumValues, meta.EnumValues...)
+			}
+		}
+	}
+
+	if !outputSeen {
+		t.Fatalf("schema dump missing top-level --output flag")
+	}
+	if len(outputEnumValues) == 0 {
+		t.Fatalf("expected top-level --output enum values in schema")
 	}
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/no_ansi_in_pipe_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/no_ansi_in_pipe_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+
+func assertNoEscapeSequenceInStdout(t *testing.T, label string, output string) {
+	t.Helper()
+	if ansiEscapeRE.MatchString(output) {
+		t.Fatalf("stdout for %s contains ANSI escape sequence:\n%q", label, output)
+	}
+}
+
+func TestNoAnsiOutputInPipedTopLevelAndListGetCommands(t *testing.T) {
+	for _, cmd := range rootCmd.Commands() {
+		if cmd == nil || cmd.Hidden || cmd.Deprecated != "" || cmd.Name() == "help" {
+			continue
+		}
+
+		t.Run("help-"+cmd.Name(), func(t *testing.T) {
+			res := runCLI(t, cmd.Name(), "--help")
+			if res.code != ExitCodeSuccess {
+				t.Fatalf("%s --help failed: code=%d stderr=%q", cmd.Name(), res.code, res.stderr)
+			}
+			assertNoEscapeSequenceInStdout(t, cmd.Name()+" --help", res.stdout)
+		})
+	}
+
+	typicalCalls := [][]string{
+		{"project", "list"},
+		{"project", "get", "sample"},
+		{"container", "list"},
+		{"container", "get", "sample"},
+		{"dataset", "list"},
+		{"dataset", "get", "sample"},
+		{"eval", "list"},
+		{"eval", "get", "1"},
+		{"trace", "list"},
+		{"trace", "get", "trace-sample"},
+		{"task", "list"},
+		{"task", "get", "1"},
+	}
+
+	for _, args := range typicalCalls {
+		label := strings.Join(args, " ")
+		t.Run(label, func(t *testing.T) {
+			res := runCLI(t, args...)
+			assertNoEscapeSequenceInStdout(t, label, res.stdout)
+		})
+	}
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/schema.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/schema.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -12,12 +14,13 @@ import (
 
 // schemaFlag describes one local flag on a command.
 type schemaFlag struct {
-	Name      string `json:"name" yaml:"name"`
-	Shorthand string `json:"shorthand" yaml:"shorthand"`
-	Type      string `json:"type" yaml:"type"`
-	Default   string `json:"default" yaml:"default"`
-	Usage     string `json:"usage" yaml:"usage"`
-	Required  bool   `json:"required" yaml:"required"`
+	Name       string   `json:"name" yaml:"name"`
+	Shorthand  string   `json:"shorthand" yaml:"shorthand"`
+	Type       string   `json:"type" yaml:"type"`
+	Default    string   `json:"default" yaml:"default"`
+	Usage      string   `json:"usage" yaml:"usage"`
+	Required   bool     `json:"required" yaml:"required"`
+	EnumValues []string `json:"enum_values" yaml:"enum_values"`
 }
 
 // schemaCommand is a single entry in the schema dump.
@@ -125,17 +128,156 @@ func collectLocalFlags(cmd *cobra.Command) []schemaFlag {
 		if annotations := f.Annotations[cobra.BashCompOneRequiredFlag]; len(annotations) > 0 && annotations[0] == "true" {
 			required = true
 		}
+		enumValues := collectFlagEnumValues(f.Usage)
+		if enumValues == nil {
+			enumValues = []string{}
+		}
 		flags = append(flags, schemaFlag{
-			Name:      f.Name,
-			Shorthand: f.Shorthand,
-			Type:      f.Value.Type(),
-			Default:   f.DefValue,
-			Usage:     f.Usage,
-			Required:  required,
+			Name:       f.Name,
+			Shorthand:  f.Shorthand,
+			Type:       f.Value.Type(),
+			Default:    f.DefValue,
+			Usage:      f.Usage,
+			Required:   required,
+			EnumValues: enumValues,
 		})
 	})
 	sort.Slice(flags, func(i, j int) bool { return flags[i].Name < flags[j].Name })
 	return flags
+}
+
+var (
+	enumValueKeywordRE = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)(?:valid values?|possible values|must be one of|valid:|valid values?:?)\s*[:;]?\s*([^\n.)]+)`),
+		regexp.MustCompile(`(?i)(?:can be one of|allowed values?|values? are)\s*[:;]?\s*([^\n.)]+)`),
+	}
+	parenthesizedRE = regexp.MustCompile(`\(([^()]*)\)`)
+	pipeValueRE     = regexp.MustCompile(`\b([A-Za-z0-9._-]+(?:\s*\|\s*[A-Za-z0-9._-]+)+)\b`)
+	quotedValueRE   = regexp.MustCompile(`'([^']+)'(?:\s*(?:/|\|)\s*'[^']+')+`)
+)
+
+func collectFlagEnumValues(usage string) []string {
+	for _, re := range enumValueKeywordRE {
+		matches := re.FindAllStringSubmatch(usage, -1)
+		for _, match := range matches {
+			values := splitEnumValueCandidates(match[1])
+			if isLikelyEnumValueSet(values) {
+				return values
+			}
+		}
+	}
+
+	for _, match := range parenthesizedRE.FindAllStringSubmatch(usage, -1) {
+		values := splitEnumValueCandidates(match[1])
+		if isLikelyEnumValueSet(values) {
+			return values
+		}
+	}
+
+	quotedValues := quotedValueRE.FindStringSubmatch(usage)
+	if len(quotedValues) > 0 {
+		return splitQuotedEnumValues(quotedValues[0])
+	}
+
+	for _, match := range pipeValueRE.FindAllStringSubmatch(usage, -1) {
+		values := splitEnumValueCandidates(match[1])
+		if isLikelyEnumValueSet(values) {
+			return values
+		}
+	}
+
+	return nil
+}
+
+func splitEnumValueCandidates(raw string) []string {
+	parts := []string{raw}
+
+	if strings.Contains(raw, "|") {
+		parts = strings.Split(raw, "|")
+	} else if strings.Contains(raw, ",") {
+		parts = strings.Split(raw, ",")
+	} else if strings.Contains(raw, " / ") || strings.Contains(raw, "/") {
+		parts = strings.Split(raw, "/")
+	}
+
+	values := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		value = strings.Trim(value, " ()")
+		value = strings.Trim(value, `"'`)
+		if !isLikelyEnumValue(value) {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	return values
+}
+
+func splitQuotedEnumValues(raw string) []string {
+	parts := quotedValueRE.FindAllStringSubmatch(raw, -1)
+	if len(parts) == 0 {
+		return nil
+	}
+
+	values := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, p := range parts {
+		value := strings.TrimSpace(p[1])
+		if !isLikelyEnumValue(value) {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	return values
+}
+
+func isLikelyEnumValue(value string) bool {
+	if value == "" {
+		return false
+	}
+	if strings.ContainsAny(value, " \t\n\r") {
+		return false
+	}
+	if strings.HasSuffix(value, ";") || strings.HasPrefix(value, ";") {
+		return false
+	}
+	switch value {
+	case "id", "name", "required", "file", "required)", "required;":
+		return false
+	}
+	return true
+}
+
+func isLikelyEnumValueSet(values []string) bool {
+	if len(values) < 2 {
+		return false
+	}
+	return len(values) == len(uniqueEnumValues(values))
+}
+
+func uniqueEnumValues(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 func argsDescription(cmd *cobra.Command) string {

--- a/scripts/review-reports/issue-251-review.md
+++ b/scripts/review-reports/issue-251-review.md
@@ -1,0 +1,70 @@
+# Review for issue #251 — PR #253
+
+## Parent PR
+- Open PR verified: `gh pr list -R OperationsPAI/aegis --head workbuddy/issue-251 --state open --json number,url -q '.[0]'`
+- Result: `{"number":253,"url":"https://github.com/OperationsPAI/aegis/pull/253"}`
+
+## Cascade preconditions
+No submodule entries exist in this worktree (`.gitmodules` is empty), therefore no submodule cascade checks were required.
+
+**command**: `git diff --submodule=short --stat origin/main...origin/workbuddy/issue-251 && echo '---' && git diff --raw origin/main...origin/workbuddy/issue-251 | awk '$1 ~ /^:/ && $5=="160000" {print}'`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ .github/workflows/aegisctl-schema-diff.yml         | 129 ++++++++++++++++
+ .../cmd/aegisctl/cmd/contract_expansion_test.go    |  69 ++++++++-
+ .../src/cmd/aegisctl/cmd/no_ansi_in_pipe_test.go   |  55 +++++++
+ AegisLab/src/cmd/aegisctl/cmd/schema.go            | 166 +++++++++++++++++++--
+ 4 files changed, 405 insertions(+), 14 deletions(-)
+---
+```
+
+## Per-AC verdicts
+
+### AC 1: CI workflow (`.github/workflows/aegisctl-schema-diff.yml`) builds `aegisctl`, runs `schema dump`, diffs against base/main, comments on PR, and fails on non-empty diff without `schema-changes-acknowledged: true` in PR body
+**verdict**: PASS
+**command**: `set -euo pipefail
+wf_file='.github/workflows/aegisctl-schema-diff.yml'
+for pat in \
+'go build -o "$build_bin" ./src/cmd/aegisctl' \
+'"$build_bin" schema dump > "$out_file"' \
+'git worktree add --detach "$base_repo" "$BASE_SHA"' \
+'diff -u "$base_json" "$current_json" > "$diff_file"' \
+'gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file "$comment_file"' \
+'schema-changes-acknowledged: true' \
+'::error::aegisctl schema changed but PR body does not include '\''schema-changes-acknowledged: true'\''.'
+do
+  if ! grep -qF "$pat" "$wf_file"; then
+    echo "MISSING: $pat" >&2
+    exit 1
+  fi
+done
+echo "schema diff workflow checks passed"`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+schema diff workflow checks passed
+```
+
+### AC 2: Add a single e2e regression test that enumerates top-level `--help` and representative `list/get` calls and asserts stdout has no ANSI escapes
+**verdict**: PASS
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestNoAnsiOutputInPipedTopLevelAndListGetCommands -count=1`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok  	aegis/cmd/aegisctl/cmd	0.052s
+```
+
+### AC 3: Ensure `aegisctl schema dump` includes `type / default / required / enum_values` per flag
+**verdict**: PASS
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestSchemaDumpFlagMetadataContainsTypeDefaultRequiredEnumValues -count=1`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok   	aegis/cmd/aegisctl/cmd	0.034s
+```
+
+## Overall
+- PASS: 3 / 3
+- FAIL: none
+- UNVERIFIABLE: none


### PR DESCRIPTION
## Summary
- Add a CLI schema diff gate workflow that compares `aegisctl schema dump` against `main` on PRs and fails when schema changed without explicit acknowledgement.
- Add a regression contract test to assert command outputs in piped stdout mode contain no ANSI escape sequences for top-level `--help` and representative `list/get` calls.
- Keep schema dump contract coverage for `type/default/required/enum_values` and keep enum extraction in place for drift detection.

## Subtask results
- subtask-1 (schema dump metadata) — DONE
  - verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run 'TestSchemaDumpEmitsValidJSON|TestSchemaDumpFlagMetadataContainsTypeDefaultRequiredEnumValues'` → exit 0, `ok  	aegis/cmd/aegisctl/cmd	0.048s`
- subtask-2 (schema diff gate workflow) — DONE
  - verify: `python3 - <<'PY'
import pathlib, yaml
path = pathlib.Path('.github/workflows/aegisctl-schema-diff.yml')
with path.open('r', encoding='utf-8') as f:
    yaml.safe_load(f)
print('loaded', path)
PY` → exit 0, `loaded .github/workflows/aegisctl-schema-diff.yml`
- subtask-3 (ANSI regression test) — DONE
  - verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestNoAnsiOutputInPipedTopLevelAndListGetCommands -count=1` → exit 0, `ok   	aegis/cmd/aegisctl/cmd	0.045s`

## Submodule changes
- AegisLab: CLI schema dump metadata + new contract test in `cmd/aegisctl/cmd`.
- AegisLab-frontend: — not modified
- chaos-experiment: — not modified
- rcabench-platform: — not modified

## Workspace-level changes
- Add `.github/workflows/aegisctl-schema-diff.yml` with PR target + PR-body ack enforcement + diff posting.

## Known gaps / blockers
- None.
