### PR TITLE
chore(seed): bump sn+media to 20260427-9397c2e (BSP fix)

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -251,7 +251,7 @@ containers:
               type: 0
               category: 2
               value_type: 0
-              default_value: 0.1.1
+              default_value: 20260427-9397c2e
               overridable: true
             - key: global.otel.endpoint
               type: 0
@@ -282,9 +282,9 @@ containers:
               overridable: true
             - key: global.defaultImageVersion
               type: 0
-              category: 1
+              category: 3
               value_type: 0
-              default_value: 20260423-61074ea
+              default_value: 20260427-9397c2e
               overridable: true
             - key: global.otel.endpoint
               type: 0

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -225,7 +225,7 @@ containers:
               type: 0
               category: 2
               value_type: 0
-              default_value: 0.1.1
+              default_value: 20260427-9397c2e
               overridable: true
             - key: global.otel.endpoint
               type: 0
@@ -256,9 +256,9 @@ containers:
               overridable: true
             - key: global.defaultImageVersion
               type: 0
-              category: 1
+              category: 3
               value_type: 0
-              default_value: 20260423-61074ea
+              default_value: 20260427-9397c2e
               overridable: true
             - key: global.otel.endpoint
               type: 0

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -256,7 +256,7 @@ containers:
               type: 0
               category: 2
               value_type: 0
-              default_value: 0.1.1
+              default_value: 20260427-9397c2e
               overridable: true
             - key: global.otel.endpoint
               type: 0
@@ -293,9 +293,9 @@ containers:
               overridable: true
             - key: global.defaultImageVersion
               type: 0
-              category: 1
+              category: 3
               value_type: 0
-              default_value: 20260423-61074ea
+              default_value: 20260427-9397c2e
               overridable: true
             - key: global.otel.endpoint
               type: 0

--- a/AegisLab/src/cmd/aegisctl/cmd/inject.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject.go
@@ -95,6 +95,14 @@ func newProjectScopedResolver() (*client.Resolver, error) {
 	return r, nil
 }
 
+func resolveInjectionID(arg string) (int, error) {
+	r, err := newProjectScopedResolver()
+	if err != nil {
+		return 0, err
+	}
+	return r.InjectionID(arg)
+}
+
 // ---------- inject root ----------
 
 var injectCmd = &cobra.Command{


### PR DESCRIPTION
## Summary
Activates BSP fix from LGU PR #54 (commit 9397c2e) by switching sn + media \`global.defaultImageVersion\` to the unified \`20260427-9397c2e\` tag built via \`benchmark-charts#5\` (\`tools/sync.sh\`).

## Verified
All 7 images live on docker.io/opspai:
- social-network-microservices, socialnetwork-loader, sn-openresty-thrift, media-frontend
- media-microservices, media-nginx, mediamicroservices-loader

## Schema
| chart | category | default_value |
|---|---|---|
| hotel-reservation | 1 (shared) | 20260423-61074ea (Go, unchanged) |
| social-network | 2 (own row) | 20260427-9397c2e |
| media-microservices | 3 (own row, NEW) | 20260427-9397c2e |

## Follow-up
- Live mysql: hot-update needed for media (category=3 row insert) + sn (update)
- Force redeploy of running sn/media ns to pick up new images (allocator-side reset)
- mm canary to verify orphan-span fix per aegis#236

🤖 Generated with [Claude Code](https://claude.com/claude-code)