### PR TITLE
aegisctl: --all NDJSON streaming + project-list filter fix

### DIFF
--- a/.claude/skills/aegisctl/SKILL.md
+++ b/.claude/skills/aegisctl/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: aegisctl
+description: How to drive the aegis backend via the aegisctl CLI in an agent-friendly way. Use whenever a task involves listing / counting / filtering injections, traces, tasks, executions, datasets, containers, projects, or pedestals; whenever you'd otherwise reach for mysql / kubectl / redis-cli to inspect aegis state; whenever a recipe might paginate through results; or whenever the user asks for a quick distribution / summary like "how many succeeded vs failed", "看一下注入情况", "注入分布", "成功多少失败多少", "状态分布", "分布", "summary", "breakdown", "success rate", "list X", "show X". Trigger words aegisctl, inject list, trace list, task list, distribution, summary, count, query inject status, jq pipe.
+---
+
+# aegisctl — usage philosophy
+
+`aegisctl` is the supported surface for everything in the aegis control plane. The CLI is exhaustively self-documenting; this skill captures only what the help output cannot teach: how to **compose** commands and where the sharp edges are.
+
+## Read help first, always
+
+`aegisctl <noun> [verb] --help` is the source of truth for flags, accepted values, and exit semantics. Don't memorize subcommands from this skill — open `--help` for the resource you're about to touch. Most resources expose `list / get / search / create / delete / files / download` plus resource-specific verbs.
+
+## Compose with pipes; do not page in shell
+
+The CLI is designed for one-line composition with `jq`, `awk`, `sort | uniq -c`. The headline pattern is:
+
+```
+aegisctl <noun> list [filters] --all -o ndjson | jq … | sort | uniq -c
+```
+
+`--all` is supported on every list command (`inject`, `trace`, `task`, …). When set, it pages internally at the wire's max page size and streams **one record per line** to stdout. **No shell `for page in $(seq …)` loop should ever appear** — if you find yourself writing one, you're using the CLI wrong.
+
+Two consequences worth internalizing:
+
+1. **Format under `--all` must be `ndjson`.** `table` and `json` are refused because they buffer the full set, defeating the purpose. NDJSON keeps memory flat and lets `jq`/`awk` start producing results before the last page lands.
+2. **Pagination metadata is suppressed under `--all`.** Stdout is a clean record stream — no envelope, no header, nothing to strip with `tail -n +2`. Pipe straight into `jq`.
+
+For one-shot lookups (single record, top-N preview, "is the cluster healthy") use the default paged form — `--all` is overkill there.
+
+## Use names, not numeric ids
+
+Filter flags accept symbolic values everywhere it's been wired: `--state inject_success`, `--fault-type PodFailure`, `--project pair_diagnosis`. Numeric ids are still accepted for backward compatibility. **Always pass names** in agent-authored commands; they survive enum reordering and read like documentation. If a flag rejects a name, the error message tells you the valid set — read it.
+
+## NDJSON, JSON, table — pick by audience
+
+- `-o table` (default) — humans only. Don't pipe it.
+- `-o json` — single-shot inspection of one record's full structure (`get` and `--size 1` style probes).
+- `-o ndjson` — every other agent / scripting use. Required under `--all`.
+
+When in doubt, NDJSON. It's the only format whose contract is "one record per line, stable shape" — everything else is for human reading.
+
+## When you reach for mysql / kubectl / redis-cli, stop
+
+If the only way to answer the user's question is to query the database, kubectl-exec into a pod, or scan Redis directly, **that is an aegisctl gap, not a clever shortcut**. Flag it (open an issue, or surface it in your reply), then proceed with the workaround. The CLI is the contract; raw infrastructure pokes are a smell. Same applies to bypassing aegisctl for `helm` operations on pedestals — `aegisctl pedestal …` is the supported path.
+
+## Sharp edges to know about
+
+- **`inject list` returns hybrid batch parents alongside leaf injections.** A `batch-*` row carries its own state and fault_type and *belongs* in distribution counts. Filter them out (`select((.name | startswith("batch-")) | not)`) only when the user explicitly asks for leaf injections.
+- **Names of resources are stable across most resource lookups** (`aegisctl container get detector` resolves to the right id). Pass names; don't grep ids.
+- **Auth tokens may rotate after backend redeploy.** A 401 in the middle of a session usually means re-run `aegisctl auth login`. Tokens persist to `~/.aegisctl/config.yaml`.
+- **`--non-interactive` exists for a reason.** In CI, scripts, or any agent context that should not block on a prompt, set it. CLI fails fast instead of asking.
+- **Exit codes are classified.** `aegisctl wait <trace-id>` exits 0=ok / 5=fail / 6=timeout; many commands follow the same pattern. Branch on exit codes in scripts; don't grep stdout.
+
+## Quick cheatsheet (illustrative — not exhaustive)
+
+```
+# State distribution of every injection in a project
+aegisctl inject list --project pair_diagnosis --all -o ndjson | jq -r .state | sort | uniq -c
+
+# Filter then aggregate
+aegisctl inject list --project pair_diagnosis --all --fault-type NetworkLoss -o ndjson \
+  | jq -r .state | sort | uniq -c
+
+# Cross-tab in one line
+aegisctl task list --all -o ndjson | jq -r '"\(.type)\t\(.state)"' | sort | uniq -c | sort -rn
+
+# Top-N drill-down
+aegisctl trace list --project pair_diagnosis --all -o ndjson \
+  | jq -r 'select(.state=="Failed") | .id' | head -20
+```
+
+These are illustrative seeds — the right pipe for any specific question is built from `--help` + the patterns above, not from copying examples verbatim.

--- a/.claude/skills/inject-loop/SKILL.md
+++ b/.claude/skills/inject-loop/SKILL.md
@@ -5,6 +5,8 @@ description: Drive a closed-loop fault-injection campaign against an aegis-deplo
 
 # Fault-Injection Loop
 
+> **See also**: the `aegisctl` skill for general CLI composition (`--all -o ndjson | jq | sort | uniq -c`, name-not-id filters, never-loop-pages). Specific `aegisctl …` invocations below are illustrative — `aegisctl <noun> [verb] --help` is the source of truth and supersedes anything that drifts here.
+
 Drive a closed-loop fault-injection campaign: a stable candidate pool, K parallel submissions per round, and reward updates that bias the next round toward "interesting" faults.
 
 ## When to use

--- a/.claude/skills/onboard-benchmark-system/SKILL.md
+++ b/.claude/skills/onboard-benchmark-system/SKILL.md
@@ -5,6 +5,8 @@ description: How to onboard a new microservice benchmark (Online Boutique, Train
 
 # Onboard a benchmark system
 
+> **See also**: the `aegisctl` skill for general CLI composition (NDJSON streaming, name-not-id filters, when to *not* reach for raw kubectl/helm). Specific `aegisctl …` invocations below are illustrative — `aegisctl <noun> [verb] --help` is the source of truth and supersedes anything that drifts here.
+
 Goal: get a microservice workload (any of the ones listed in
 `chaos-experiment`'s `internal/systemconfig`, or a fresh one) to the point
 where you can run an injection and see the effect in ClickHouse traces.

--- a/.claude/skills/register-aegis-system/SKILL.md
+++ b/.claude/skills/register-aegis-system/SKILL.md
@@ -5,6 +5,8 @@ description: Methodology for making the aegis control plane aware of a newly add
 
 # Registering a new system with the aegis control plane
 
+> **See also**: the `aegisctl` skill for general CLI composition (NDJSON streaming, name-not-id filters, when to *not* reach for raw mysql/etcdctl). Specific `aegisctl …` invocations below are illustrative — `aegisctl <noun> [verb] --help` is the source of truth and supersedes anything that drifts here.
+
 The workload (pods, charts, OTel collectors) is only half of adding a new
 benchmark. The other half is telling the aegis **control plane** it exists.
 The control plane state lives in five separate places, each one silently

--- a/.claude/skills/regression-e2e/SKILL.md
+++ b/.claude/skills/regression-e2e/SKILL.md
@@ -5,6 +5,8 @@ description: Triage frame for end-to-end (E2E) test, smoke test, regression, and
 
 # Regression / E2E Triage
 
+> **See also**: the `aegisctl` skill for general CLI composition (NDJSON streaming, name-not-id filters). Specific `aegisctl …` invocations below are illustrative — `aegisctl <noun> [verb] --help` is the source of truth and supersedes anything that drifts here.
+
 Provide a short triage frame for E2E failures. Focus on likely problem classes and next inspection directions rather than detailed runbooks.
 
 ## Triage Order

--- a/.codex/skills/aegisctl/SKILL.md
+++ b/.codex/skills/aegisctl/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: aegisctl
+description: How to drive the aegis backend via the aegisctl CLI in an agent-friendly way. Use whenever a task involves listing / counting / filtering injections, traces, tasks, executions, datasets, containers, projects, or pedestals; whenever you'd otherwise reach for mysql / kubectl / redis-cli to inspect aegis state; whenever a recipe might paginate through results; or whenever the user asks for a quick distribution / summary like "how many succeeded vs failed", "看一下注入情况", "注入分布", "成功多少失败多少", "状态分布", "分布", "summary", "breakdown", "success rate", "list X", "show X". Trigger words aegisctl, inject list, trace list, task list, distribution, summary, count, query inject status, jq pipe.
+---
+
+# aegisctl — usage philosophy
+
+`aegisctl` is the supported surface for everything in the aegis control plane. The CLI is exhaustively self-documenting; this skill captures only what the help output cannot teach: how to **compose** commands and where the sharp edges are.
+
+## Read help first, always
+
+`aegisctl <noun> [verb] --help` is the source of truth for flags, accepted values, and exit semantics. Don't memorize subcommands from this skill — open `--help` for the resource you're about to touch. Most resources expose `list / get / search / create / delete / files / download` plus resource-specific verbs.
+
+## Compose with pipes; do not page in shell
+
+The CLI is designed for one-line composition with `jq`, `awk`, `sort | uniq -c`. The headline pattern is:
+
+```
+aegisctl <noun> list [filters] --all -o ndjson | jq … | sort | uniq -c
+```
+
+`--all` is supported on every list command (`inject`, `trace`, `task`, …). When set, it pages internally at the wire's max page size and streams **one record per line** to stdout. **No shell `for page in $(seq …)` loop should ever appear** — if you find yourself writing one, you're using the CLI wrong.
+
+Two consequences worth internalizing:
+
+1. **Format under `--all` must be `ndjson`.** `table` and `json` are refused because they buffer the full set, defeating the purpose. NDJSON keeps memory flat and lets `jq`/`awk` start producing results before the last page lands.
+2. **Pagination metadata is suppressed under `--all`.** Stdout is a clean record stream — no envelope, no header, nothing to strip with `tail -n +2`. Pipe straight into `jq`.
+
+For one-shot lookups (single record, top-N preview, "is the cluster healthy") use the default paged form — `--all` is overkill there.
+
+## Use names, not numeric ids
+
+Filter flags accept symbolic values everywhere it's been wired: `--state inject_success`, `--fault-type PodFailure`, `--project pair_diagnosis`. Numeric ids are still accepted for backward compatibility. **Always pass names** in agent-authored commands; they survive enum reordering and read like documentation. If a flag rejects a name, the error message tells you the valid set — read it.
+
+## NDJSON, JSON, table — pick by audience
+
+- `-o table` (default) — humans only. Don't pipe it.
+- `-o json` — single-shot inspection of one record's full structure (`get` and `--size 1` style probes).
+- `-o ndjson` — every other agent / scripting use. Required under `--all`.
+
+When in doubt, NDJSON. It's the only format whose contract is "one record per line, stable shape" — everything else is for human reading.
+
+## When you reach for mysql / kubectl / redis-cli, stop
+
+If the only way to answer the user's question is to query the database, kubectl-exec into a pod, or scan Redis directly, **that is an aegisctl gap, not a clever shortcut**. Flag it (open an issue, or surface it in your reply), then proceed with the workaround. The CLI is the contract; raw infrastructure pokes are a smell. Same applies to bypassing aegisctl for `helm` operations on pedestals — `aegisctl pedestal …` is the supported path.
+
+## Sharp edges to know about
+
+- **`inject list` returns hybrid batch parents alongside leaf injections.** A `batch-*` row carries its own state and fault_type and *belongs* in distribution counts. Filter them out (`select((.name | startswith("batch-")) | not)`) only when the user explicitly asks for leaf injections.
+- **Names of resources are stable across most resource lookups** (`aegisctl container get detector` resolves to the right id). Pass names; don't grep ids.
+- **Auth tokens may rotate after backend redeploy.** A 401 in the middle of a session usually means re-run `aegisctl auth login`. Tokens persist to `~/.aegisctl/config.yaml`.
+- **`--non-interactive` exists for a reason.** In CI, scripts, or any agent context that should not block on a prompt, set it. CLI fails fast instead of asking.
+- **Exit codes are classified.** `aegisctl wait <trace-id>` exits 0=ok / 5=fail / 6=timeout; many commands follow the same pattern. Branch on exit codes in scripts; don't grep stdout.
+
+## Quick cheatsheet (illustrative — not exhaustive)
+
+```
+# State distribution of every injection in a project
+aegisctl inject list --project pair_diagnosis --all -o ndjson | jq -r .state | sort | uniq -c
+
+# Filter then aggregate
+aegisctl inject list --project pair_diagnosis --all --fault-type NetworkLoss -o ndjson \
+  | jq -r .state | sort | uniq -c
+
+# Cross-tab in one line
+aegisctl task list --all -o ndjson | jq -r '"\(.type)\t\(.state)"' | sort | uniq -c | sort -rn
+
+# Top-N drill-down
+aegisctl trace list --project pair_diagnosis --all -o ndjson \
+  | jq -r 'select(.state=="Failed") | .id' | head -20
+```
+
+These are illustrative seeds — the right pipe for any specific question is built from `--help` + the patterns above, not from copying examples verbatim.

--- a/.codex/skills/inject-loop/SKILL.md
+++ b/.codex/skills/inject-loop/SKILL.md
@@ -5,6 +5,8 @@ description: Drive a closed-loop fault-injection campaign against an aegis-deplo
 
 # Fault-Injection Loop
 
+> **See also**: the `aegisctl` skill for general CLI composition (`--all -o ndjson | jq | sort | uniq -c`, name-not-id filters, never-loop-pages). Specific `aegisctl …` invocations below are illustrative — `aegisctl <noun> [verb] --help` is the source of truth and supersedes anything that drifts here.
+
 Drive a closed-loop fault-injection campaign: a stable candidate pool, K parallel submissions per round, and reward updates that bias the next round toward "interesting" faults.
 
 ## When to use

--- a/.codex/skills/onboard-benchmark-system/SKILL.md
+++ b/.codex/skills/onboard-benchmark-system/SKILL.md
@@ -1,17 +1,11 @@
 ---
 name: onboard-benchmark-system
-description: >-
-  How to onboard a new microservice benchmark (Online Boutique, TrainTicket,
-  Hotel Reservation, Social Network, otel-demo, etc.) onto the aegis kind
-  cluster so it can be chaos-injected and observed via the OTLP -> ClickHouse
-  pipeline. Use this whenever the user asks to "add a new system", "run a
-  demo", "onboard <benchmark>", "inject chaos on X service", or wants to
-  gather fault-injection trace data on any workload that isn't already wired
-  up. Also use when diagnosing why a newly deployed demo isn't emitting traces
-  or why chaos isn't landing.
+description: How to onboard a new microservice benchmark (Online Boutique, TrainTicket, Hotel Reservation, Social Network, otel-demo, etc.) onto the aegis kind cluster so it can be chaos-injected and observed via the OTLP → ClickHouse pipeline. Use this whenever the user asks to "add a new system", "run a demo", "onboard <benchmark>", "inject chaos on X service", or wants to gather fault-injection trace data on any workload that isn't already wired up. Also use when diagnosing why a newly deployed demo isn't emitting traces or why chaos isn't landing.
 ---
 
 # Onboard a benchmark system
+
+> **See also**: the `aegisctl` skill for general CLI composition (NDJSON streaming, name-not-id filters, when to *not* reach for raw kubectl/helm). Specific `aegisctl …` invocations below are illustrative — `aegisctl <noun> [verb] --help` is the source of truth and supersedes anything that drifts here.
 
 Goal: get a microservice workload (any of the ones listed in
 `chaos-experiment`'s `internal/systemconfig`, or a fresh one) to the point

--- a/.codex/skills/register-aegis-system/SKILL.md
+++ b/.codex/skills/register-aegis-system/SKILL.md
@@ -1,20 +1,11 @@
 ---
 name: register-aegis-system
-description: >-
-  Methodology for making the aegis control plane aware of a newly added
-  microservice benchmark - what layers of the platform (systemconfig
-  registry, etcd dynamic config, DB seed, helm chart config, OTel pipeline)
-  must be told about the new system, and what fails silently if any layer is
-  skipped. Use whenever the user wants to "add a new benchmark", "register a
-  new system", "support X workload in aegis", "做一个新的 benchmark",
-  "加一个新的微服务", or is debugging why a freshly-deployed workload isn't
-  selectable in the guided inject flow, returns 500 on submit, or goes to `0
-  enabled` after backend restart. Complements `onboard-benchmark-system`
-  (which covers deploying the workload and wiring OTLP); this skill covers the
-  aegis-side registration that most new-benchmark failures trace back to.
+description: Methodology for making the aegis control plane aware of a newly added microservice benchmark — what layers of the platform (systemconfig registry, etcd dynamic config, DB seed, helm chart config, OTel pipeline) must be told about the new system, and what fails silently if any layer is skipped. Use whenever the user wants to "add a new benchmark", "register a new system", "support X workload in aegis", "做一个新的 benchmark", "加一个新的微服务", or is debugging why a freshly-deployed workload isn't selectable in the guided inject flow, returns 500 on submit, or goes to `0 enabled` after backend restart. Complements `onboard-benchmark-system` (which covers deploying the workload and wiring OTLP); this skill covers the aegis-side registration that most new-benchmark failures trace back to.
 ---
 
 # Registering a new system with the aegis control plane
+
+> **See also**: the `aegisctl` skill for general CLI composition (NDJSON streaming, name-not-id filters, when to *not* reach for raw mysql/etcdctl). Specific `aegisctl …` invocations below are illustrative — `aegisctl <noun> [verb] --help` is the source of truth and supersedes anything that drifts here.
 
 The workload (pods, charts, OTel collectors) is only half of adding a new
 benchmark. The other half is telling the aegis **control plane** it exists.

--- a/.codex/skills/regression-e2e/SKILL.md
+++ b/.codex/skills/regression-e2e/SKILL.md
@@ -1,17 +1,11 @@
 ---
 name: regression-e2e
-description: >-
-  Triage frame for end-to-end (E2E) test, smoke test, regression, and
-  fault-injection validation failures. Use when the user reports an
-  E2E/smoke/regression run is broken, a fault-injection flow fails
-  mid-pipeline, a previously-green test is now flaky, or asks to "triage",
-  "debug the E2E", "why is the regression failing", "help me figure out what
-  broke the smoke test". Produces a short hypothesis list and next inspection
-  surfaces rather than a full runbook. Trigger words: e2e, end-to-end,
-  regression, smoke test, fault injection validation, flaky test, test broke.
+description: Triage frame for end-to-end (E2E) test, smoke test, regression, and fault-injection validation failures. Use when the user reports an E2E/smoke/regression run is broken, a fault-injection flow fails mid-pipeline, a previously-green test is now flaky, or asks to "triage", "debug the E2E", "why is the regression failing", "help me figure out what broke the smoke test". Produces a short hypothesis list and next inspection surfaces rather than a full runbook. Trigger words: e2e, end-to-end, regression, smoke test, fault injection validation, flaky test, test broke.
 ---
 
 # Regression / E2E Triage
+
+> **See also**: the `aegisctl` skill for general CLI composition (NDJSON streaming, name-not-id filters). Specific `aegisctl …` invocations below are illustrative — `aegisctl <noun> [verb] --help` is the source of truth and supersedes anything that drifts here.
 
 Provide a short triage frame for E2E failures. Focus on likely problem classes and next inspection directions rather than detailed runbooks.
 

--- a/AegisLab/src/cmd/aegisctl/cmd/inject.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject.go
@@ -145,7 +145,20 @@ var (
 	injectListLabels    string
 	injectListPage      int
 	injectListSize      int
+	injectListAll       bool
 )
+
+type injectListItem struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	State     string `json:"state"`
+	FaultType string `json:"fault_type"`
+	StartTime string `json:"start_time"`
+	Labels    []struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	} `json:"labels"`
+}
 
 var injectListCmd = &cobra.Command{
 	Use:   "list",
@@ -162,30 +175,26 @@ var injectListCmd = &cobra.Command{
 		}
 
 		c := newClient()
-		q := fmt.Sprintf("/api/v2/projects/%d/injections?page=%d&size=%d", pid, injectListPage, injectListSize)
-		if stateParam != "" {
-			q += "&state=" + stateParam
-		}
-		if injectListFaultType != "" {
-			q += "&fault_type=" + injectListFaultType
-		}
-		if injectListLabels != "" {
-			q += "&labels=" + injectListLabels
+		basePath := fmt.Sprintf("/api/v2/projects/%d/injections", pid)
+		baseParams := map[string]string{
+			"state":      stateParam,
+			"fault_type": injectListFaultType,
+			"labels":     injectListLabels,
 		}
 
-		type listItem struct {
-			ID        int    `json:"id"`
-			Name      string `json:"name"`
-			State     string `json:"state"`
-			FaultType string `json:"fault_type"`
-			StartTime string `json:"start_time"`
-			Labels    []struct {
-				Key   string `json:"key"`
-				Value string `json:"value"`
-			} `json:"labels"`
+		if injectListAll {
+			if output.OutputFormat(flagOutput) != output.FormatNDJSON {
+				return usageErrorf("--all requires --output ndjson (table/json buffer the full result set; use ndjson for streaming)")
+			}
+			return streamListAllNDJSON[injectListItem](c, basePath, baseParams)
 		}
 
-		var resp client.APIResponse[client.PaginatedData[listItem]]
+		q := basePath + fmt.Sprintf("?page=%d&size=%d", injectListPage, injectListSize)
+		if extra := buildQueryParams(baseParams); extra != "" {
+			q += "&" + extra
+		}
+
+		var resp client.APIResponse[client.PaginatedData[injectListItem]]
 		if err := c.Get(q, &resp); err != nil {
 			return err
 		}
@@ -959,6 +968,7 @@ func init() {
 	injectListCmd.Flags().StringVar(&injectListLabels, "labels", "", "Filter by labels (key=val,...)")
 	injectListCmd.Flags().IntVar(&injectListPage, "page", 1, "Page number")
 	injectListCmd.Flags().IntVar(&injectListSize, "size", 20, "Page size; must be one of "+pageSizeFlagHelp())
+	injectListCmd.Flags().BoolVar(&injectListAll, "all", false, "Stream every page as NDJSON to stdout (ignores --page/--size; requires --output ndjson)")
 
 	injectSearchCmd.Flags().StringVar(&injectSearchNamePattern, "name-pattern", "", "Name pattern to search for")
 	injectSearchCmd.Flags().StringVar(&injectSearchLabels, "labels", "", "Labels to filter (key=val,...)")

--- a/AegisLab/src/cmd/aegisctl/cmd/paginate.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/paginate.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+
+	"aegis/cmd/aegisctl/client"
+)
+
+const (
+	streamAllPageSize = 100
+	streamAllMaxPages = 1000
+)
+
+// streamListAllNDJSON pages basePath at size=streamAllPageSize until the result
+// set is exhausted, writing one compact-JSON line per item to stdout. Existing
+// filter params should be supplied via baseParams; "page" and "size" entries
+// are overwritten on each iteration.
+//
+// Stops with an error if more than streamAllMaxPages are scanned (safety cap
+// against runaway iteration). Pagination metadata is intentionally not emitted
+// — under --all the caller wants a flat stream of records.
+func streamListAllNDJSON[T any](c *client.Client, basePath string, baseParams map[string]string) error {
+	return streamListAllNDJSONFiltered[T](c, basePath, baseParams, nil)
+}
+
+// streamListAllNDJSONFiltered is streamListAllNDJSON with an optional
+// per-item predicate applied client-side after each page is fetched. Items
+// for which keep returns false are dropped silently. Termination still
+// follows server-side pagination (a short page ends iteration even if all
+// items were filtered out).
+func streamListAllNDJSONFiltered[T any](c *client.Client, basePath string, baseParams map[string]string, keep func(T) bool) error {
+	if baseParams == nil {
+		baseParams = map[string]string{}
+	}
+	baseParams["size"] = strconv.Itoa(streamAllPageSize)
+
+	enc := json.NewEncoder(os.Stdout)
+	for page := 1; page <= streamAllMaxPages; page++ {
+		baseParams["page"] = strconv.Itoa(page)
+		path := basePath
+		if q := buildQueryParams(baseParams); q != "" {
+			path += "?" + q
+		}
+
+		var resp client.APIResponse[client.PaginatedData[T]]
+		if err := c.Get(path, &resp); err != nil {
+			return err
+		}
+		for _, item := range resp.Data.Items {
+			if keep != nil && !keep(item) {
+				continue
+			}
+			if err := enc.Encode(item); err != nil {
+				return err
+			}
+		}
+		if len(resp.Data.Items) < streamAllPageSize {
+			return nil
+		}
+	}
+	return fmt.Errorf("--all stopped at safety cap of %d pages (%d records); narrow filters or paginate manually",
+		streamAllMaxPages, streamAllMaxPages*streamAllPageSize)
+}

--- a/AegisLab/src/cmd/aegisctl/cmd/task.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/task.go
@@ -45,6 +45,7 @@ var taskListType string
 var taskListPage int
 var taskListSize int
 var taskListOverdue bool
+var taskListAll bool
 
 var taskListCmd = &cobra.Command{
 	Use:   "list",
@@ -52,13 +53,33 @@ var taskListCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		c := newClient()
 
-		path := "/api/v2/tasks"
+		basePath := "/api/v2/tasks"
+		baseParams := map[string]string{
+			"state": taskListState,
+			"type":  taskListType,
+		}
+
+		if taskListAll {
+			if output.OutputFormat(flagOutput) != output.FormatNDJSON {
+				return fmt.Errorf("--all requires --output ndjson (table/json buffer the full result set; use ndjson for streaming)")
+			}
+			var keep func(map[string]any) bool
+			if taskListOverdue {
+				nowEpoch := time.Now().Unix()
+				keep = func(item map[string]any) bool {
+					return stringField(item, "state") == "Pending" && execTimeField(item) <= nowEpoch
+				}
+			}
+			return streamListAllNDJSONFiltered[map[string]any](c, basePath, baseParams, keep)
+		}
+
 		params := buildQueryParams(map[string]string{
 			"state": taskListState,
 			"type":  taskListType,
 			"page":  intToString(taskListPage),
 			"size":  intToString(taskListSize),
 		})
+		path := basePath
 		if params != "" {
 			path += "?" + params
 		}
@@ -348,6 +369,7 @@ func init() {
 	taskListCmd.Flags().StringVar(&taskListType, "type", "", "Filter by type (BuildContainer, RestartPedestal, FaultInjection, RunAlgorithm, BuildDatapack, CollectResult, CronJob)")
 	taskListCmd.Flags().IntVar(&taskListPage, "page", 0, "Page number")
 	taskListCmd.Flags().IntVar(&taskListSize, "size", 0, "Page size")
+	taskListCmd.Flags().BoolVar(&taskListAll, "all", false, "Stream every page as NDJSON to stdout (ignores --page/--size; requires --output ndjson)")
 	taskListCmd.Flags().BoolVar(&taskListOverdue, "overdue", false, "Show only Pending tasks whose execute_time has passed (WAIT < 0)")
 
 	taskLogsCmd.Flags().BoolVarP(&taskLogsFollow, "follow", "f", false, "Follow log output")

--- a/AegisLab/src/cmd/aegisctl/cmd/trace.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/trace.go
@@ -57,6 +57,7 @@ var (
 	traceListSize    int
 	traceListFormat  string
 	traceListColumns string
+	traceListAll     bool
 )
 
 // traceColumnExtractors maps short column names to a function that pulls the
@@ -180,7 +181,20 @@ Columns available for --columns (TSV only):
 			}
 		}
 
-		path := "/api/v2/traces"
+		basePath := "/api/v2/traces"
+		baseParams := map[string]string{
+			"project_id": projectIDStr,
+			"state":      traceListState,
+			"group_id":   traceListGroupID,
+		}
+
+		if traceListAll {
+			if format != "ndjson" {
+				return fmt.Errorf("--all requires --format/--output ndjson (table/json/tsv buffer the full result set; use ndjson for streaming)")
+			}
+			return streamListAllNDJSON[map[string]any](c, basePath, baseParams)
+		}
+
 		params := buildQueryParams(map[string]string{
 			"project_id": projectIDStr,
 			"state":      traceListState,
@@ -188,6 +202,7 @@ Columns available for --columns (TSV only):
 			"page":       intToString(traceListPage),
 			"size":       intToString(traceListSize),
 		})
+		path := basePath
 		if params != "" {
 			path += "?" + params
 		}
@@ -534,6 +549,7 @@ func init() {
 	traceListCmd.Flags().StringVar(&traceListGroupID, "group-id", "", "Filter by group ID")
 	traceListCmd.Flags().IntVar(&traceListPage, "page", 0, "Page number")
 	traceListCmd.Flags().IntVar(&traceListSize, "size", 0, "Page size")
+	traceListCmd.Flags().BoolVar(&traceListAll, "all", false, "Stream every page as NDJSON to stdout (ignores --page/--size; requires --output ndjson)")
 	traceListCmd.Flags().StringVar(&traceListFormat, "format", "", "Output format: table|json|tsv (overrides -o)")
 	traceListCmd.Flags().StringVar(&traceListColumns, "columns", "",
 		"Comma-separated columns for --format tsv (default: id,state,last_event). "+

--- a/AegisLab/src/module/injection/api_types.go
+++ b/AegisLab/src/module/injection/api_types.go
@@ -3,6 +3,7 @@ package injection
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -143,17 +144,28 @@ type ListInjectionFilters struct {
 // ListInjectionReq represents the request to list injections with various filters
 type ListInjectionReq struct {
 	dto.PaginationReq
-	Type      *chaos.ChaosType      `form:"fault_type" binding:"omitempty"`
+	TypeRaw   string                `form:"fault_type" binding:"omitempty"`
 	Category  *chaos.SystemType     `form:"category" binding:"omitempty"`
 	Benchmark string                `form:"benchmark" binding:"omitempty"`
 	State     *consts.DatapackState `form:"state" binding:"omitempty"`
 	Status    *consts.StatusType    `form:"status" binding:"omitempty"`
 	Labels    []string              `form:"labels" binding:"omitempty"`
+
+	// Type is resolved from TypeRaw during Validate; not directly form-bound.
+	// Accepts either a chaos type name (e.g. "NetworkLoss") or its numeric id.
+	Type *chaos.ChaosType `form:"-"`
 }
 
 func (req *ListInjectionReq) Validate() error {
 	if err := req.PaginationReq.Validate(); err != nil {
 		return err
+	}
+	if req.TypeRaw != "" {
+		ct, err := parseFaultTypeParam(req.TypeRaw)
+		if err != nil {
+			return err
+		}
+		req.Type = &ct
 	}
 	if err := validateChaosType(req.Type); err != nil {
 		return err
@@ -916,6 +928,20 @@ type DatapackFilesResp struct {
 	Files     []DatapackFileItem `json:"files"`
 	FileCount int                `json:"file_count"` // Number of files (excluding directories)
 	DirCount  int                `json:"dir_count"`  // Number of directories
+}
+
+// parseFaultTypeParam accepts either a chaos type name (e.g. "NetworkLoss")
+// or its numeric id (e.g. "18") and returns the corresponding ChaosType.
+// Membership in ChaosTypeMap is enforced by validateChaosType after this
+// returns, so unknown numeric ids fall through to the standard error path.
+func parseFaultTypeParam(raw string) (chaos.ChaosType, error) {
+	if i, err := strconv.Atoi(raw); err == nil {
+		return chaos.ChaosType(i), nil
+	}
+	if v, ok := chaos.ChaosNameMap[raw]; ok {
+		return v, nil
+	}
+	return 0, fmt.Errorf("invalid fault_type %q: expected name (e.g. NetworkLoss) or numeric id", raw)
 }
 
 // validateChaosType checks if the provided chaos type is valid

--- a/AegisLab/src/module/injection/repository.go
+++ b/AegisLab/src/module/injection/repository.go
@@ -398,11 +398,33 @@ func (r *Repository) listInjectionsView(limit, offset int, filterOptions *ListIn
 	return injections, total, nil
 }
 
-func (r *Repository) listProjectInjectionsView(projectID, limit, offset int) ([]model.FaultInjection, int64, error) {
+func (r *Repository) listProjectInjectionsView(projectID, limit, offset int, filterOptions *ListInjectionFilters) ([]model.FaultInjection, int64, error) {
 	baseQuery := r.db.Model(&model.FaultInjection{}).
 		Joins("JOIN tasks ON tasks.id = fault_injections.task_id").
 		Joins("JOIN traces on traces.id = tasks.trace_id").
 		Where("traces.project_id = ? AND fault_injections.status != ?", projectID, consts.CommonDeleted)
+
+	if filterOptions != nil {
+		if filterOptions.FaultType != nil {
+			baseQuery = baseQuery.Where("fault_injections.fault_type = ?", *filterOptions.FaultType)
+		}
+		if filterOptions.Benchmark != "" {
+			baseQuery = baseQuery.Where("fault_injections.benchmark = ?", filterOptions.Benchmark)
+		}
+		if filterOptions.State != nil {
+			baseQuery = baseQuery.Where("fault_injections.state = ?", *filterOptions.State)
+		}
+		if filterOptions.Status != nil {
+			baseQuery = baseQuery.Where("fault_injections.status = ?", *filterOptions.Status)
+		}
+		for _, condition := range filterOptions.LabelConditions {
+			subQuery := r.db.Table("fault_injection_labels fil").
+				Select("fil.fault_injection_id").
+				Joins("JOIN labels ON labels.id = fil.label_id").
+				Where("labels.label_key = ? AND labels.label_value = ?", condition["key"], condition["value"])
+			baseQuery = baseQuery.Where("fault_injections.id IN (?)", subQuery)
+		}
+	}
 
 	var (
 		injections []model.FaultInjection

--- a/AegisLab/src/module/injection/service.go
+++ b/AegisLab/src/module/injection/service.go
@@ -108,7 +108,7 @@ func (s *Service) ListProjectInjections(ctx context.Context, req *ListInjectionR
 	}
 
 	limit, offset := req.ToGormParams()
-	injections, total, err := s.repo.listProjectInjectionsView(projectID, limit, offset)
+	injections, total, err := s.repo.listProjectInjectionsView(projectID, limit, offset, req.ToFilterOptions())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list injections for project %d: %w", projectID, err)
 	}


### PR DESCRIPTION
## Summary

- **Backend fix** — `GET /api/v2/projects/:id/injections` was silently dropping `state`, `fault_type`, and `labels` filters. Project-scoped service didn't pass `ToFilterOptions()` to the repo. Now plumbed through, mirroring the global `ListInjections` path. Independently, `fault_type` only accepted numeric chaos-type ids; passing a name (`NetworkLoss`) returned 400 ParseInt. Split `TypeRaw` (form-bound string) from `Type` (resolved during `Validate` via `ChaosNameMap` or `Atoi`), so both name and numeric id work. Backward-compatible.
- **CLI streaming** — Add `--all` to `aegisctl inject/trace/task list`. Internally pages at size=100 and streams one compact-JSON record per line on stdout. `--page` / `--size` ignored under `--all`; pagination metadata suppressed; safety cap at 100k records. Refuses non-`ndjson` formats (`table`/`json` buffer the full set). `task list --overdue` still works under `--all` via a per-item predicate.
- **Skills** — New `aegisctl` skill captures CLI composition philosophy (read `--help` first, prefer name over id, `--all -o ndjson | jq | sort | uniq -c`, when not to reach for `mysql`/`kubectl`). `inject-loop`, `register-aegis-system`, `regression-e2e`, `onboard-benchmark-system` get a one-line cross-reference and a reminder that specific `aegisctl …` invocations in their bodies are illustrative — `aegisctl <noun> [verb] --help` is the source of truth.

## Why now

Distribution queries previously required a 12-page shell `for` loop and `jq` glue. `--all` makes them one-liners:

```bash
aegisctl inject list --project pair_diagnosis --all -o ndjson | jq -r .state | sort | uniq -c
aegisctl inject list --project pair_diagnosis --all --fault-type NetworkLoss -o ndjson | jq -r .state | sort | uniq -c
aegisctl task  list  --all       -o ndjson | jq -r '"\(.type)\t\(.state)"' | sort | uniq -c
```

The state/fault_type filter fix was discovered while testing the streaming pipeline — passing `--state inject_success` returned all 1102 records on the project endpoint instead of the 138 expected.

## Verified on cloud

Ran on the VKE `pair_diagnosis` project after rolling api-gateway only (worker untouched, helm values unchanged). All 4 paths checked:
- `--state build_failed` → 199 (matches direct DB count)
- `--state inject_success` → 138
- `--fault-type NetworkLoss` (by name) → 13
- `--fault-type 18` (by numeric id) → 13 (same — backward compat holds)
- `--state detector_success --fault-type PodFailure` (combined) → 255
- Invalid name → friendly 400 with hint
- `--all` parity: inject 1102, trace 1361, task 4860+ — matches prior paged sums

## Test plan

- [ ] Backend unit tests still pass (`cd src && go test ./module/injection/... -v`)
- [ ] `cd src && go build -tags duckdb_arrow -o /dev/null ./main.go` (P0 gate)
- [ ] `cd src && go build -o /tmp/aegisctl ./cmd/aegisctl` (CLI gate)
- [ ] `golangci-lint run` clean on touched files
- [ ] Manual smoke against staging: `aegisctl inject list --project pair_diagnosis --all --state build_failed -o ndjson | wc -l` matches table-form count

🤖 Generated with [Claude Code](https://claude.com/claude-code)