### PR TITLE
fix(aegisctl): restore color helpers (post #257 fix)

### DIFF
--- a/AegisLab/src/cmd/aegisctl/output/output.go
+++ b/AegisLab/src/cmd/aegisctl/output/output.go
@@ -6,10 +6,57 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+
+	"golang.org/x/term"
 )
 
 // Quiet suppresses informational messages when true.
 var Quiet bool
+
+var colorDisabled = false
+
+// isTerminal is overridden in tests to emulate tty behavior.
+var isTerminal = term.IsTerminal
+
+// SetNoColor disables ANSI color codes regardless of TTY status.
+func SetNoColor(v bool) {
+	colorDisabled = v
+}
+
+// IsStdoutColor returns true when stdout should be colored.
+func IsStdoutColor() bool {
+	return supportsANSI(os.Stdout)
+}
+
+// IsStderrColor returns true when stderr should be colored.
+func IsStderrColor() bool {
+	return supportsANSI(os.Stderr)
+}
+
+func supportsANSI(file *os.File) bool {
+	if colorDisabled || os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	return isTerminal(int(file.Fd()))
+}
+
+// Colorize wraps s with ANSI color code when enabled for file.
+func Colorize(file *os.File, code, value string) string {
+	if !supportsANSI(file) {
+		return value
+	}
+	return "\x1b[" + code + "m" + value + "\x1b[0m"
+}
+
+// ColorGreen returns a green colored value when allowed.
+func ColorGreen(file *os.File, value string) string {
+	return Colorize(file, "32", value)
+}
+
+// ColorRed returns a red colored value when allowed.
+func ColorRed(file *os.File, value string) string {
+	return Colorize(file, "31", value)
+}
 
 // OutputFormat represents the output format type.
 type OutputFormat string


### PR DESCRIPTION
Hotfix: restore output color helpers dropped in #257 rebase.