### PR TITLE
feat(aegisctl): inject list --system filter + leaf engine_config in ndjson

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/inject.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject.go
@@ -142,6 +142,7 @@ NOTE: --project is required for list, search, and guided --apply.
 var (
 	injectListState     string
 	injectListFaultType string
+	injectListSystem    string
 	injectListLabels    string
 	injectListPage      int
 	injectListSize      int
@@ -149,12 +150,14 @@ var (
 )
 
 type injectListItem struct {
-	ID        int    `json:"id"`
-	Name      string `json:"name"`
-	State     string `json:"state"`
-	FaultType string `json:"fault_type"`
-	StartTime string `json:"start_time"`
-	Labels    []struct {
+	ID                  int              `json:"id"`
+	Name                string           `json:"name"`
+	State               string           `json:"state"`
+	FaultType           string           `json:"fault_type"`
+	Category            string           `json:"category"`
+	StartTime           string           `json:"start_time"`
+	EngineConfigSummary []map[string]any `json:"engine_config_summary,omitempty"`
+	Labels              []struct {
 		Key   string `json:"key"`
 		Value string `json:"value"`
 	} `json:"labels"`
@@ -179,6 +182,7 @@ var injectListCmd = &cobra.Command{
 		baseParams := map[string]string{
 			"state":      stateParam,
 			"fault_type": injectListFaultType,
+			"category":   injectListSystem,
 			"labels":     injectListLabels,
 		}
 
@@ -210,7 +214,7 @@ var injectListCmd = &cobra.Command{
 			return output.PrintNDJSON(resp.Data.Items)
 		}
 
-		headers := []string{"NAME", "STATE", "FAULT-TYPE", "START-TIME", "LABELS"}
+		headers := []string{"NAME", "STATE", "FAULT-TYPE", "SYSTEM", "START-TIME", "LABELS"}
 		var rows [][]string
 		for _, item := range resp.Data.Items {
 			var lbls []string
@@ -221,6 +225,7 @@ var injectListCmd = &cobra.Command{
 				item.Name,
 				item.State,
 				item.FaultType,
+				item.Category,
 				item.StartTime,
 				strings.Join(lbls, ","),
 			})
@@ -965,6 +970,7 @@ func runBatchTarget(httpClient *http.Client, resolver *client.Resolver, t batchT
 func init() {
 	injectListCmd.Flags().StringVar(&injectListState, "state", "", "Filter by datapack state (name or numeric id; valid: "+datapackStateFlagHelp()+")")
 	injectListCmd.Flags().StringVar(&injectListFaultType, "fault-type", "", "Filter by fault type")
+	injectListCmd.Flags().StringVar(&injectListSystem, "system", "", "Filter by system code / pedestal category (e.g. ts, hs, sn, mm, otel-demo)")
 	injectListCmd.Flags().StringVar(&injectListLabels, "labels", "", "Filter by labels (key=val,...)")
 	injectListCmd.Flags().IntVar(&injectListPage, "page", 1, "Page number")
 	injectListCmd.Flags().IntVar(&injectListSize, "size", 20, "Page size; must be one of "+pageSizeFlagHelp())

--- a/AegisLab/src/cmd/aegisctl/cmd/inject_list_ndjson_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/inject_list_ndjson_test.go
@@ -31,8 +31,24 @@ func TestInjectList_NDJSONOutput(t *testing.T) {
 				"message": "success",
 				"data": map[string]any{
 					"items": []map[string]any{
-						{"id": 11, "name": "inj-1", "state": "Created", "fault_type": "cpu"},
-						{"id": 12, "name": "inj-2", "state": "Created", "fault_type": "mem"},
+						{
+							"id":         11,
+							"name":       "inj-1",
+							"state":      "Created",
+							"fault_type": "cpu",
+							"category":   "ts",
+						},
+						{
+							"id":         12,
+							"name":       "batch-hybrid-1",
+							"state":      "Created",
+							"fault_type": "hybrid",
+							"category":   "ts",
+							"engine_config_summary": []map[string]any{
+								{"chaos_type": "JVMException", "app": "ts-cancel-service", "method": "calculateRefund"},
+								{"chaos_type": "NetworkLoss", "app": "ts-user-service"},
+							},
+						},
 					},
 					"pagination": map[string]any{"page": 1, "size": 20, "total": 2, "total_pages": 1},
 				},
@@ -89,5 +105,46 @@ func TestInjectList_NDJSONOutput(t *testing.T) {
 	}
 	if len(requestedPaths) != 0 {
 		t.Fatalf("invalid --output should not send requests; got %v", requestedPaths)
+	}
+
+	// --system maps to the backend's `category` query param, and the hybrid
+	// row's engine_config_summary survives end-to-end NDJSON marshaling.
+	requestedPaths = nil
+	res = runCLI(t, "inject", "list", "--project", "pair_diagnosis", "--system", "ts",
+		"--output", "ndjson", "--server", ts.URL, "--token", "tok")
+	if res.code != ExitCodeSuccess {
+		t.Fatalf("--system: exit = %d, want %d; stderr=%q", res.code, ExitCodeSuccess, res.stderr)
+	}
+	var sawCategoryParam bool
+	for _, p := range requestedPaths {
+		if strings.HasPrefix(p, "/api/v2/projects/7/injections") && strings.Contains(p, "category=ts") {
+			sawCategoryParam = true
+		}
+	}
+	if !sawCategoryParam {
+		t.Fatalf("--system=ts should send category=ts; got requests=%v", requestedPaths)
+	}
+
+	var sawHybridLeaves bool
+	for _, line := range strings.Split(strings.TrimSpace(res.stdout), "\n") {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			t.Fatalf("invalid JSON line: %q (%v)", line, err)
+		}
+		if obj["fault_type"] != "hybrid" {
+			continue
+		}
+		leaves, ok := obj["engine_config_summary"].([]any)
+		if !ok || len(leaves) != 2 {
+			t.Fatalf("hybrid row missing engine_config_summary: %v", obj)
+		}
+		first, _ := leaves[0].(map[string]any)
+		if first["chaos_type"] != "JVMException" || first["app"] != "ts-cancel-service" {
+			t.Fatalf("hybrid leaf 0 wrong shape: %v", first)
+		}
+		sawHybridLeaves = true
+	}
+	if !sawHybridLeaves {
+		t.Fatalf("expected at least one hybrid row with engine_config_summary; stdout=%q", res.stdout)
 	}
 }

--- a/AegisLab/src/module/injection/api_types.go
+++ b/AegisLab/src/module/injection/api_types.go
@@ -199,6 +199,7 @@ func (req *ListInjectionReq) ToFilterOptions() *ListInjectionFilters {
 
 	return &ListInjectionFilters{
 		FaultType:       req.Type,
+		Category:        req.Category,
 		Benchmark:       req.Benchmark,
 		State:           req.State,
 		Status:          req.Status,
@@ -541,6 +542,11 @@ type InjectionResp struct {
 	UpdatedAt         time.Time            `json:"updated_at"`
 
 	Labels []dto.LabelItem `json:"labels,omitempty"`
+
+	// EngineConfigSummary is the parsed leaf list for hybrid batch parents only.
+	// For non-hybrid (single-leaf) injections it's omitted because the row's
+	// own fault_type and display_config already describe the leaf.
+	EngineConfigSummary []map[string]any `json:"engine_config_summary,omitempty" swaggertype:"array,object"`
 }
 
 func NewInjectionResp(injection *model.FaultInjection) *InjectionResp {
@@ -563,6 +569,12 @@ func NewInjectionResp(injection *model.FaultInjection) *InjectionResp {
 
 	if injection.FaultType == consts.Hybrid {
 		resp.FaultType = "hybrid"
+		if injection.EngineConfig != "" {
+			var leaves []map[string]any
+			if err := json.Unmarshal([]byte(injection.EngineConfig), &leaves); err == nil {
+				resp.EngineConfigSummary = leaves
+			}
+		}
 	} else {
 		resp.FaultType = chaos.ChaosTypeMap[injection.FaultType]
 	}

--- a/AegisLab/src/module/injection/repository.go
+++ b/AegisLab/src/module/injection/repository.go
@@ -408,6 +408,9 @@ func (r *Repository) listProjectInjectionsView(projectID, limit, offset int, fil
 		if filterOptions.FaultType != nil {
 			baseQuery = baseQuery.Where("fault_injections.fault_type = ?", *filterOptions.FaultType)
 		}
+		if filterOptions.Category != nil {
+			baseQuery = baseQuery.Where("fault_injections.category = ?", *filterOptions.Category)
+		}
 		if filterOptions.Benchmark != "" {
 			baseQuery = baseQuery.Where("fault_injections.benchmark = ?", filterOptions.Benchmark)
 		}


### PR DESCRIPTION
## Summary

Two ergonomics gaps surfaced by the fault-injection-author agent loop on `ts`:

1. **No way to filter `inject list` by system/category**, so checking \"how many ts injections succeeded\" required iterating 100x `inject get` and jq-filtering on `.category`.
2. **Hybrid batch parents show `fault_type=hybrid`** with no per-leaf detail in list output, so seeing what was actually injected required another round of `inject get`.

## What changed

**Backend (`AegisLab/src/module/injection/`)**
- `ToFilterOptions()` now passes `Category` through (it was already bound on `ListInjectionReq` and validated, just not plumbed).
- `listProjectInjectionsView` now applies the `category` WHERE clause when set.
- `InjectionResp.EngineConfigSummary` is populated only for `fault_type=hybrid` rows by parsing the existing `engine_config` JSON column. Non-hybrid leaves are unchanged (their `fault_type` and `display_config` already describe the single leaf).

**aegisctl CLI (`AegisLab/src/cmd/aegisctl/cmd/inject.go`)**
- New `--system <code>` flag (matches the existing `--fault-type` flag pattern). Maps to the backend's `category` query param.
- NDJSON / JSON output now carries `category` and `engine_config_summary` (the latter only on hybrid rows).
- Table output gains a `SYSTEM` column so `--system` has a visual anchor.

**Tests**
- Existing `TestInjectList_NDJSONOutput` extended in place: asserts `--system ts` sends `category=ts`, asserts `engine_config_summary` flows through NDJSON for the hybrid mock row.

Backend extension was minimal (3 lines repo + 1 line filter wiring + the `EngineConfigSummary` field) — chose server-side over client-side because the wiring was already 90% there.

## Notes for the reviewer

- Backend redeploy required for the smoke tests to actually hit the new code path live; before redeploy, the live server silently ignores `category` (param is validated, just doesn't filter) and returns `engine_config_summary: null` on hybrid rows. Both contracts are forward-compatible — the CLI works against old and new servers.
- I considered just doing client-side filtering on `category`, but the backend already validated the param and the repo wiring was a one-liner. Server-side is strictly faster (1 page vs N) and the change is small enough not to balloon scope.

## Test plan

- [x] `go test ./cmd/aegisctl/...` — green
- [x] `go test -tags duckdb_arrow ./module/injection/...` — green
- [x] `go vet -tags duckdb_arrow ./...` — clean
- [x] `go build -tags duckdb_arrow ./main.go` — clean
- [x] Live smoke against http://118.196.98.67:8082 (server pre-redeploy): `inject list --system ts -o ndjson` returns rows; `engine_config_summary` is null on hybrid rows as expected pre-redeploy.
- [ ] Post-redeploy: `inject list --system ts -o ndjson | jq -c 'select(.fault_type=="hybrid") | {name, leaves: .engine_config_summary}'` should show leaf detail.
- [ ] Post-redeploy: count of `--system ts` rows < total count.