### PR TITLE
fix(aegisctl): fix status ANSI leakage and trace-id rendering

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
@@ -216,6 +216,13 @@ func TestRootPersistentFlagsExposeNonInteractiveMode(t *testing.T) {
 	}
 }
 
+func TestRootPersistentFlagsExposeNoColorMode(t *testing.T) {
+	f := rootCmd.PersistentFlags().Lookup("no-color")
+	if f == nil {
+		t.Fatalf("expected --no-color persistent flag to be registered")
+	}
+}
+
 func TestAuthLoginMissingSecretUsesUsageExitCode(t *testing.T) {
 	res := runCLI(t, "auth", "login", "--server", "http://example.test", "--key-id", "pk_test")
 	if res.code != ExitCodeUsage {

--- a/AegisLab/src/cmd/aegisctl/cmd/rate_limiter.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/rate_limiter.go
@@ -52,21 +52,6 @@ type rlGCResp struct {
 	TouchedBuckets int `json:"touched_buckets"`
 }
 
-const (
-	ansiRed   = "\x1b[31m"
-	ansiReset = "\x1b[0m"
-)
-
-func useColor() bool {
-	if os.Getenv("NO_COLOR") != "" {
-		return false
-	}
-	if fi, err := os.Stdout.Stat(); err == nil {
-		return (fi.Mode() & os.ModeCharDevice) != 0
-	}
-	return false
-}
-
 var rateLimiterStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "List token-bucket rate limiters, their holders, and DB state",
@@ -80,19 +65,17 @@ var rateLimiterStatusCmd = &cobra.Command{
 			output.PrintJSON(resp.Data)
 			return nil
 		}
-		color := useColor()
+		color := output.IsStdoutColor()
 		headers := []string{"BUCKET", "HELD/CAP", "HOLDERS"}
 		var rows [][]string
 		for _, item := range resp.Data.Items {
 			var parts []string
 			for _, h := range item.Holders {
 				s := fmt.Sprintf("%s[%s]", h.TaskID, h.TaskState)
-				if h.IsTerminal {
-					if color {
-						s = ansiRed + s + " (LEAKED)" + ansiReset
-					} else {
-						s = s + " (LEAKED)"
-					}
+				if h.IsTerminal && color {
+					s = output.ColorRed(os.Stdout, s+" (LEAKED)")
+				} else if h.IsTerminal {
+					s = s + " (LEAKED)"
 				}
 				parts = append(parts, s)
 			}

--- a/AegisLab/src/cmd/aegisctl/cmd/root.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/root.go
@@ -19,6 +19,7 @@ var (
 	flagOutput         string
 	flagRequestTimeout int
 	flagQuiet          bool
+	flagNoColor        bool
 	flagNonInteractive bool
 	flagDryRun         bool
 
@@ -165,6 +166,9 @@ NAMING CONVENTION:
 			}
 		}
 
+		// Respect --no-color and NO_COLOR for all colorized output.
+		output.SetNoColor(flagNoColor || os.Getenv("NO_COLOR") != "")
+
 		// Forward quiet flag into the output package.
 		output.Quiet = flagQuiet
 
@@ -189,6 +193,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&flagOutput, "output", "o", "", "Output format: table|json (env: AEGIS_OUTPUT)")
 	rootCmd.PersistentFlags().IntVar(&flagRequestTimeout, "request-timeout", 0, "Request timeout in seconds (env: AEGIS_TIMEOUT)")
 	rootCmd.PersistentFlags().BoolVarP(&flagQuiet, "quiet", "q", false, "Suppress informational output")
+	rootCmd.PersistentFlags().BoolVar(&flagNoColor, "no-color", false, "Disable ANSI color output (env: NO_COLOR)")
 	rootCmd.PersistentFlags().BoolVar(&flagNonInteractive, "non-interactive", false, "Disable prompts and require explicit input (env: AEGIS_NON_INTERACTIVE)")
 	rootCmd.PersistentFlags().BoolVar(&flagDryRun, "dry-run", false, "Show what would be done without executing")
 

--- a/AegisLab/src/cmd/aegisctl/cmd/status.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/status.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"sort"
 
 	"aegis/cmd/aegisctl/client"
@@ -23,11 +24,19 @@ type taskItem struct {
 }
 
 type traceItem struct {
+	ID        string `json:"id"`
 	TraceID   string `json:"trace_id"`
 	State     string `json:"state"`
 	Type      string `json:"type"`
 	Project   string `json:"project_name"`
 	ProjectID int    `json:"project_id"`
+}
+
+func traceID(item traceItem) string {
+	if item.ID != "" {
+		return item.ID
+	}
+	return item.TraceID
 }
 
 type healthServiceInfo struct {
@@ -134,7 +143,7 @@ var statusCmd = &cobra.Command{
 				if project == "" {
 					project = fmt.Sprintf("%d", t.ProjectID)
 				}
-				rows = append(rows, []string{t.TraceID, t.State, t.Type, project})
+				rows = append(rows, []string{traceID(t), t.State, t.Type, project})
 			}
 			output.PrintTable([]string{"Trace-ID", "State", "Type", "Project"}, rows)
 		}
@@ -144,7 +153,7 @@ var statusCmd = &cobra.Command{
 		fmt.Println("Infrastructure Health:")
 		var healthResp client.APIResponse[healthCheckResp]
 		if err := c.Get("/api/v2/system/health", &healthResp); err != nil {
-			fmt.Printf("  \033[31m\u2717\033[0m Could not reach health endpoint: %v\n", err)
+			fmt.Printf("  %s Could not reach health endpoint: %v\n", output.ColorRed(os.Stdout, "\u2717"), err)
 		} else {
 			names := make([]string, 0, len(healthResp.Data.Services))
 			for name := range healthResp.Data.Services {
@@ -154,13 +163,13 @@ var statusCmd = &cobra.Command{
 			for _, name := range names {
 				svc := healthResp.Data.Services[name]
 				if svc.Status == "healthy" {
-					fmt.Printf("  \033[32m\u2713\033[0m %-12s %s\n", name, svc.ResponseTime)
+					fmt.Printf("  %s %-12s %s\n", output.ColorGreen(os.Stdout, "\u2713"), name, svc.ResponseTime)
 				} else {
 					errMsg := svc.Error
 					if errMsg == "" {
 						errMsg = "unhealthy"
 					}
-					fmt.Printf("  \033[31m\u2717\033[0m %-12s %s (%s)\n", name, svc.ResponseTime, errMsg)
+					fmt.Printf("  %s %-12s %s (%s)\n", output.ColorRed(os.Stdout, "\u2717"), name, svc.ResponseTime, errMsg)
 				}
 			}
 		}

--- a/AegisLab/src/cmd/aegisctl/cmd/status_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/status_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -228,5 +229,83 @@ func TestStatusJSON(t *testing.T) {
 		if _, exists := services[svc]; !exists {
 			t.Errorf("health.services should contain %q", svc)
 		}
+	}
+}
+
+func TestStatusIntegrationNonTTYNoANSIAndTraceID(t *testing.T) {
+	ts := newTestServer(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/system/health":
+			json.NewEncoder(w).Encode(healthyResponse())
+		case "/api/v2/auth/profile":
+			json.NewEncoder(w).Encode(map[string]any{
+				"code":    200,
+				"message": "success",
+				"data":    map[string]any{"id": 1, "username": "admin"},
+			})
+		case "/api/v2/tasks":
+			json.NewEncoder(w).Encode(map[string]any{
+				"code":    200,
+				"message": "success",
+				"data": map[string]any{
+					"items":      []any{},
+					"pagination": map[string]any{"page": 1, "size": 100, "total": 0, "total_pages": 0},
+				},
+			})
+		case "/api/v2/traces":
+			json.NewEncoder(w).Encode(map[string]any{
+				"code":    200,
+				"message": "success",
+				"data": map[string]any{
+					"items": []any{
+						map[string]any{
+							"id":           "trace-id-001",
+							"state":        "Completed",
+							"type":         "FullPipeline",
+							"project_name": "case-a",
+							"project_id":   101,
+						},
+					},
+					"pagination": map[string]any{"page": 1, "size": 10, "total": 1, "total_pages": 1},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]any{"code": 401, "message": "unauthorized"})
+		}
+	})
+	defer ts.Close()
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	flagServer = ts.URL
+	flagOutput = "table"
+	flagToken = "test-token"
+	output.SetNoColor(true)
+	defer output.SetNoColor(false)
+
+	err := statusCmd.RunE(nil, nil)
+
+	_ = w.Close()
+	os.Stdout = old
+
+	if err != nil {
+		t.Fatalf("statusCmd should not return error, got: %v", err)
+	}
+
+	var buf [4096]byte
+	n, _ := r.Read(buf[:])
+	got := string(buf[:n])
+
+	if regexp.MustCompile(`\x1b\[`).MatchString(got) {
+		t.Fatalf("status output contains ANSI escape: %q", got)
+	}
+	if !strings.Contains(got, "Recent Traces:") {
+		t.Fatalf("missing Recent Traces section: %q", got)
+	}
+	if !strings.Contains(got, "trace-id-001") {
+		t.Fatalf("trace-id should be rendered in table: %q", got)
 	}
 }

--- a/AegisLab/src/cmd/aegisctl/output/output.go
+++ b/AegisLab/src/cmd/aegisctl/output/output.go
@@ -6,10 +6,57 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+
+	"golang.org/x/term"
 )
 
 // Quiet suppresses informational messages when true.
 var Quiet bool
+
+var colorDisabled = false
+
+// isTerminal is overridden in tests to emulate tty behavior.
+var isTerminal = term.IsTerminal
+
+// SetNoColor disables ANSI color codes regardless of TTY status.
+func SetNoColor(v bool) {
+	colorDisabled = v
+}
+
+// IsStdoutColor returns true when stdout should be colored.
+func IsStdoutColor() bool {
+	return supportsANSI(os.Stdout)
+}
+
+// IsStderrColor returns true when stderr should be colored.
+func IsStderrColor() bool {
+	return supportsANSI(os.Stderr)
+}
+
+func supportsANSI(file *os.File) bool {
+	if colorDisabled || os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	return isTerminal(int(file.Fd()))
+}
+
+// Colorize wraps s with ANSI color code when enabled for file.
+func Colorize(file *os.File, code, value string) string {
+	if !supportsANSI(file) {
+		return value
+	}
+	return "\x1b[" + code + "m" + value + "\x1b[0m"
+}
+
+// ColorGreen returns a green colored value when allowed.
+func ColorGreen(file *os.File, value string) string {
+	return Colorize(file, "32", value)
+}
+
+// ColorRed returns a red colored value when allowed.
+func ColorRed(file *os.File, value string) string {
+	return Colorize(file, "31", value)
+}
 
 // OutputFormat represents the output format type.
 type OutputFormat string

--- a/AegisLab/src/cmd/aegisctl/output/output_test.go
+++ b/AegisLab/src/cmd/aegisctl/output/output_test.go
@@ -45,6 +45,29 @@ func TestOutputFormat_Conversion(t *testing.T) {
 	}
 }
 
+func TestOutputNoColorRespectsNoColorEnv(t *testing.T) {
+	oldTerminal := isTerminal
+	isTerminal = func(_ int) bool { return true }
+	defer func() {
+		isTerminal = oldTerminal
+	}()
+
+	previous, hadPrevious := os.LookupEnv("NO_COLOR")
+	if hadPrevious {
+		defer os.Setenv("NO_COLOR", previous)
+	} else {
+		defer os.Unsetenv("NO_COLOR")
+	}
+	if err := os.Setenv("NO_COLOR", "1"); err != nil {
+		t.Fatalf("set NO_COLOR: %v", err)
+	}
+
+	SetNoColor(false)
+	if IsStdoutColor() {
+		t.Fatalf("NO_COLOR should disable stdout ANSI")
+	}
+}
+
 func TestPrintInfo_Normal(t *testing.T) {
 	Quiet = false
 	got := captureStderr(func() {

--- a/scripts/review-reports/issue-244-review.md
+++ b/scripts/review-reports/issue-244-review.md
@@ -1,0 +1,66 @@
+# Review for issue #244 — PR #256
+
+## Cascade preconditions
+
+| submodule | remote branch | SHA match | FF-able |
+|-----------|---------------|-----------|---------|
+| (no submodule pointer changes detected) | N/A | N/A | N/A |
+
+Submodule check command (regular files only changed):
+
+**command**: `git diff --submodule=log --name-only origin/main...origin/workbuddy/issue-244`
+
+**stdout** (first 20 lines):
+```
+AegisLab/src/cmd/aegisctl/cmd/contract_test.go
+AegisLab/src/cmd/aegisctl/cmd/rate_limiter.go
+AegisLab/src/cmd/aegisctl/cmd/root.go
+AegisLab/src/cmd/aegisctl/cmd/status.go
+AegisLab/src/cmd/aegisctl/cmd/status_test.go
+AegisLab/src/cmd/aegisctl/output/output.go
+AegisLab/src/cmd/aegisctl/output/output_test.go
+```
+
+## Per-AC verdicts
+
+### AC 1: `aegisctl status` 在 stdout 非 TTY（`isatty(stdout.Fd())==false`）时，stdout **完全无 ANSI 转义序列**；stderr 是否带颜色由 stderr 自己的 isatty 判定。
+**verdict**: PASS
+**command**: `cd AegisLab/src && python3 - <<'PY'\nimport http.server, json, socketserver, subprocess, threading, re, sys\n\nclass Handler(http.server.BaseHTTPRequestHandler):\n    def do_GET(self):\n        if self.path == '/api/v2/auth/profile':\n            body = {"code": 200, "message": "success", "data": {"id": 1, "username": "admin"}}\n        elif self.path == '/api/v2/tasks':\n            body = {"code": 200, "message": "success", "data": {"items": [], "pagination": {"page": 1, "size": 100, "total": 0, "total_pages": 0}}}\n        elif self.path == '/api/v2/traces':\n            body = {"code": 200, "message": "success", "data": {"items": [{"id": "trace-001", "state": "Completed", "type": "Full", "project_name": "case-a", "project_id": 1}], "pagination": {"page": 1, "size": 10, "total": 1, "total_pages": 1}}}\n        elif self.path == '/api/v2/system/health':\n            body = {"code": 200, "message": "success", "data": {"status": "healthy", "version": "1.0.0", "uptime": "1m", "services": {"redis": {"status": "healthy", "response_time": "1ms"}}}}\n        else:\n            self.send_response(404); self.end_headers(); return\n        payload = json.dumps(body).encode('utf-8')\n        self.send_response(200)\n        self.send_header('Content-Type', 'application/json')\n        self.send_header('Content-Length', str(len(payload)))\n        self.end_headers()\n        self.wfile.write(payload)\n    def log_message(self, format, *args):\n        pass\n\nwith socketserver.TCPServer(('127.0.0.1', 0), Handler) as httpd:\n    port = httpd.server_address[1]\n    thread = threading.Thread(target=httpd.serve_forever, daemon=True)\n    thread.start()\n    try:\n        result = subprocess.run([\n            '/tmp/aegisctl-issue-244',\n            'status', '--server', f'http://127.0.0.1:{port}', '--token', 't', '--output', 'table',\n        ], capture_output=True)\n    finally:\n        httpd.shutdown()\n        thread.join(timeout=1)\n\n    out = result.stdout.decode('utf-8', errors='replace')\n    if re.search(r'\\x1b\\[', out):\n        print('FAIL: ANSI in stdout')\n        sys.exit(1)\n    if result.returncode != 0:\n        print('FAIL: non-zero exit', result.returncode)\n        sys.exit(1)\n    print('PASS: non-tty stdout contains no ANSI')\nPY`  
+**exit**: 0
+**stdout** (first 20 lines):
+```
+PASS: non-tty stdout contains no ANSI
+```
+
+### AC 2: 全局 `--no-color` flag 与 `NO_COLOR` env 任一为真时，强制关闭所有 ANSI 输出（stdout 与 stderr 都是）。
+**verdict**: PASS
+**command**: `cd AegisLab/src && python3 - <<'PY'\nimport http.server, json, socketserver, subprocess, threading, re, sys, os\nfrom urllib.parse import urlparse\n\nclass Handler(http.server.BaseHTTPRequestHandler):\n    def do_GET(self):\n        path = urlparse(self.path).path\n        if path == '/api/v2/auth/profile':\n            body = {"code": 200, "message": "success", "data": {"id": 1, "username": "admin"}}\n        elif path == '/api/v2/tasks':\n            body = {"code": 200, "message": "success", "data": {"items": [], "pagination": {"page": 1, "size": 100, "total": 0, "total_pages": 0}}}\n        elif path == '/api/v2/traces':\n            body = {"code": 200, "message": "success", "data": {"items": [{"id": "trace-001", "state": "Completed", "type": "Full", "project_name": "case-a", "project_id": 1}], "pagination": {"page": 1, "size": 10, "total": 1, "total_pages": 1}}}\n        elif path == '/api/v2/system/health':\n            body = {"code": 200, "message": "success", "data": {"status": "healthy", "version": "1.0.0", "uptime": "1m", "services": {"redis": {"status": "healthy", "response_time": "1ms"}, "db": {"status": "healthy", "response_time": "1ms"}}}}\n        else:\n            self.send_response(404); self.end_headers(); return\n        payload = json.dumps(body).encode('utf-8')\n        self.send_response(200)\n        self.send_header('Content-Type', 'application/json')\n        self.send_header('Content-Length', str(len(payload)))\n        self.end_headers()\n        self.wfile.write(payload)\n    def log_message(self, format, *args):\n        pass\n\ndef run_case(cmd_env, extra_args):\n    with socketserver.TCPServer(('127.0.0.1', 0), Handler) as httpd:\n        port = httpd.server_address[1]\n        thread = threading.Thread(target=httpd.serve_forever, daemon=True)\n        thread.start()\n        env = os.environ.copy()\n        env.update(cmd_env)\n        command = f"/tmp/aegisctl-issue-244 status --server http://127.0.0.1:{port} --token t --output table {extra_args}"\n        result = subprocess.run(['script', '-q', '-c', command, '/dev/null'], env=env, capture_output=True, text=True)\n        httpd.shutdown()\n        thread.join(timeout=1)\n        return result\n\ncases = [\n    ('NO_COLOR env', {'NO_COLOR': '1'}, ''),\n    ('--no-color flag', {}, '--no-color'),\n]\n\nfor label, env_add, extra in cases:\n    result = run_case(env_add, extra)\n    combined = result.stdout + (result.stderr or '')\n    if result.returncode != 0:\n        print(f'FAIL: {label} command exit {result.returncode}')\n        sys.exit(1)\n    if re.search(r'\\x1b\\[', combined):\n        print(f'FAIL: {label} output has ANSI')\n        sys.exit(1)\n\nprint('PASS: NO_COLOR env and --no-color disable ANSI on tty-like execution')\nPY` 
+**exit**: 0
+**stdout** (first 20 lines):
+```
+PASS: NO_COLOR env and --no-color disable ANSI on tty-like execution
+```
+
+### AC 3: `aegisctl status` 的 Recent Traces 表格 Trace-ID 列填充正确值（与 `trace list -o json` 的 `id` 字段一致）。
+**verdict**: PASS
+**command**: `cd AegisLab/src && python3 - <<'PY'\nimport http.server, json, socketserver, subprocess, threading, sys\nfrom urllib.parse import urlparse\n\nclass Handler(http.server.BaseHTTPRequestHandler):\n    def do_GET(self):\n        path = urlparse(self.path).path\n        if path == '/api/v2/auth/profile':\n            body = {"code": 200, "message": "success", "data": {"id": 1, "username": "admin"}}\n        elif path == '/api/v2/tasks':\n            body = {"code": 200, "message": "success", "data": {"items": [], "pagination": {"page": 1, "size": 100, "total": 0, "total_pages": 0}}}\n        elif path == '/api/v2/traces':\n            body = {"code": 200, "message": "success", "data": {"items": [{"id": "trace-id-123", "state": "Completed", "type": "Full", "project_name": "case-a", "project_id": 1}], "pagination": {"page": 1, "size": 10, "total": 1, "total_pages": 1}}}\n        elif path == '/api/v2/system/health':\n            body = {"code": 200, "message": "success", "data": {"status": "healthy", "version": "1.0.0", "uptime": "1m", "services": {"redis": {"status": "healthy", "response_time": "1ms"}}}}\n        else:\n            self.send_response(404); self.end_headers(); return\n        payload = json.dumps(body).encode('utf-8')\n        self.send_response(200)\n        self.send_header('Content-Type', 'application/json')\n        self.send_header('Content-Length', str(len(payload)))\n        self.end_headers()\n        self.wfile.write(payload)\n    def log_message(self, format, *args):\n        pass\n\nwith socketserver.TCPServer(('127.0.0.1', 0), Handler) as httpd:\n    port = httpd.server_address[1]\n    thread = threading.Thread(target=httpd.serve_forever, daemon=True)\n    thread.start()\n    try:\n        result = subprocess.run(['/tmp/aegisctl-issue-244', 'status', '--server', f'http://127.0.0.1:{port}', '--token', 't', '--output', 'table'], capture_output=True)\n    finally:\n        httpd.shutdown()\n        thread.join(timeout=1)\n\nout = result.stdout.decode('utf-8', errors='replace')\nif result.returncode != 0:\n    print('FAIL: status exit', result.returncode)\n    sys.exit(1)\nif 'Recent Traces:' not in out:\n    print('FAIL: missing Recent Traces section')\n    print(out)\n    sys.exit(1)\nif 'trace-id-123' not in out:\n    print('FAIL: expected trace-id-123 in output')\n    print(out)\n    sys.exit(1)\nprint('PASS: trace-id rendered as id field value')\nPY` 
+**exit**: 0
+**stdout** (first 20 lines):
+```
+PASS: trace-id rendered as id field value
+```
+
+### AC 4: 增加一个 integration test（仅一个）：用伪 TTY=false 跑 `status`，把 stdout 通过 `grep -P '\\x1b\\['` 检查无 ANSI；用 mock trace 数据断言 Trace-ID 列非空。
+**verdict**: PASS
+**command**: `cd /home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-244 && rg -n "func TestStatusIntegration" AegisLab/src/cmd/aegisctl/cmd/status_test.go | wc -l && rg -n "func TestStatusIntegration" AegisLab/src/cmd/aegisctl/cmd/status_test.go`
+**exit**: 0
+**stdout** (first 20 lines):
+```
+1
+235:func TestStatusIntegrationNonTTYNoANSIAndTraceID(t *testing.T)
+```
+
+## Overall
+- PASS: 4 / 4
+- FAIL: none
+- UNVERIFIABLE: none


### PR DESCRIPTION
## Summary
- add tty-aware ANSI color helpers and route status/rate-limiter status output through them
- add global --no-color support in root and wire NO_COLOR to output no-color behavior
- fix status recent traces to use `id` first, keeping `trace_id` compatibility, with integration coverage

## Subtask results
- subtask-1 (status ANSI + trace-id mapping) — DONE
  - verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestStatus` → exit 0, ok
- subtask-2 (global no-color flag) — DONE
  - verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestRootPersistentFlagsExposeNoColorMode` → exit 0, ok
- subtask-3 (no-color output layer) — DONE
  - verify: `cd AegisLab/src && go test ./cmd/aegisctl/output -run TestOutputNoColorRespectsNoColorEnv` → exit 0, ok
- subtask-4 (integration verification) — DONE
  - verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestStatusIntegrationNonTTYNoANSIAndTraceID` → exit 0, ok

## Submodule changes
- AegisLab: status/rate-limiter status color policy, root --no-color wiring, and status Trace-ID/id mapping + tests
- AegisLab-frontend: — not modified
- chaos-experiment: — not modified
- rcabench-platform: — not modified

## Workspace-level changes
- — none

## Known gaps / blockers
- — none

Fixes #244
