### PR TITLE
chore(seed): bump sn defaultImageVersion to 0.1.1 (BSP fix)

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -249,9 +249,9 @@ containers:
               overridable: true
             - key: global.defaultImageVersion
               type: 0
-              category: 1
+              category: 2
               value_type: 0
-              default_value: 20260423-61074ea
+              default_value: 0.1.1
               overridable: true
             - key: global.otel.endpoint
               type: 0

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -223,9 +223,9 @@ containers:
               overridable: true
             - key: global.defaultImageVersion
               type: 0
-              category: 1
+              category: 2
               value_type: 0
-              default_value: 20260423-61074ea
+              default_value: 0.1.1
               overridable: true
             - key: global.otel.endpoint
               type: 0

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -254,9 +254,9 @@ containers:
               overridable: true
             - key: global.defaultImageVersion
               type: 0
-              category: 1
+              category: 2
               value_type: 0
-              default_value: 20260423-61074ea
+              default_value: 0.1.1
               overridable: true
             - key: global.otel.endpoint
               type: 0


### PR DESCRIPTION
## Summary
- LGU-SE-Internal/DeathStarBench#54 (merged) introduced \`BatchSpanProcessor + flush\` for sn/mm in C++.
- LGU CI auto-built the new sn image: \`docker.io/opspai/social-network-microservices:0.1.1\`.
- Bump aegis seed for sn ONLY (hs Go-stack unaffected; mm has no push workflow yet, tracked in LGU-SE-Internal/DeathStarBench#55).

## Schema note
Used \`category: 2\` for sn's \`global.defaultImageVersion\` so it gets its own \`parameter_configs\` row distinct from hs/media (which share category=1). This satisfies the \`(config_key, type, category)\` unique index.

## Live state
byte-cluster mysql already hot-fixed to match. This PR is for reseed-survivability + staging/prod parity.

## Follow-up
- LGU-SE-Internal/DeathStarBench#55: add mediamicroservices-push.yaml so a future merge actually publishes mm:0.1.1 → seed bump for media follows that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)