### PR TITLE
fix(byte-cluster): install chaos-mesh from OperationsPAI fork chart

### DIFF
--- a/AegisLab/manifests/byte-cluster/README.md
+++ b/AegisLab/manifests/byte-cluster/README.md
@@ -43,15 +43,40 @@ kubectl create namespace exp --dry-run=client -o yaml | kubectl apply -f -
 
 ## 1. Install Chaos Mesh
 
+We use the **OperationsPAI fork** of chaos-mesh (`pair-cn-shanghai.cr.volces.com/opspai/chaos-mesh:20260425-517f3df`,
+mirrored from `docker.io/opspai/*`). The fork carries patches we need —
+notably the `RuntimeMutatorChaos` controller for JVM mutator-agent injection
+that upstream v2.8.0 does not have. The matching helm chart is published at
+`https://operationspai.github.io/chaos-mesh/`, but its `index.yaml` `urls:`
+fields point to a stale `lgu-se-internal.github.io` host and 404 — fetch the
+chart tarball from the working `operationspai.github.io` host directly:
+
 ```bash
-helm upgrade --install chaos-mesh chaos-mesh/chaos-mesh   --namespace chaos-mesh   --create-namespace   --version 2.8.0   -f AegisLab/manifests/byte-cluster/chaos-mesh.values.yaml   --wait --timeout 10m
+mkdir -p /tmp/chaos-mesh-install && cd /tmp/chaos-mesh-install
+curl -sfL https://operationspai.github.io/chaos-mesh/chaos-mesh-0.0.1-test.tgz \
+  -o chaos-mesh-0.0.1-test.tgz
+tar -xzf chaos-mesh-0.0.1-test.tgz
+helm install chaos-mesh ./chaos-mesh \
+  --namespace chaos-mesh --create-namespace \
+  -f /path/to/aegis/AegisLab/manifests/byte-cluster/chaos-mesh.values.yaml \
+  --wait --timeout 10m
 ```
 
-Verify:
+Why a chart-only path (no `helm repo add`): the published `index.yaml` lies
+about tarball URLs, so `helm pull` against the repo fails. Pinning the
+tarball download by URL keeps the install deterministic until the index is
+fixed upstream.
+
+Verify — controller-manager pods Running with **0** restarts and **24**
+chaos-mesh CRDs (the upstream chart only ships 23; the 24th is
+`runtimemutatorchaos.chaos-mesh.org`, which is what unblocks the JVM
+mutator-agent path). If you see only 23 CRDs after install, the wrong chart
+was used:
 
 ```bash
 kubectl get pods -n chaos-mesh
-kubectl get crd | grep chaos-mesh
+kubectl get crd | grep -c chaos-mesh   # expect 24
+kubectl get crd runtimemutatorchaos.chaos-mesh.org
 ```
 
 ## 2. Install ClickStack / ClickHouse


### PR DESCRIPTION
## Summary

- Switches the byte-cluster runbook from the upstream chaos-mesh chart (which was missing the fork-only `RuntimeMutatorChaos` CRD) to the OperationsPAI fork's published chart at `https://operationspai.github.io/chaos-mesh/`.
- Documents the published-chart URL pitfall — the index.yaml's `urls:` fields point to a stale `lgu-se-internal.github.io` host that 404s, so `helm pull` against the repo fails. The runbook fetches the tarball by direct URL from the working `operationspai.github.io` host instead.
- Pins to chart `0.0.1-test`; image tag continues to be set via `chaos-mesh.values.yaml` (`20260425-517f3df`).

Closes #287.

## Why

The byte-cluster install was using the upstream chart for everything except the image. Upstream's chart has 23 chaos-mesh CRDs; the fork ships 24 (the extra is `runtimemutatorchaos.chaos-mesh.org`, needed by the fork's JVM mutator-agent controller). With a fork image but upstream CRDs, the controller-manager pod blocks at startup waiting for a CRD that isn't there:

```
ERROR controller-runtime.source.Kind  if kind is a CRD, it should be installed before calling Start
{"kind": "RuntimeMutatorChaos.chaos-mesh.org",
 "error": "no matches for kind \"RuntimeMutatorChaos\" in version \"chaos-mesh.org/v1alpha1\""}
ERROR setup unable to start manager
{"error": "failed to wait for runtimemutatorchaos-pipeline caches to sync ...
           timed out waiting for cache to be synced"}
ERROR error received after stop sequence was engaged {"error": "leader election lost"}
```

Cache sync times out → leader election lost → pod restarts → repeat. On byte-cluster this had been ongoing for 2+ days (558+ restart cycles per replica). Endpoints periodically went to zero → `kubectl apply <chaos>` and `aegisctl inject` fail with "no endpoints available for service \"chaos-mesh-controller-manager\"" before producing any datapack.

## How

In addition to updating the runbook, the byte-cluster was reinstalled with this procedure during prep:

1. Force-deleted zombie chaos resources accumulated during the controller-manager outage (5 podchaos, 3 httpchaos, 1 podhttpchaos, all 43h+ past their declared duration but never reconciled).
2. Deleted the chaos-mesh namespace, the cluster-scoped ClusterRoles/Bindings, and the three webhook configurations.
3. `helm install` from the fork chart with the existing `chaos-mesh.values.yaml`.

Behavioral verification on byte-cluster post-reinstall:

```
$ kubectl get pods -n chaos-mesh -l app.kubernetes.io/component=controller-manager
NAME                                        READY   STATUS    RESTARTS   AGE
chaos-controller-manager-65556bc6b6-65vdc   1/1     Running   0          15m
chaos-controller-manager-65556bc6b6-98zf4   1/1     Running   0          15m
chaos-controller-manager-65556bc6b6-vxxm6   1/1     Running   0          15m

$ kubectl get crd | grep -c chaos-mesh
24

$ kubectl get crd runtimemutatorchaos.chaos-mesh.org
NAME                                 CREATED AT
runtimemutatorchaos.chaos-mesh.org   2026-04-29T04:25:56Z
```

Smoke trace `c4fefc1c-f012-4bb1-bcea-ced965e5dcd3` (NetworkDelay, ts0/ts-basic-service → ts-station-service, 5min) walked the full pipeline:

```
RestartPedestal  ✅ Completed
FaultInjection   ✅ Completed   ← chaos-mesh fork install
BuildDatapack    ✅ Completed   ← #286 CH+collector fix
RunAlgorithm     ✅ Completed   ← d5fcb05 drain3 removal
CollectResult    ✅ Completed
trace state:     Completed
```

This is the first end-to-end fully-Completed trace after the three fixes (this PR + #286 + d5fcb05) all landed.

## Test plan

- [ ] On a fresh kind cluster, follow the updated runbook and confirm `kubectl get crd runtimemutatorchaos.chaos-mesh.org` returns Established=True.
- [ ] Submit one NetworkDelay via `aegisctl inject` and confirm FaultInjection reaches Completed (not Error / not webhook timeout).
- [ ] Confirm chart tarball URL still resolves (`curl -sfL https://operationspai.github.io/chaos-mesh/chaos-mesh-0.0.1-test.tgz | wc -c` ≈ 305654).

## Follow-ups (not in this PR)

- Fix the published `index.yaml` `urls:` entries upstream in the fork repo so `helm pull operationspai-chaos-mesh/chaos-mesh` works directly (would let us drop the manual tarball download step).
- The `helm list -A` output reports the release as `pending-install` even though `helm install` exited 0 with `STATUS: deployed` — likely a metadata-write race during the install. Functional state is correct (all pods Running, all resources owned by the release); cosmetic-only. Worth a follow-up to repro on a fresh cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)