### PR TITLE
fix(aegisctl): standardize task list json envelope

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/task.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/task.go
@@ -87,7 +87,8 @@ var taskListCmd = &cobra.Command{
 		}
 
 		if output.OutputFormat(flagOutput) == output.FormatJSON {
-			output.PrintJSON(items)
+			resp.Data.Items = items
+			output.PrintJSON(resp.Data)
 			return nil
 		}
 

--- a/AegisLab/src/cmd/aegisctl/cmd/task_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/task_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -44,5 +47,50 @@ func TestExecTimeField(t *testing.T) {
 	}
 	if got := execTimeField(map[string]any{"execute_time": "nope"}); got != 0 {
 		t.Fatalf("unknown type: got %d", got)
+	}
+}
+
+func TestTaskListJSONEnvelope(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v2/tasks" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"code":    200,
+			"message": "success",
+			"data": map[string]any{
+				"items": []map[string]any{
+					{"id": "task-1", "state": "Running", "type": "FaultInjection"},
+					{"id": "task-2", "state": "Error", "type": "RestartPedestal"},
+				},
+				"pagination": map[string]any{"page": 1, "size": 100, "total": 2, "total_pages": 1},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	res := runCLI(t, "task", "list",
+		"--server", ts.URL, "--token", "tok", "--output", "json")
+	if res.code != ExitCodeSuccess {
+		t.Fatalf("exit = %d, want %d; stderr=%q stdout=%q", res.code, ExitCodeSuccess, res.stderr, res.stdout)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(res.stdout), &payload); err != nil {
+		t.Fatalf("stdout should be JSON object: %v; got %q", err, res.stdout)
+	}
+	if _, ok := payload["items"]; !ok {
+		t.Fatalf("missing items key in payload: %v", payload)
+	}
+	if _, ok := payload["pagination"]; !ok {
+		t.Fatalf("missing pagination key in payload: %v", payload)
+	}
+	items, ok := payload["items"].([]any)
+	if !ok {
+		t.Fatalf("items is %T, want []any", payload["items"])
+	}
+	if len(items) != 2 {
+		t.Fatalf("items length = %d, want 2", len(items))
 	}
 }

--- a/scripts/review-reports/issue-242-review.md
+++ b/scripts/review-reports/issue-242-review.md
@@ -1,0 +1,76 @@
+# Review for issue #242 — PR #259
+
+## Parent PR
+- Open PR verified: `gh pr list -R OperationsPAI/aegis --head workbuddy/issue-242 --state open --json number,url -q '.[0]'`
+- Result: `{"number":259,"url":"https://github.com/OperationsPAI/aegis/pull/259"}`
+
+## Cascade preconditions
+No submodules were modified in `origin/main...origin/workbuddy/issue-242`, so no cascade precondition checks for submodule branches were applicable.
+
+**command**: `git diff --submodule --name-status origin/main...origin/workbuddy/issue-242`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+M	AegisLab/src/cmd/aegisctl/cmd/task.go
+M	AegisLab/src/cmd/aegisctl/cmd/task_test.go
+```
+
+## Per-AC verdicts
+
+### AC 1: `aegisctl task list -o json` output envelope is `{"items":[...],"pagination":{"page":N,"size":N,"total":N,"total_pages":N}}`
+**verdict**: PASS
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestTaskListJSONEnvelope -count=1`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok  	aegis/cmd/aegisctl/cmd	0.027s
+```
+
+### AC 2: Default table output shape for `task list` remains unchanged
+**verdict**: PASS
+**command**: `git diff --unified=0 origin/main...HEAD -- AegisLab/src/cmd/aegisctl/cmd/task.go`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+diff --git a/AegisLab/src/cmd/aegisctl/cmd/task.go b/AegisLab/src/cmd/aegisctl/cmd/task.go
+index eb255c7..eb14ff0 100644
+--- a/AegisLab/src/cmd/aegisctl/cmd/task.go
++++ b/AegisLab/src/cmd/aegisctl/cmd/task.go
+@@ -90 +90,2 @@ var taskListCmd = &cobra.Command{
+-            output.PrintJSON(items)
++            resp.Data.Items = items
++            output.PrintJSON(resp.Data)
+```
+**notes**: Diff shows only JSON-printing block changed; table output path (`output.PrintTable(...)` and `output.PrintInfo(...)`) is untouched.
+
+### AC 3: There is one integration test validating JSON output shape and keys
+**verdict**: PASS
+**command**: `git diff --unified=0 origin/main...HEAD -- AegisLab/src/cmd/aegisctl/cmd/task_test.go`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+diff --git a/AegisLab/src/cmd/aegisctl/cmd/task_test.go b/AegisLab/src/cmd/aegisctl/cmd/task_test.go
+index 50e9eeb..399087e 100644
+--- a/AegisLab/src/cmd/aegisctl/cmd/task_test.go
++++ b/AegisLab/src/cmd/aegisctl/cmd/task_test.go
+@@ -3,0 +4,3 @@ import (
++    "encoding/json"
++    "net/http"
++    "net/http/httptest"
+@@ -48,0 +52,45 @@ func TestExecTimeField(t *testing.T) {
++func TestTaskListJSONEnvelope(t *testing.T) {
+```
+
+### Subtask verification: regression run for related list commands
+**verdict**: PASS
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run "TestTask(List|Task|Trace|Project|Container|Dataset)" -count=1`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok  	aegis/cmd/aegisctl/cmd	0.016s
+```
+
+## Overall
+- PASS: 3 / 3
+- FAIL: none
+- UNVERIFIABLE: none


### PR DESCRIPTION
## Summary
- Make `aegisctl task list -o json` emit a unified envelope with `items` and `pagination`.
- Keep table-mode task list output unchanged, including the existing page info line.
- Add a single integration test asserting `task list -o json` shape.

## Subtask results
- subtask-1 (locate rendering path and compare with other list commands) — DONE
  - verify: `cd AegisLab && rg -n "type .*Output|pagination|items|task list|output list|PrintJSON" src/cmd/aegisctl/cmd/*.go` → exit 0, found `PrintJSON(resp.Data)` on sibling list paths and `PrintJSON(items)` only in task list.
- subtask-2 (make task list JSON output unified envelope) — DONE
  - verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestTaskList -count=1` → exit 0, no matching tests.
- subtask-3 (add integration test for task list JSON envelope) — DONE
  - verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestTaskList.*JSON -count=1` → exit 0, test passed.
- subtask-4 (run related list command regression command) — DONE
  - verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run "TestTask(List|Task|Trace|Project|Container|Dataset)" -count=1` → exit 0, all selected tests passed.

## Submodule changes
- AegisLab: `src/cmd/aegisctl/cmd/task.go` and `src/cmd/aegisctl/cmd/task_test.go`
- AegisLab-frontend: — not modified
- chaos-experiment: — not modified
- rcabench-platform: — not modified

## Workspace-level changes
- none

## Known gaps / blockers
- none

Fixes #242
