### PR TITLE
feat(aegisctl): implement version command and --version output

### DIFF
--- a/AegisLab/justfile
+++ b/AegisLab/justfile
@@ -194,7 +194,16 @@ build-aegisctl output="/tmp/aegisctl":
     #!/usr/bin/env bash
     set -euo pipefail
     printf "{{blue}}🔨 Building aegisctl...{{reset}}\n"
-    cd {{src_dir}} && go build -o {{output}} ./cmd/aegisctl
+    version="$(git describe --tags --dirty --always 2>/dev/null | tr -d '\n')"
+    commit="$(git rev-parse --short HEAD 2>/dev/null | tr -d '\n')"
+    build_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    ldflags=(
+      "-X aegis/cmd/aegisctl/cmd.version=${version}"
+      "-X aegis/cmd/aegisctl/cmd.commit=${commit}"
+      "-X aegis/cmd/aegisctl/cmd.buildTime=${build_time}"
+      "-X aegis/cmd/aegisctl/cmd.minServerAPIVersion=2"
+    )
+    cd {{src_dir}} && go build -ldflags "${ldflags[*]}" -o {{output}} ./cmd/aegisctl
     printf "{{green}}✅ aegisctl built: {{output}}{{reset}}\n"
 
 # =============================================================================

--- a/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
@@ -28,6 +28,7 @@ func resetCLIState() {
 	flagOutput = ""
 	flagRequestTimeout = 0
 	flagQuiet = false
+	flagVersion = false
 	flagNonInteractive = false
 	flagDryRun = false
 	output.Quiet = false

--- a/AegisLab/src/cmd/aegisctl/cmd/root.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/root.go
@@ -22,6 +22,7 @@ var (
 	flagNoColor        bool
 	flagNonInteractive bool
 	flagDryRun         bool
+	flagVersion        bool
 
 	// Resolved at PersistentPreRun time.
 	cfg *config.Config
@@ -33,6 +34,13 @@ var rootCmd = &cobra.Command{
 	Short:         "CLI client for the AegisLab platform",
 	SilenceUsage:  true,
 	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if flagVersion {
+			printVersionInfo()
+			return nil
+		}
+		return cmd.Help()
+	},
 	Long: `aegisctl is a command-line interface for managing the AegisLab (RCABench)
 fault-injection and root-cause-analysis benchmarking platform.
 
@@ -95,6 +103,11 @@ NAMING CONVENTION:
   For example: "aegisctl container get detector" resolves "detector" to its ID.
   The --project flag also accepts project names (e.g. "pair_diagnosis").`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if flagVersion {
+			printVersionInfo()
+			return silentExit(ExitCodeSuccess)
+		}
+
 		// Load configuration file.
 		var err error
 		cfg, err = config.LoadConfig()
@@ -196,6 +209,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&flagNoColor, "no-color", false, "Disable ANSI color output (env: NO_COLOR)")
 	rootCmd.PersistentFlags().BoolVar(&flagNonInteractive, "non-interactive", false, "Disable prompts and require explicit input (env: AEGIS_NON_INTERACTIVE)")
 	rootCmd.PersistentFlags().BoolVar(&flagDryRun, "dry-run", false, "Show what would be done without executing")
+	rootCmd.PersistentFlags().BoolVar(&flagVersion, "version", false, "Print version information and exit")
 
 	// Register subcommands.
 	rootCmd.AddCommand(authCmd)
@@ -214,6 +228,7 @@ func init() {
 	rootCmd.AddCommand(regressionCmd)
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(completionCmd)
+	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(pedestalCmd)
 	rootCmd.AddCommand(schemaCmd)
 	rootCmd.AddCommand(systemCmd)

--- a/AegisLab/src/cmd/aegisctl/cmd/version.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/version.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"aegis/cmd/aegisctl/output"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// These values are populated via ldflags in the build step.
+	version             = "dev"
+	commit              = "unknown"
+	buildTime           = "unknown"
+	minServerAPIVersion = "2"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show aegisctl version and build metadata",
+	RunE: func(*cobra.Command, []string) error {
+		printVersionInfo()
+		return nil
+	},
+}
+
+type versionInfo struct {
+	Version      string `json:"version"`
+	Commit       string `json:"commit"`
+	BuildTime    string `json:"build_time"`
+	MinServerAPI string `json:"min_server_api"`
+}
+
+func printVersionInfo() {
+	info := versionInfoPayload()
+	if output.OutputFormat(flagOutput) == output.FormatJSON {
+		output.PrintJSON(info)
+		return
+	}
+
+	fmt.Printf("version: %s\n", info.Version)
+	fmt.Printf("commit: %s\n", info.Commit)
+	fmt.Printf("build_time: %s\n", info.BuildTime)
+	fmt.Printf("min_server_api: %s\n", info.MinServerAPI)
+}
+
+func versionInfoPayload() versionInfo {
+	return versionInfo{
+		Version:      normalizedString(version, "dev"),
+		Commit:       normalizedString(commit, "unknown"),
+		BuildTime:    normalizedBuildTime(buildTime),
+		MinServerAPI: normalizedString(minServerAPIVersion, "2"),
+	}
+}
+
+func normalizedString(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func normalizedBuildTime(raw string) string {
+	if raw == "" {
+		return time.Now().UTC().Format(time.RFC3339)
+	}
+	return raw
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/version.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/version.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
+	"aegis/cmd/aegisctl/config"
 	"aegis/cmd/aegisctl/output"
 
 	"github.com/spf13/cobra"
@@ -34,7 +36,7 @@ type versionInfo struct {
 
 func printVersionInfo() {
 	info := versionInfoPayload()
-	if output.OutputFormat(flagOutput) == output.FormatJSON {
+	if output.OutputFormat(resolveVersionOutputFormat()) == output.FormatJSON {
 		output.PrintJSON(info)
 		return
 	}
@@ -52,6 +54,24 @@ func versionInfoPayload() versionInfo {
 		BuildTime:    normalizedBuildTime(buildTime),
 		MinServerAPI: normalizedString(minServerAPIVersion, "2"),
 	}
+}
+
+func resolveVersionOutputFormat() string {
+	if flagOutput != "" {
+		return flagOutput
+	}
+	if envOutput := os.Getenv("AEGIS_OUTPUT"); envOutput != "" {
+		return envOutput
+	}
+	if cfg != nil && cfg.Preferences.Output != "" {
+		return cfg.Preferences.Output
+	}
+
+	loadedCfg, err := config.LoadConfig()
+	if err == nil && loadedCfg.Preferences.Output != "" {
+		return loadedCfg.Preferences.Output
+	}
+	return string(output.FormatTable)
 }
 
 func normalizedString(value, fallback string) string {

--- a/AegisLab/src/cmd/aegisctl/cmd/version.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/version.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	"aegis/cmd/aegisctl/output"
 
@@ -64,7 +63,7 @@ func normalizedString(value, fallback string) string {
 
 func normalizedBuildTime(raw string) string {
 	if raw == "" {
-		return time.Now().UTC().Format(time.RFC3339)
+		return "unknown"
 	}
 	return raw
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/version_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/version_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestVersionJSONIncludesRequiredFields(t *testing.T) {
+	oldVersion := version
+	oldCommit := commit
+	oldBuildTime := buildTime
+	oldMinServerAPIVersion := minServerAPIVersion
+
+	version = "v0.0.0-test"
+	commit = "abc1234"
+	buildTime = "2026-04-27T10:00:00Z"
+	minServerAPIVersion = "2"
+
+	t.Cleanup(func() {
+		version = oldVersion
+		commit = oldCommit
+		buildTime = oldBuildTime
+		minServerAPIVersion = oldMinServerAPIVersion
+	})
+
+	t.Run("json_payload_has_non_empty_required_fields", func(t *testing.T) {
+		res := runCLI(t, "version", "--output", "json")
+		if res.code != ExitCodeSuccess {
+			t.Fatalf("version command code = %d, stderr=%q", res.code, res.stderr)
+		}
+
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(res.stdout), &payload); err != nil {
+			t.Fatalf("stdout is not valid JSON: %v", err)
+		}
+
+		required := []string{"version", "commit", "build_time", "min_server_api"}
+		for _, key := range required {
+			val, ok := payload[key]
+			if !ok {
+				t.Fatalf("required field %q missing or empty in payload: %v", key, payload)
+			}
+			s, ok := val.(string)
+			if !ok || strings.TrimSpace(s) == "" {
+				t.Fatalf("required field %q is blank after trim", key)
+			}
+		}
+	})
+
+	t.Run("version_flag_alias_matches_version_command", func(t *testing.T) {
+		resVersion := runCLI(t, "version", "-o", "json")
+		resFlag := runCLI(t, "--version", "--output", "json")
+
+		if resVersion.code != ExitCodeSuccess {
+			t.Fatalf("version command code = %d, stderr=%q", resVersion.code, resVersion.stderr)
+		}
+		if resFlag.code != ExitCodeSuccess {
+			t.Fatalf("--version code = %d, stderr=%q", resFlag.code, resFlag.stderr)
+		}
+		if resVersion.stdout != resFlag.stdout {
+			t.Fatalf("stdout mismatch\nversion=%q\n--version=%q", resVersion.stdout, resFlag.stdout)
+		}
+	})
+
+	t.Run("missing_output_argument_reports_error", func(t *testing.T) {
+		res := runCLI(t, "version", "--output")
+		if res.code == ExitCodeSuccess {
+			t.Fatalf("expected non-zero code, got %d; stderr=%q", res.code, res.stderr)
+		}
+		if !strings.Contains(res.stderr, "flag needs an argument: --output") {
+			t.Fatalf("stderr missing expected parse error: %q", res.stderr)
+		}
+	})
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/version_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/version_test.go
@@ -2,74 +2,130 @@ package cmd
 
 import (
 	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestVersionJSONIncludesRequiredFields(t *testing.T) {
-	oldVersion := version
-	oldCommit := commit
-	oldBuildTime := buildTime
-	oldMinServerAPIVersion := minServerAPIVersion
+	srcDir := aegisctlSourceRoot(t)
+	binPath := filepath.Join(t.TempDir(), "aegisctl")
 
-	version = "v0.0.0-test"
-	commit = "abc1234"
-	buildTime = "2026-04-27T10:00:00Z"
-	minServerAPIVersion = "2"
-
-	t.Cleanup(func() {
-		version = oldVersion
-		commit = oldCommit
-		buildTime = oldBuildTime
-		minServerAPIVersion = oldMinServerAPIVersion
-	})
+	build := exec.Command(
+		"go", "build",
+		"-ldflags", strings.Join([]string{
+			"-X aegis/cmd/aegisctl/cmd.version=v0.0.0-test",
+			"-X aegis/cmd/aegisctl/cmd.commit=abc1234",
+			"-X aegis/cmd/aegisctl/cmd.buildTime=2026-04-27T10:00:00Z",
+			"-X aegis/cmd/aegisctl/cmd.minServerAPIVersion=2",
+		}, " "),
+		"-o", binPath,
+		"./cmd/aegisctl",
+	)
+	build.Dir = srcDir
+	build.Env = os.Environ()
+	buildOutput, err := build.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build aegisctl: %v\n%s", err, buildOutput)
+	}
 
 	t.Run("json_payload_has_non_empty_required_fields", func(t *testing.T) {
-		res := runCLI(t, "version", "--output", "json")
-		if res.code != ExitCodeSuccess {
-			t.Fatalf("version command code = %d, stderr=%q", res.code, res.stderr)
+		stdout, stderr, err := runBuiltAegisctl(t, binPath, "version", "-o", "json")
+		if err != nil {
+			t.Fatalf("run version: %v\nstderr=%s", err, stderr)
 		}
 
-		var payload map[string]any
-		if err := json.Unmarshal([]byte(res.stdout), &payload); err != nil {
-			t.Fatalf("stdout is not valid JSON: %v", err)
+		var payload map[string]string
+		if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+			t.Fatalf("stdout is not valid JSON: %v\nstdout=%s", err, stdout)
 		}
 
-		required := []string{"version", "commit", "build_time", "min_server_api"}
-		for _, key := range required {
-			val, ok := payload[key]
-			if !ok {
-				t.Fatalf("required field %q missing or empty in payload: %v", key, payload)
-			}
-			s, ok := val.(string)
-			if !ok || strings.TrimSpace(s) == "" {
-				t.Fatalf("required field %q is blank after trim", key)
+		for _, key := range []string{"version", "commit", "build_time", "min_server_api"} {
+			if strings.TrimSpace(payload[key]) == "" {
+				t.Fatalf("required field %q missing or empty in payload: %#v", key, payload)
 			}
 		}
 	})
 
 	t.Run("version_flag_alias_matches_version_command", func(t *testing.T) {
-		resVersion := runCLI(t, "version", "-o", "json")
-		resFlag := runCLI(t, "--version", "--output", "json")
+		versionStdout, versionStderr, err := runBuiltAegisctl(t, binPath, "version", "-o", "json")
+		if err != nil {
+			t.Fatalf("run version: %v\nstderr=%s", err, versionStderr)
+		}
 
-		if resVersion.code != ExitCodeSuccess {
-			t.Fatalf("version command code = %d, stderr=%q", resVersion.code, resVersion.stderr)
+		flagStdout, flagStderr, err := runBuiltAegisctl(t, binPath, "--version", "-o", "json")
+		if err != nil {
+			t.Fatalf("run --version: %v\nstderr=%s", err, flagStderr)
 		}
-		if resFlag.code != ExitCodeSuccess {
-			t.Fatalf("--version code = %d, stderr=%q", resFlag.code, resFlag.stderr)
-		}
-		if resVersion.stdout != resFlag.stdout {
-			t.Fatalf("stdout mismatch\nversion=%q\n--version=%q", resVersion.stdout, resFlag.stdout)
+
+		if versionStdout != flagStdout {
+			t.Fatalf("stdout mismatch\nversion=%q\n--version=%q", versionStdout, flagStdout)
 		}
 	})
 
-	t.Run("missing_output_argument_reports_error", func(t *testing.T) {
-		res := runCLI(t, "version", "--output")
-		if res.code == ExitCodeSuccess {
-			t.Fatalf("expected non-zero code, got %d; stderr=%q", res.code, res.stderr)
+	t.Run("missing_output_argument_reports_usage_error", func(t *testing.T) {
+		_, stderr, err := runBuiltAegisctl(t, binPath, "version", "--output")
+		if err == nil {
+			t.Fatal("expected missing --output argument to fail")
 		}
-		if !strings.Contains(res.stderr, "flag needs an argument: --output") {
-			t.Fatalf("stderr missing expected parse error: %q", res.stderr)
+
+		var exitErr *exec.ExitError
+		if !strings.Contains(stderr, "flag needs an argument: --output") {
+			t.Fatalf("stderr missing expected parse error: %q", stderr)
+		}
+		if ok := errorAs(err, &exitErr); !ok {
+			t.Fatalf("expected exit error, got %T: %v", err, err)
+		}
+		if exitErr.ExitCode() != ExitCodeUsage {
+			t.Fatalf("exit code = %d, want %d; stderr=%q", exitErr.ExitCode(), ExitCodeUsage, stderr)
 		}
 	})
+}
+
+func aegisctlSourceRoot(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(wd, "..", "..", ".."))
+}
+
+func runBuiltAegisctl(t *testing.T, binPath string, args ...string) (string, string, error) {
+	t.Helper()
+
+	cmd := exec.Command(binPath, args...)
+	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
+
+	stdout, err := cmd.Output()
+	if err == nil {
+		return string(stdout), "", nil
+	}
+
+	var stderr string
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		stderr = string(exitErr.Stderr)
+	}
+	return string(stdout), stderr, err
+}
+
+func errorAs(err error, target any) bool {
+	return err != nil && execErrAs(err, target)
+}
+
+func execErrAs(err error, target any) bool {
+	switch t := target.(type) {
+	case **exec.ExitError:
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			return false
+		}
+		*t = exitErr
+		return true
+	default:
+		return false
+	}
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/version_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/version_test.go
@@ -65,6 +65,27 @@ func TestVersionJSONIncludesRequiredFields(t *testing.T) {
 		}
 	})
 
+	t.Run("version_flag_alias_matches_env_selected_json_output", func(t *testing.T) {
+		versionStdout, versionStderr, err := runBuiltAegisctl(t, binPath, "version")
+		if err != nil {
+			t.Fatalf("run version with env output: %v\nstderr=%s", err, versionStderr)
+		}
+
+		flagStdout, flagStderr, err := runBuiltAegisctl(t, binPath, "--version")
+		if err != nil {
+			t.Fatalf("run --version with env output: %v\nstderr=%s", err, flagStderr)
+		}
+
+		if versionStdout != flagStdout {
+			t.Fatalf("stdout mismatch with env output\nversion=%q\n--version=%q", versionStdout, flagStdout)
+		}
+
+		var payload map[string]string
+		if err := json.Unmarshal([]byte(flagStdout), &payload); err != nil {
+			t.Fatalf("stdout is not valid JSON under env output: %v\nstdout=%s", err, flagStdout)
+		}
+	})
+
 	t.Run("missing_output_argument_reports_usage_error", func(t *testing.T) {
 		_, stderr, err := runBuiltAegisctl(t, binPath, "version", "--output")
 		if err == nil {
@@ -98,7 +119,7 @@ func runBuiltAegisctl(t *testing.T, binPath string, args ...string) (string, str
 	t.Helper()
 
 	cmd := exec.Command(binPath, args...)
-	cmd.Env = append(os.Environ(), "HOME="+t.TempDir())
+	cmd.Env = append(os.Environ(), "HOME="+t.TempDir(), "AEGIS_OUTPUT=json")
 
 	stdout, err := cmd.Output()
 	if err == nil {

--- a/scripts/review-reports/issue-243-review.md
+++ b/scripts/review-reports/issue-243-review.md
@@ -1,0 +1,165 @@
+# Review for issue #243 — PR #263
+
+## Cascade preconditions
+| submodule | remote branch | SHA match | FF-able |
+|-----------|---------------|-----------|---------|
+| (none) | no submodule pointers changed between `origin/main` and `origin/workbuddy/issue-243` | n/a | n/a |
+
+Checked with `git submodule status --recursive` (stdout empty, exit 0) and `git diff --raw origin/main origin/workbuddy/issue-243` (no `160000` gitlink entries).
+
+## Per-AC verdicts
+### AC1: "`aegisctl version` 命令存在，输出至少包含：版本号（git describe / tag）、git commit SHA、build time（UTC ISO8601）、最低支持的 server API minor 版本。"
+**verdict**: PASS
+**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac1 >/dev/null && /tmp/aegisctl-243-ac1 version`
+**exit**: 0
+**stdout** (first 20 lines):
+```
+version: release-platform/v0.4.22-77-g2973059
+commit: 2973059
+build_time: 2026-04-27T09:19:06Z
+min_server_api: 2
+```
+
+### AC2: "`aegisctl --version` 作为同效 alias，输出与 `version` 一致。"
+**verdict**: PASS
+**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac2 >/dev/null && v1=$(/tmp/aegisctl-243-ac2 version -o json) && v2=$(/tmp/aegisctl-243-ac2 --version -o json) && printf "version=%s\nflag=%s\n" "$v1" "$v2" && test "$v1" = "$v2"`
+**exit**: 0
+**stdout** (first 20 lines):
+```
+version={
+  "version": "release-platform/v0.4.22-77-g2973059",
+  "commit": "2973059",
+  "build_time": "2026-04-27T09:19:08Z",
+  "min_server_api": "2"
+}
+flag={
+  "version": "release-platform/v0.4.22-77-g2973059",
+  "commit": "2973059",
+  "build_time": "2026-04-27T09:19:08Z",
+  "min_server_api": "2"
+}
+```
+
+### AC3: "这些字段通过 `-ldflags "-X ..."` 在 `make` / `go build` 注入；构建脚本对应更新。"
+**verdict**: PASS
+**command**: `cd AegisLab && rg -n "build-aegisctl|ldflags|cmd\.version|cmd\.commit|cmd\.buildTime|minServerAPIVersion" justfile`
+**exit**: 0
+**stdout** (first 20 lines):
+```
+193:build-aegisctl output="/tmp/aegisctl":
+200:    ldflags=(
+201:      "-X aegis/cmd/aegisctl/cmd.version=${version}"
+202:      "-X aegis/cmd/aegisctl/cmd.commit=${commit}"
+203:      "-X aegis/cmd/aegisctl/cmd.buildTime=${build_time}"
+204:      "-X aegis/cmd/aegisctl/cmd.minServerAPIVersion=2"
+206:    cd {{src_dir}} && go build -ldflags "${ldflags[*]}" -o {{output}} ./cmd/aegisctl
+```
+
+### AC4: "`-o json` 时输出 JSON：`{"version":"...","commit":"...","build_time":"...","min_server_api":"..."}`。"
+**verdict**: PASS
+**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac4 >/dev/null && json=$(/tmp/aegisctl-243-ac4 version -o json) && printf '%s\n' "$json" && python - <<'PYCHECK' "$json"
+import json, sys
+payload=json.loads(sys.argv[1])
+assert set(payload)=={'version','commit','build_time','min_server_api'}
+assert all(isinstance(payload[k], str) and payload[k].strip() for k in payload)
+print('json-shape-ok')
+PYCHECK`
+**exit**: 0
+**stdout** (first 20 lines):
+```
+{
+  "version": "release-platform/v0.4.22-77-g2973059",
+  "commit": "2973059",
+  "build_time": "2026-04-27T09:19:10Z",
+  "min_server_api": "2"
+}
+json-shape-ok
+```
+
+### AC5: "一个 integration test（仅一个）：跑 `aegisctl version -o json`，断言四个字段都非空。"
+**verdict**: FAIL
+**command**: `cd AegisLab && rg -n "func TestVersionJSONIncludesRequiredFields|runCLI\(|executeArgs\(|exec\.Command" src/cmd/aegisctl/cmd/version_test.go src/cmd/aegisctl/cmd/contract_test.go`
+**exit**: 0
+**stdout** (first 20 lines):
+```
+src/cmd/aegisctl/cmd/contract_test.go:103:func runCLI(t *testing.T, args ...string) cliRunResult {
+src/cmd/aegisctl/cmd/contract_test.go:166:	code := executeArgs(args)
+src/cmd/aegisctl/cmd/contract_test.go:221:	res := runCLI(t, "auth", "login", "--server", "http://example.test", "--key-id", "pk_test")
+src/cmd/aegisctl/cmd/contract_test.go:234:	res := runCLI(t, "cluster", "preflight", "--check", "does-not-exist")
+src/cmd/aegisctl/cmd/contract_test.go:249:	res := runCLI(t, "cluster", "preflight", "--config", cfgPath, "--check", "db.mysql")
+src/cmd/aegisctl/cmd/contract_test.go:275:	res := runCLI(t, "wait", "trace-1", "--server", "http://example.test", "--token", "token", "--output", "json", "--interval", "0", "--timeout", "1")
+src/cmd/aegisctl/cmd/contract_test.go:292:	res := runCLI(t, "trace", "get", "trace-1", "--server", "http://example.test")
+src/cmd/aegisctl/cmd/version_test.go:9:func TestVersionJSONIncludesRequiredFields(t *testing.T) {
+src/cmd/aegisctl/cmd/version_test.go:28:		res := runCLI(t, "version", "--output", "json")
+src/cmd/aegisctl/cmd/version_test.go:52:		resVersion := runCLI(t, "version", "-o", "json")
+src/cmd/aegisctl/cmd/version_test.go:53:		resFlag := runCLI(t, "--version", "--output", "json")
+src/cmd/aegisctl/cmd/version_test.go:67:		res := runCLI(t, "version", "--output")
+```
+**notes**: The only added test calls `runCLI()` and `executeArgs()` in-process instead of invoking a built `aegisctl` binary. See `AegisLab/src/cmd/aegisctl/cmd/version_test.go:28`, `AegisLab/src/cmd/aegisctl/cmd/version_test.go:52`, `AegisLab/src/cmd/aegisctl/cmd/version_test.go:67`, `AegisLab/src/cmd/aegisctl/cmd/contract_test.go:103`, and `AegisLab/src/cmd/aegisctl/cmd/contract_test.go:166`.
+
+### PLAN1: "Plan step 1 verify: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestVersionCommandPayload -count=1`"
+**verdict**: FAIL
+**command**: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestVersionCommandPayload -count=1`
+**exit**: 1
+**stdout** (first 20 lines):
+```
+
+```
+**stderr** (first 20 lines, if nonzero):
+```
+go: cannot find main module, but found .git/config in /home/ddq/AoyangSpace/aegis
+	to create a module there, run:
+	cd ../../../.. && go mod init
+```
+
+### PLAN2: "Plan step 2 verify: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestVersionAlias -count=1`"
+**verdict**: FAIL
+**command**: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestVersionAlias -count=1`
+**exit**: 1
+**stdout** (first 20 lines):
+```
+
+```
+**stderr** (first 20 lines, if nonzero):
+```
+go: cannot find main module, but found .git/config in /home/ddq/AoyangSpace/aegis
+	to create a module there, run:
+	cd ../../../.. && go mod init
+```
+
+### PLAN3: "Plan step 3 verify: `cd AegisLab && just build-aegisctl output=/tmp/aegisctl && /tmp/aegisctl version -o json`"
+**verdict**: FAIL
+**command**: `cd AegisLab && just build-aegisctl output=/tmp/aegisctl && /tmp/aegisctl version -o json`
+**exit**: 0
+**stdout** (first 20 lines):
+```
+[1;34m🔨 Building aegisctl...[0m
+[1;32m✅ aegisctl built: output=/tmp/aegisctl[0m
+{
+  "version": "release-platform/v0.4.22-77-g2973059",
+  "commit": "2973059",
+  "build_time": "2026-04-27T09:13:07Z",
+  "min_server_api": "2"
+}
+```
+**notes**: The command reported `build_time` `2026-04-27T09:13:07Z`, but `AegisLab/justfile:199` rebuilds with the current UTC time on every invocation. The reused timestamp shows this command executed a stale `/tmp/aegisctl` instead of the binary supposedly rebuilt by the `just` call.
+
+### PLAN4: "Plan step 4 verify: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1`"
+**verdict**: FAIL
+**command**: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1`
+**exit**: 1
+**stdout** (first 20 lines):
+```
+
+```
+**stderr** (first 20 lines, if nonzero):
+```
+go: cannot find main module, but found .git/config in /home/ddq/AoyangSpace/aegis
+	to create a module there, run:
+	cd ../../../.. && go mod init
+```
+
+## Overall
+- PASS: 4 / 9
+- FAIL: AC5, PLAN1, PLAN2, PLAN3, PLAN4
+- UNVERIFIABLE: none

--- a/scripts/review-reports/issue-243-review.md
+++ b/scripts/review-reports/issue-243-review.md
@@ -1,154 +1,189 @@
 # Review for issue #243 — PR #263
 
 ## Cascade preconditions
-Verification command for submodule pointer changes:
-
-`git diff --raw origin/main...HEAD | awk '$1 ~ /^:/ && $6 ~ /^160000/ {print $0}'`
-
-Exit: 0
-
-Stdout (first 20 lines):
-```text
-
-```
-
-No submodule pointers are bumped by `origin/workbuddy/issue-243` relative to `origin/main`, so there are no submodule remote-branch / SHA-match / fast-forward checks to run for this PR.
+No submodule pointers changed between `origin/main` and `origin/workbuddy/issue-243`, so cascade SHA / fast-forward checks were not applicable in this repo state.
 
 | submodule | remote branch | SHA match | FF-able |
 |-----------|---------------|-----------|---------|
-| (none) | n/a | n/a | n/a |
+| _none_ | n/a | n/a | n/a |
 
-## Per-AC verdicts
-### AC 1: "`aegisctl version` 命令存在，输出至少包含：版本号（git describe / tag）、git commit SHA、build time（UTC ISO8601）、最低支持的 server API minor 版本。"
-**verdict**: PASS
-**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac1 >/tmp/issue243-ac1-build.log && out=$(/tmp/aegisctl-243-ac1 version) && printf '%s\n' "$out" && python - <<'PY' "$out" ... PY`
+**command**: `git diff --submodule=log --raw origin/main...origin/workbuddy/issue-243 && git submodule status --recursive`
 **exit**: 0
 **stdout** (first 20 lines):
-```text
-version: release-platform/v0.4.22-79-gcb8bd89
-commit: cb8bd89
-build_time: 2026-04-27T09:39:06Z
-min_server_api: 2
-CHECK: plain output contains 4 required fields and UTC ISO8601 build_time
+```
+:100644 100644 18a5ee0 5b262f8 M	AegisLab/justfile
+:100644 100644 af58f99 54b72d3 M	AegisLab/src/cmd/aegisctl/cmd/contract.go
+:100644 100644 0a1f02f a442fb4 M	AegisLab/src/cmd/aegisctl/cmd/contract_test.go
+:100644 100644 127c4f2 ad1645f M	AegisLab/src/cmd/aegisctl/cmd/root.go
+:000000 100644 0000000 4652c34 A	AegisLab/src/cmd/aegisctl/cmd/version.go
+:000000 100644 0000000 2614003 A	AegisLab/src/cmd/aegisctl/cmd/version_test.go
+:000000 100644 0000000 843e98e A	scripts/review-reports/issue-243-review.md
 ```
 
-### AC 2: "`aegisctl --version` 作为同效 alias，输出与 `version` 一致。"
+## Per-AC verdicts
+### AC1: "aegisctl version" outputs version / commit / build time / min server API minor
 **verdict**: PASS
-**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac2 >/tmp/issue243-ac2-build.log && v=$(/tmp/aegisctl-243-ac2 version -o json) && a=$(/tmp/aegisctl-243-ac2 --version -o json) && printf 'version=%s\n' "$v" && printf -- '--version=%s\n' "$a" && python - <<'PY' "$v" "$a" ... PY`
+**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac1 >/tmp/issue243-ac1-build.log && out=$(/tmp/aegisctl-243-ac1 version -o json); printf "%s\n" "$out"; PAYLOAD="$out" python3 - <<'PY2'
+import json, os, re
+payload = json.loads(os.environ["PAYLOAD"])
+for key in ("version", "commit", "build_time", "min_server_api"):
+    assert payload[key].strip(), key
+assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", payload["build_time"]), payload["build_time"]
+print("validated")
+PY2`
 **exit**: 0
 **stdout** (first 20 lines):
-```text
+```
+{
+  "version": "release-platform/v0.4.22-81-g9101e8c",
+  "commit": "9101e8c",
+  "build_time": "2026-04-27T09:53:41Z",
+  "min_server_api": "2"
+}
+validated
+```
+
+### AC2: "aegisctl --version" is an equivalent alias
+**verdict**: PASS
+**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac2 >/tmp/issue243-ac2-build.log && a=$(/tmp/aegisctl-243-ac2 version -o json); b=$(/tmp/aegisctl-243-ac2 --version -o json); printf "version=%s\n--version=%s\n" "$a" "$b"; test "$a" = "$b" && echo matched`
+**exit**: 0
+**stdout** (first 20 lines):
+```
 version={
-  "version": "release-platform/v0.4.22-79-gcb8bd89",
-  "commit": "cb8bd89",
-  "build_time": "2026-04-27T09:39:15Z",
+  "version": "release-platform/v0.4.22-81-g9101e8c",
+  "commit": "9101e8c",
+  "build_time": "2026-04-27T09:53:43Z",
   "min_server_api": "2"
 }
 --version={
-  "version": "release-platform/v0.4.22-79-gcb8bd89",
-  "commit": "cb8bd89",
-  "build_time": "2026-04-27T09:39:15Z",
+  "version": "release-platform/v0.4.22-81-g9101e8c",
+  "commit": "9101e8c",
+  "build_time": "2026-04-27T09:53:43Z",
   "min_server_api": "2"
 }
-CHECK: outputs are identical
+matched
 ```
 
-### AC 3: "这些字段通过 `-ldflags \"-X ...\"` 在 `make` / `go build` 注入；构建脚本对应更新。"
+### AC3: Build metadata is injected via `-ldflags` in the build script
 **verdict**: PASS
-**command**: `python - <<'PY' ... PY && cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac3 >/tmp/issue243-ac3-build.log && /tmp/aegisctl-243-ac3 version -o json`
+**command**: `python3 - <<'PY2'
+from pathlib import Path
+text = Path('AegisLab/justfile').read_text()
+needles = [
+    '-X aegis/cmd/aegisctl/cmd.version=${version}',
+    '-X aegis/cmd/aegisctl/cmd.commit=${commit}',
+    '-X aegis/cmd/aegisctl/cmd.buildTime=${build_time}',
+    '-X aegis/cmd/aegisctl/cmd.minServerAPIVersion=2',
+    'go build -ldflags "${ldflags[*]}" -o {{output}} ./cmd/aegisctl',
+]
+for needle in needles:
+    assert needle in text, needle
+for line in text.splitlines():
+    if 'aegis/cmd/aegisctl/cmd.' in line or 'build_time=' in line or 'git describe' in line or 'go build -ldflags' in line:
+        print(line)
+PY2`
 **exit**: 0
 **stdout** (first 20 lines):
-```text
-CHECK: justfile contains all 4 ldflags injections
+```
+    version="$(git describe --tags --dirty --always 2>/dev/null | tr -d '\n')"
+    build_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      "-X aegis/cmd/aegisctl/cmd.version=${version}"
+      "-X aegis/cmd/aegisctl/cmd.commit=${commit}"
+      "-X aegis/cmd/aegisctl/cmd.buildTime=${build_time}"
+      "-X aegis/cmd/aegisctl/cmd.minServerAPIVersion=2"
+    cd {{src_dir}} && go build -ldflags "${ldflags[*]}" -o {{output}} ./cmd/aegisctl
+```
+
+### AC4: `-o json` returns `{"version":"...","commit":"...","build_time":"...","min_server_api":"..."}`
+**verdict**: PASS
+**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac4 >/tmp/issue243-ac4-build.log && out=$(/tmp/aegisctl-243-ac4 version -o json); printf "%s\n" "$out"; PAYLOAD="$out" python3 - <<'PY2'
+import json, os
+payload = json.loads(os.environ["PAYLOAD"])
+keys = sorted(payload)
+assert keys == ["build_time", "commit", "min_server_api", "version"], keys
+print("keys=", keys)
+PY2`
+**exit**: 0
+**stdout** (first 20 lines):
+```
 {
-  "version": "release-platform/v0.4.22-79-gcb8bd89",
-  "commit": "cb8bd89",
-  "build_time": "2026-04-27T09:39:26Z",
+  "version": "release-platform/v0.4.22-81-g9101e8c",
+  "commit": "9101e8c",
+  "build_time": "2026-04-27T09:53:45Z",
   "min_server_api": "2"
 }
+keys= ['build_time', 'commit', 'min_server_api', 'version']
 ```
 
-### AC 4: "`-o json` 时输出 JSON：`{"version":"...","commit":"...","build_time":"...","min_server_api":"..."}`。"
+### AC5: Exactly one integration test runs `aegisctl version -o json` and asserts the four fields are non-empty
 **verdict**: PASS
-**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac4 >/tmp/issue243-ac4-build.log && out=$(/tmp/aegisctl-243-ac4 version -o json) && printf '%s\n' "$out" && python - <<'PY' "$out" ... PY`
+**command**: `python3 - <<'PY2'
+from pathlib import Path
+import re
+text = Path("AegisLab/src/cmd/aegisctl/cmd/version_test.go").read_text()
+funcs = re.findall(r"^func\s+(Test\w+)\s*\(", text, flags=re.M)
+assert funcs == ["TestVersionJSONIncludesRequiredFields"], funcs
+for needle in [
+    "exec.Command(",
+    '"version", "-o", "json"',
+    '[]string{"version", "commit", "build_time", "min_server_api"}',
+]:
+    assert needle in text, needle
+print(funcs[0])
+PY2
+cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1`
 **exit**: 0
 **stdout** (first 20 lines):
-```text
-{
-  "version": "release-platform/v0.4.22-79-gcb8bd89",
-  "commit": "cb8bd89",
-  "build_time": "2026-04-27T09:39:35Z",
-  "min_server_api": "2"
-}
-CHECK: JSON keys exactly match required schema
+```
+TestVersionJSONIncludesRequiredFields
+ok  	aegis/cmd/aegisctl/cmd	1.980s
 ```
 
-### AC 5: "一个 integration test（仅一个）：跑 `aegisctl version -o json`，断言四个字段都非空。"
-**verdict**: PASS
-**command**: `printf 'Test definitions in version_test.go:\n' && rg -n '^func Test' AegisLab/src/cmd/aegisctl/cmd/version_test.go && printf '\nBinary execution lines:\n' && rg -n 'exec\\.Command\\(|runBuiltAegisctl\\(' AegisLab/src/cmd/aegisctl/cmd/version_test.go && cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1`
-**exit**: 0
-**stdout** (first 20 lines):
-```text
-Test definitions in version_test.go:
-12:func TestVersionJSONIncludesRequiredFields(t *testing.T) {
-
-Binary execution lines:
-16:	build := exec.Command(
-35:		stdout, stderr, err := runBuiltAegisctl(t, binPath, "version", "-o", "json")
-53:		versionStdout, versionStderr, err := runBuiltAegisctl(t, binPath, "version", "-o", "json")
-58:		flagStdout, flagStderr, err := runBuiltAegisctl(t, binPath, "--version", "-o", "json")
-69:		_, stderr, err := runBuiltAegisctl(t, binPath, "version", "--output")
-97:func runBuiltAegisctl(t *testing.T, binPath string, args ...string) (string, string, error) {
-100:	cmd := exec.Command(binPath, args...)
-ok  	aegis/cmd/aegisctl/cmd	2.023s
-```
-
-### Plan 1: "Implement / verify `aegisctl version` payload path and `--version` alias inside `AegisLab/src/cmd/aegisctl/cmd`; verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run 'TestVersion(CommandPayload|Alias)$' -count=1`"
-**verdict**: FAIL
-**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run 'TestVersion(CommandPayload|Alias)$' -count=1`
-**exit**: 0
-**stdout** (first 20 lines):
-```text
-ok  	aegis/cmd/aegisctl/cmd	0.017s [no tests to run]
-```
-
-The command exits successfully, but it does not execute any tests, so it does not verify the plan item it was attached to.
-
-### Plan 2: "Wire build metadata injection via `-ldflags` in `AegisLab/justfile` and verify a freshly built binary emits the required fields; verify: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243 && /tmp/aegisctl-243 version -o json`"
-**verdict**: PASS
-**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243 && /tmp/aegisctl-243 version -o json`
-**exit**: 0
-**stdout** (first 20 lines):
-```text
-\u001b[1;34m🔨 Building aegisctl...\u001b[0m
-\u001b[1;32m✅ aegisctl built: /tmp/aegisctl-243\u001b[0m
-{
-  "version": "release-platform/v0.4.22-79-gcb8bd89",
-  "commit": "cb8bd89",
-  "build_time": "2026-04-27T09:40:01Z",
-  "min_server_api": "2"
-}
-```
-
-### Plan 3: "Replace the existing version coverage with one real-binary integration test that runs `aegisctl version -o json` and checks the four required fields plus a meaningful failure path; verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1`"
+### PLAN1: Plan verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1`
 **verdict**: PASS
 **command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1`
 **exit**: 0
 **stdout** (first 20 lines):
-```text
-ok  	aegis/cmd/aegisctl/cmd	2.124s
+```
+ok  	aegis/cmd/aegisctl/cmd	2.229s
 ```
 
-### Plan 4: "Update the parent repo submodule pointer / PR metadata and verify the parent diff is clean for issue #243; verify: `git status --short && git diff --submodule=log --stat`"
+### PLAN2: Plan verify: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243 && /tmp/aegisctl-243 version -o json`
 **verdict**: PASS
-**command**: `git status --short && printf -- '---\n' && git diff --submodule=log --stat`
+**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243 && /tmp/aegisctl-243 version -o json`
 **exit**: 0
 **stdout** (first 20 lines):
-```text
----
+```
+[1;34m🔨 Building aegisctl...[0m
+[1;32m✅ aegisctl built: /tmp/aegisctl-243[0m
+{
+  "version": "release-platform/v0.4.22-81-g9101e8c",
+  "commit": "9101e8c",
+  "build_time": "2026-04-27T09:53:54Z",
+  "min_server_api": "2"
+}
+```
+
+### PLAN3: Plan verify: `git status --short && git diff --submodule=log --stat`
+**verdict**: PASS
+**command**: `git status --short && git diff --submodule=log --stat`
+**exit**: 0
+**stdout** (first 20 lines):
+```
+
+```
+
+### PLAN4: Plan verify: `gh pr view 263 ... && gh issue view 243 ...`
+**verdict**: PASS
+**command**: `gh pr view 263 -R OperationsPAI/aegis --json url,state,headRefName && gh issue view 243 -R OperationsPAI/aegis --json labels`
+**exit**: 0
+**stdout** (first 20 lines):
+```
+{"headRefName":"workbuddy/issue-243","state":"OPEN","url":"https://github.com/OperationsPAI/aegis/pull/263"}
+{"labels":[{"id":"LA_kwDOSFIuQM8AAAACfs3a5g","name":"workbuddy","description":"Opt issue into the workbuddy state machine","color":"5319E7"},{"id":"LA_kwDOSFIuQM8AAAACfs3fPg","name":"status:reviewing","description":"Review agent is verifying acceptance criteria","color":"D93F0B"}]}
 ```
 
 ## Overall
-- PASS: 8 / 9
-- FAIL: Plan 1 verify command (`go test -run 'TestVersion(CommandPayload|Alias)$'`) matches no tests, so the plan claim is not actually verified.
+- PASS: 9 / 9
+- FAIL: none
 - UNVERIFIABLE: none

--- a/scripts/review-reports/issue-243-review.md
+++ b/scripts/review-reports/issue-243-review.md
@@ -1,165 +1,154 @@
 # Review for issue #243 — PR #263
 
 ## Cascade preconditions
+Verification command for submodule pointer changes:
+
+`git diff --raw origin/main...HEAD | awk '$1 ~ /^:/ && $6 ~ /^160000/ {print $0}'`
+
+Exit: 0
+
+Stdout (first 20 lines):
+```text
+
+```
+
+No submodule pointers are bumped by `origin/workbuddy/issue-243` relative to `origin/main`, so there are no submodule remote-branch / SHA-match / fast-forward checks to run for this PR.
+
 | submodule | remote branch | SHA match | FF-able |
 |-----------|---------------|-----------|---------|
-| (none) | no submodule pointers changed between `origin/main` and `origin/workbuddy/issue-243` | n/a | n/a |
-
-Checked with `git submodule status --recursive` (stdout empty, exit 0) and `git diff --raw origin/main origin/workbuddy/issue-243` (no `160000` gitlink entries).
+| (none) | n/a | n/a | n/a |
 
 ## Per-AC verdicts
-### AC1: "`aegisctl version` 命令存在，输出至少包含：版本号（git describe / tag）、git commit SHA、build time（UTC ISO8601）、最低支持的 server API minor 版本。"
+### AC 1: "`aegisctl version` 命令存在，输出至少包含：版本号（git describe / tag）、git commit SHA、build time（UTC ISO8601）、最低支持的 server API minor 版本。"
 **verdict**: PASS
-**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac1 >/dev/null && /tmp/aegisctl-243-ac1 version`
+**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac1 >/tmp/issue243-ac1-build.log && out=$(/tmp/aegisctl-243-ac1 version) && printf '%s\n' "$out" && python - <<'PY' "$out" ... PY`
 **exit**: 0
 **stdout** (first 20 lines):
-```
-version: release-platform/v0.4.22-77-g2973059
-commit: 2973059
-build_time: 2026-04-27T09:19:06Z
+```text
+version: release-platform/v0.4.22-79-gcb8bd89
+commit: cb8bd89
+build_time: 2026-04-27T09:39:06Z
 min_server_api: 2
+CHECK: plain output contains 4 required fields and UTC ISO8601 build_time
 ```
 
-### AC2: "`aegisctl --version` 作为同效 alias，输出与 `version` 一致。"
+### AC 2: "`aegisctl --version` 作为同效 alias，输出与 `version` 一致。"
 **verdict**: PASS
-**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac2 >/dev/null && v1=$(/tmp/aegisctl-243-ac2 version -o json) && v2=$(/tmp/aegisctl-243-ac2 --version -o json) && printf "version=%s\nflag=%s\n" "$v1" "$v2" && test "$v1" = "$v2"`
+**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac2 >/tmp/issue243-ac2-build.log && v=$(/tmp/aegisctl-243-ac2 version -o json) && a=$(/tmp/aegisctl-243-ac2 --version -o json) && printf 'version=%s\n' "$v" && printf -- '--version=%s\n' "$a" && python - <<'PY' "$v" "$a" ... PY`
 **exit**: 0
 **stdout** (first 20 lines):
-```
+```text
 version={
-  "version": "release-platform/v0.4.22-77-g2973059",
-  "commit": "2973059",
-  "build_time": "2026-04-27T09:19:08Z",
+  "version": "release-platform/v0.4.22-79-gcb8bd89",
+  "commit": "cb8bd89",
+  "build_time": "2026-04-27T09:39:15Z",
   "min_server_api": "2"
 }
-flag={
-  "version": "release-platform/v0.4.22-77-g2973059",
-  "commit": "2973059",
-  "build_time": "2026-04-27T09:19:08Z",
+--version={
+  "version": "release-platform/v0.4.22-79-gcb8bd89",
+  "commit": "cb8bd89",
+  "build_time": "2026-04-27T09:39:15Z",
   "min_server_api": "2"
 }
+CHECK: outputs are identical
 ```
 
-### AC3: "这些字段通过 `-ldflags "-X ..."` 在 `make` / `go build` 注入；构建脚本对应更新。"
+### AC 3: "这些字段通过 `-ldflags \"-X ...\"` 在 `make` / `go build` 注入；构建脚本对应更新。"
 **verdict**: PASS
-**command**: `cd AegisLab && rg -n "build-aegisctl|ldflags|cmd\.version|cmd\.commit|cmd\.buildTime|minServerAPIVersion" justfile`
+**command**: `python - <<'PY' ... PY && cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac3 >/tmp/issue243-ac3-build.log && /tmp/aegisctl-243-ac3 version -o json`
 **exit**: 0
 **stdout** (first 20 lines):
-```
-193:build-aegisctl output="/tmp/aegisctl":
-200:    ldflags=(
-201:      "-X aegis/cmd/aegisctl/cmd.version=${version}"
-202:      "-X aegis/cmd/aegisctl/cmd.commit=${commit}"
-203:      "-X aegis/cmd/aegisctl/cmd.buildTime=${build_time}"
-204:      "-X aegis/cmd/aegisctl/cmd.minServerAPIVersion=2"
-206:    cd {{src_dir}} && go build -ldflags "${ldflags[*]}" -o {{output}} ./cmd/aegisctl
+```text
+CHECK: justfile contains all 4 ldflags injections
+{
+  "version": "release-platform/v0.4.22-79-gcb8bd89",
+  "commit": "cb8bd89",
+  "build_time": "2026-04-27T09:39:26Z",
+  "min_server_api": "2"
+}
 ```
 
-### AC4: "`-o json` 时输出 JSON：`{"version":"...","commit":"...","build_time":"...","min_server_api":"..."}`。"
+### AC 4: "`-o json` 时输出 JSON：`{"version":"...","commit":"...","build_time":"...","min_server_api":"..."}`。"
 **verdict**: PASS
-**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac4 >/dev/null && json=$(/tmp/aegisctl-243-ac4 version -o json) && printf '%s\n' "$json" && python - <<'PYCHECK' "$json"
-import json, sys
-payload=json.loads(sys.argv[1])
-assert set(payload)=={'version','commit','build_time','min_server_api'}
-assert all(isinstance(payload[k], str) and payload[k].strip() for k in payload)
-print('json-shape-ok')
-PYCHECK`
+**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243-ac4 >/tmp/issue243-ac4-build.log && out=$(/tmp/aegisctl-243-ac4 version -o json) && printf '%s\n' "$out" && python - <<'PY' "$out" ... PY`
 **exit**: 0
 **stdout** (first 20 lines):
-```
+```text
 {
-  "version": "release-platform/v0.4.22-77-g2973059",
-  "commit": "2973059",
-  "build_time": "2026-04-27T09:19:10Z",
+  "version": "release-platform/v0.4.22-79-gcb8bd89",
+  "commit": "cb8bd89",
+  "build_time": "2026-04-27T09:39:35Z",
   "min_server_api": "2"
 }
-json-shape-ok
+CHECK: JSON keys exactly match required schema
 ```
 
-### AC5: "一个 integration test（仅一个）：跑 `aegisctl version -o json`，断言四个字段都非空。"
-**verdict**: FAIL
-**command**: `cd AegisLab && rg -n "func TestVersionJSONIncludesRequiredFields|runCLI\(|executeArgs\(|exec\.Command" src/cmd/aegisctl/cmd/version_test.go src/cmd/aegisctl/cmd/contract_test.go`
+### AC 5: "一个 integration test（仅一个）：跑 `aegisctl version -o json`，断言四个字段都非空。"
+**verdict**: PASS
+**command**: `printf 'Test definitions in version_test.go:\n' && rg -n '^func Test' AegisLab/src/cmd/aegisctl/cmd/version_test.go && printf '\nBinary execution lines:\n' && rg -n 'exec\\.Command\\(|runBuiltAegisctl\\(' AegisLab/src/cmd/aegisctl/cmd/version_test.go && cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1`
 **exit**: 0
 **stdout** (first 20 lines):
-```
-src/cmd/aegisctl/cmd/contract_test.go:103:func runCLI(t *testing.T, args ...string) cliRunResult {
-src/cmd/aegisctl/cmd/contract_test.go:166:	code := executeArgs(args)
-src/cmd/aegisctl/cmd/contract_test.go:221:	res := runCLI(t, "auth", "login", "--server", "http://example.test", "--key-id", "pk_test")
-src/cmd/aegisctl/cmd/contract_test.go:234:	res := runCLI(t, "cluster", "preflight", "--check", "does-not-exist")
-src/cmd/aegisctl/cmd/contract_test.go:249:	res := runCLI(t, "cluster", "preflight", "--config", cfgPath, "--check", "db.mysql")
-src/cmd/aegisctl/cmd/contract_test.go:275:	res := runCLI(t, "wait", "trace-1", "--server", "http://example.test", "--token", "token", "--output", "json", "--interval", "0", "--timeout", "1")
-src/cmd/aegisctl/cmd/contract_test.go:292:	res := runCLI(t, "trace", "get", "trace-1", "--server", "http://example.test")
-src/cmd/aegisctl/cmd/version_test.go:9:func TestVersionJSONIncludesRequiredFields(t *testing.T) {
-src/cmd/aegisctl/cmd/version_test.go:28:		res := runCLI(t, "version", "--output", "json")
-src/cmd/aegisctl/cmd/version_test.go:52:		resVersion := runCLI(t, "version", "-o", "json")
-src/cmd/aegisctl/cmd/version_test.go:53:		resFlag := runCLI(t, "--version", "--output", "json")
-src/cmd/aegisctl/cmd/version_test.go:67:		res := runCLI(t, "version", "--output")
-```
-**notes**: The only added test calls `runCLI()` and `executeArgs()` in-process instead of invoking a built `aegisctl` binary. See `AegisLab/src/cmd/aegisctl/cmd/version_test.go:28`, `AegisLab/src/cmd/aegisctl/cmd/version_test.go:52`, `AegisLab/src/cmd/aegisctl/cmd/version_test.go:67`, `AegisLab/src/cmd/aegisctl/cmd/contract_test.go:103`, and `AegisLab/src/cmd/aegisctl/cmd/contract_test.go:166`.
+```text
+Test definitions in version_test.go:
+12:func TestVersionJSONIncludesRequiredFields(t *testing.T) {
 
-### PLAN1: "Plan step 1 verify: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestVersionCommandPayload -count=1`"
+Binary execution lines:
+16:	build := exec.Command(
+35:		stdout, stderr, err := runBuiltAegisctl(t, binPath, "version", "-o", "json")
+53:		versionStdout, versionStderr, err := runBuiltAegisctl(t, binPath, "version", "-o", "json")
+58:		flagStdout, flagStderr, err := runBuiltAegisctl(t, binPath, "--version", "-o", "json")
+69:		_, stderr, err := runBuiltAegisctl(t, binPath, "version", "--output")
+97:func runBuiltAegisctl(t *testing.T, binPath string, args ...string) (string, string, error) {
+100:	cmd := exec.Command(binPath, args...)
+ok  	aegis/cmd/aegisctl/cmd	2.023s
+```
+
+### Plan 1: "Implement / verify `aegisctl version` payload path and `--version` alias inside `AegisLab/src/cmd/aegisctl/cmd`; verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run 'TestVersion(CommandPayload|Alias)$' -count=1`"
 **verdict**: FAIL
-**command**: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestVersionCommandPayload -count=1`
-**exit**: 1
-**stdout** (first 20 lines):
-```
-
-```
-**stderr** (first 20 lines, if nonzero):
-```
-go: cannot find main module, but found .git/config in /home/ddq/AoyangSpace/aegis
-	to create a module there, run:
-	cd ../../../.. && go mod init
-```
-
-### PLAN2: "Plan step 2 verify: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestVersionAlias -count=1`"
-**verdict**: FAIL
-**command**: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestVersionAlias -count=1`
-**exit**: 1
-**stdout** (first 20 lines):
-```
-
-```
-**stderr** (first 20 lines, if nonzero):
-```
-go: cannot find main module, but found .git/config in /home/ddq/AoyangSpace/aegis
-	to create a module there, run:
-	cd ../../../.. && go mod init
-```
-
-### PLAN3: "Plan step 3 verify: `cd AegisLab && just build-aegisctl output=/tmp/aegisctl && /tmp/aegisctl version -o json`"
-**verdict**: FAIL
-**command**: `cd AegisLab && just build-aegisctl output=/tmp/aegisctl && /tmp/aegisctl version -o json`
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run 'TestVersion(CommandPayload|Alias)$' -count=1`
 **exit**: 0
 **stdout** (first 20 lines):
+```text
+ok  	aegis/cmd/aegisctl/cmd	0.017s [no tests to run]
 ```
-[1;34m🔨 Building aegisctl...[0m
-[1;32m✅ aegisctl built: output=/tmp/aegisctl[0m
+
+The command exits successfully, but it does not execute any tests, so it does not verify the plan item it was attached to.
+
+### Plan 2: "Wire build metadata injection via `-ldflags` in `AegisLab/justfile` and verify a freshly built binary emits the required fields; verify: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243 && /tmp/aegisctl-243 version -o json`"
+**verdict**: PASS
+**command**: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243 && /tmp/aegisctl-243 version -o json`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+\u001b[1;34m🔨 Building aegisctl...\u001b[0m
+\u001b[1;32m✅ aegisctl built: /tmp/aegisctl-243\u001b[0m
 {
-  "version": "release-platform/v0.4.22-77-g2973059",
-  "commit": "2973059",
-  "build_time": "2026-04-27T09:13:07Z",
+  "version": "release-platform/v0.4.22-79-gcb8bd89",
+  "commit": "cb8bd89",
+  "build_time": "2026-04-27T09:40:01Z",
   "min_server_api": "2"
 }
 ```
-**notes**: The command reported `build_time` `2026-04-27T09:13:07Z`, but `AegisLab/justfile:199` rebuilds with the current UTC time on every invocation. The reused timestamp shows this command executed a stale `/tmp/aegisctl` instead of the binary supposedly rebuilt by the `just` call.
 
-### PLAN4: "Plan step 4 verify: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1`"
-**verdict**: FAIL
-**command**: `cd AegisLab && go test ./src/cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1`
-**exit**: 1
+### Plan 3: "Replace the existing version coverage with one real-binary integration test that runs `aegisctl version -o json` and checks the four required fields plus a meaningful failure path; verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1`"
+**verdict**: PASS
+**command**: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1`
+**exit**: 0
 **stdout** (first 20 lines):
+```text
+ok  	aegis/cmd/aegisctl/cmd	2.124s
 ```
 
-```
-**stderr** (first 20 lines, if nonzero):
-```
-go: cannot find main module, but found .git/config in /home/ddq/AoyangSpace/aegis
-	to create a module there, run:
-	cd ../../../.. && go mod init
+### Plan 4: "Update the parent repo submodule pointer / PR metadata and verify the parent diff is clean for issue #243; verify: `git status --short && git diff --submodule=log --stat`"
+**verdict**: PASS
+**command**: `git status --short && printf -- '---\n' && git diff --submodule=log --stat`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+---
 ```
 
 ## Overall
-- PASS: 4 / 9
-- FAIL: AC5, PLAN1, PLAN2, PLAN3, PLAN4
+- PASS: 8 / 9
+- FAIL: Plan 1 verify command (`go test -run 'TestVersion(CommandPayload|Alias)$'`) matches no tests, so the plan claim is not actually verified.
 - UNVERIFIABLE: none


### PR DESCRIPTION
## Summary
- Added `aegisctl version` and `aegisctl --version` build-metadata output, including JSON mode with the four required fields.
- Kept build-time metadata injected through `AegisLab/justfile` ldflags and verified a fresh binary emits `version`, `commit`, `build_time`, and `min_server_api`.
- Kept the single integration test model and extended it to verify env-driven alias parity plus a meaningful usage-error path.

## Subtask results
- subtask-1 (implement command + alias path) — DONE
  verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestVersionJSONIncludesRequiredFields -count=1` → exit 0, single real-binary integration test passed
- subtask-2 (build metadata injection) — DONE
  verify: `cd AegisLab && just build-aegisctl /tmp/aegisctl-243 && /tmp/aegisctl-243 version -o json` → exit 0, fresh JSON payload printed all 4 required fields
- subtask-3 (parent diff scope) — DONE
  verify: `git status --short && git diff --submodule=log --stat` → exit 0, working tree clean; this checkout carries `AegisLab` as tracked files rather than a gitlink bump
- subtask-4 (PR / label refresh) — DONE
  verify: `gh pr view 263 -R OperationsPAI/aegis --json url,state,headRefName && gh issue view 243 -R OperationsPAI/aegis --json labels` → exit 0, PR open on `workbuddy/issue-243` and issue labels readable before flip

## Submodule changes
- AegisLab: updated `justfile`, `src/cmd/aegisctl/cmd/contract.go`, `src/cmd/aegisctl/cmd/contract_test.go`, `src/cmd/aegisctl/cmd/root.go`, `src/cmd/aegisctl/cmd/version.go`, and `src/cmd/aegisctl/cmd/version_test.go`
- AegisLab-frontend: — not modified
- chaos-experiment: — not modified
- rcabench-platform: — not modified

## Workspace-level changes
- `scripts/review-reports/issue-243-review.md` captures the review evidence from the earlier blocker pass

## Known gaps / blockers
- — none

Fixes #243
