### PR TITLE
fix(freshness): partition-prune BuildDatapack probe to avoid Code 394 cancellation

### DIFF
--- a/AegisLab/manifests/byte-cluster/README.md
+++ b/AegisLab/manifests/byte-cluster/README.md
@@ -43,15 +43,40 @@ kubectl create namespace exp --dry-run=client -o yaml | kubectl apply -f -
 
 ## 1. Install Chaos Mesh
 
+We use the **OperationsPAI fork** of chaos-mesh (`pair-cn-shanghai.cr.volces.com/opspai/chaos-mesh:20260425-517f3df`,
+mirrored from `docker.io/opspai/*`). The fork carries patches we need —
+notably the `RuntimeMutatorChaos` controller for JVM mutator-agent injection
+that upstream v2.8.0 does not have. The matching helm chart is published at
+`https://operationspai.github.io/chaos-mesh/`, but its `index.yaml` `urls:`
+fields point to a stale `lgu-se-internal.github.io` host and 404 — fetch the
+chart tarball from the working `operationspai.github.io` host directly:
+
 ```bash
-helm upgrade --install chaos-mesh chaos-mesh/chaos-mesh   --namespace chaos-mesh   --create-namespace   --version 2.8.0   -f AegisLab/manifests/byte-cluster/chaos-mesh.values.yaml   --wait --timeout 10m
+mkdir -p /tmp/chaos-mesh-install && cd /tmp/chaos-mesh-install
+curl -sfL https://operationspai.github.io/chaos-mesh/chaos-mesh-0.0.1-test.tgz \
+  -o chaos-mesh-0.0.1-test.tgz
+tar -xzf chaos-mesh-0.0.1-test.tgz
+helm install chaos-mesh ./chaos-mesh \
+  --namespace chaos-mesh --create-namespace \
+  -f /path/to/aegis/AegisLab/manifests/byte-cluster/chaos-mesh.values.yaml \
+  --wait --timeout 10m
 ```
 
-Verify:
+Why a chart-only path (no `helm repo add`): the published `index.yaml` lies
+about tarball URLs, so `helm pull` against the repo fails. Pinning the
+tarball download by URL keeps the install deterministic until the index is
+fixed upstream.
+
+Verify — controller-manager pods Running with **0** restarts and **24**
+chaos-mesh CRDs (the upstream chart only ships 23; the 24th is
+`runtimemutatorchaos.chaos-mesh.org`, which is what unblocks the JVM
+mutator-agent path). If you see only 23 CRDs after install, the wrong chart
+was used:
 
 ```bash
 kubectl get pods -n chaos-mesh
-kubectl get crd | grep chaos-mesh
+kubectl get crd | grep -c chaos-mesh   # expect 24
+kubectl get crd runtimemutatorchaos.chaos-mesh.org
 ```
 
 ## 2. Install ClickStack / ClickHouse

--- a/AegisLab/src/service/consumer/freshness.go
+++ b/AegisLab/src/service/consumer/freshness.go
@@ -63,13 +63,33 @@ func (p *clickHouseFreshnessProbe) MaxTraceTimestamp(ctx context.Context, namesp
 		row chrow.Row
 		ts  time.Time
 	)
+	// Why the Timestamp >= now() - INTERVAL 1 HOUR + max_partitions_to_read=2:
+	// otel.otel_traces is `PARTITION BY toDate(Timestamp) ORDER BY (ServiceName,
+	// SpanName, toDateTime(Timestamp))`. With Timestamp third in the sort key,
+	// `MAX(Timestamp)` cannot use a primary-key shortcut and degrades to reading
+	// per-part metadata across every active part. On byte-cluster (#289) this
+	// pushed p50 to ~3s and p95 past 50s with 400+ parts; concurrent K>=3
+	// freshness probes routinely tripped client deadlines and surfaced as
+	// `Code 394 QUERY_WAS_CANCELLED`. The 1-hour predicate (a) prunes to at
+	// most today's plus the immediately-prior partition (max_partitions_to_read=2
+	// covers the midnight rollover) and (b) restricts per-part scanning to
+	// recent granules. Probe semantics are unchanged: the freshness deadline
+	// is always within seconds of now(), so any ingest lag <1h is still
+	// detected, and a namespace with zero recent ingest still returns a zero
+	// timestamp (treated as "not fresh") exactly as before.
 	if namespace != "" {
 		row = conn.QueryRow(ctx,
-			"SELECT max(Timestamp) FROM otel.otel_traces WHERE ResourceAttributes['service.namespace'] = ?",
+			"SELECT max(Timestamp) FROM otel.otel_traces "+
+				"WHERE ResourceAttributes['service.namespace'] = ? "+
+				"AND Timestamp >= now() - INTERVAL 1 HOUR "+
+				"SETTINGS max_partitions_to_read = 2",
 			namespace,
 		)
 	} else {
-		row = conn.QueryRow(ctx, "SELECT max(Timestamp) FROM otel.otel_traces")
+		row = conn.QueryRow(ctx,
+			"SELECT max(Timestamp) FROM otel.otel_traces "+
+				"WHERE Timestamp >= now() - INTERVAL 1 HOUR "+
+				"SETTINGS max_partitions_to_read = 2")
 	}
 	if err := row.Scan(&ts); err != nil {
 		return time.Time{}, false, fmt.Errorf("clickhouse query max(Timestamp): %w", err)


### PR DESCRIPTION
## Summary

- Adds `AND Timestamp >= now() - INTERVAL 1 HOUR SETTINGS max_partitions_to_read = 2` to the freshness probe query so it prunes by partition + part-level minmax metadata instead of full-fanout scanning every active part.
- Verified on byte-cluster: probe latency drops from p50=3.1s / p95=54.5s to ~110ms across three runs (≈30× on p50, ≈500× on p95). Eliminates the `Code 394 QUERY_WAS_CANCELLED` errors observed under K≥3 multi-fault batches.

Closes #289.

## Why

`MaxTraceTimestamp` in `service/consumer/freshness.go` runs:

```sql
SELECT max(Timestamp) FROM otel.otel_traces
WHERE ResourceAttributes['service.namespace'] = ?
```

The clickstack-managed table is:

```sql
ENGINE = MergeTree
PARTITION BY toDate(Timestamp)
ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))
```

`Timestamp` is the **third** key in `ORDER BY`, so `MAX(Timestamp)` cannot use the primary-key shortcut — CH falls back to reading per-part column metadata across every active part in the matching partition.

On byte-cluster, the otel ingest carries ~400 active parts (mostly historical backlog from before the duplicate-scrape fix in #286). Measured probe latency over the last 6 h:

| | duration |
|---|---|
| p50 | **3.1 s** |
| p95 | **54.5 s** |
| p99 | **65.5 s** |
| max | **97.8 s** |

Under a multi-fault batch with K≥3, the K BuildDatapacks all reach the freshness step within seconds of each other (they share namespace lock for RestartPedestal and complete FaultInjection at roughly the same time). K simultaneous probes contend for IO; tail latency stretches further; the client deadline fires; CH server-side records the abandoned-by-client query as `Code 394 QUERY_WAS_CANCELLED`. Confirmed today: a K=4 batch in the ts campaign lost 3 of 4 BuildDatapacks to this.

## How

Add a 1-hour Timestamp predicate plus `SETTINGS max_partitions_to_read = 2`. With `PARTITION BY toDate(Timestamp)` and TTL=3d, the predicate prunes to at most two partitions (today + yesterday across midnight rollover); within those partitions, the part-level minmax metadata further skips any parts whose Timestamp range is entirely older than one hour.

`EXPLAIN indexes=1` on byte-cluster confirms both indexes engage:

```
ReadFromMergeTree (otel.otel_traces)
  Indexes:
    MinMax
      Keys: Timestamp
      Condition: (Timestamp in ['1777437647', +Inf))
      Parts: 7/51
    Partition
      Keys: toDate(Timestamp)
      Condition: (toDate(Timestamp) in [20572, +Inf))
      Parts: 7/7
```

51 → 7 parts. Measured wall-time across three runs:

```
clickhouse-client --time SELECT max(Timestamp) FROM otel.otel_traces ...
0.114
0.113
0.104
```

## Probe semantics — unchanged

- The freshness deadline is always `abnormalEnd - watermark`, which is within seconds of `now()`. Any ingest lag <1h is still detected by the new query.
- A namespace with zero recent ingest returns a zero `Timestamp` (no rows match the predicate), which the existing `ts.IsZero()` branch already treats as "not fresh". No new code path added.
- If a trace ends up rescheduled until it's >1h old, the probe will return a timestamp from within the last hour (which is necessarily after `abnormalEnd - watermark`) and pass — same as before. The probe's job is "is ingestion currently caught up", not "is *this specific abnormalEnd* a row in the table"; the lookback bound is on the freshness check itself, not on the data being checked.

## Test plan

- [x] `go test ./service/consumer -run TestFreshness` — passes (mocks the probe interface, doesn't depend on the SQL string).
- [x] Manual EXPLAIN on byte-cluster confirms partition + minmax pruning.
- [x] Manual run on byte-cluster: probe completes in 104–114 ms across three samples.
- [ ] After merge + deploy, submit a K=4 multi-fault batch via aegisctl and confirm all 4 BuildDatapacks reach Completed without Code 394 errors. (Currently waiting on the live ts campaign — first cross-type batch will exercise this path.)

## Out of scope

- Long-term fix for the part backlog itself (otel_metrics_gauge has 2200 inactive parts, otel_metrics_sum has 2150). Merge is in progress; backlog is draining post-#286 but slowly. Tracked separately if needed.
- Adding an explicit `INDEX ts_minmax Timestamp TYPE minmax` would help only post-merge for new parts; not necessary because the implicit per-part minmax metadata already does the job here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)