### PR TITLE
feat(aegisctl): add execute create/list-files with deprecation aliases

### DIFF
--- a/AegisLab/src/cmd/aegisctl/README.md
+++ b/AegisLab/src/cmd/aegisctl/README.md
@@ -44,7 +44,7 @@ printf %s\n "$AEGIS_PASSWORD" | ./bin/aegisctl auth login \
   --interval 10 --pre-duration 5
 
 # 5. Submit algorithm execution against a datapack or dataset
-./bin/aegisctl execute submit --project pair_diagnosis --spec ./execution.yaml -o json
+./bin/aegisctl execute create --project pair_diagnosis --input ./execution.yaml -o json
 ```
 
 The full CLI contract, including output and exit-code expectations, lives in

--- a/AegisLab/src/cmd/aegisctl/cmd/contract_expansion_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/contract_expansion_test.go
@@ -155,3 +155,31 @@ func TestSchemaDumpFlagMetadataContainsTypeDefaultRequiredEnumValues(t *testing.
 		t.Fatalf("expected top-level --output enum values in schema")
 	}
 }
+
+func TestSchemaDumpMarksDeprecatedAliases(t *testing.T) {
+	doc := buildSchemaDocument()
+
+	findByPath := func(path string) *schemaCommand {
+		for _, c := range doc.Commands {
+			if c.Path == path {
+				return &c
+			}
+		}
+		return nil
+	}
+
+	assertDeprecated := func(path string, wantDeprecated bool) {
+		c := findByPath(path)
+		if c == nil {
+			t.Fatalf("schema missing path %s", path)
+		}
+		if c.Deprecated != wantDeprecated {
+			t.Fatalf("schema path %s deprecated=%v, want %v", path, c.Deprecated, wantDeprecated)
+		}
+	}
+
+	assertDeprecated("aegisctl execute create", false)
+	assertDeprecated("aegisctl execute submit", true)
+	assertDeprecated("aegisctl inject list-files", false)
+	assertDeprecated("aegisctl inject files", true)
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
@@ -36,6 +36,9 @@ func resetCLIState() {
 	output.Quiet = false
 	commandStdin = os.Stdin
 
+	executeCreateInput = ""
+	executeCreateSpec = ""
+
 	authLoginServer = ""
 	authLoginKeyID = ""
 	authLoginKeySecret = ""

--- a/AegisLab/src/cmd/aegisctl/cmd/deprecation_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/deprecation_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"aegis/internal/cli/deprecate"
+)
+
+func TestExecuteCreateSpecFlagsAreMutuallyExclusive(t *testing.T) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		resetCommandFlags(rootCmd)
+		executeCreateInput = ""
+		executeCreateSpec = ""
+	})
+	executeCreateInput = ""
+	executeCreateSpec = ""
+
+	if err := executeCreateCmd.Flags().Set("input", "/tmp/input.yaml"); err != nil {
+		t.Fatalf("set input: %v", err)
+	}
+	if err := executeCreateCmd.Flags().Set("spec", "/tmp/spec.yaml"); err != nil {
+		t.Fatalf("set spec: %v", err)
+	}
+
+	_, err := resolveExecuteSpecPath(executeCreateCmd)
+	if err == nil {
+		t.Fatal("expected mutually exclusive flags to fail")
+	}
+	if exitCodeFor(err) != ExitCodeUsage {
+		t.Fatalf("exit code = %d, want %d", exitCodeFor(err), ExitCodeUsage)
+	}
+	if !strings.Contains(err.Error(), "at most one of") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExecuteSubmitAndCreateOutputAreByteIdentical(t *testing.T) {
+	home := t.TempDir()
+	specPath := home + "/execution.yaml"
+	writeTestFile(t, specPath, `
+specs:
+  - algorithm:
+      name: random
+      version: "1.0.0"
+    datapack: sample-datapack
+`)
+	payload := map[string]any{
+		"code":    200,
+		"message": "success",
+		"data": map[string]any{
+			"items": []any{
+				map[string]any{
+					"id":   7,
+					"name": "pair_diagnosis",
+				},
+			},
+			"pagination": map[string]any{
+				"page":        1,
+				"size":        100,
+				"total":       1,
+				"total_pages": 1,
+			},
+		},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v2/projects":
+			_ = json.NewEncoder(w).Encode(payload)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	server := ts.URL
+	baseArgs := []string{"--server", server, "--token", "jwt-test-token", "--project", "pair_diagnosis", "--output", "json", "--dry-run"}
+	create := runCLI(t, append([]string{"execute", "create", "--input", specPath}, baseArgs...)...)
+	submit := runCLI(t, append([]string{"execute", "submit", "--spec", specPath}, baseArgs...)...)
+
+	if create.code != ExitCodeSuccess || submit.code != ExitCodeSuccess {
+		t.Fatalf("execute create exited %d, submit exited %d", create.code, submit.code)
+	}
+
+	if create.stdout != submit.stdout {
+		t.Fatalf("execute submit/stdout mismatch:\ncreate=%q\nsubmit=%q", create.stdout, submit.stdout)
+	}
+	if create.stderr != "" {
+		t.Fatalf("execute create should not emit stderr: %q", create.stderr)
+	}
+	if !strings.Contains(submit.stderr, deprecate.Message("submit", "create")) {
+		t.Fatalf("execute submit stderr missing warning: %q", submit.stderr)
+	}
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/execute.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/execute.go
@@ -6,6 +6,7 @@ import (
 
 	"aegis/cmd/aegisctl/client"
 	"aegis/cmd/aegisctl/output"
+	"aegis/internal/cli/deprecate"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -40,8 +41,8 @@ var executeCmd = &cobra.Command{
 	Long: `Manage RCA algorithm executions in AegisLab projects.
 
 WORKFLOW:
-  # Submit algorithm execution from a YAML spec file
-  aegisctl execute submit --spec execution.yaml --project pair_diagnosis
+  # Create algorithm execution from a YAML spec file
+  aegisctl execute create --input execution.yaml --project pair_diagnosis
 
   # List executions in a project
   aegisctl execute list --project pair_diagnosis
@@ -66,56 +67,77 @@ SPEC FILE FORMAT (execution.yaml):
       value: algorithm-comparison`,
 }
 
-// ---------- execute submit ----------
+// ---------- execute create ----------
 
-var executeSubmitSpec string
+var (
+	executeCreateInput string
+	executeCreateSpec  string
+)
 
-var executeSubmitCmd = &cobra.Command{
-	Use:   "submit",
+var executeCreateCmd = &cobra.Command{
+	Use:   "create",
 	Short: "Submit an algorithm execution from a YAML spec",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if executeSubmitSpec == "" {
-			return fmt.Errorf("--spec is required")
-		}
+		return runExecuteCreate(cmd, args)
+	},
+}
 
-		data, err := os.ReadFile(executeSubmitSpec)
-		if err != nil {
-			return fmt.Errorf("read spec file: %w", err)
-		}
+func runExecuteCreate(cmd *cobra.Command, args []string) error {
+	if err := resolveExclusiveFlags(cmd); err != nil {
+		return usageErrorf("%s", err)
+	}
+	specPath, err := resolveExecuteSpecPath(cmd)
+	if err != nil {
+		return err
+	}
 
-		var spec ExecuteSpec
-		if err := yaml.Unmarshal(data, &spec); err != nil {
-			return fmt.Errorf("parse spec YAML: %w", err)
-		}
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		return fmt.Errorf("read spec file: %w", err)
+	}
 
-		pid, err := resolveProjectIDByName()
-		if err != nil {
-			return err
-		}
+	var spec ExecuteSpec
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return fmt.Errorf("parse spec YAML: %w", err)
+	}
 
-		path := fmt.Sprintf("/api/v2/projects/%d/executions/execute", pid)
-		if flagDryRun {
-			plan := map[string]any{
-				"dry_run":    true,
-				"operation":  "execute_submit",
-				"project":    flagProject,
-				"project_id": pid,
-				"method":     "POST",
-				"path":       path,
-				"spec":       spec,
-			}
-			output.PrintJSON(plan)
-			return nil
-		}
+	pid, err := resolveProjectIDByName()
+	if err != nil {
+		return err
+	}
 
-		c := newClient()
-		var resp client.APIResponse[any]
-		if err := c.Post(path, spec, &resp); err != nil {
-			return err
+	path := fmt.Sprintf("/api/v2/projects/%d/executions/execute", pid)
+	if flagDryRun {
+		plan := map[string]any{
+			"dry_run":    true,
+			"operation":  "execute_submit",
+			"project":    flagProject,
+			"project_id": pid,
+			"method":     "POST",
+			"path":       path,
+			"spec":       spec,
 		}
-
-		output.PrintJSON(resp.Data)
+		output.PrintJSON(plan)
 		return nil
+	}
+
+	c := newClient()
+	var resp client.APIResponse[any]
+	if err := c.Post(path, spec, &resp); err != nil {
+		return err
+	}
+
+	output.PrintJSON(resp.Data)
+	return nil
+}
+
+var executeSubmitCmd = &cobra.Command{
+	Use:        "submit",
+	Short:      executeCreateCmd.Short,
+	Deprecated: deprecate.Message("submit", "create"),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		deprecate.Warn("submit", "create")
+		return runExecuteCreate(cmd, args)
 	},
 }
 
@@ -202,12 +224,71 @@ var executeGetCmd = &cobra.Command{
 // ---------- init ----------
 
 func init() {
-	executeSubmitCmd.Flags().StringVar(&executeSubmitSpec, "spec", "", "Path to execution spec YAML file")
-
 	executeListCmd.Flags().IntVar(&executeListPage, "page", 1, "Page number")
 	executeListCmd.Flags().IntVar(&executeListSize, "size", 20, "Page size")
 
+	executeCmd.AddCommand(executeCreateCmd)
 	executeCmd.AddCommand(executeSubmitCmd)
 	executeCmd.AddCommand(executeListCmd)
 	executeCmd.AddCommand(executeGetCmd)
+}
+
+func resolveExecuteSpecPath(cmd *cobra.Command) (string, error) {
+	var specPath string
+	inputProvided := false
+	specProvided := false
+
+	if cmd != nil {
+		if flag := cmd.Flags().Lookup("input"); flag != nil && flag.Changed {
+			inputProvided = true
+			specPath = executeCreateInput
+		}
+		if flag := cmd.Flags().Lookup("spec"); flag != nil && flag.Changed {
+			specProvided = true
+			if specPath == "" {
+				specPath = executeCreateSpec
+			}
+		}
+	}
+
+	if !inputProvided && !specProvided {
+		switch {
+		case executeCreateInput != "":
+			specPath = executeCreateInput
+		case executeCreateSpec != "":
+			specPath = executeCreateSpec
+		default:
+			return "", usageErrorf("--spec or --input is required")
+		}
+	} else if inputProvided && specProvided {
+		return "", usageErrorf("at most one of --spec, --input, --input(-f) may be specified")
+	}
+
+	if specPath == "" {
+		return "", usageErrorf("--spec or --input is required")
+	}
+	return specPath, nil
+}
+
+func resolveExclusiveFlags(cmd *cobra.Command) error {
+	if cmd != nil {
+		return deprecate.EnsureMutuallyExclusiveStringFlags(cmd.Flags(), "spec", "input")
+	}
+
+	if executeCreateInput != "" && executeCreateSpec != "" {
+		return fmt.Errorf("at most one of --spec, --input, --input(-f) may be specified")
+	}
+
+	return nil
+}
+
+func init() {
+	bindExecuteSpecFlags(executeCreateCmd)
+	bindExecuteSpecFlags(executeSubmitCmd)
+}
+
+func bindExecuteSpecFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&executeCreateInput, "input", "f", "", "Path to execution spec YAML file (required)")
+	cmd.Flags().StringVar(&executeCreateSpec, "spec", "", "Deprecated. Path to execution spec YAML file")
+	_ = cmd.Flags().MarkDeprecated("spec", "use --input/-f instead")
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/root.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/root.go
@@ -304,6 +304,9 @@ func setupDryRunRegistry() {
 	if injectGuidedCmd != nil {
 		markDryRunSupported(injectGuidedCmd)
 	}
+	if executeCreateCmd != nil {
+		markDryRunSupported(executeCreateCmd)
+	}
 	if executeSubmitCmd != nil {
 		markDryRunSupported(executeSubmitCmd)
 	}

--- a/AegisLab/src/cmd/aegisctl/cmd/schema.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/schema.go
@@ -27,10 +27,11 @@ type schemaFlag struct {
 
 // schemaCommand is a single entry in the schema dump.
 type schemaCommand struct {
-	Path  string       `json:"path" yaml:"path"`
-	Short string       `json:"short" yaml:"short"`
-	Flags []schemaFlag `json:"flags" yaml:"flags"`
-	Args  string       `json:"args" yaml:"args"`
+	Path       string       `json:"path" yaml:"path"`
+	Short      string       `json:"short" yaml:"short"`
+	Flags      []schemaFlag `json:"flags" yaml:"flags"`
+	Args       string       `json:"args" yaml:"args"`
+	Deprecated bool         `json:"deprecated" yaml:"deprecated"`
 }
 
 // schemaDocument is the top-level document emitted by `aegisctl schema dump`.
@@ -105,15 +106,16 @@ func collectSchemaCommands(cmd *cobra.Command, out *[]schemaCommand) {
 	if cmd == nil {
 		return
 	}
-	if cmd.Hidden || cmd.Deprecated != "" {
+	if cmd.Hidden {
 		return
 	}
 
 	entry := schemaCommand{
-		Path:  cmd.CommandPath(),
-		Short: cmd.Short,
-		Flags: collectLocalFlags(cmd),
-		Args:  argsDescription(cmd),
+		Path:       cmd.CommandPath(),
+		Short:      cmd.Short,
+		Flags:      collectLocalFlags(cmd),
+		Args:       argsDescription(cmd),
+		Deprecated: cmd.Deprecated != "",
 	}
 	*out = append(*out, entry)
 

--- a/AegisLab/src/cmd/aegisctl/cmd/validation_contract_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/validation_contract_test.go
@@ -399,7 +399,7 @@ labels:
 	flagProject = "pair_diagnosis"
 	flagOutput = "json"
 	flagDryRun = true
-	executeSubmitSpec = execSpec
+	executeCreateSpec = execSpec
 
 	stdout, _, err = captureStdIO(t, func() error {
 		return executeSubmitCmd.RunE(nil, nil)

--- a/AegisLab/src/internal/cli/deprecate/deprecate.go
+++ b/AegisLab/src/internal/cli/deprecate/deprecate.go
@@ -1,0 +1,42 @@
+package deprecate
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	// RemovedVersion is the placeholder for the deprecation removal message.
+	RemovedVersion = "v<NEXT_MINOR>"
+)
+
+// Message returns the canonical deprecation warning payload.
+func Message(item, replacement string) string {
+	return fmt.Sprintf("[deprecated] '%s' will be removed in %s; use '%s'", item, RemovedVersion, replacement)
+}
+
+// Warn prints a deprecation warning to stderr.
+func Warn(item, replacement string) {
+	fmt.Fprintln(os.Stderr, Message(item, replacement))
+}
+
+// EnsureMutuallyExclusiveStringFlags validates that at most one of the given flags
+// is explicitly set.
+func EnsureMutuallyExclusiveStringFlags(fs *pflag.FlagSet, names ...string) error {
+	set := make([]string, 0, len(names))
+	for _, name := range names {
+		flag := fs.Lookup(name)
+		if flag != nil && flag.Changed {
+			set = append(set, "--"+name)
+		}
+	}
+	if len(set) > 1 {
+		sort.Strings(set)
+		return fmt.Errorf("%s are mutually exclusive", strings.Join(set, ", "))
+	}
+	return nil
+}

--- a/scripts/review-reports/issue-250-review.md
+++ b/scripts/review-reports/issue-250-review.md
@@ -1,0 +1,109 @@
+# Review for issue #250 — PR #254
+
+## Cascade preconditions
+| submodule | remote branch | SHA match | FF-able |
+|-----------|---------------|-----------|---------|
+| _None_    | _none_        | N/A       | N/A     |
+
+Commands ran:
+`git ls-files --stage | awk '$1 ~ /^160000/'` (no output)
+`git submodule status` (no output)
+
+## Per-AC verdicts
+
+### AC 1: `aegisctl execute create 与 `aegisctl execute submit` 行为相同；后者在 stderr 打印 [deprecated] ... warning，不影响退出码。`
+**verdict**: PASS
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestExecuteSubmitAndCreateOutputAreByteIdentical -count=1`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok   	aegis/cmd/aegisctl/cmd	0.035s
+```
+**stderr** (first 20 lines, if nonzero):
+```text
+(none)
+```
+
+### AC 2: `aegisctl inject list-files 与 aegisctl inject files 行为相同；同上 deprecation warning 规则。`
+**verdict**: PASS
+**command**: `cd AegisLab/src && go build -o /tmp/aegisctl_issue250 ./cmd/aegisctl && python3 /tmp/issue250_verify_server.py >/tmp/issue250_verify_server.log 2>&1 & server_pid=$!; sleep 0.3; /tmp/aegisctl_issue250 inject list-files my_injection --server http://127.0.0.1:18443 --token t --project pair_diagnosis --output json 1> /tmp/issue250_create_stdout 2> /tmp/issue250_create_stderr; ec1=$?; /tmp/aegisctl_issue250 inject files my_injection --server http://127.0.0.1:18443 --token t --project pair_diagnosis --output json 1> /tmp/issue250_files_stdout 2> /tmp/issue250_files_stderr; ec2=$?; kill $server_pid; if [ "$ec1" -ne 0 ] || [ "$ec2" -ne 0 ]; then echo "exit create=$ec1 files=$ec2"; cat /tmp/issue250_create_stderr; cat /tmp/issue250_files_stderr; exit 1; fi; diff -u /tmp/issue250_create_stdout /tmp/issue250_files_stdout >/tmp/issue250_diff || { echo "stdout mismatch"; cat /tmp/issue250_diff; exit 2; }; grep -q "\[deprecated\] 'files' will be removed in v<NEXT_MINOR>; use 'list-files'" /tmp/issue250_files_stderr || { echo "missing warning"; cat /tmp/issue250_files_stderr; exit 3; }`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+PASS
+```
+**stderr** (first 20 lines, if nonzero):
+```text
+(none)
+```
+
+### AC 3: `所有接受 --spec 的命令同时接受 -f / --input；三者互斥（任两个同时给 → EXIT=2）。`
+**verdict**: PASS
+**command**: `cd AegisLab/src && go build -o /tmp/aegisctl_issue250 ./cmd/aegisctl && python3 /tmp/issue250_verify_server2.py >/tmp/issue250_verify_server2.log 2>&1 & server_pid=$!; sleep 0.2; /tmp/aegisctl_issue250 execute create --input /tmp/issue250_spec.yaml --server http://127.0.0.1:18444 --token t --project pair_diagnosis --output json --dry-run 1> /tmp/issue250_exec_input_stdout 2> /tmp/issue250_exec_input_stderr; ec_input=$?; /tmp/aegisctl_issue250 execute create -f /tmp/issue250_spec.yaml --server http://127.0.0.1:18444 --token t --project pair_diagnosis --output json --dry-run 1> /tmp/issue250_exec_short_stdout 2> /tmp/issue250_exec_short_stderr; ec_short=$?; /tmp/aegisctl_issue250 execute create --spec /tmp/issue250_spec.yaml -f /tmp/issue250_spec.yaml --server http://127.0.0.1:18444 --token t --project pair_diagnosis --output json --dry-run 1> /tmp/issue250_exec_both_stdout 2> /tmp/issue250_exec_both_stderr; ec_both=$?; kill $server_pid; if [ "$ec_input" -ne 0 ] || [ "$ec_short" -ne 0 ]; then echo "single flag failed"; exit 1; fi; if [ "$ec_both" -ne 2 ]; then echo "exit expected 2, got $ec_both"; exit 2; fi; diff -u /tmp/issue250_exec_input_stdout /tmp/issue250_exec_short_stdout >/tmp/issue250_exec_diff || { echo "stdout mismatch"; cat /tmp/issue250_exec_diff; exit 3; }; grep -q "mutually exclusive" /tmp/issue250_exec_both_stderr || { echo "missing mutual exclusivity message"; cat /tmp/issue250_exec_both_stderr; exit 4; }`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+PASS
+```
+**stderr** (first 20 lines, if nonzero):
+```text
+(none)
+```
+
+### AC 4: `schema dump 输出中新名是 primary，老名标 deprecated:true。`
+**verdict**: PASS
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestSchemaDumpMarksDeprecatedAliases -count=1`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok   	aegis/cmd/aegisctl/cmd	0.022s
+```
+**stderr** (first 20 lines, if nonzero):
+```text
+(none)
+```
+
+### AC 5: `一个 integration test（仅一个）：对 execute submit 跑一次，断言 stderr 含 deprecation warning 且 stdout 与 execute create 输出 byte-identical。`
+**verdict**: PASS
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestExecuteSubmitAndCreateOutputAreByteIdentical -count=1 && rg -c "TestExecuteSubmitAndCreateOutputAreByteIdentical" cmd/aegisctl/cmd/*_test.go`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok   	aegis/cmd/aegisctl/cmd	0.032s
+cmd/aegisctl/cmd/deprecation_test.go:1
+```
+**stderr** (first 20 lines, if nonzero):
+```text
+(none)
+```
+
+## Plan verify commands (from dev-agent)
+
+### Plan 1: `TestValidationWorkflowCommandHelpMentionsMachineReadableFlags`
+**verdict**: PASS
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestValidationWorkflowCommandHelpMentionsMachineReadableFlags -count=1`
+**exit**: 0
+**stdout**: `ok   	aegis/cmd/aegisctl/cmd	0.017s`
+
+### Plan 2: `TestExecuteCreateSpecFlagsAreMutuallyExclusive`
+**verdict**: PASS
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestExecuteCreateSpecFlagsAreMutuallyExclusive -count=1`
+**exit**: 0
+**stdout**: `ok   	aegis/cmd/aegisctl/cmd	0.035s`
+
+### Plan 3: `TestSchemaDumpMarksDeprecatedAliases`
+**verdict**: PASS
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestSchemaDumpMarksDeprecatedAliases -count=1`
+**exit**: 0
+**stdout**: `ok   	aegis/cmd/aegisctl/cmd	0.022s`
+
+### Plan 4: `TestExecuteSubmitAndCreateOutputAreByteIdentical`
+**verdict**: PASS
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestExecuteSubmitAndCreateOutputAreByteIdentical -count=1`
+**exit**: 0
+**stdout**: `ok   	aegis/cmd/aegisctl/cmd	0.035s`
+
+## Overall
+- PASS: 5 / 5
+- FAIL: none
+- UNVERIFIABLE: none


### PR DESCRIPTION
## Summary
- Added execute + inject deprecations with alias behavior: `execute create` as primary with `execute submit` alias, and `inject list-files` as primary with `inject files` alias.
- Introduced shared deprecation helper for exit-safe warning formatting and mutual-exclusion checks, plus migrated execute spec input flags to `-f/--input` while retaining `--spec` as deprecated alias.
- Updated schema dump and tests to mark deprecated aliases and added the required single integration test for deprecated submit behavior.

## Subtask results
- subtask-1 (command alias migration) — DONE
  verify: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestValidationWorkflowCommandHelpMentionsMachineReadableFlags -count=1` → exit 0
- subtask-2 (spec flag migration and mutual exclusivity) — DONE
  verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestExecuteCreateSpecFlagsAreMutuallyExclusive -count=1` → exit 0
- subtask-3 (schema deprecation metadata) — DONE
  verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestSchemaDumpMarksDeprecatedAliases -count=1` → exit 0
- subtask-4 (integration parity test) — DONE
  verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestExecuteSubmitAndCreateOutputAreByteIdentical -count=1` → exit 0

## Submodule changes
- AegisLab: ✅ execute submit/list-files rename and --input flag migration; `AegisLab/src/internal/cli/deprecate` helper; schema/deprecation coverage updates
- AegisLab-frontend: — not modified
- chaos-experiment: — not modified
- rcabench-platform: — not modified

## Workspace-level changes
- None.

## Known gaps / blockers
- None.

Fixes #250
