### PR TITLE
fix(aegisctl): rename obsolete ExitCodeDecodeResponse in test

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/contract_expansion_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/contract_expansion_test.go
@@ -60,8 +60,8 @@ func TestSchemaDumpEmitsValidJSON(t *testing.T) {
 		t.Fatalf("schema document missing exit code 11 entry")
 	}
 
-	if got := exitCodeFor(fmt.Errorf("decode response: unexpected payload format")); got != ExitCodeDecodeResponse {
-		t.Fatalf("exit code for decode response error = %d, want %d", got, ExitCodeDecodeResponse)
+	if got := exitCodeFor(fmt.Errorf("decode response: unexpected payload format")); got != ExitCodeDecodeFailure {
+		t.Fatalf("exit code for decode response error = %d, want %d", got, ExitCodeDecodeFailure)
 	}
 }
 


### PR DESCRIPTION
Hotfix: test referenced removed constant; rename to ExitCodeDecodeFailure.