### PR TITLE
feat(aegisctl): add stdin batch execution

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
@@ -31,6 +31,7 @@ func resetCLIState() {
 	flagNonInteractive = false
 	flagDryRun = false
 	output.Quiet = false
+	commandStdin = os.Stdin
 
 	authLoginServer = ""
 	authLoginKeyID = ""
@@ -80,6 +81,25 @@ func resetCLIState() {
 
 	waitTimeout = 0
 	waitInterval = 0
+	waitStdin = false
+	waitStdinField = ""
+
+	injectGetStdin = false
+	injectGetStdinField = ""
+	injectFilesStdin = false
+	injectFilesStdinField = ""
+	injectDownloadStdin = false
+	injectDownloadStdinField = ""
+
+	taskGetStdin = false
+	taskGetStdinField = ""
+	taskLogsStdin = false
+	taskLogsStdinField = ""
+
+	traceGetStdin = false
+	traceGetStdinField = ""
+	traceWatchStdin = false
+	traceWatchStdinField = ""
 
 	resetCommandFlags(rootCmd)
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/contract_test.go
@@ -86,20 +86,28 @@ func resetCLIState() {
 
 	injectGetStdin = false
 	injectGetStdinField = ""
+	injectGetStdinFailFast = false
 	injectFilesStdin = false
 	injectFilesStdinField = ""
+	injectFilesStdinFailFast = false
 	injectDownloadStdin = false
 	injectDownloadStdinField = ""
+	injectDownloadStdinFailFast = false
 
 	taskGetStdin = false
 	taskGetStdinField = ""
+	taskGetStdinFailFast = false
 	taskLogsStdin = false
 	taskLogsStdinField = ""
+	taskLogsStdinFailFast = false
 
 	traceGetStdin = false
 	traceGetStdinField = ""
+	traceGetStdinFailFast = false
 	traceWatchStdin = false
 	traceWatchStdinField = ""
+	traceWatchStdinFailFast = false
+	waitStdinFailFast = false
 
 	resetCommandFlags(rootCmd)
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/inject.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject.go
@@ -208,13 +208,25 @@ var injectListCmd = &cobra.Command{
 var injectGetCmd = &cobra.Command{
 	Use:   "get <name>",
 	Short: "Get detailed info about an injection",
-	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		return runStdinItems("inject get", "inject get <name>", args, stdinOptions{
+			enabled: injectGetStdin,
+			field:   injectGetStdinField,
+		}, runInjectGet)
+	},
+}
+
+var (
+	injectGetStdin      bool
+	injectGetStdinField string
+)
+
+func runInjectGet(name string) error {
 		r, err := newProjectScopedResolver()
 		if err != nil {
 			return err
 		}
-		id, err := r.InjectionID(args[0])
+		id, err := r.InjectionID(name)
 		if err != nil {
 			return err
 		}
@@ -280,7 +292,6 @@ var injectGetCmd = &cobra.Command{
 
 		output.PrintTable(headers, rows)
 		return nil
-	},
 }
 
 func formatInjectGetValue(v any) string {
@@ -345,13 +356,25 @@ var injectSearchCmd = &cobra.Command{
 var injectFilesCmd = &cobra.Command{
 	Use:   "files <name>",
 	Short: "List files produced by an injection",
-	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		return runStdinItems("inject files", "inject files <name>", args, stdinOptions{
+			enabled: injectFilesStdin,
+			field:   injectFilesStdinField,
+		}, runInjectFiles)
+	},
+}
+
+var (
+	injectFilesStdin      bool
+	injectFilesStdinField string
+)
+
+func runInjectFiles(name string) error {
 		r, err := newProjectScopedResolver()
 		if err != nil {
 			return err
 		}
-		id, err := r.InjectionID(args[0])
+		id, err := r.InjectionID(name)
 		if err != nil {
 			return err
 		}
@@ -380,7 +403,6 @@ var injectFilesCmd = &cobra.Command{
 		}
 		output.PrintTable(headers, rows)
 		return nil
-	},
 }
 
 // ---------- inject download ----------
@@ -391,6 +413,8 @@ var (
 	injectDownloadInclude  string
 	injectDownloadFilePar  int
 	injectDownloadTimeout  int
+	injectDownloadStdin    bool
+	injectDownloadStdinField string
 )
 
 const (
@@ -580,8 +604,18 @@ var injectDownloadCmd = &cobra.Command{
 	Long: `Download a datapack either as a single zip file (--output-file) or extracted
 into a directory (--output-dir). When extracting, --include selects which
 subset of the datapack to fetch.`,
-	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if injectDownloadStdin && injectDownloadOutput != "" {
+			return usageErrorf("--stdin requires --output-dir; --output-file only supports a single positional target")
+		}
+		return runStdinItems("inject download", "inject download <name>", args, stdinOptions{
+			enabled: injectDownloadStdin,
+			field:   injectDownloadStdinField,
+		}, runInjectDownload)
+	},
+}
+
+func runInjectDownload(name string) error {
 		if injectDownloadOutput == "" && injectDownloadDir == "" {
 			return usageErrorf("either --output-file <path> or --output-dir <dir> is required")
 		}
@@ -598,7 +632,7 @@ subset of the datapack to fetch.`,
 		if err != nil {
 			return err
 		}
-		id, err := r.InjectionID(args[0])
+		id, err := r.InjectionID(name)
 		if err != nil {
 			return err
 		}
@@ -610,14 +644,14 @@ subset of the datapack to fetch.`,
 		httpClient := &http.Client{Timeout: time.Duration(timeoutSec) * time.Second}
 
 		if injectDownloadDir != "" {
-			outDir := filepathJoin(injectDownloadDir, args[0])
+			outDir := filepathJoin(injectDownloadDir, name)
 			if err := os.MkdirAll(outDir, 0o755); err != nil {
 				return fmt.Errorf("create output dir: %w", err)
 			}
-			if err := downloadPackToDir(httpClient, flagServer, flagToken, id, args[0], outDir, include, injectDownloadFilePar); err != nil {
-				return fmt.Errorf("download %s: %w", args[0], err)
+			if err := downloadPackToDir(httpClient, flagServer, flagToken, id, name, outDir, include, injectDownloadFilePar); err != nil {
+				return fmt.Errorf("download %s: %w", name, err)
 			}
-			output.PrintInfo(fmt.Sprintf("Downloaded %s (include=%s) to %s", args[0], include, outDir))
+			output.PrintInfo(fmt.Sprintf("Downloaded %s (include=%s) to %s", name, include, outDir))
 			return nil
 		}
 
@@ -650,8 +684,7 @@ subset of the datapack to fetch.`,
 		}
 		output.PrintInfo(fmt.Sprintf("Downloaded %d bytes to %s", n, injectDownloadOutput))
 		return nil
-	},
-}
+	}
 
 // ---------- inject download-batch ----------
 
@@ -890,6 +923,9 @@ func init() {
 	injectDownloadCmd.Flags().StringVar(&injectDownloadInclude, "include", "converted", "Which subset to download when using --output-dir: "+injectIncludeFlagHelp())
 	injectDownloadCmd.Flags().IntVar(&injectDownloadFilePar, "parallel-files", 4, "Concurrent file downloads when using --output-dir")
 	injectDownloadCmd.Flags().IntVar(&injectDownloadTimeout, "request-timeout-override", 0, "Per-request HTTP timeout in seconds (0 = use global --request-timeout)")
+	addStdinFlags(injectGetCmd, &injectGetStdin, &injectGetStdinField)
+	addStdinFlags(injectFilesCmd, &injectFilesStdin, &injectFilesStdinField)
+	addStdinFlags(injectDownloadCmd, &injectDownloadStdin, &injectDownloadStdinField)
 
 	injectDownloadBatchCmd.Flags().StringVar(&injectBatchOutputDir, "output-dir", "", "Required: directory under which each pack is extracted as <output-dir>/<name>/")
 	injectDownloadBatchCmd.Flags().StringVar(&injectBatchInclude, "include", "converted", "Which subset to download per pack: "+injectIncludeFlagHelp())

--- a/AegisLab/src/cmd/aegisctl/cmd/inject.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject.go
@@ -210,15 +210,17 @@ var injectGetCmd = &cobra.Command{
 	Short: "Get detailed info about an injection",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runStdinItems("inject get", "inject get <name>", args, stdinOptions{
-			enabled: injectGetStdin,
-			field:   injectGetStdinField,
+			enabled:  injectGetStdin,
+			field:    injectGetStdinField,
+			failFast: injectGetStdinFailFast,
 		}, runInjectGet)
 	},
 }
 
 var (
-	injectGetStdin      bool
-	injectGetStdinField string
+	injectGetStdin         bool
+	injectGetStdinField    string
+	injectGetStdinFailFast bool
 )
 
 func runInjectGet(name string) error {
@@ -358,15 +360,17 @@ var injectFilesCmd = &cobra.Command{
 	Short: "List files produced by an injection",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runStdinItems("inject files", "inject files <name>", args, stdinOptions{
-			enabled: injectFilesStdin,
-			field:   injectFilesStdinField,
+			enabled:  injectFilesStdin,
+			field:    injectFilesStdinField,
+			failFast: injectFilesStdinFailFast,
 		}, runInjectFiles)
 	},
 }
 
 var (
-	injectFilesStdin      bool
-	injectFilesStdinField string
+	injectFilesStdin         bool
+	injectFilesStdinField    string
+	injectFilesStdinFailFast bool
 )
 
 func runInjectFiles(name string) error {
@@ -408,13 +412,14 @@ func runInjectFiles(name string) error {
 // ---------- inject download ----------
 
 var (
-	injectDownloadOutput   string
-	injectDownloadDir      string
-	injectDownloadInclude  string
-	injectDownloadFilePar  int
-	injectDownloadTimeout  int
-	injectDownloadStdin    bool
-	injectDownloadStdinField string
+	injectDownloadOutput        string
+	injectDownloadDir           string
+	injectDownloadInclude       string
+	injectDownloadFilePar       int
+	injectDownloadTimeout       int
+	injectDownloadStdin         bool
+	injectDownloadStdinField    string
+	injectDownloadStdinFailFast bool
 )
 
 const (
@@ -609,8 +614,9 @@ subset of the datapack to fetch.`,
 			return usageErrorf("--stdin requires --output-dir; --output-file only supports a single positional target")
 		}
 		return runStdinItems("inject download", "inject download <name>", args, stdinOptions{
-			enabled: injectDownloadStdin,
-			field:   injectDownloadStdinField,
+			enabled:  injectDownloadStdin,
+			field:    injectDownloadStdinField,
+			failFast: injectDownloadStdinFailFast,
 		}, runInjectDownload)
 	},
 }
@@ -923,9 +929,9 @@ func init() {
 	injectDownloadCmd.Flags().StringVar(&injectDownloadInclude, "include", "converted", "Which subset to download when using --output-dir: "+injectIncludeFlagHelp())
 	injectDownloadCmd.Flags().IntVar(&injectDownloadFilePar, "parallel-files", 4, "Concurrent file downloads when using --output-dir")
 	injectDownloadCmd.Flags().IntVar(&injectDownloadTimeout, "request-timeout-override", 0, "Per-request HTTP timeout in seconds (0 = use global --request-timeout)")
-	addStdinFlags(injectGetCmd, &injectGetStdin, &injectGetStdinField)
-	addStdinFlags(injectFilesCmd, &injectFilesStdin, &injectFilesStdinField)
-	addStdinFlags(injectDownloadCmd, &injectDownloadStdin, &injectDownloadStdinField)
+	addStdinFlags(injectGetCmd, &injectGetStdin, &injectGetStdinField, &injectGetStdinFailFast)
+	addStdinFlags(injectFilesCmd, &injectFilesStdin, &injectFilesStdinField, &injectFilesStdinFailFast)
+	addStdinFlags(injectDownloadCmd, &injectDownloadStdin, &injectDownloadStdinField, &injectDownloadStdinFailFast)
 
 	injectDownloadBatchCmd.Flags().StringVar(&injectBatchOutputDir, "output-dir", "", "Required: directory under which each pack is extracted as <output-dir>/<name>/")
 	injectDownloadBatchCmd.Flags().StringVar(&injectBatchInclude, "include", "converted", "Which subset to download per pack: "+injectIncludeFlagHelp())

--- a/AegisLab/src/cmd/aegisctl/cmd/inject.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject.go
@@ -182,6 +182,16 @@ var injectListCmd = &cobra.Command{
 			output.PrintJSON(resp.Data)
 			return nil
 		}
+		if output.OutputFormat(flagOutput) == output.FormatNDJSON {
+			for _, item := range resp.Data.Items {
+				data, err := json.Marshal(item)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(os.Stdout, string(data))
+			}
+			return nil
+		}
 
 		headers := []string{"NAME", "STATE", "FAULT-TYPE", "START-TIME", "LABELS"}
 		var rows [][]string

--- a/AegisLab/src/cmd/aegisctl/cmd/stdin_command_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/stdin_command_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"aegis/cmd/aegisctl/client"
+)
+
+func TestInjectTaskTraceWaitStdin(t *testing.T) {
+	resetCLIState()
+
+	t.Run("rejects positional args when stdin is enabled", func(t *testing.T) {
+		cases := []struct {
+			name string
+			run  func() error
+		}{
+			{
+				name: "inject get",
+				run: func() error {
+					injectGetStdin = true
+					return injectGetCmd.RunE(injectGetCmd, []string{"inject-a"})
+				},
+			},
+			{
+				name: "task get",
+				run: func() error {
+					taskGetStdin = true
+					return taskGetCmd.RunE(taskGetCmd, []string{"task-a"})
+				},
+			},
+			{
+				name: "trace get",
+				run: func() error {
+					traceGetStdin = true
+					return traceGetCmd.RunE(traceGetCmd, []string{"trace-a"})
+				},
+			},
+			{
+				name: "wait",
+				run: func() error {
+					waitStdin = true
+					return waitCmd.RunE(waitCmd, []string{"trace-a"})
+				},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				resetCLIState()
+				err := tc.run()
+				if code := exitCodeFor(err); code != ExitCodeUsage {
+					t.Fatalf("exitCodeFor(%s) = %d, want %d", tc.name, code, ExitCodeUsage)
+				}
+			})
+		}
+	})
+
+	t.Run("wait reads trace_id from ndjson by default", func(t *testing.T) {
+		resetCLIState()
+		commandStdin = strings.NewReader("{\"trace_id\":\"trace-123\"}\n")
+		waitStdin = true
+		flagServer = "http://example.test"
+		flagToken = "tok"
+		waitTimeout = 1
+		waitInterval = 1
+
+		oldDetect := waitDetectResourceType
+		oldPoll := waitPollState
+		t.Cleanup(func() {
+			waitDetectResourceType = oldDetect
+			waitPollState = oldPoll
+			commandStdin = nil
+		})
+
+		waitDetectResourceType = func(c *client.Client, id string) (string, error) {
+			if id != "trace-123" {
+				t.Fatalf("id = %q, want trace-123", id)
+			}
+			return "trace", nil
+		}
+		waitPollState = func(c *client.Client, resourceType, id string) (string, any, error) {
+			return "Completed", map[string]any{"id": id, "state": "Completed"}, nil
+		}
+
+		_, stderr, err := captureStdIO(t, func() error {
+			return waitCmd.RunE(waitCmd, nil)
+		})
+		if err != nil {
+			t.Fatalf("waitCmd.RunE: %v", err)
+		}
+		if !strings.Contains(stderr, "Waiting for trace-123") {
+			t.Fatalf("stderr = %q, want wait progress for stdin item", stderr)
+		}
+	})
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/stdin_command_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/stdin_command_test.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"aegis/cmd/aegisctl/client"
+	"aegis/cmd/aegisctl/output"
 )
 
 func TestInjectTaskTraceWaitStdin(t *testing.T) {
@@ -91,6 +93,72 @@ func TestInjectTaskTraceWaitStdin(t *testing.T) {
 		}
 		if !strings.Contains(stderr, "Waiting for trace-123") {
 			t.Fatalf("stderr = %q, want wait progress for stdin item", stderr)
+		}
+	})
+}
+
+func TestRunItemsExitCodeProgressAndFailFast(t *testing.T) {
+	t.Run("mixed results return exit 9 with progress lines", func(t *testing.T) {
+		resetCLIState()
+		commandStdin = strings.NewReader("ok-item\nmissing-item\n")
+		t.Cleanup(func() { commandStdin = os.Stdin })
+
+		_, stderr, err := captureStdIO(t, func() error {
+			return runStdinItems("trace get", "trace get <trace-id>", nil, stdinOptions{enabled: true}, func(item string) error {
+				if item == "missing-item" {
+					return notFoundErrorf("missing %s", item)
+				}
+				return nil
+			})
+		})
+		if code := exitCodeFor(err); code != ExitCodeDedupeSuppressed {
+			t.Fatalf("exitCodeFor = %d, want %d", code, ExitCodeDedupeSuppressed)
+		}
+		if !strings.Contains(stderr, "[1/2] get ok-item: ok") || !strings.Contains(stderr, "[2/2] get missing-item: failed (not-found)") {
+			t.Fatalf("stderr = %q, want per-item progress lines", stderr)
+		}
+	})
+
+	t.Run("fail-fast stops at first failure", func(t *testing.T) {
+		resetCLIState()
+		commandStdin = strings.NewReader("bad-item\ngood-item\n")
+		t.Cleanup(func() { commandStdin = os.Stdin })
+
+		calls := 0
+		err := runStdinItems("task get", "task get <task-id>", nil, stdinOptions{enabled: true, failFast: true}, func(item string) error {
+			calls++
+			if item == "bad-item" {
+				return usageErrorf("bad item")
+			}
+			return nil
+		})
+		if code := exitCodeFor(err); code != ExitCodeUsage {
+			t.Fatalf("exitCodeFor = %d, want %d", code, ExitCodeUsage)
+		}
+		if calls != 1 {
+			t.Fatalf("calls = %d, want 1 with fail-fast", calls)
+		}
+	})
+
+	t.Run("quiet suppresses progress lines", func(t *testing.T) {
+		resetCLIState()
+		commandStdin = strings.NewReader("ok-item\n")
+		output.Quiet = true
+		t.Cleanup(func() {
+			commandStdin = os.Stdin
+			output.Quiet = false
+		})
+
+		_, stderr, err := captureStdIO(t, func() error {
+			return runStdinItems("inject get", "inject get <name>", nil, stdinOptions{enabled: true}, func(string) error {
+				return nil
+			})
+		})
+		if err != nil {
+			t.Fatalf("runStdinItems: %v", err)
+		}
+		if strings.TrimSpace(stderr) != "" {
+			t.Fatalf("stderr = %q, want quiet progress suppression", stderr)
 		}
 	})
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/stdin_helpers.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/stdin_helpers.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	clistdin "aegis/internal/cli/stdin"
+
+	"github.com/spf13/cobra"
+)
+
+var commandStdin io.Reader = os.Stdin
+
+type stdinOptions struct {
+	enabled bool
+	field   string
+}
+
+func addStdinFlags(cmd *cobra.Command, enabled *bool, field *string) {
+	cmd.Flags().BoolVar(enabled, "stdin", false, "Read batch input from stdin")
+	cmd.Flags().StringVar(field, "stdin-field", "", "Field to read from NDJSON stdin objects")
+}
+
+func stdinItems(commandPath string, args []string, opts stdinOptions) ([]string, bool, error) {
+	if !opts.enabled {
+		return nil, false, nil
+	}
+	if len(args) > 0 {
+		return nil, true, usageErrorf("--stdin cannot be combined with positional arguments")
+	}
+
+	items, err := clistdin.Parse(commandStdin, clistdin.ParseConfig{
+		Field:          opts.field,
+		FallbackFields: clistdin.DefaultFields(commandPath),
+	})
+	if err != nil {
+		return nil, true, usageErrorf("%v", err)
+	}
+	if len(items) == 0 {
+		return nil, true, usageErrorf("stdin did not provide any items")
+	}
+	return items, true, nil
+}
+
+func singleArgOrStdin(commandPath, usage string, args []string, opts stdinOptions) ([]string, error) {
+	if items, handled, err := stdinItems(commandPath, args, opts); handled {
+		return items, err
+	}
+	if len(args) != 1 {
+		return nil, usageErrorf("expected 1 argument(s); usage: %s", usage)
+	}
+	return []string{strings.TrimSpace(args[0])}, nil
+}
+
+func runStdinItems(commandPath, usage string, args []string, opts stdinOptions, fn func(string) error) error {
+	items, err := singleArgOrStdin(commandPath, usage, args, opts)
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		if err := fn(item); err != nil {
+			return fmt.Errorf("%s %s: %w", commandPath, item, err)
+		}
+	}
+	return nil
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/stdin_helpers.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/stdin_helpers.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"aegis/cmd/aegisctl/output"
 	clistdin "aegis/internal/cli/stdin"
 
 	"github.com/spf13/cobra"
@@ -14,13 +15,15 @@ import (
 var commandStdin io.Reader = os.Stdin
 
 type stdinOptions struct {
-	enabled bool
-	field   string
+	enabled  bool
+	field    string
+	failFast bool
 }
 
-func addStdinFlags(cmd *cobra.Command, enabled *bool, field *string) {
+func addStdinFlags(cmd *cobra.Command, enabled *bool, field *string, failFast *bool) {
 	cmd.Flags().BoolVar(enabled, "stdin", false, "Read batch input from stdin")
 	cmd.Flags().StringVar(field, "stdin-field", "", "Field to read from NDJSON stdin objects")
+	cmd.Flags().BoolVar(failFast, "fail-fast", false, "Stop stdin batch execution on the first failed item")
 }
 
 func stdinItems(commandPath string, args []string, opts stdinOptions) ([]string, bool, error) {
@@ -59,10 +62,60 @@ func runStdinItems(commandPath, usage string, args []string, opts stdinOptions, 
 	if err != nil {
 		return err
 	}
-	for _, item := range items {
+	firstErr := error(nil)
+	successes := 0
+	failures := 0
+	verb := batchVerb(commandPath)
+	for i, item := range items {
 		if err := fn(item); err != nil {
-			return fmt.Errorf("%s %s: %w", commandPath, item, err)
+			wrapped := fmt.Errorf("%s %s: %w", commandPath, item, err)
+			failures++
+			output.PrintInfo(fmt.Sprintf("[%d/%d] %s %s: failed (%s)", i+1, len(items), verb, item, exitType(exitCodeFor(err))))
+			if firstErr == nil {
+				firstErr = wrapped
+			}
+			if opts.failFast {
+				return firstErr
+			}
+			continue
 		}
+		successes++
+		output.PrintInfo(fmt.Sprintf("[%d/%d] %s %s: ok", i+1, len(items), verb, item))
 	}
-	return nil
+	if failures == 0 {
+		return nil
+	}
+	if successes == 0 {
+		return firstErr
+	}
+	return silentExit(ExitCodeDedupeSuppressed)
+}
+
+func batchVerb(commandPath string) string {
+	parts := strings.Fields(commandPath)
+	if len(parts) == 0 {
+		return "run"
+	}
+	return parts[len(parts)-1]
+}
+
+func exitType(code int) string {
+	switch code {
+	case ExitCodeUsage:
+		return "usage"
+	case ExitCodeAuthFailure:
+		return "auth"
+	case ExitCodeMissingEnv:
+		return "missing-env"
+	case ExitCodeWorkflowFailure:
+		return "workflow"
+	case ExitCodeTimeout:
+		return "timeout"
+	case ExitCodeNotFound:
+		return "not-found"
+	case ExitCodeConflict:
+		return "conflict"
+	default:
+		return "unexpected"
+	}
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/stdin_integration_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/stdin_integration_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"aegis/cmd/aegisctl/output"
+)
+
+func TestInjectDownloadFromStdinPipe(t *testing.T) {
+	resetCLIState()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v2/projects":
+			_, _ = w.Write([]byte(`{"code":0,"data":{"items":[{"id":1,"name":"proj"}],"pagination":{"page":1,"size":100,"total":1,"total_pages":1}}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v2/projects/1/injections":
+			_, _ = w.Write([]byte(`{"code":0,"data":{"items":[{"id":11,"name":"inject-a","state":"build_success","fault_type":"cpu","start_time":"2026-04-27T00:00:00Z","labels":[]},{"id":12,"name":"inject-b","state":"build_success","fault_type":"cpu","start_time":"2026-04-27T00:00:00Z","labels":[]}],"pagination":{"page":1,"size":100,"total":2,"total_pages":1}}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v2/injections/11/files":
+			_, _ = w.Write([]byte(`{"code":0,"data":{"files":[{"path":"converted/result.txt"}]}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v2/injections/12/files":
+			_, _ = w.Write([]byte(`{"code":0,"data":{"files":[{"path":"converted/result.txt"}]}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v2/injections/11/files/download":
+			_, _ = w.Write([]byte("alpha"))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v2/injections/12/files/download":
+			_, _ = w.Write([]byte("beta"))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	flagServer = srv.URL
+	flagToken = "tok"
+	flagProject = "proj"
+	flagOutput = string(output.FormatNDJSON)
+	injectListSize = 100
+
+	stdout, stderr, err := captureStdIO(t, func() error {
+		return injectListCmd.RunE(injectListCmd, nil)
+	})
+	if err != nil {
+		t.Fatalf("injectListCmd.RunE: %v", err)
+	}
+	if strings.TrimSpace(stderr) != "" {
+		t.Fatalf("list stderr = %q, want empty", stderr)
+	}
+	if !strings.Contains(stdout, `"name":"inject-a"`) || !strings.Contains(stdout, `"name":"inject-b"`) {
+		t.Fatalf("list stdout = %q, want NDJSON items", stdout)
+	}
+
+	resetCLIState()
+	flagServer = srv.URL
+	flagToken = "tok"
+	flagProject = "proj"
+	injectDownloadDir = t.TempDir()
+	injectDownloadStdin = true
+	commandStdin = strings.NewReader(stdout)
+	t.Cleanup(func() { commandStdin = os.Stdin })
+
+	_, downloadStderr, err := captureStdIO(t, func() error {
+		return injectDownloadCmd.RunE(injectDownloadCmd, nil)
+	})
+	if err != nil {
+		t.Fatalf("injectDownloadCmd.RunE: %v", err)
+	}
+	if !strings.Contains(downloadStderr, "[1/2] download inject-a: ok") || !strings.Contains(downloadStderr, "[2/2] download inject-b: ok") {
+		t.Fatalf("download stderr = %q, want batch progress lines", downloadStderr)
+	}
+
+	assertFile := func(rel, want string) {
+		t.Helper()
+		got, readErr := os.ReadFile(filepath.Join(injectDownloadDir, rel))
+		if readErr != nil {
+			t.Fatalf("read %s: %v", rel, readErr)
+		}
+		if string(got) != want {
+			t.Fatalf("%s = %q, want %q", rel, string(got), want)
+		}
+	}
+	assertFile(filepath.Join("inject-a", "result.txt"), "alpha")
+	assertFile(filepath.Join("inject-b", "result.txt"), "beta")
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/task.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/task.go
@@ -187,15 +187,17 @@ var taskGetCmd = &cobra.Command{
 	Short: "Show detailed task information",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runStdinItems("task get", "task get <task-id>", args, stdinOptions{
-			enabled: taskGetStdin,
-			field:   taskGetStdinField,
+			enabled:  taskGetStdin,
+			field:    taskGetStdinField,
+			failFast: taskGetStdinFailFast,
 		}, runTaskGet)
 	},
 }
 
 var (
-	taskGetStdin      bool
-	taskGetStdinField string
+	taskGetStdin         bool
+	taskGetStdinField    string
+	taskGetStdinFailFast bool
 )
 
 func runTaskGet(taskID string) error {
@@ -228,15 +230,17 @@ var taskLogsCmd = &cobra.Command{
 	Short: "Stream task logs via WebSocket",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runStdinItems("task logs", "task logs <task-id>", args, stdinOptions{
-			enabled: taskLogsStdin,
-			field:   taskLogsStdinField,
+			enabled:  taskLogsStdin,
+			field:    taskLogsStdinField,
+			failFast: taskLogsStdinFailFast,
 		}, runTaskLogs)
 	},
 }
 
 var (
-	taskLogsStdin      bool
-	taskLogsStdinField string
+	taskLogsStdin         bool
+	taskLogsStdinField    string
+	taskLogsStdinFailFast bool
 )
 
 func runTaskLogs(taskID string) error {
@@ -340,8 +344,8 @@ func init() {
 	taskListCmd.Flags().BoolVar(&taskListOverdue, "overdue", false, "Show only Pending tasks whose execute_time has passed (WAIT < 0)")
 
 	taskLogsCmd.Flags().BoolVarP(&taskLogsFollow, "follow", "f", false, "Follow log output")
-	addStdinFlags(taskGetCmd, &taskGetStdin, &taskGetStdinField)
-	addStdinFlags(taskLogsCmd, &taskLogsStdin, &taskLogsStdinField)
+	addStdinFlags(taskGetCmd, &taskGetStdin, &taskGetStdinField, &taskGetStdinFailFast)
+	addStdinFlags(taskLogsCmd, &taskLogsStdin, &taskLogsStdinField, &taskLogsStdinFailFast)
 
 	taskCmd.AddCommand(taskListCmd)
 	taskCmd.AddCommand(taskGetCmd)

--- a/AegisLab/src/cmd/aegisctl/cmd/task.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/task.go
@@ -185,11 +185,23 @@ func execTimeField(m map[string]any) int64 {
 var taskGetCmd = &cobra.Command{
 	Use:   "get <task-id>",
 	Short: "Show detailed task information",
-	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		return runStdinItems("task get", "task get <task-id>", args, stdinOptions{
+			enabled: taskGetStdin,
+			field:   taskGetStdinField,
+		}, runTaskGet)
+	},
+}
+
+var (
+	taskGetStdin      bool
+	taskGetStdinField string
+)
+
+func runTaskGet(taskID string) error {
 		c := newClient()
 
-		path := fmt.Sprintf("/api/v2/tasks/%s", args[0])
+		path := fmt.Sprintf("/api/v2/tasks/%s", taskID)
 		var resp client.APIResponse[map[string]any]
 		if err := c.Get(path, &resp); err != nil {
 			return err
@@ -205,7 +217,6 @@ var taskGetCmd = &cobra.Command{
 			fmt.Printf("%-20s %v\n", k+":", v)
 		}
 		return nil
-	},
 }
 
 // --- task logs ---
@@ -215,9 +226,20 @@ var taskLogsFollow bool
 var taskLogsCmd = &cobra.Command{
 	Use:   "logs <task-id>",
 	Short: "Stream task logs via WebSocket",
-	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		taskID := args[0]
+		return runStdinItems("task logs", "task logs <task-id>", args, stdinOptions{
+			enabled: taskLogsStdin,
+			field:   taskLogsStdinField,
+		}, runTaskLogs)
+	},
+}
+
+var (
+	taskLogsStdin      bool
+	taskLogsStdinField string
+)
+
+func runTaskLogs(taskID string) error {
 		wsPath := fmt.Sprintf("/api/v2/tasks/%s/logs/ws", taskID)
 		reader := client.NewWSReader(flagServer, wsPath, flagToken)
 
@@ -274,7 +296,6 @@ var taskLogsCmd = &cobra.Command{
 				}
 			}
 		}
-	},
 }
 
 // Helper functions shared by task and trace commands.
@@ -319,6 +340,8 @@ func init() {
 	taskListCmd.Flags().BoolVar(&taskListOverdue, "overdue", false, "Show only Pending tasks whose execute_time has passed (WAIT < 0)")
 
 	taskLogsCmd.Flags().BoolVarP(&taskLogsFollow, "follow", "f", false, "Follow log output")
+	addStdinFlags(taskGetCmd, &taskGetStdin, &taskGetStdinField)
+	addStdinFlags(taskLogsCmd, &taskLogsStdin, &taskLogsStdinField)
 
 	taskCmd.AddCommand(taskListCmd)
 	taskCmd.AddCommand(taskGetCmd)

--- a/AegisLab/src/cmd/aegisctl/cmd/trace.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/trace.go
@@ -252,14 +252,26 @@ func printTracesTSV(columns []string, items []map[string]any) error {
 var traceGetCmd = &cobra.Command{
 	Use:   "get <trace-id>",
 	Short: "Show detailed trace information",
-	Args:  exactArgs(1, "trace get <trace-id>"),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		return runStdinItems("trace get", "trace get <trace-id>", args, stdinOptions{
+			enabled: traceGetStdin,
+			field:   traceGetStdinField,
+		}, runTraceGet)
+	},
+}
+
+var (
+	traceGetStdin      bool
+	traceGetStdinField string
+)
+
+func runTraceGet(traceID string) error {
 		if err := requireAPIContext(true); err != nil {
 			return err
 		}
 		c := newClient()
 
-		path := fmt.Sprintf("/api/v2/traces/%s", args[0])
+		path := fmt.Sprintf("/api/v2/traces/%s", traceID)
 		var resp client.APIResponse[map[string]any]
 		if err := c.Get(path, &resp); err != nil {
 			return err
@@ -303,7 +315,6 @@ var traceGetCmd = &cobra.Command{
 			}
 		}
 		return nil
-	},
 }
 
 // --- trace watch ---
@@ -311,9 +322,20 @@ var traceGetCmd = &cobra.Command{
 var traceWatchCmd = &cobra.Command{
 	Use:   "watch <trace-id>",
 	Short: "Watch trace events via SSE stream",
-	Args:  exactArgs(1, "trace watch <trace-id>"),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		traceID := args[0]
+		return runStdinItems("trace watch", "trace watch <trace-id>", args, stdinOptions{
+			enabled: traceWatchStdin,
+			field:   traceWatchStdinField,
+		}, runTraceWatch)
+	},
+}
+
+var (
+	traceWatchStdin      bool
+	traceWatchStdinField string
+)
+
+func runTraceWatch(traceID string) error {
 		ssePath := fmt.Sprintf("/api/v2/traces/%s/stream", traceID)
 		reader := client.NewSSEReader(flagServer, ssePath, flagToken)
 
@@ -354,7 +376,6 @@ var traceWatchCmd = &cobra.Command{
 				return nil
 			}
 		}
-	},
 }
 
 // --- trace cancel ---
@@ -509,6 +530,8 @@ func init() {
 			"Valid: id,type,state,status,project,project_id,group_id,last_event,final_event,created_at,start_time,end_time,leaf_num")
 
 	traceCancelCmd.Flags().BoolVarP(&traceCancelForce, "force", "f", false, "Skip confirmation prompt")
+	addStdinFlags(traceGetCmd, &traceGetStdin, &traceGetStdinField)
+	addStdinFlags(traceWatchCmd, &traceWatchStdin, &traceWatchStdinField)
 
 	traceCmd.AddCommand(traceListCmd)
 	traceCmd.AddCommand(traceGetCmd)

--- a/AegisLab/src/cmd/aegisctl/cmd/trace.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/trace.go
@@ -254,15 +254,17 @@ var traceGetCmd = &cobra.Command{
 	Short: "Show detailed trace information",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runStdinItems("trace get", "trace get <trace-id>", args, stdinOptions{
-			enabled: traceGetStdin,
-			field:   traceGetStdinField,
+			enabled:  traceGetStdin,
+			field:    traceGetStdinField,
+			failFast: traceGetStdinFailFast,
 		}, runTraceGet)
 	},
 }
 
 var (
-	traceGetStdin      bool
-	traceGetStdinField string
+	traceGetStdin         bool
+	traceGetStdinField    string
+	traceGetStdinFailFast bool
 )
 
 func runTraceGet(traceID string) error {
@@ -324,15 +326,17 @@ var traceWatchCmd = &cobra.Command{
 	Short: "Watch trace events via SSE stream",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runStdinItems("trace watch", "trace watch <trace-id>", args, stdinOptions{
-			enabled: traceWatchStdin,
-			field:   traceWatchStdinField,
+			enabled:  traceWatchStdin,
+			field:    traceWatchStdinField,
+			failFast: traceWatchStdinFailFast,
 		}, runTraceWatch)
 	},
 }
 
 var (
-	traceWatchStdin      bool
-	traceWatchStdinField string
+	traceWatchStdin         bool
+	traceWatchStdinField    string
+	traceWatchStdinFailFast bool
 )
 
 func runTraceWatch(traceID string) error {
@@ -530,8 +534,8 @@ func init() {
 			"Valid: id,type,state,status,project,project_id,group_id,last_event,final_event,created_at,start_time,end_time,leaf_num")
 
 	traceCancelCmd.Flags().BoolVarP(&traceCancelForce, "force", "f", false, "Skip confirmation prompt")
-	addStdinFlags(traceGetCmd, &traceGetStdin, &traceGetStdinField)
-	addStdinFlags(traceWatchCmd, &traceWatchStdin, &traceWatchStdinField)
+	addStdinFlags(traceGetCmd, &traceGetStdin, &traceGetStdinField, &traceGetStdinFailFast)
+	addStdinFlags(traceWatchCmd, &traceWatchStdin, &traceWatchStdinField, &traceWatchStdinFailFast)
 
 	traceCmd.AddCommand(traceListCmd)
 	traceCmd.AddCommand(traceGetCmd)

--- a/AegisLab/src/cmd/aegisctl/cmd/validation_contract_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/validation_contract_test.go
@@ -31,20 +31,28 @@ func resetCLIStateForTest() {
 
 	waitStdin = false
 	waitStdinField = ""
+	waitStdinFailFast = false
 	injectGetStdin = false
 	injectGetStdinField = ""
+	injectGetStdinFailFast = false
 	injectFilesStdin = false
 	injectFilesStdinField = ""
+	injectFilesStdinFailFast = false
 	injectDownloadStdin = false
 	injectDownloadStdinField = ""
+	injectDownloadStdinFailFast = false
 	taskGetStdin = false
 	taskGetStdinField = ""
+	taskGetStdinFailFast = false
 	taskLogsStdin = false
 	taskLogsStdinField = ""
+	taskLogsStdinFailFast = false
 	traceGetStdin = false
 	traceGetStdinField = ""
+	traceGetStdinFailFast = false
 	traceWatchStdin = false
 	traceWatchStdinField = ""
+	traceWatchStdinFailFast = false
 }
 
 func captureStdIO(t *testing.T, fn func() error) (stdout string, stderr string, err error) {

--- a/AegisLab/src/cmd/aegisctl/cmd/validation_contract_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/validation_contract_test.go
@@ -27,6 +27,24 @@ func resetCLIStateForTest() {
 	output.Quiet = false
 	flagDryRun = false
 	cfg = nil
+	commandStdin = os.Stdin
+
+	waitStdin = false
+	waitStdinField = ""
+	injectGetStdin = false
+	injectGetStdinField = ""
+	injectFilesStdin = false
+	injectFilesStdinField = ""
+	injectDownloadStdin = false
+	injectDownloadStdinField = ""
+	taskGetStdin = false
+	taskGetStdinField = ""
+	taskLogsStdin = false
+	taskLogsStdinField = ""
+	traceGetStdin = false
+	traceGetStdinField = ""
+	traceWatchStdin = false
+	traceWatchStdinField = ""
 }
 
 func captureStdIO(t *testing.T, fn func() error) (stdout string, stderr string, err error) {

--- a/AegisLab/src/cmd/aegisctl/cmd/wait.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/wait.go
@@ -11,8 +11,10 @@ import (
 )
 
 var (
-	waitTimeout  int
-	waitInterval int
+	waitTimeout    int
+	waitInterval   int
+	waitStdin      bool
+	waitStdinField string
 )
 
 var (
@@ -47,12 +49,18 @@ EXAMPLES:
     --benchmark-name otel-demo-bench --benchmark-tag 1.0.0 \
     --interval 10 --pre-duration 5 | \
     jq -r '.items[0].trace_id' | xargs aegisctl wait`,
-	Args: exactArgs(1, "wait <trace-id|task-id>"),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		return runStdinItems("wait", "wait <trace-id|task-id>", args, stdinOptions{
+			enabled: waitStdin,
+			field:   waitStdinField,
+		}, runWait)
+	},
+}
+
+func runWait(id string) error {
 		if err := requireAPIContext(true); err != nil {
 			return err
 		}
-		id := args[0]
 		c := newClient()
 
 		// Determine resource type: try trace first, then task.
@@ -103,7 +111,6 @@ EXAMPLES:
 
 			time.Sleep(interval)
 		}
-	},
 }
 
 // detectResourceType probes the API to determine if the id refers to a trace
@@ -167,4 +174,5 @@ func isTerminal(resourceType, state string) bool {
 func init() {
 	waitCmd.Flags().IntVar(&waitTimeout, "timeout", 600, "Maximum time to wait in seconds")
 	waitCmd.Flags().IntVar(&waitInterval, "interval", 5, "Poll interval in seconds")
+	addStdinFlags(waitCmd, &waitStdin, &waitStdinField)
 }

--- a/AegisLab/src/cmd/aegisctl/cmd/wait.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/wait.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	waitTimeout    int
-	waitInterval   int
-	waitStdin      bool
-	waitStdinField string
+	waitTimeout       int
+	waitInterval      int
+	waitStdin         bool
+	waitStdinField    string
+	waitStdinFailFast bool
 )
 
 var (
@@ -51,8 +52,9 @@ EXAMPLES:
     jq -r '.items[0].trace_id' | xargs aegisctl wait`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runStdinItems("wait", "wait <trace-id|task-id>", args, stdinOptions{
-			enabled: waitStdin,
-			field:   waitStdinField,
+			enabled:  waitStdin,
+			field:    waitStdinField,
+			failFast: waitStdinFailFast,
 		}, runWait)
 	},
 }
@@ -174,5 +176,5 @@ func isTerminal(resourceType, state string) bool {
 func init() {
 	waitCmd.Flags().IntVar(&waitTimeout, "timeout", 600, "Maximum time to wait in seconds")
 	waitCmd.Flags().IntVar(&waitInterval, "interval", 5, "Poll interval in seconds")
-	addStdinFlags(waitCmd, &waitStdin, &waitStdinField)
+	addStdinFlags(waitCmd, &waitStdin, &waitStdinField, &waitStdinFailFast)
 }

--- a/AegisLab/src/cmd/aegisctl/output/output.go
+++ b/AegisLab/src/cmd/aegisctl/output/output.go
@@ -17,6 +17,7 @@ type OutputFormat string
 const (
 	FormatTable OutputFormat = "table"
 	FormatJSON  OutputFormat = "json"
+	FormatNDJSON OutputFormat = "ndjson"
 )
 
 // PrintJSON writes v as indented JSON to stdout.

--- a/AegisLab/src/internal/cli/stdin/parser.go
+++ b/AegisLab/src/internal/cli/stdin/parser.go
@@ -1,0 +1,99 @@
+package stdin
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	defaultScanBuffer = 64 * 1024
+	maxScanBuffer     = 1024 * 1024
+)
+
+type ParseConfig struct {
+	Field          string
+	FallbackFields []string
+}
+
+func DefaultFields(commandPath string) []string {
+	switch strings.TrimSpace(commandPath) {
+	case "inject get", "inject files", "inject download":
+		return []string{"name"}
+	case "trace get", "trace watch":
+		return []string{"id"}
+	case "task get", "task logs":
+		return []string{"id"}
+	case "wait":
+		return []string{"trace_id", "id"}
+	default:
+		return nil
+	}
+}
+
+func Parse(r io.Reader, cfg ParseConfig) ([]string, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, defaultScanBuffer), maxScanBuffer)
+
+	var (
+		items    []string
+		modeJSON bool
+		modeSet  bool
+		lineNo   int
+	)
+	for scanner.Scan() {
+		lineNo++
+		raw := strings.TrimSpace(scanner.Text())
+		if raw == "" {
+			continue
+		}
+		if !modeSet {
+			modeJSON = strings.HasPrefix(raw, "{")
+			modeSet = true
+		}
+		if modeJSON {
+			item, err := parseJSONLine(raw, cfg, lineNo)
+			if err != nil {
+				return nil, err
+			}
+			items = append(items, item)
+			continue
+		}
+		items = append(items, raw)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read stdin: %w", err)
+	}
+	return items, nil
+}
+
+func parseJSONLine(raw string, cfg ParseConfig, lineNo int) (string, error) {
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return "", fmt.Errorf("parse stdin line %d as json: %w", lineNo, err)
+	}
+
+	fields := cfg.FallbackFields
+	if field := strings.TrimSpace(cfg.Field); field != "" {
+		fields = []string{field}
+	}
+	for _, field := range fields {
+		if value := strings.TrimSpace(stringValue(payload[field])); value != "" {
+			return value, nil
+		}
+	}
+
+	if len(fields) == 0 {
+		return "", fmt.Errorf("stdin line %d did not match a supported format", lineNo)
+	}
+	return "", fmt.Errorf("stdin line %d missing field %q", lineNo, strings.Join(fields, " or "))
+}
+
+func stringValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", v)
+}

--- a/AegisLab/src/internal/cli/stdin/parser_test.go
+++ b/AegisLab/src/internal/cli/stdin/parser_test.go
@@ -1,0 +1,39 @@
+package stdin
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBatchStdinParser(t *testing.T) {
+	t.Run("raw lines pass through", func(t *testing.T) {
+		items, err := Parse(strings.NewReader("trace-a\ntrace-b\n"), ParseConfig{})
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		if got, want := strings.Join(items, ","), "trace-a,trace-b"; got != want {
+			t.Fatalf("items = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("ndjson uses inferred fallback field", func(t *testing.T) {
+		items, err := Parse(strings.NewReader("{\"trace_id\":\"trace-a\"}\n{\"id\":\"trace-b\"}\n"), ParseConfig{
+			FallbackFields: DefaultFields("wait"),
+		})
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		if got, want := strings.Join(items, ","), "trace-a,trace-b"; got != want {
+			t.Fatalf("items = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("ndjson missing field fails clearly", func(t *testing.T) {
+		_, err := Parse(strings.NewReader("{\"name\":\"inject-a\"}\n"), ParseConfig{
+			FallbackFields: DefaultFields("trace get"),
+		})
+		if err == nil || !strings.Contains(err.Error(), "missing field") {
+			t.Fatalf("err = %v, want missing field diagnostic", err)
+		}
+	})
+}

--- a/scripts/review-reports/issue-247-review.md
+++ b/scripts/review-reports/issue-247-review.md
@@ -1,0 +1,181 @@
+# Review for issue #247 — PR #266
+
+## Cascade preconditions
+| submodule | remote branch | SHA match | FF-able |
+|-----------|---------------|-----------|---------|
+| none (no submodule pointer changes in `origin/main...origin/workbuddy/issue-247`) | N/A | N/A | N/A |
+
+**cascade command**: `python - <<'PY'
+from pathlib import Path
+import subprocess
+changed = Path('/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-247')
+res = subprocess.run(['git','diff','--raw','origin/main...origin/workbuddy/issue-247'], cwd=changed, text=True, capture_output=True, check=True)
+submods = [line for line in res.stdout.splitlines() if line.startswith(':160000') or '\t' in line and '160000' in line]
+print('submodule_rows=' + str(len(submods)))
+print('raw_diff_lines=' + str(len(res.stdout.splitlines())))
+print('result=' + ('PASS:no-submodule-pointer-changes' if not submods else 'FAIL:submodule-pointer-changes-found'))
+PY`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+submodule_rows=0
+raw_diff_lines=12
+result=PASS:no-submodule-pointer-changes
+```
+
+## Per-AC verdicts
+### AC 1: "上述命令均新增 `--stdin` flag；与位置参数互斥（同时给 → EXIT=2）。"
+**verdict**: PASS
+**command**: `python - <<'PY'
+from pathlib import Path
+cmd_dir = Path('/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-247/AegisLab/src/cmd/aegisctl/cmd')
+checks = {
+    'inject.go': ['addStdinFlags(injectGetCmd', 'addStdinFlags(injectFilesCmd', 'addStdinFlags(injectDownloadCmd', 'runStdinItems("inject get"', 'runStdinItems("inject files"', 'runStdinItems("inject download"'],
+    'task.go': ['addStdinFlags(taskGetCmd', 'addStdinFlags(taskLogsCmd', 'runStdinItems("task get"', 'runStdinItems("task logs"'],
+    'trace.go': ['addStdinFlags(traceGetCmd', 'addStdinFlags(traceWatchCmd', 'runStdinItems("trace get"', 'runStdinItems("trace watch"'],
+    'wait.go': ['addStdinFlags(waitCmd', 'runStdinItems("wait"'],
+    'stdin_helpers.go': ['if len(args) > 0 {', 'usageErrorf("--stdin cannot be combined with positional arguments")'],
+}
+missing = []
+for rel, needles in checks.items():
+    text = (cmd_dir / rel).read_text()
+    for needle in needles:
+        if needle not in text:
+            missing.append(f'{rel}: {needle}')
+print('checked_files=' + str(len(checks)))
+print('missing=' + str(len(missing)))
+for item in missing:
+    print(item)
+if missing:
+    raise SystemExit(1)
+print('result=PASS:all-target-commands-wire---stdin-and-share-mutual-exclusion-helper')
+PY`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+checked_files=5
+missing=0
+result=PASS:all-target-commands-wire---stdin-and-share-mutual-exclusion-helper
+```
+
+### AC 2: "输入自动识别：单行非 JSON → 当 1 个 ID；以 `{` 开头 → NDJSON 对象，按 `--stdin-field` 取字段（默认推导：`inject *`→`name`、`trace *`→`id`、`task *`→`id`、`wait`→`trace_id` 或 `id`）。"
+**verdict**: PASS
+**command**: `python - <<'PY'
+from pathlib import Path
+text = Path('/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-247/AegisLab/src/internal/cli/stdin/parser.go').read_text()
+needles = [
+    'case "inject get", "inject files", "inject download":',
+    'return []string{"name"}',
+    'case "trace get", "trace watch":',
+    'return []string{"id"}',
+    'case "task get", "task logs":',
+    'case "wait":',
+    'return []string{"trace_id", "id"}',
+    'modeJSON = strings.HasPrefix(raw, "{")',
+    'items = append(items, raw)',
+    'parse stdin line %d as json',
+    'missing field %q',
+]
+missing = [n for n in needles if n not in text]
+print('checked_needles=' + str(len(needles)))
+print('missing=' + str(len(missing)))
+for item in missing:
+    print(item)
+if missing:
+    raise SystemExit(1)
+print('result=PASS:parser-defaults-and-line-vs-ndjson-dispatch-present')
+PY`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+checked_needles=11
+missing=0
+result=PASS:parser-defaults-and-line-vs-ndjson-dispatch-present
+```
+
+### AC 3: "退出码：全成功→0；全失败→首个 error 的码；部分成功→9；`--fail-fast` 立即停止并取首个失败码。"
+**verdict**: PASS
+**command**: `go test ./cmd/aegisctl/cmd -run 'TestRunItemsExitCodeProgressAndFailFast' -count=1`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok   	aegis/cmd/aegisctl/cmd	0.033s
+```
+
+### AC 4: "stderr per-item 进度行：`[i/N] <verb> <id>: ok|failed (<type>)`；`-q/--quiet` 抑制。"
+**verdict**: PASS
+**command**: `python - <<'PY'
+from pathlib import Path
+helpers = Path('/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-247/AegisLab/src/cmd/aegisctl/cmd/stdin_helpers.go').read_text()
+output = Path('/home/ddq/AoyangSpace/aegis/.workbuddy/worktrees/issue-247/AegisLab/src/cmd/aegisctl/output/output.go').read_text()
+needles = [
+    'output.PrintInfo(fmt.Sprintf("[%d/%d] %s %s: failed (%s)"',
+    'output.PrintInfo(fmt.Sprintf("[%d/%d] %s %s: ok"',
+    'if !Quiet {',
+]
+missing = [n for n in needles if (helpers + '\n' + output).find(n) == -1]
+print('checked_needles=' + str(len(needles)))
+print('missing=' + str(len(missing)))
+for item in missing:
+    print(item)
+if missing:
+    raise SystemExit(1)
+print('result=PASS:progress-format-and-quiet-suppression-implemented-via-PrintInfo')
+PY`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+checked_needles=3
+missing=0
+result=PASS:progress-format-and-quiet-suppression-implemented-via-PrintInfo
+```
+
+### AC 5: "一个 integration test（仅一个）：覆盖父 issue §3.6 的 pattern #1（`inject list -o ndjson | inject download --stdin --output-dir`）端到端跑通；其余 4 个 pattern 用 unit test 覆盖 stdin 解析层即可。"
+**verdict**: PASS
+**command**: `go test ./cmd/aegisctl/cmd -run TestInjectDownloadFromStdinPipe -count=1`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok   	aegis/cmd/aegisctl/cmd	0.033s
+```
+
+### Mini-AC 6 (plan verify #1): `cd AegisLab/src && go test ./internal/cli/stdin -run 'Test.*Stdin.*Parser' -count=1`
+**verdict**: PASS
+**command**: `go test ./internal/cli/stdin -run 'Test.*Stdin.*Parser' -count=1`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok   	aegis/internal/cli/stdin	0.009s
+```
+
+### Mini-AC 7 (plan verify #2): `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run 'Test.*(Inject|Task|Trace|Wait).*Stdin' -count=1`
+**verdict**: PASS
+**command**: `go test ./cmd/aegisctl/cmd -run 'Test.*(Inject|Task|Trace|Wait).*Stdin' -count=1`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok   	aegis/cmd/aegisctl/cmd	0.022s
+```
+
+### Mini-AC 8 (plan verify #3): `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run 'Test.*(RunItems|ExitCode|FailFast|Progress).*' -count=1`
+**verdict**: PASS
+**command**: `go test ./cmd/aegisctl/cmd -run 'Test.*(RunItems|ExitCode|FailFast|Progress).*' -count=1`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok   	aegis/cmd/aegisctl/cmd	0.017s
+```
+
+### Mini-AC 9 (plan verify #4): `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestInjectDownloadFromStdinPipe -count=1`
+**verdict**: PASS
+**command**: `go test ./cmd/aegisctl/cmd -run TestInjectDownloadFromStdinPipe -count=1`
+**exit**: 0
+**stdout** (first 20 lines):
+```text
+ok   	aegis/cmd/aegisctl/cmd	0.017s
+```
+
+## Overall
+- PASS: 9 / 9
+- FAIL: none
+- UNVERIFIABLE: none


### PR DESCRIPTION
## Summary
- add shared stdin parsing and batch execution support for the targeted aegisctl commands
- wire `--stdin`, `--stdin-field`, and `--fail-fast` into inject/task/trace/wait flows with per-item stderr progress
- cover the required `inject list -o ndjson | inject download --stdin --output-dir` pipe path end to end

## Subtask results
- subtask-1 (shared stdin parser utility + parser test) — DONE
  verify: `cd AegisLab/src && go test ./internal/cli/stdin -run 'Test.*Stdin.*Parser' -count=1` → exit 0, parser package passed with raw-line + NDJSON coverage
- subtask-2 (wire `--stdin` / `--stdin-field` with positional-arg exclusion) — DONE
  verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run 'Test.*(Inject|Task|Trace|Wait).*Stdin' -count=1` → exit 0, command stdin wiring tests passed
- subtask-3 (shared batch execution semantics) — DONE
  verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run 'Test.*(RunItems|ExitCode|FailFast|Progress).*' -count=1` → exit 0, batch progress / fail-fast / exit-code tests passed
- subtask-4 (pattern #1 integration) — DONE
  verify: `cd AegisLab/src && go test ./cmd/aegisctl/cmd -run TestInjectDownloadFromStdinPipe -count=1` → exit 0, list→download stdin pipe test passed

## Submodule changes
- AegisLab: implement stdin parser, batch runner, command flag wiring, NDJSON list support, and the required tests
- AegisLab-frontend: — not modified
- chaos-experiment: — not modified
- rcabench-platform: — not modified

## Workspace-level changes
- — none

## Known gaps / blockers
- none

Fixes #247