### PR TITLE
ci(schema-diff): fix cwd so go build can find the module

### DIFF
--- a/.github/workflows/aegisctl-schema-diff.yml
+++ b/.github/workflows/aegisctl-schema-diff.yml
@@ -48,7 +48,10 @@ jobs:
             local repo_root=$1
             local out_file=$2
 
-            (cd "$repo_root/AegisLab" && go build -o "$build_bin" ./src/cmd/aegisctl)
+            # `go build` must run from the module root (AegisLab/src, where
+            # go.mod lives). Running it from AegisLab/ walks up to the repo
+            # root and fails with "cannot find main module".
+            (cd "$repo_root/AegisLab/src" && go build -o "$build_bin" ./cmd/aegisctl)
             (cd "$repo_root/AegisLab/src" && "$build_bin" schema dump > "$out_file")
           }
 


### PR DESCRIPTION
## Summary

The aegisctl schema-diff gate has been failing on **every PR** (including merged ones like #276 and #277). The error is `go: cannot find main module, but found .git/config in .../aegis`, raised before the schema-dump step ever runs.

Root cause: `build_schema` ran `cd $repo_root/AegisLab && go build ./src/cmd/aegisctl`, but go.mod is at `AegisLab/src/go.mod`, not `AegisLab/`. From `AegisLab/`, Go walks up looking for go.mod, hits `.git/config` at the repo root, and errors. Has nothing to do with worktree mode — both the head and worktree branches of `build_schema` were broken the same way.

Fix is one line: cd into `AegisLab/src/` (where the second line of `build_schema` already cds) and build `./cmd/aegisctl`.

## Why nothing detected this before

The gate is non-blocking — recent merges (e.g. #276, #277) all show `schema gate fail` but went in anyway. So the workflow has been silently broken for many PRs, returning a fail that everyone learned to ignore. Today's investigation traced it back to this single line.

## Test plan

- [ ] Once merged, the schema-diff gate on the next PR should either PASS (no schema change) or post the expected diff comment + PASS-with-acknowledged / FAIL-without
- [ ] Reproduce locally before merge: `cd AegisLab/src && go build -o /tmp/x ./cmd/aegisctl && /tmp/x schema dump | head` should produce structured JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)