### PR TITLE
fix(otel): bump deployment-collector mem 8Gi → 16Gi (follow-up to #279)

### DIFF
--- a/AegisLab/manifests/byte-cluster/otel-kube-stack.values.yaml
+++ b/AegisLab/manifests/byte-cluster/otel-kube-stack.values.yaml
@@ -352,9 +352,10 @@ collectors:
     autoscaler:
       # Under TT firehose (50+ services × 16 ns) the HPA pegged at 40 with
       # memory_limiter at 174 %/60 %, dropping every TT span via UNAVAILABLE
-      # responses (Java agent OkHttp gRPC exporter does not retry). Raised
-      # ceiling to 120 and per-pod limit to 8Gi so the limiter can scale before
-      # rejecting; cluster (36 nodes, ~120Gi each) has headroom.
+      # responses (Java agent OkHttp gRPC exporter does not retry). First lift
+      # (#279) was 40→120 + 4Gi→8Gi; the post-roll fleet still saturated at
+      # 8Gi (75 %/60 %), so the limit went 8Gi→16Gi as well. Cluster (36
+      # nodes, ~120Gi each) absorbs 120 × 16Gi ≈ 53Gi/node worst case.
       minReplicas: 6
       maxReplicas: 120
       targetCPUUtilization: 55
@@ -364,10 +365,10 @@ collectors:
     resources:
       limits:
         cpu: 4000m
-        memory: 8000Mi
+        memory: 16000Mi
       requests:
         cpu: 1000m
-        memory: 3000Mi
+        memory: 6000Mi
     presets:
       kubernetesEvents:
         enabled: true


### PR DESCRIPTION
## Why

The 4 → 8 Gi roll from #279 wasn't enough. Once the new fleet stabilized:

\`\`\`
HPA opentelemetry-kube-stack-deployment-collector
  memory: 75% / 60%   ← still over target
  cpu:    16% / 55%
  replicas: 120 / 120 ← pegged at new max
  per-pod usage: 6.4-6.9 Gi (80-86% of the 8 Gi limit)
\`\`\`

\`memory_limiter\` (75% threshold) began rejecting again, so the silent ts/teastore drop pattern came back. Doubling per-pod headroom keeps the limiter quiet without raising replica count further.

## Change

| | before | after |
|---|---|---|
| \`resources.limits.memory\`   | 8000Mi | **16000Mi** |
| \`resources.requests.memory\` | 3000Mi |  **6000Mi** |

\`maxReplicas: 120\` and the rest stay as-is from #279.

## Capacity check

- Worst case 120 × 16 Gi = **1920 GiB** across 36 VKE nodes ≈ 53 GiB/node
- Nodes currently 18-30% mem use (most), 46-58% on a few hot ones — well within node capacity
- topologySpreadConstraints \`ScheduleAnyway\`, no scheduling stalls expected

## Live state

Cluster patched directly via \`kubectl patch otelcol\` to unblock the inject loop; this PR aligns the values file. **After the 16Gi roll, HPA memory dropped from 75% → 14% of target** — collector now has substantial headroom and HPA should scale back below 120 once cooldown passes.

## Test plan

- [x] HPA \`memory%\` after the bump (expected ≤ 30%)
- [ ] HPA \`replicas\` settles below 120 after cooldown
- [ ] Confirm ts9 spans land in CH after rollout completes