### PR TITLE
fix(consumer): reconcile traces stuck after fault.injection.{started,completed} via DB-driven loop (closes #293)

### DIFF
--- a/AegisLab/src/consts/consts.go
+++ b/AegisLab/src/consts/consts.go
@@ -437,6 +437,21 @@ const (
 	MaxTokensKeyNamespaceWarming  = "rate_limiting.max_concurrent_ns_warming"
 	MaxConcurrentNamespaceWarming = 30
 	NamespaceWarmingServiceName   = "namespace_warming"
+
+	// Stuck-trace reconciler (issue #293). Closes the latent gap where the
+	// chaos-mesh CRD-success path is the only thing that submits the
+	// BuildDatapack task: a worker restart, an in-memory batchManager race,
+	// or a silently early-returning postProcess closure leaves the trace
+	// pinned at last_event=fault.injection.{started,completed} with no
+	// downstream task. The reconciler is a periodic DB-driven sweep; it
+	// re-fires the equivalent of postProcess for traces older than the
+	// stuck threshold, idempotent on the per-fault-injection-task
+	// BuildDatapack child task. Both keys are read on every tick so a
+	// runtime aegisctl push to etcd applies without a backend rebuild.
+	StuckTraceReconcileIntervalKey         = "rate_limiting.stuck_trace_reconcile_interval_seconds"
+	StuckTraceReconcileStuckThresholdKey   = "rate_limiting.stuck_trace_reconcile_stuck_threshold_seconds"
+	DefaultStuckTraceReconcileIntervalSecs = 60
+	DefaultStuckTraceReconcileStuckSecs    = 600
 )
 
 type EventType string

--- a/AegisLab/src/interface/controller/module.go
+++ b/AegisLab/src/interface/controller/module.go
@@ -65,6 +65,21 @@ func (r *Lifecycle) start(ctx context.Context, cancel context.CancelFunc) error 
 			r.params.InjectionOwner,
 		),
 	)
+	// Stuck-trace reconciler (issue #293). Runs alongside the chaos-mesh
+	// CRD informer; recovers traces stuck after fault.injection.{started,
+	// completed} when the CRD-success path failed to submit BuildDatapack
+	// (worker restart, in-memory batchManager race, silent postProcess
+	// early-return). Idempotent: a BuildDatapack child task already linked
+	// to the FaultInjection task is the trigger to skip.
+	consumer.StartStuckTraceReconciler(
+		ctx,
+		consumer.NewStuckTraceReconciler(
+			r.params.DB,
+			r.params.RedisGateway,
+			r.params.ExecutionOwner,
+			r.params.InjectionOwner,
+		),
+	)
 	return nil
 }
 

--- a/AegisLab/src/service/consumer/k8s_handler.go
+++ b/AegisLab/src/service/consumer/k8s_handler.go
@@ -12,6 +12,7 @@ import (
 	"aegis/dto"
 	k8s "aegis/infra/k8s"
 	redis "aegis/infra/redis"
+	"aegis/model"
 	container "aegis/module/container"
 	"aegis/service/common"
 	"aegis/utils"
@@ -299,8 +300,22 @@ func (h *k8sHandler) HandleCRDSucceeded(namespace, pod, name string, startTime, 
 
 		datapack, err := h.store.updateInjectionTimestamp(taskCtx, injectionName, startTime, endTime)
 		if err != nil {
-			errCtx.Warn(nil, "update injection timestamps failed", err)
-			return
+			// The timestamp persist failed (DB blip, transient lock, etc.)
+			// but we already have the authoritative startTime/endTime
+			// from the chaos-mesh CRD callback args. Returning here used
+			// to drop the BuildDatapack submit and was the third candidate
+			// latent failure mode behind issue #293's stuck traces. Build
+			// a synthetic InjectionItem from the row we can still read +
+			// the args we received and continue. The stuck-trace
+			// reconciler will retry the timestamp persist on a later tick
+			// if it ends up needed for downstream queries.
+			errCtx.Warn(nil, "update injection timestamps failed; continuing with synthesized datapack", err)
+			fallback, lookupErr := buildFallbackInjectionItem(h.db, injectionName, startTime, endTime)
+			if lookupErr != nil {
+				errCtx.Warn(nil, "lookup injection for fallback datapack failed", lookupErr)
+				return
+			}
+			datapack = &fallback
 		}
 
 		// Seeded env vars (from container_version_env_vars) must reach the
@@ -364,6 +379,28 @@ func (h *k8sHandler) HandleCRDSucceeded(namespace, pod, name string, startTime, 
 			postProcess(parsedLabels.batchID)
 		}
 	}
+}
+
+// buildFallbackInjectionItem produces the InjectionItem the BuildDatapack
+// payload needs when updateInjectionTimestamp can't persist. It reads the
+// FaultInjection row directly (we still need the ID + PreDuration) and
+// stamps the in-flight startTime/endTime from the chaos-mesh callback —
+// those are the authoritative values the timestamp persist would have
+// written anyway. Used by HandleCRDSucceeded to keep the BuildDatapack
+// chain alive when a transient DB error would otherwise drop the trace.
+func buildFallbackInjectionItem(db *gorm.DB, name string, startTime, endTime time.Time) (dto.InjectionItem, error) {
+	var row model.FaultInjection
+	if err := db.Where("name = ? AND status != ?", name, consts.CommonDeleted).
+		First(&row).Error; err != nil {
+		return dto.InjectionItem{}, err
+	}
+	return dto.InjectionItem{
+		ID:          row.ID,
+		Name:        row.Name,
+		PreDuration: row.PreDuration,
+		StartTime:   startTime,
+		EndTime:     endTime,
+	}, nil
 }
 
 func (h *k8sHandler) HandleJobAdd(name string, annotations map[string]string, labels map[string]string) {

--- a/AegisLab/src/service/consumer/k8s_handler_test.go
+++ b/AegisLab/src/service/consumer/k8s_handler_test.go
@@ -1,0 +1,80 @@
+package consumer
+
+import (
+	"testing"
+	"time"
+
+	"aegis/consts"
+	"aegis/model"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newK8sHandlerTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&model.FaultInjection{}))
+	return db
+}
+
+// TestBuildFallbackInjectionItem_UsesArgsAndRow verifies the fallback
+// constructed when updateInjectionTimestamp fails: ID and PreDuration come
+// from the persisted row (we can still read it; only the UPDATE failed),
+// while StartTime/EndTime come from the chaos-mesh callback args (those
+// are the authoritative values the failed UPDATE would have written).
+// Pins the issue #293 latent fix: HandleCRDSucceeded used to return early
+// on this warning, dropping the BuildDatapack submit and stranding the
+// trace.
+func TestBuildFallbackInjectionItem_UsesArgsAndRow(t *testing.T) {
+	db := newK8sHandlerTestDB(t)
+	require.NoError(t, db.Create(&model.FaultInjection{
+		Name:        "fi-fallback-test",
+		PreDuration: 3,
+		Status:      consts.CommonEnabled,
+	}).Error)
+
+	wantStart := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	wantEnd := wantStart.Add(2 * time.Minute)
+
+	got, err := buildFallbackInjectionItem(db, "fi-fallback-test", wantStart, wantEnd)
+	require.NoError(t, err)
+	require.Equal(t, "fi-fallback-test", got.Name)
+	require.Equal(t, 3, got.PreDuration, "PreDuration must be read from the persisted row")
+	require.True(t, got.StartTime.Equal(wantStart),
+		"StartTime must come from the callback args, not from the row")
+	require.True(t, got.EndTime.Equal(wantEnd),
+		"EndTime must come from the callback args, not from the row")
+	require.NotZero(t, got.ID, "ID must be populated from the row so downstream tasks can join")
+}
+
+// TestBuildFallbackInjectionItem_SkipsDeletedRows confirms a tombstoned
+// FaultInjection row is treated the same way the rest of the pipeline
+// treats it (status=-1 means "deleted"), so a stale CRD callback can't
+// resurrect it via the fallback path.
+func TestBuildFallbackInjectionItem_SkipsDeletedRows(t *testing.T) {
+	db := newK8sHandlerTestDB(t)
+	require.NoError(t, db.Create(&model.FaultInjection{
+		Name:        "fi-deleted",
+		PreDuration: 1,
+		Status:      consts.CommonDeleted,
+	}).Error)
+
+	_, err := buildFallbackInjectionItem(db, "fi-deleted", time.Now(), time.Now())
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+// TestBuildFallbackInjectionItem_ReportsMissingRow makes sure the helper
+// signals a real lookup failure instead of silently producing a zero-ID
+// InjectionItem (which would lie to BuildDatapack about which row to
+// process).
+func TestBuildFallbackInjectionItem_ReportsMissingRow(t *testing.T) {
+	db := newK8sHandlerTestDB(t)
+	_, err := buildFallbackInjectionItem(db, "no-such-injection", time.Now(), time.Now())
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}

--- a/AegisLab/src/service/consumer/stuck_trace_reconciler.go
+++ b/AegisLab/src/service/consumer/stuck_trace_reconciler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 
 	"aegis/config"
 	"aegis/consts"
@@ -82,20 +83,23 @@ func NewStuckTraceReconciler(
 // initial sleep is a full interval so a fresh worker doesn't immediately
 // stomp the just-arrived CRD-success path; the bug we're closing only
 // matters for traces that have been stuck longer than the threshold anyway.
+//
+// Interval changes pushed via etcd at runtime are picked up at the next tick
+// by re-reading r.intervalSeconds() and calling ticker.Reset when the value
+// has changed — no worker restart required.
 func (r *StuckTraceReconciler) Run(ctx context.Context) {
 	if r == nil || r.db == nil {
 		logrus.Warn("StuckTraceReconciler.Run skipped: missing db")
 		return
 	}
+	currentInterval := r.resolveInterval()
+	ticker := time.NewTicker(currentInterval)
+	defer ticker.Stop()
 	for {
-		interval := time.Duration(r.intervalSeconds()) * time.Second
-		if interval <= 0 {
-			interval = time.Duration(consts.DefaultStuckTraceReconcileIntervalSecs) * time.Second
-		}
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(interval):
+		case <-ticker.C:
 		}
 		processed, err := r.tick(ctx)
 		if err != nil {
@@ -106,7 +110,19 @@ func (r *StuckTraceReconciler) Run(ctx context.Context) {
 		if r.tickHook != nil {
 			r.tickHook(processed, err)
 		}
+		if next := r.resolveInterval(); next != currentInterval {
+			ticker.Reset(next)
+			currentInterval = next
+		}
 	}
+}
+
+func (r *StuckTraceReconciler) resolveInterval() time.Duration {
+	v := time.Duration(r.intervalSeconds()) * time.Second
+	if v <= 0 {
+		v = time.Duration(consts.DefaultStuckTraceReconcileIntervalSecs) * time.Second
+	}
+	return v
 }
 
 // tick runs one reconcile sweep and returns the number of traces it
@@ -127,6 +143,8 @@ func (r *StuckTraceReconciler) tick(ctx context.Context) (int, error) {
 			cutoff,
 			consts.CommonDeleted,
 		).
+		Order("updated_at ASC").
+		Order("id ASC").
 		Limit(r.maxBatchPerTick).
 		Find(&traces).Error
 	if err != nil {
@@ -181,10 +199,11 @@ func (r *StuckTraceReconciler) recoverTrace(ctx context.Context, trace *model.Tr
 		return false, fmt.Errorf("lookup fault-injection task: %w", err)
 	}
 
-	// Idempotency: if a BuildDatapack child task already exists, the
-	// CRD-success path raced us to the punch. Bail out — the next tick
-	// will see the trace in TraceRunning with last_event=datapack.* and
-	// skip it cleanly.
+	// Cheap fast-path idempotency check: if a BuildDatapack child task
+	// already exists, we don't need to bother re-deriving payloads or
+	// updating timestamps. The authoritative check still runs inside the
+	// per-parent-row transaction in submitIfNoChild — this is just an
+	// early exit to skip the work in the common already-advanced case.
 	var existingDatapackCount int64
 	if err := r.db.WithContext(ctx).
 		Model(&model.Task{}).
@@ -285,8 +304,15 @@ func (r *StuckTraceReconciler) recoverTrace(ctx context.Context, trace *model.Tr
 		logEntry.WithError(err).Warn("update injection state failed (continuing)")
 	}
 
-	startTime := chosen.UpdatedAt.Add(-time.Duration(guidedDuration) * time.Minute)
-	endTime := chosen.UpdatedAt
+	// On a fresh FaultInjection row UpdatedAt is the *start* of the
+	// injection (the row is written when the chaos CRD is created and
+	// updateInjectionTimestamp hasn't yet run). The fault then runs
+	// forward from that point for `guidedDuration` minutes, so the
+	// abnormal window is [UpdatedAt, UpdatedAt + duration] — emphatically
+	// NOT the [UpdatedAt - duration, UpdatedAt] form an earlier draft
+	// used. Stored StartTime/EndTime override both.
+	startTime := chosen.UpdatedAt
+	endTime := chosen.UpdatedAt.Add(time.Duration(guidedDuration) * time.Minute)
 	if chosen.StartTime != nil {
 		startTime = *chosen.StartTime
 	}
@@ -331,13 +357,93 @@ func (r *StuckTraceReconciler) recoverTrace(ctx context.Context, trace *model.Tr
 	if r.submitTask == nil {
 		return false, fmt.Errorf("submitTask not configured")
 	}
-	if err := r.submitTask(ctx, r.db, r.redisGateway, buildTask); err != nil {
-		return false, fmt.Errorf("submit recovered BuildDatapack task: %w", err)
+
+	// Replica-safe submit. Two reconciler ticks (across replicas or even
+	// the same replica racing on a slow submit) can both observe zero
+	// BuildDatapack children at the unsynchronized count. Serialize via
+	// a row-level write lock on the parent FaultInjection task and
+	// re-check inside the transaction; whichever transaction commits
+	// first wins and the other one's recheck-zero collapses to "child
+	// already exists, bail out". On dialects without FOR UPDATE (sqlite
+	// in our tests) the per-DB serial-write lock gives the same effect.
+	submitted, err := r.submitIfNoChild(ctx, &fiTask, buildTask, logEntry)
+	if err != nil {
+		return false, err
+	}
+	if !submitted {
+		return false, nil
 	}
 
 	logEntry.WithField("fault_injection_task_id", fiTask.ID).
 		Info("stuck trace reconciled: BuildDatapack task submitted")
 	return true, nil
+}
+
+// submitIfNoChild atomically rechecks "does this FaultInjection task already
+// have a BuildDatapack child?" under a row-level write lock on the parent
+// task, and only submits the recovery task if not. Returns (true, nil) iff
+// it actually submitted; (false, nil) means the CRD-success path or another
+// reconciler replica beat us to it.
+func (r *StuckTraceReconciler) submitIfNoChild(
+	ctx context.Context,
+	parent *model.Task,
+	buildTask *dto.UnifiedTask,
+	logEntry *logrus.Entry,
+) (bool, error) {
+	submitted := false
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		lockedQuery := tx.Model(&model.Task{}).
+			Where("id = ?", parent.ID)
+		if r.supportsRowLock() {
+			lockedQuery = lockedQuery.Clauses(clause.Locking{Strength: "UPDATE"})
+		}
+		var locked model.Task
+		if err := lockedQuery.First(&locked).Error; err != nil {
+			return fmt.Errorf("lock parent task: %w", err)
+		}
+
+		var existingDatapackCount int64
+		if err := tx.Model(&model.Task{}).
+			Where("parent_task_id = ? AND type = ? AND status != ?",
+				parent.ID,
+				consts.TaskTypeBuildDatapack,
+				consts.CommonDeleted,
+			).
+			Count(&existingDatapackCount).Error; err != nil {
+			return fmt.Errorf("idempotency check: %w", err)
+		}
+		if existingDatapackCount > 0 {
+			logEntry.Debug("BuildDatapack task already exists for fault-injection task, skipping")
+			return nil
+		}
+
+		if err := r.submitTask(ctx, tx, r.redisGateway, buildTask); err != nil {
+			return fmt.Errorf("submit recovered BuildDatapack task: %w", err)
+		}
+		submitted = true
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return submitted, nil
+}
+
+// supportsRowLock returns true on dialects that honor SELECT ... FOR UPDATE
+// (MySQL, Postgres). SQLite — the in-memory test driver — has implicit
+// per-connection serialization for writes and rejects FOR UPDATE syntax
+// outright, so we drop the clause there. The transaction itself still
+// gives us the recheck-and-submit atomicity we need.
+func (r *StuckTraceReconciler) supportsRowLock() bool {
+	if r.db == nil || r.db.Dialector == nil {
+		return false
+	}
+	switch r.db.Dialector.Name() {
+	case "mysql", "postgres":
+		return true
+	default:
+		return false
+	}
 }
 
 // stuckGraceWindow is added on top of the inject duration to absorb the

--- a/AegisLab/src/service/consumer/stuck_trace_reconciler.go
+++ b/AegisLab/src/service/consumer/stuck_trace_reconciler.go
@@ -1,0 +1,463 @@
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+
+	"aegis/config"
+	"aegis/consts"
+	"aegis/dto"
+	redis "aegis/infra/redis"
+	"aegis/model"
+	container "aegis/module/container"
+	"aegis/service/common"
+	"aegis/utils"
+
+	"github.com/OperationsPAI/chaos-experiment/pkg/guidedcli"
+)
+
+// StuckTraceReconciler is a DB-driven sweep that recovers traces stuck at
+// last_event in {fault.injection.started, fault.injection.completed} with no
+// BuildDatapack child task. Closes issue #293: the CRD-success path is the
+// only thing that submits BuildDatapack, so a worker restart between
+// CRD-success and SubmitTaskWithDB, an in-memory batchManager race, or a
+// silently early-returning postProcess closure leaves the trace pinned and
+// the campaign loses the datapack.
+//
+// Idempotency: a child BuildDatapack task already linked to the
+// FaultInjection task is treated as "already fired" and skipped, so multiple
+// replicas can run the reconciler safely without distributed locks.
+type StuckTraceReconciler struct {
+	db                    *gorm.DB
+	redisGateway          *redis.Gateway
+	store                 *stateStore
+	containerRepo         containerEnvVarLister
+	now                   func() time.Time
+	intervalSeconds       func() int
+	stuckThresholdSeconds func() int
+	submitTask            taskSubmitter
+	maxBatchPerTick       int
+	tickHook              func(processed int, err error)
+}
+
+// taskSubmitter is the seam tests use to capture the recovered BuildDatapack
+// task without standing up the producer-side Redis machinery. The production
+// implementation is common.SubmitTaskWithDB.
+type taskSubmitter func(ctx context.Context, db *gorm.DB, redisGateway *redis.Gateway, task *dto.UnifiedTask) error
+
+// container.Repository is needed for the same env-var merge postProcess does;
+// re-stated as a tiny seam so we don't have to spin up the real repo in tests.
+type containerEnvVarLister interface {
+	ListEnvVarsByVersionID(versionID int) ([]dto.ParameterItem, error)
+}
+
+// NewStuckTraceReconciler builds the production reconciler. The constructor
+// is also used by the controller module's fx wiring.
+func NewStuckTraceReconciler(
+	db *gorm.DB,
+	redisGateway *redis.Gateway,
+	executionOwner ExecutionOwner,
+	injectionOwner InjectionOwner,
+) *StuckTraceReconciler {
+	return &StuckTraceReconciler{
+		db:                    db,
+		redisGateway:          redisGateway,
+		store:                 newStateStore(executionOwner, injectionOwner),
+		containerRepo:         container.NewRepository(db),
+		now:                   time.Now,
+		intervalSeconds:       intervalSecondsFromConfig,
+		stuckThresholdSeconds: stuckThresholdSecondsFromConfig,
+		submitTask:            common.SubmitTaskWithDB,
+		maxBatchPerTick:       50,
+	}
+}
+
+// Run drives the reconciler ticker. It exits when ctx is cancelled. The
+// initial sleep is a full interval so a fresh worker doesn't immediately
+// stomp the just-arrived CRD-success path; the bug we're closing only
+// matters for traces that have been stuck longer than the threshold anyway.
+func (r *StuckTraceReconciler) Run(ctx context.Context) {
+	if r == nil || r.db == nil {
+		logrus.Warn("StuckTraceReconciler.Run skipped: missing db")
+		return
+	}
+	for {
+		interval := time.Duration(r.intervalSeconds()) * time.Second
+		if interval <= 0 {
+			interval = time.Duration(consts.DefaultStuckTraceReconcileIntervalSecs) * time.Second
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
+		}
+		processed, err := r.tick(ctx)
+		if err != nil {
+			logrus.WithError(err).Warn("stuck trace reconcile tick failed")
+		} else if processed > 0 {
+			logrus.Infof("stuck trace reconcile tick recovered %d trace(s)", processed)
+		}
+		if r.tickHook != nil {
+			r.tickHook(processed, err)
+		}
+	}
+}
+
+// tick runs one reconcile sweep and returns the number of traces it
+// successfully recovered.
+func (r *StuckTraceReconciler) tick(ctx context.Context) (int, error) {
+	stuckSecs := r.stuckThresholdSeconds()
+	if stuckSecs <= 0 {
+		stuckSecs = consts.DefaultStuckTraceReconcileStuckSecs
+	}
+	cutoff := r.now().Add(-time.Duration(stuckSecs) * time.Second)
+
+	var traces []model.Trace
+	err := r.db.WithContext(ctx).
+		Model(&model.Trace{}).
+		Where("state = ? AND last_event IN ? AND updated_at < ? AND status != ?",
+			consts.TraceRunning,
+			[]consts.EventType{consts.EventFaultInjectionStarted, consts.EventFaultInjectionCompleted},
+			cutoff,
+			consts.CommonDeleted,
+		).
+		Limit(r.maxBatchPerTick).
+		Find(&traces).Error
+	if err != nil {
+		return 0, fmt.Errorf("query stuck traces: %w", err)
+	}
+
+	processed := 0
+	for i := range traces {
+		recovered, err := r.recoverTrace(ctx, &traces[i])
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"trace_id":   traces[i].ID,
+				"last_event": traces[i].LastEvent,
+			}).WithError(err).Warn("failed to recover stuck trace")
+			continue
+		}
+		if recovered {
+			processed++
+		}
+	}
+	return processed, nil
+}
+
+// recoverTrace handles a single stuck trace. Returns (true, nil) iff a
+// BuildDatapack task was actually submitted. (false, nil) means the trace
+// was already advancing on its own (idempotency guard), so the next tick
+// will skip it cleanly.
+func (r *StuckTraceReconciler) recoverTrace(ctx context.Context, trace *model.Trace) (bool, error) {
+	logEntry := logrus.WithFields(logrus.Fields{
+		"trace_id":   trace.ID,
+		"last_event": trace.LastEvent,
+	})
+
+	// Find the FaultInjection task for this trace. Single-leaf and hybrid
+	// batches both have exactly one FaultInjection task per trace; the
+	// hybrid path differentiates only in how postProcess fans in (via
+	// batchManager) and which name (chaos CRD vs. batch_id) it passes
+	// into updateInjectionState. The DB-driven recovery does not need that
+	// distinction — we look up the FaultInjection record(s) by TaskID.
+	var fiTask model.Task
+	err := r.db.WithContext(ctx).
+		Where("trace_id = ? AND type = ? AND status != ?",
+			trace.ID,
+			consts.TaskTypeFaultInjection,
+			consts.CommonDeleted,
+		).
+		First(&fiTask).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return false, nil
+		}
+		return false, fmt.Errorf("lookup fault-injection task: %w", err)
+	}
+
+	// Idempotency: if a BuildDatapack child task already exists, the
+	// CRD-success path raced us to the punch. Bail out — the next tick
+	// will see the trace in TraceRunning with last_event=datapack.* and
+	// skip it cleanly.
+	var existingDatapackCount int64
+	if err := r.db.WithContext(ctx).
+		Model(&model.Task{}).
+		Where("parent_task_id = ? AND type = ? AND status != ?",
+			fiTask.ID,
+			consts.TaskTypeBuildDatapack,
+			consts.CommonDeleted,
+		).
+		Count(&existingDatapackCount).Error; err != nil {
+		return false, fmt.Errorf("idempotency check: %w", err)
+	}
+	if existingDatapackCount > 0 {
+		logEntry.Debug("BuildDatapack task already exists for fault-injection task, skipping")
+		return false, nil
+	}
+
+	// Find the FaultInjection record(s). For hybrid K_inner>=2 batches
+	// there are multiple records sharing the same TaskID; we recover the
+	// trace iff every leaf is past the inject window (StartTime/EndTime
+	// non-nil OR the record's UpdatedAt is older than the stuck window —
+	// the latter handles the case where the CRD-success closure failed
+	// before updateInjectionTimestamp).
+	var injections []model.FaultInjection
+	if err := r.db.WithContext(ctx).
+		Where("task_id = ? AND status != ?", fiTask.ID, consts.CommonDeleted).
+		Find(&injections).Error; err != nil {
+		return false, fmt.Errorf("lookup fault-injection records: %w", err)
+	}
+	if len(injections) == 0 {
+		// FaultInjection record never made it to the DB — the inject
+		// itself failed before CreateInjection ran. Not our problem;
+		// upstream error handling owns this case.
+		logEntry.Debug("no FaultInjection records for stuck trace, skipping")
+		return false, nil
+	}
+
+	// Reconstruct the BuildDatapack payload from the FaultInjection task's
+	// own payload — that's the only place the benchmark ContainerVersionItem
+	// is preserved verbatim from the original submit. We don't need (and
+	// won't try) to reconstruct the chaos-mesh CRD state.
+	taskPayload, err := decodeTaskPayload(&fiTask)
+	if err != nil {
+		return false, fmt.Errorf("decode fault-injection payload: %w", err)
+	}
+	benchmark, err := utils.ConvertToType[dto.ContainerVersionItem](taskPayload[consts.InjectBenchmark])
+	if err != nil {
+		return false, fmt.Errorf("missing benchmark in fault-injection payload: %w", err)
+	}
+	namespace, _ := taskPayload[consts.InjectNamespace].(string)
+
+	// Verify every leaf is "done enough". If a guided config has a
+	// duration and the FaultInjection record's UpdatedAt + duration is
+	// still in the future, the fault is genuinely still running — leave
+	// it for a later tick. We do NOT query chaos-mesh here: under the
+	// failure modes we're closing (informer event drop, worker restart,
+	// silent postProcess early-return), chaos-mesh would tell us either
+	// "Phase=Stop" (fault done, GC pending) or "not found" (already GC'd)
+	// — both equivalent to "go ahead and finalize". The DB-side
+	// updated_at + duration check is a sufficient proxy that doesn't
+	// require us to wire a dynamic chaos-mesh client into this layer.
+	guidedDuration := maxGuidedDurationMinutes(taskPayload)
+	now := r.now()
+	for i := range injections {
+		inj := &injections[i]
+		// If timestamps are populated, trust them: end_time + buffer is
+		// the natural "done enough" marker.
+		if inj.EndTime != nil {
+			if now.Before(inj.EndTime.Add(stuckGraceWindow)) {
+				logEntry.WithField("inj_name", inj.Name).
+					Debug("FaultInjection.EndTime in future + grace, skipping")
+				return false, nil
+			}
+			continue
+		}
+		// No timestamps: fall back to (UpdatedAt + max guided duration +
+		// grace). This covers the round-3 byte-cluster case where the
+		// worker died between CRD-add and CRD-success and updateInjectionTimestamp
+		// was never called.
+		threshold := inj.UpdatedAt.Add(time.Duration(guidedDuration)*time.Minute + stuckGraceWindow)
+		if now.Before(threshold) {
+			logEntry.WithField("inj_name", inj.Name).
+				Debug("FaultInjection.UpdatedAt + duration still in future, skipping")
+			return false, nil
+		}
+	}
+
+	// Choose the injection record we'll attach to the BuildDatapack
+	// payload. For single-leaf this is the only record; for hybrid we
+	// pick the most-recently-updated row (the one with the freshest
+	// CRD-success timestamps if the per-leaf updateInjectionTimestamp
+	// landed at all).
+	chosen := pickInjectionForDatapack(injections)
+
+	// Update injection state + timestamps the same way postProcess does.
+	// updateInjectionTimestamp is what produces the *dto.InjectionItem
+	// fed into the BuildDatapack payload.
+	if err := r.store.updateInjectionState(ctx, chosen.Name, consts.DatapackInjectSuccess); err != nil {
+		logEntry.WithError(err).Warn("update injection state failed (continuing)")
+	}
+
+	startTime := chosen.UpdatedAt.Add(-time.Duration(guidedDuration) * time.Minute)
+	endTime := chosen.UpdatedAt
+	if chosen.StartTime != nil {
+		startTime = *chosen.StartTime
+	}
+	if chosen.EndTime != nil {
+		endTime = *chosen.EndTime
+	}
+	updatedItem, err := r.store.updateInjectionTimestamp(ctx, chosen.Name, startTime, endTime)
+	if err != nil {
+		// Non-fatal — the FaultInjection row may already have timestamps
+		// (the post-CRD-success path wrote them). Build a synthetic item
+		// from the row we already have.
+		logEntry.WithError(err).Warn("update injection timestamps failed, falling back to existing record")
+		fallback := dto.NewInjectionItem(chosen)
+		updatedItem = &fallback
+	}
+
+	mergedEnvVars := mergeBenchmarkEnvVars(r.containerRepo, benchmark.ID, namespace, logEntry)
+	benchmark.EnvVars = mergedEnvVars
+
+	// We deliberately do NOT carry over the original CRD-annotation trace
+	// carrier: it was scoped to the chaos-mesh CRD lifetime, the CRD has
+	// long since been GC'd by the time we run, and the downstream
+	// BuildDatapack executor will mint a fresh trace span anyway. Leaving
+	// the carriers nil is the same shape SubmitTaskWithDB sees for any
+	// fresh task.
+	taskID := fiTask.ID
+	buildTask := &dto.UnifiedTask{
+		Type:      consts.TaskTypeBuildDatapack,
+		Immediate: true,
+		Payload: map[string]any{
+			consts.BuildBenchmark:        benchmark,
+			consts.BuildDatapack:         *updatedItem,
+			consts.BuildDatasetVersionID: consts.DefaultInvalidID,
+		},
+		ParentTaskID: utils.StringPtr(taskID),
+		TraceID:      trace.ID,
+		GroupID:      trace.GroupID,
+		ProjectID:    trace.ProjectID,
+		State:        consts.TaskPending,
+	}
+
+	if r.submitTask == nil {
+		return false, fmt.Errorf("submitTask not configured")
+	}
+	if err := r.submitTask(ctx, r.db, r.redisGateway, buildTask); err != nil {
+		return false, fmt.Errorf("submit recovered BuildDatapack task: %w", err)
+	}
+
+	logEntry.WithField("fault_injection_task_id", fiTask.ID).
+		Info("stuck trace reconciled: BuildDatapack task submitted")
+	return true, nil
+}
+
+// stuckGraceWindow is added on top of the inject duration to absorb the
+// usual k8s-controller queue + chaos-mesh recovery-check delay. With
+// CheckRecovery's 1-minute retry budget on top, two minutes is a safe lower
+// bound; we keep it conservative since the reconciler is the slow path.
+const stuckGraceWindow = 2 * time.Minute
+
+func intervalSecondsFromConfig() int {
+	v := config.GetInt(consts.StuckTraceReconcileIntervalKey)
+	if v <= 0 {
+		return consts.DefaultStuckTraceReconcileIntervalSecs
+	}
+	return v
+}
+
+func stuckThresholdSecondsFromConfig() int {
+	v := config.GetInt(consts.StuckTraceReconcileStuckThresholdKey)
+	if v <= 0 {
+		return consts.DefaultStuckTraceReconcileStuckSecs
+	}
+	return v
+}
+
+// decodeTaskPayload deserializes the FaultInjection task's payload (stored
+// as a JSON string in the tasks.payload column) back into the map shape the
+// rest of the consumer code consumes.
+func decodeTaskPayload(t *model.Task) (map[string]any, error) {
+	if t.Payload == "" {
+		return nil, fmt.Errorf("empty task payload")
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(t.Payload), &out); err != nil {
+		return nil, fmt.Errorf("unmarshal task payload: %w", err)
+	}
+	return out, nil
+}
+
+// maxGuidedDurationMinutes returns the largest guided_configs[i].Duration in
+// the FaultInjection task's payload, in minutes. Defaults to 5 (the
+// chaos-experiment guided default) if no duration is present.
+func maxGuidedDurationMinutes(payload map[string]any) int {
+	configs, err := utils.ConvertToType[[]guidedcli.GuidedConfig](payload[consts.InjectGuidedConfigs])
+	if err != nil {
+		return 5
+	}
+	longest := 0
+	for _, c := range configs {
+		if c.Duration != nil && *c.Duration > longest {
+			longest = *c.Duration
+		}
+	}
+	if longest == 0 {
+		return 5
+	}
+	return longest
+}
+
+// pickInjectionForDatapack chooses the FaultInjection row whose Name will be
+// passed into updateInjectionTimestamp. For single-leaf this is trivial.
+// For hybrid we pick the row with the latest UpdatedAt — that's the one
+// most likely to carry the freshest timestamp data; the BuildDatapack
+// pipeline only consumes one InjectionItem per task.
+func pickInjectionForDatapack(injections []model.FaultInjection) *model.FaultInjection {
+	if len(injections) == 1 {
+		return &injections[0]
+	}
+	bestIdx := 0
+	bestTime := injections[0].UpdatedAt
+	for i := 1; i < len(injections); i++ {
+		if injections[i].UpdatedAt.After(bestTime) {
+			bestIdx = i
+			bestTime = injections[i].UpdatedAt
+		}
+	}
+	return &injections[bestIdx]
+}
+
+// mergeBenchmarkEnvVars rebuilds the env-var slice that postProcess in
+// HandleCRDSucceeded would have constructed: NAMESPACE override at the top,
+// then de-duplicated benchmark env vars from container_version_env_vars.
+// We tolerate ListEnvVarsByVersionID failures the same way postProcess does
+// — treat as empty list, log and continue.
+func mergeBenchmarkEnvVars(repo containerEnvVarLister, benchmarkID int, namespace string, logEntry *logrus.Entry) []dto.ParameterItem {
+	var benchEnvVars []dto.ParameterItem
+	if repo != nil {
+		var err error
+		benchEnvVars, err = repo.ListEnvVarsByVersionID(benchmarkID)
+		if err != nil {
+			logEntry.WithError(err).Warn("list benchmark env vars failed (continuing)")
+			benchEnvVars = nil
+		}
+	}
+	merged := make([]dto.ParameterItem, 0, len(benchEnvVars)+1)
+	seen := map[string]bool{}
+	if namespace != "" {
+		nsOverride := dto.ParameterItem{Key: "NAMESPACE", Value: namespace}
+		merged = append(merged, nsOverride)
+		seen[nsOverride.Key] = true
+	}
+	for _, ev := range benchEnvVars {
+		if seen[ev.Key] {
+			continue
+		}
+		seen[ev.Key] = true
+		merged = append(merged, ev)
+	}
+	return merged
+}
+
+// runSingleton guards against double-Run from a misconfigured fx wiring.
+var runSingleton sync.Once
+
+// StartStuckTraceReconciler is the fx hook entry point. It launches Run on
+// a goroutine and is safe against double-invocation.
+func StartStuckTraceReconciler(ctx context.Context, r *StuckTraceReconciler) {
+	if r == nil {
+		return
+	}
+	runSingleton.Do(func() {
+		go r.Run(ctx)
+	})
+}

--- a/AegisLab/src/service/consumer/stuck_trace_reconciler.go
+++ b/AegisLab/src/service/consumer/stuck_trace_reconciler.go
@@ -278,14 +278,16 @@ func (r *StuckTraceReconciler) recoverTrace(ctx context.Context, trace *model.Tr
 			}
 			continue
 		}
-		// No timestamps: fall back to (UpdatedAt + max guided duration +
+		// No timestamps: fall back to (CreatedAt + max guided duration +
 		// grace). This covers the round-3 byte-cluster case where the
 		// worker died between CRD-add and CRD-success and updateInjectionTimestamp
-		// was never called.
-		threshold := inj.UpdatedAt.Add(time.Duration(guidedDuration)*time.Minute + stuckGraceWindow)
+		// was never called. CreatedAt is the immutable INSERT timestamp
+		// — UpdatedAt is auto-bumped by GORM on any subsequent write
+		// (UpdateInjectionState, etc.) and would shift the window.
+		threshold := inj.CreatedAt.Add(time.Duration(guidedDuration)*time.Minute + stuckGraceWindow)
 		if now.Before(threshold) {
 			logEntry.WithField("inj_name", inj.Name).
-				Debug("FaultInjection.UpdatedAt + duration still in future, skipping")
+				Debug("FaultInjection.CreatedAt + duration still in future, skipping")
 			return false, nil
 		}
 	}
@@ -304,15 +306,17 @@ func (r *StuckTraceReconciler) recoverTrace(ctx context.Context, trace *model.Tr
 		logEntry.WithError(err).Warn("update injection state failed (continuing)")
 	}
 
-	// On a fresh FaultInjection row UpdatedAt is the *start* of the
-	// injection (the row is written when the chaos CRD is created and
-	// updateInjectionTimestamp hasn't yet run). The fault then runs
-	// forward from that point for `guidedDuration` minutes, so the
-	// abnormal window is [UpdatedAt, UpdatedAt + duration] — emphatically
-	// NOT the [UpdatedAt - duration, UpdatedAt] form an earlier draft
-	// used. Stored StartTime/EndTime override both.
-	startTime := chosen.UpdatedAt
-	endTime := chosen.UpdatedAt.Add(time.Duration(guidedDuration) * time.Minute)
+	// CreatedAt is the row INSERT timestamp, written exactly once when
+	// the chaos CRD is created — that's "fault start" within seconds.
+	// UpdatedAt would be tempting (it's set to the same value at INSERT
+	// on a fresh row) but GORM auto-bumps it on every save, including
+	// the UpdateInjectionState call a few lines up, so by the time we
+	// hit synthesis here UpdatedAt no longer corresponds to fault start.
+	// The fault runs forward from CreatedAt for `guidedDuration` minutes,
+	// so the abnormal window is [CreatedAt, CreatedAt + duration].
+	// Stored StartTime/EndTime override both when present.
+	startTime := chosen.CreatedAt
+	endTime := chosen.CreatedAt.Add(time.Duration(guidedDuration) * time.Minute)
 	if chosen.StartTime != nil {
 		startTime = *chosen.StartTime
 	}
@@ -321,12 +325,21 @@ func (r *StuckTraceReconciler) recoverTrace(ctx context.Context, trace *model.Tr
 	}
 	updatedItem, err := r.store.updateInjectionTimestamp(ctx, chosen.Name, startTime, endTime)
 	if err != nil {
-		// Non-fatal — the FaultInjection row may already have timestamps
-		// (the post-CRD-success path wrote them). Build a synthetic item
-		// from the row we already have.
-		logEntry.WithError(err).Warn("update injection timestamps failed, falling back to existing record")
-		fallback := dto.NewInjectionItem(chosen)
-		updatedItem = &fallback
+		// Non-fatal — even if the persist failed, BuildDatapack still
+		// needs a valid time window or it will query CH for an empty
+		// range and produce an empty datapack. dto.NewInjectionItem
+		// would copy chosen.StartTime/EndTime, which are nil in the
+		// stuck-trace fallback case. Build the item directly from the
+		// already-computed [startTime, endTime] (anchored to CreatedAt
+		// or to the stored timestamps if they were present).
+		logEntry.WithError(err).Warn("update injection timestamps failed, falling back to computed window")
+		updatedItem = &dto.InjectionItem{
+			ID:          chosen.ID,
+			Name:        chosen.Name,
+			PreDuration: chosen.PreDuration,
+			StartTime:   startTime,
+			EndTime:     endTime,
+		}
 	}
 
 	mergedEnvVars := mergeBenchmarkEnvVars(r.containerRepo, benchmark.ID, namespace, logEntry)

--- a/AegisLab/src/service/consumer/stuck_trace_reconciler.go
+++ b/AegisLab/src/service/consumer/stuck_trace_reconciler.go
@@ -45,6 +45,12 @@ type StuckTraceReconciler struct {
 	submitTask            taskSubmitter
 	maxBatchPerTick       int
 	tickHook              func(processed int, err error)
+	// runOnce guards Run from a misconfigured fx wiring that calls
+	// StartStuckTraceReconciler twice on the same instance. Instance-
+	// scoped (not package-scoped) so a fresh reconciler from a new fx
+	// lifecycle can start the loop again — important for tests and any
+	// future in-process controller restart.
+	runOnce sync.Once
 }
 
 // taskSubmitter is the seam tests use to capture the recovered BuildDatapack
@@ -371,6 +377,36 @@ func (r *StuckTraceReconciler) recoverTrace(ctx context.Context, trace *model.Tr
 		return false, fmt.Errorf("submitTask not configured")
 	}
 
+	// For traces stuck at fault.injection.started, the FaultInjection
+	// parent task is still TaskRunning in the DB. selectBestLastEvent
+	// ranks EventFaultInjectionCompleted highest among leaf events, but
+	// only TaskCompleted leaves are candidates — leaving the parent at
+	// TaskRunning means trace.last_event stays pinned at
+	// fault.injection.started even after BuildDatapack/RunAlgorithm/
+	// CollectResult complete downstream. Mark the parent TaskCompleted so
+	// the next downstream task transition re-derives last_event
+	// correctly via updateTraceState.
+	//
+	// We deliberately update only the task row here, not the trace's
+	// last_event field directly. The very next event in this trace is
+	// BuildDatapack's state change (which we're about to submit), and
+	// that path's updateTraceState will reread all task rows and pick
+	// the highest-priority completed event — at which point our just-
+	// completed FaultInjection becomes the source for last_event. This
+	// avoids tying the reconciler to redisGateway availability and
+	// avoids racing with the goroutine-launched updateTraceState used
+	// elsewhere.
+	if trace.LastEvent == consts.EventFaultInjectionStarted {
+		if err := r.db.WithContext(ctx).Model(&model.Task{}).
+			Where("id = ? AND state = ?", fiTask.ID, consts.TaskRunning).
+			Update("state", consts.TaskCompleted).Error; err != nil {
+			return false, fmt.Errorf("advance fault-injection parent task: %w", err)
+		}
+		fiTask.State = consts.TaskCompleted
+		logEntry.WithField("fault_injection_task_id", fiTask.ID).
+			Info("advanced FaultInjection parent task to TaskCompleted before BuildDatapack submit")
+	}
+
 	// Replica-safe submit. Two reconciler ticks (across replicas or even
 	// the same replica racing on a slow submit) can both observe zero
 	// BuildDatapack children at the unsynchronized count. Serialize via
@@ -567,16 +603,16 @@ func mergeBenchmarkEnvVars(repo containerEnvVarLister, benchmarkID int, namespac
 	return merged
 }
 
-// runSingleton guards against double-Run from a misconfigured fx wiring.
-var runSingleton sync.Once
-
 // StartStuckTraceReconciler is the fx hook entry point. It launches Run on
-// a goroutine and is safe against double-invocation.
+// a goroutine. The runOnce guard is instance-scoped (not package-scoped) so
+// multiple fx app start/stop cycles in the same process — common in tests
+// and any future in-process controller restart — can each spawn the loop
+// against a fresh ctx without being silently no-op'd.
 func StartStuckTraceReconciler(ctx context.Context, r *StuckTraceReconciler) {
 	if r == nil {
 		return
 	}
-	runSingleton.Do(func() {
+	r.runOnce.Do(func() {
 		go r.Run(ctx)
 	})
 }

--- a/AegisLab/src/service/consumer/stuck_trace_reconciler_test.go
+++ b/AegisLab/src/service/consumer/stuck_trace_reconciler_test.go
@@ -386,10 +386,10 @@ func TestReconciler_StuckAtFaultInjectionStartedFinalizesAfterDuration(t *testin
 	require.Len(t, captured, 1)
 }
 
-// TestReconciler_TolersatesStateUpdateError verifies the reconciler does not
+// TestReconciler_ToleratesStateUpdateError verifies the reconciler does not
 // fail closed when the injection state update fails — postProcess in
 // k8s_handler.go uses errCtx.Warn for this exact case, so we must mirror.
-func TestReconciler_TolersatesStateUpdateError(t *testing.T) {
+func TestReconciler_ToleratesStateUpdateError(t *testing.T) {
 	db := newReconcilerTestDB(t)
 	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, 1, 30*time.Minute, false)
 
@@ -456,4 +456,184 @@ func TestMaxGuidedDurationMinutes_PicksLargest(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// TestReconciler_SynthesizesAbnormalWindowForward pins the regression for
+// Copilot's time-math comment on stuck_trace_reconciler.go:296. When a
+// FaultInjection row is missing both StartTime and EndTime, the reconciler
+// must derive [UpdatedAt, UpdatedAt + duration]. UpdatedAt at row creation
+// is the *start* of the injection (the row is written when the chaos CRD
+// is created); the fault then runs forward for `duration` minutes. The
+// earlier draft inverted this and produced [UpdatedAt - duration,
+// UpdatedAt], which made BuildDatapack query a window shifted entirely
+// before the actual fault.
+func TestReconciler_SynthesizesAbnormalWindowForward(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	const durationMin = 5
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, durationMin, 30*time.Minute, false)
+
+	// Mirror the fixture's stuck_at exactly so the assertion reads the
+	// synthesized window without timing fuzz.
+	var row model.FaultInjection
+	require.NoError(t, db.Where("name = ?", fix.injectionName).First(&row).Error)
+	require.Nil(t, row.StartTime, "fixture must NOT set StartTime; this test exercises the synthesis path")
+	require.Nil(t, row.EndTime, "fixture must NOT set EndTime; this test exercises the synthesis path")
+	stuckAt := row.UpdatedAt
+
+	owner := newFakeInjectionOwner([]model.FaultInjection{
+		{ID: row.ID, Name: fix.injectionName, TaskID: &fix.faultTaskID, UpdatedAt: stuckAt},
+	})
+
+	submitter := taskSubmitter(func(_ context.Context, _ *gorm.DB, _ *redis.Gateway, _ *dto.UnifiedTask) error {
+		return nil
+	})
+	r := newReconcilerForTest(t, db, owner, submitter)
+	processed, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+
+	require.Len(t, owner.timestampUpdates, 1)
+	got := owner.timestampUpdates[0]
+	wantStart := stuckAt
+	wantEnd := stuckAt.Add(durationMin * time.Minute)
+	require.True(t, got.StartTime.Equal(wantStart),
+		"start_time must equal UpdatedAt (%s), got %s", wantStart, got.StartTime)
+	require.True(t, got.EndTime.Equal(wantEnd),
+		"end_time must equal UpdatedAt + duration (%s), got %s", wantEnd, got.EndTime)
+	require.True(t, got.EndTime.After(got.StartTime),
+		"window must run forward from UpdatedAt, not backward")
+}
+
+// TestReconciler_PrefersStoredTimestampsOverSynthesis verifies that stored
+// StartTime/EndTime on the FaultInjection row override the synthesis path.
+// This is the post-CRD-success case: the per-leaf updateInjectionTimestamp
+// landed in the DB but BuildDatapack never got submitted.
+func TestReconciler_PrefersStoredTimestampsOverSynthesis(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, 5, 30*time.Minute, false)
+
+	storedStart := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	storedEnd := storedStart.Add(7 * time.Minute)
+	require.NoError(t, db.Model(&model.FaultInjection{}).
+		Where("name = ?", fix.injectionName).
+		Updates(map[string]any{"start_time": storedStart, "end_time": storedEnd}).Error)
+
+	owner := newFakeInjectionOwner([]model.FaultInjection{
+		{ID: 1, Name: fix.injectionName, TaskID: &fix.faultTaskID, StartTime: &storedStart, EndTime: &storedEnd},
+	})
+	submitter := taskSubmitter(func(_ context.Context, _ *gorm.DB, _ *redis.Gateway, _ *dto.UnifiedTask) error {
+		return nil
+	})
+	r := newReconcilerForTest(t, db, owner, submitter)
+	processed, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+
+	require.Len(t, owner.timestampUpdates, 1)
+	got := owner.timestampUpdates[0]
+	require.True(t, got.StartTime.Equal(storedStart), "stored StartTime must win over synthesis")
+	require.True(t, got.EndTime.Equal(storedEnd), "stored EndTime must win over synthesis")
+}
+
+// TestReconciler_ConcurrentTicksSubmitOnce simulates two reconciler replicas
+// running tick() concurrently against the same stuck trace. The transaction
+// + recheck must guarantee exactly one BuildDatapack lands. Without the
+// FOR UPDATE / re-check coupling this races and submits twice.
+func TestReconciler_ConcurrentTicksSubmitOnce(t *testing.T) {
+	// Use a shared in-memory DSN so both goroutines and the orchestrator
+	// see the same SQLite database. The default ":memory:" form gives
+	// each connection its own isolated DB, which would let the race
+	// "succeed" trivially even under buggy code.
+	db, err := gorm.Open(
+		sqlite.Open("file:reconciler_race?mode=memory&cache=shared"),
+		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)},
+	)
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&model.Trace{}, &model.Task{}, &model.FaultInjection{}))
+	t.Cleanup(func() {
+		sql, err := db.DB()
+		if err == nil {
+			_ = sql.Close()
+		}
+	})
+
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, 1, 30*time.Minute, false)
+	rowSnapshot := model.FaultInjection{ID: 1, Name: fix.injectionName, TaskID: &fix.faultTaskID}
+
+	// The submitter persists a child Task row inside the same tx the
+	// reconciler hands it. This is what the production submitter (
+	// common.SubmitTaskWithDB) does, and it's what the in-tx idempotency
+	// recheck on the second goroutine needs to observe.
+	persistChild := func(_ context.Context, tx *gorm.DB, _ *redis.Gateway, task *dto.UnifiedTask) error {
+		row := &model.Task{
+			ID:           uuid.NewString(),
+			Type:         task.Type,
+			TraceID:      task.TraceID,
+			ParentTaskID: task.ParentTaskID,
+			Payload:      "{}",
+			State:        consts.TaskPending,
+			Status:       consts.CommonEnabled,
+		}
+		return tx.Create(row).Error
+	}
+
+	tickOnce := func() (int, error) {
+		owner := newFakeInjectionOwner([]model.FaultInjection{rowSnapshot})
+		r := newReconcilerForTest(t, db, owner, persistChild)
+		return r.tick(context.Background())
+	}
+
+	var wg sync.WaitGroup
+	results := make([]int, 2)
+	errs := make([]error, 2)
+	wg.Add(2)
+	start := make(chan struct{})
+	for i := 0; i < 2; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i], errs[i] = tickOnce()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "goroutine %d", i)
+	}
+	require.Equal(t, 1, results[0]+results[1],
+		"exactly one of the racing reconcilers must observe a successful submit; got %v", results)
+
+	// Belt-and-braces: the DB itself must hold exactly one BuildDatapack
+	// child row.
+	var n int64
+	require.NoError(t, db.Model(&model.Task{}).
+		Where("parent_task_id = ? AND type = ?", fix.faultTaskID, consts.TaskTypeBuildDatapack).
+		Count(&n).Error)
+	require.Equal(t, int64(1), n, "exactly one BuildDatapack child must exist after concurrent ticks")
+}
+
+// TestReconciler_ResolveIntervalRespectsConfig pins the ticker plumbing
+// (Copilot comment on Run): the reconciler must read interval-from-config
+// on every cycle so an etcd push at runtime is honored without a worker
+// restart. Resolution is unit-tested directly; the live ticker.Reset is
+// exercised by integration suites — running a real ticker in unit tests
+// is racy and adds no signal.
+func TestReconciler_ResolveIntervalRespectsConfig(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	r := newReconcilerForTest(t, db, newFakeInjectionOwner(nil), nil)
+
+	configured := 7
+	r.intervalSeconds = func() int { return configured }
+	require.Equal(t, 7*time.Second, r.resolveInterval())
+
+	configured = 30
+	require.Equal(t, 30*time.Second, r.resolveInterval(),
+		"resolveInterval must re-read the config getter, not cache")
+
+	configured = 0
+	require.Equal(t,
+		time.Duration(consts.DefaultStuckTraceReconcileIntervalSecs)*time.Second,
+		r.resolveInterval(),
+		"non-positive config must fall through to the default")
 }

--- a/AegisLab/src/service/consumer/stuck_trace_reconciler_test.go
+++ b/AegisLab/src/service/consumer/stuck_trace_reconciler_test.go
@@ -174,6 +174,12 @@ func makeStuckFixture(t *testing.T, db *gorm.DB, lastEvent consts.EventType, dur
 		UpdatedAt: stuckAt,
 	}).Error)
 
+	// Set CreatedAt explicitly: it's the immutable "fault start" anchor
+	// the reconciler now uses for both the duration gate and the
+	// synthesized abnormal window. UpdatedAt is left as auto-now to
+	// reflect production semantics — GORM bumps it on every save (e.g.
+	// UpdateInjectionState), so a test that pinned UpdatedAt to stuckAt
+	// would mask the very bug we're guarding against.
 	injectionName := "fi-" + uuid.NewString()
 	require.NoError(t, db.Create(&model.FaultInjection{
 		Name:      injectionName,
@@ -181,7 +187,7 @@ func makeStuckFixture(t *testing.T, db *gorm.DB, lastEvent consts.EventType, dur
 		TaskID:    &faultTaskID,
 		State:     consts.DatapackInitial,
 		Status:    consts.CommonEnabled,
-		UpdatedAt: stuckAt,
+		CreatedAt: stuckAt,
 	}).Error)
 	if hybrid {
 		require.NoError(t, db.Create(&model.FaultInjection{
@@ -190,7 +196,7 @@ func makeStuckFixture(t *testing.T, db *gorm.DB, lastEvent consts.EventType, dur
 			TaskID:    &faultTaskID,
 			State:     consts.DatapackInitial,
 			Status:    consts.CommonEnabled,
-			UpdatedAt: stuckAt.Add(time.Second),
+			CreatedAt: stuckAt.Add(time.Second),
 		}).Error)
 	}
 
@@ -459,29 +465,29 @@ func TestMaxGuidedDurationMinutes_PicksLargest(t *testing.T) {
 }
 
 // TestReconciler_SynthesizesAbnormalWindowForward pins the regression for
-// Copilot's time-math comment on stuck_trace_reconciler.go:296. When a
+// Copilot's time-math comment on stuck_trace_reconciler.go. When a
 // FaultInjection row is missing both StartTime and EndTime, the reconciler
-// must derive [UpdatedAt, UpdatedAt + duration]. UpdatedAt at row creation
-// is the *start* of the injection (the row is written when the chaos CRD
-// is created); the fault then runs forward for `duration` minutes. The
-// earlier draft inverted this and produced [UpdatedAt - duration,
-// UpdatedAt], which made BuildDatapack query a window shifted entirely
-// before the actual fault.
+// must derive [CreatedAt, CreatedAt + duration]. CreatedAt is the immutable
+// row-INSERT timestamp written when the chaos CRD is created; the fault
+// then runs forward for `duration` minutes. UpdatedAt would be wrong here
+// because GORM bumps it on every save (e.g. UpdateInjectionState a few
+// lines earlier), so anchoring synthesis to UpdatedAt would shift the
+// window forward by however long the unrelated state-write took.
 func TestReconciler_SynthesizesAbnormalWindowForward(t *testing.T) {
 	db := newReconcilerTestDB(t)
 	const durationMin = 5
 	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, durationMin, 30*time.Minute, false)
 
-	// Mirror the fixture's stuck_at exactly so the assertion reads the
+	// Mirror the fixture's CreatedAt exactly so the assertion reads the
 	// synthesized window without timing fuzz.
 	var row model.FaultInjection
 	require.NoError(t, db.Where("name = ?", fix.injectionName).First(&row).Error)
 	require.Nil(t, row.StartTime, "fixture must NOT set StartTime; this test exercises the synthesis path")
 	require.Nil(t, row.EndTime, "fixture must NOT set EndTime; this test exercises the synthesis path")
-	stuckAt := row.UpdatedAt
+	createdAt := row.CreatedAt
 
 	owner := newFakeInjectionOwner([]model.FaultInjection{
-		{ID: row.ID, Name: fix.injectionName, TaskID: &fix.faultTaskID, UpdatedAt: stuckAt},
+		{ID: row.ID, Name: fix.injectionName, TaskID: &fix.faultTaskID, CreatedAt: createdAt},
 	})
 
 	submitter := taskSubmitter(func(_ context.Context, _ *gorm.DB, _ *redis.Gateway, _ *dto.UnifiedTask) error {
@@ -494,14 +500,14 @@ func TestReconciler_SynthesizesAbnormalWindowForward(t *testing.T) {
 
 	require.Len(t, owner.timestampUpdates, 1)
 	got := owner.timestampUpdates[0]
-	wantStart := stuckAt
-	wantEnd := stuckAt.Add(durationMin * time.Minute)
+	wantStart := createdAt
+	wantEnd := createdAt.Add(durationMin * time.Minute)
 	require.True(t, got.StartTime.Equal(wantStart),
-		"start_time must equal UpdatedAt (%s), got %s", wantStart, got.StartTime)
+		"start_time must equal CreatedAt (%s), got %s", wantStart, got.StartTime)
 	require.True(t, got.EndTime.Equal(wantEnd),
-		"end_time must equal UpdatedAt + duration (%s), got %s", wantEnd, got.EndTime)
+		"end_time must equal CreatedAt + duration (%s), got %s", wantEnd, got.EndTime)
 	require.True(t, got.EndTime.After(got.StartTime),
-		"window must run forward from UpdatedAt, not backward")
+		"window must run forward from CreatedAt, not backward")
 }
 
 // TestReconciler_PrefersStoredTimestampsOverSynthesis verifies that stored
@@ -636,4 +642,81 @@ func TestReconciler_ResolveIntervalRespectsConfig(t *testing.T) {
 		time.Duration(consts.DefaultStuckTraceReconcileIntervalSecs)*time.Second,
 		r.resolveInterval(),
 		"non-positive config must fall through to the default")
+}
+
+// TestReconciler_GatesAndSynthesisIgnoreUpdatedAtBumps reproduces the
+// production failure mode the CreatedAt switch is closing.
+//
+// Setup: a FaultInjection row born well past the fault window
+// (CreatedAt = now - 30min, guidedDuration = 5min, so the window
+// [CreatedAt, CreatedAt + 5min] ended ~25min ago). Then an unrelated
+// control-plane write — modeled here by a GORM Save that flips State —
+// auto-bumps UpdatedAt to ~now via autoUpdateTime. This is exactly what
+// UpdateInjectionState does in production once the chaos-mesh
+// informer fires.
+//
+// Pre-fix behavior: the duration gate read inj.UpdatedAt (~now), so
+// threshold = now + 5min + grace, the gate said "still in window",
+// and the trace was kept stuck across ticks even though the fault
+// completed half an hour ago. Recovery would never fire until the
+// trace fell out of the scan window.
+//
+// Post-fix behavior: the gate reads inj.CreatedAt (now - 30min), so
+// threshold = now - 23min, the gate correctly says "past window", and
+// the reconciler proceeds. The synthesis path then anchors start/end
+// to CreatedAt, not UpdatedAt — so BuildDatapack queries the correct
+// abnormal window even though UpdatedAt is far in the future relative
+// to the actual fault.
+func TestReconciler_GatesAndSynthesisIgnoreUpdatedAtBumps(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	const durationMin = 5
+	const stalenessMin = 30
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, durationMin, stalenessMin*time.Minute, false)
+
+	// Simulate the unrelated state write that happens in production
+	// (UpdateInjectionState et al.). Use a real GORM Save so
+	// autoUpdateTime bumps UpdatedAt to ~now — exactly what bites the
+	// reconciler. CreatedAt stays at the fixture's stuckAt.
+	var row model.FaultInjection
+	require.NoError(t, db.Where("name = ?", fix.injectionName).First(&row).Error)
+	originalCreatedAt := row.CreatedAt
+	row.State = consts.DatapackInjectSuccess
+	require.NoError(t, db.Save(&row).Error)
+
+	var afterBump model.FaultInjection
+	require.NoError(t, db.Where("name = ?", fix.injectionName).First(&afterBump).Error)
+	require.True(t, afterBump.CreatedAt.Equal(originalCreatedAt),
+		"GORM Save must preserve CreatedAt; got %s want %s",
+		afterBump.CreatedAt, originalCreatedAt)
+	require.True(t, afterBump.UpdatedAt.After(originalCreatedAt.Add(time.Duration(stalenessMin-1)*time.Minute)),
+		"GORM autoUpdateTime must have bumped UpdatedAt to ~now (>= %d min after CreatedAt); got UpdatedAt=%s CreatedAt=%s",
+		stalenessMin-1, afterBump.UpdatedAt, originalCreatedAt)
+
+	owner := newFakeInjectionOwner([]model.FaultInjection{afterBump})
+	var captured []*dto.UnifiedTask
+	submitter := taskSubmitter(func(_ context.Context, _ *gorm.DB, _ *redis.Gateway, t *dto.UnifiedTask) error {
+		captured = append(captured, t)
+		return nil
+	})
+
+	r := newReconcilerForTest(t, db, owner, submitter)
+	processed, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed,
+		"duration gate anchored to CreatedAt must let the trace finalize: "+
+			"row was created %dmin ago and the %dmin fault window has long since elapsed",
+		stalenessMin, durationMin)
+	require.Len(t, captured, 1)
+
+	// Synthesis must use CreatedAt, not the auto-bumped UpdatedAt.
+	require.Len(t, owner.timestampUpdates, 1)
+	got := owner.timestampUpdates[0]
+	require.True(t, got.StartTime.Equal(originalCreatedAt),
+		"synthesized start_time must equal CreatedAt (%s), got %s — "+
+			"if this asserts UpdatedAt the synthesis is reading the "+
+			"auto-bumped field and BuildDatapack will query the wrong window",
+		originalCreatedAt, got.StartTime)
+	require.True(t, got.EndTime.Equal(originalCreatedAt.Add(durationMin*time.Minute)),
+		"synthesized end_time must equal CreatedAt + duration; got %s",
+		got.EndTime)
 }

--- a/AegisLab/src/service/consumer/stuck_trace_reconciler_test.go
+++ b/AegisLab/src/service/consumer/stuck_trace_reconciler_test.go
@@ -390,6 +390,53 @@ func TestReconciler_StuckAtFaultInjectionStartedFinalizesAfterDuration(t *testin
 	require.NoError(t, err)
 	require.Equal(t, 1, processed)
 	require.Len(t, captured, 1)
+
+	// Parent FaultInjection task must be advanced to TaskCompleted, otherwise
+	// selectBestLastEvent leaves trace.last_event pinned at fault.injection.started
+	// even after the recovered BuildDatapack chain finishes downstream. This
+	// is the behavior the second round of Copilot review on PR #294 caught:
+	// submitting BuildDatapack alone without advancing the parent task wedges
+	// the trace status at the originally-stuck event forever.
+	var parent model.Task
+	require.NoError(t, db.Where("id = ?", fix.faultTaskID).First(&parent).Error)
+	require.Equal(t, consts.TaskCompleted, parent.State, "FaultInjection parent must be advanced to TaskCompleted")
+}
+
+// TestReconciler_StuckAtFaultInjectionCompletedDoesNotReadvanceParent
+// verifies the parent-advance step is gated to last_event=Started — for
+// traces already past Completed, the parent is already TaskCompleted, so
+// re-touching it would be a wasted DB write at best and a regression
+// signal at worst (we'd be implying we re-derive Completed traces, which
+// we don't).
+func TestReconciler_StuckAtFaultInjectionCompletedDoesNotReadvanceParent(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	// 30min staleness vs 5min guided duration so we're past the duration gate.
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, 5, 30*time.Minute, false)
+
+	// Inflate a non-current updated_at on the parent task so we can detect
+	// whether the reconciler wrote to it. If it doesn't write, updated_at
+	// stays at this old value (within 1ms tolerance).
+	frozen := time.Now().Add(-15 * time.Minute)
+	require.NoError(t, db.Model(&model.Task{}).
+		Where("id = ?", fix.faultTaskID).
+		UpdateColumn("updated_at", frozen).Error)
+
+	owner := newFakeInjectionOwner([]model.FaultInjection{
+		{ID: 1, Name: fix.injectionName, TaskID: &fix.faultTaskID},
+	})
+	submitter := taskSubmitter(func(_ context.Context, _ *gorm.DB, _ *redis.Gateway, _ *dto.UnifiedTask) error {
+		return nil
+	})
+	r := newReconcilerForTest(t, db, owner, submitter)
+	r.stuckThresholdSeconds = func() int { return 60 }
+	processed, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+
+	var parent model.Task
+	require.NoError(t, db.Where("id = ?", fix.faultTaskID).First(&parent).Error)
+	require.WithinDuration(t, frozen, parent.UpdatedAt, time.Second,
+		"parent task updated_at should not have moved — completed-stuck path must not re-touch the parent")
 }
 
 // TestReconciler_ToleratesStateUpdateError verifies the reconciler does not

--- a/AegisLab/src/service/consumer/stuck_trace_reconciler_test.go
+++ b/AegisLab/src/service/consumer/stuck_trace_reconciler_test.go
@@ -1,0 +1,459 @@
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"aegis/consts"
+	"aegis/dto"
+	redis "aegis/infra/redis"
+	"aegis/model"
+	execution "aegis/module/execution"
+	injection "aegis/module/injection"
+
+	"github.com/OperationsPAI/chaos-experiment/pkg/guidedcli"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// fakeInjectionOwner is the minimal seam reconciler tests need: it captures
+// the state/timestamp updates the recovery path applies to a stuck trace.
+type fakeInjectionOwner struct {
+	mu                 sync.Mutex
+	stateUpdates       []injection.RuntimeUpdateInjectionStateReq
+	timestampUpdates   []injection.RuntimeUpdateInjectionTimestampReq
+	timestampReturnErr error
+	stateReturnErr     error
+	// stored mirrors the FaultInjection rows we wrote so
+	// UpdateInjectionTimestamps can return a populated InjectionItem.
+	stored map[string]*model.FaultInjection
+}
+
+func newFakeInjectionOwner(rows []model.FaultInjection) *fakeInjectionOwner {
+	stored := make(map[string]*model.FaultInjection, len(rows))
+	for i := range rows {
+		stored[rows[i].Name] = &rows[i]
+	}
+	return &fakeInjectionOwner{stored: stored}
+}
+
+func (f *fakeInjectionOwner) CreateInjection(_ context.Context, _ *injection.RuntimeCreateInjectionReq) (*dto.InjectionItem, error) {
+	return nil, nil
+}
+
+func (f *fakeInjectionOwner) UpdateInjectionState(_ context.Context, req *injection.RuntimeUpdateInjectionStateReq) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stateUpdates = append(f.stateUpdates, *req)
+	return f.stateReturnErr
+}
+
+func (f *fakeInjectionOwner) UpdateInjectionTimestamps(_ context.Context, req *injection.RuntimeUpdateInjectionTimestampReq) (*dto.InjectionItem, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.timestampUpdates = append(f.timestampUpdates, *req)
+	if f.timestampReturnErr != nil {
+		return nil, f.timestampReturnErr
+	}
+	row, ok := f.stored[req.Name]
+	if !ok {
+		row = &model.FaultInjection{ID: 1, Name: req.Name}
+	}
+	start := req.StartTime
+	end := req.EndTime
+	row.StartTime = &start
+	row.EndTime = &end
+	item := dto.NewInjectionItem(row)
+	return &item, nil
+}
+
+type fakeExecutionOwner struct{}
+
+func (fakeExecutionOwner) CreateExecution(context.Context, *execution.RuntimeCreateExecutionReq) (int, error) {
+	return 0, nil
+}
+func (fakeExecutionOwner) GetExecution(context.Context, int) (*execution.ExecutionDetailResp, error) {
+	return nil, nil
+}
+func (fakeExecutionOwner) UpdateExecutionState(context.Context, *execution.RuntimeUpdateExecutionStateReq) error {
+	return nil
+}
+
+type fakeEnvVarLister struct {
+	envVars []dto.ParameterItem
+	err     error
+}
+
+func (f *fakeEnvVarLister) ListEnvVarsByVersionID(int) ([]dto.ParameterItem, error) {
+	return f.envVars, f.err
+}
+
+func newReconcilerTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(
+		&model.Trace{},
+		&model.Task{},
+		&model.FaultInjection{},
+	))
+	return db
+}
+
+// reconcilerFixture builds a stuck trace + its FaultInjection task + a
+// FaultInjection record at the given staleness.
+type reconcilerFixture struct {
+	traceID         string
+	faultTaskID     string
+	injectionName   string
+	durationMinutes int
+}
+
+func makeStuckFixture(t *testing.T, db *gorm.DB, lastEvent consts.EventType, durationMin int, staleness time.Duration, hybrid bool) reconcilerFixture {
+	t.Helper()
+	now := time.Now()
+	stuckAt := now.Add(-staleness)
+
+	traceID := uuid.NewString()
+	require.NoError(t, db.Create(&model.Trace{
+		ID:        traceID,
+		Type:      consts.TraceTypeFullPipeline,
+		LastEvent: lastEvent,
+		StartTime: stuckAt.Add(-1 * time.Minute),
+		State:     consts.TraceRunning,
+		Status:    consts.CommonEnabled,
+		LeafNum:   1,
+		UpdatedAt: stuckAt,
+	}).Error)
+
+	faultTaskID := uuid.NewString()
+	guidedConfigs := []guidedcli.GuidedConfig{{
+		System:    "ts",
+		Namespace: "ts",
+		ChaosType: "PodKill",
+		Duration:  intPtr(durationMin),
+	}}
+	if hybrid {
+		guidedConfigs = append(guidedConfigs, guidedcli.GuidedConfig{
+			System:    "ts",
+			Namespace: "ts",
+			ChaosType: "JVMReturn",
+			Duration:  intPtr(durationMin),
+		})
+	}
+	payload := map[string]any{
+		consts.InjectBenchmark: dto.ContainerVersionItem{
+			ID: 7, ContainerName: "rcabench", Command: "/bin/echo",
+		},
+		consts.InjectPreDuration:   float64(1),
+		consts.InjectGuidedConfigs: guidedConfigs,
+		consts.InjectNamespace:     "ts",
+		consts.InjectPedestal:      "ts",
+		consts.InjectPedestalID:    float64(11),
+		consts.InjectSystem:        "ts",
+	}
+	pj, err := json.Marshal(payload)
+	require.NoError(t, err)
+	require.NoError(t, db.Create(&model.Task{
+		ID:        faultTaskID,
+		Type:      consts.TaskTypeFaultInjection,
+		TraceID:   traceID,
+		Payload:   string(pj),
+		State:     consts.TaskRunning,
+		Status:    consts.CommonEnabled,
+		Level:     1,
+		Sequence:  0,
+		UpdatedAt: stuckAt,
+	}).Error)
+
+	injectionName := "fi-" + uuid.NewString()
+	require.NoError(t, db.Create(&model.FaultInjection{
+		Name:      injectionName,
+		Category:  "ts",
+		TaskID:    &faultTaskID,
+		State:     consts.DatapackInitial,
+		Status:    consts.CommonEnabled,
+		UpdatedAt: stuckAt,
+	}).Error)
+	if hybrid {
+		require.NoError(t, db.Create(&model.FaultInjection{
+			Name:      injectionName + "-leaf2",
+			Category:  "ts",
+			TaskID:    &faultTaskID,
+			State:     consts.DatapackInitial,
+			Status:    consts.CommonEnabled,
+			UpdatedAt: stuckAt.Add(time.Second),
+		}).Error)
+	}
+
+	return reconcilerFixture{
+		traceID:         traceID,
+		faultTaskID:     faultTaskID,
+		injectionName:   injectionName,
+		durationMinutes: durationMin,
+	}
+}
+
+func intPtr(v int) *int { return &v }
+
+func newReconcilerForTest(t *testing.T, db *gorm.DB, owner *fakeInjectionOwner, submit taskSubmitter) *StuckTraceReconciler {
+	t.Helper()
+	r := &StuckTraceReconciler{
+		db:                    db,
+		store:                 newStateStore(fakeExecutionOwner{}, owner),
+		containerRepo:         &fakeEnvVarLister{},
+		now:                   time.Now,
+		intervalSeconds:       func() int { return 60 },
+		stuckThresholdSeconds: func() int { return 60 },
+		submitTask:            submit,
+		maxBatchPerTick:       50,
+	}
+	return r
+}
+
+// TestReconciler_RecoversTraceStuckAtFaultInjectionCompleted exercises the
+// in-memory batchManager-loss path described in the issue #293 timeline:
+// fault.injection.completed was the trace's last_event but no BuildDatapack
+// task ever materialised. The reconciler must submit one.
+func TestReconciler_RecoversTraceStuckAtFaultInjectionCompleted(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, 1, 30*time.Minute, false)
+
+	owner := newFakeInjectionOwner([]model.FaultInjection{
+		{ID: 1, Name: fix.injectionName, TaskID: &fix.faultTaskID, PreDuration: 1},
+	})
+
+	var captured []*dto.UnifiedTask
+	submitter := taskSubmitter(func(_ context.Context, _ *gorm.DB, _ *redis.Gateway, t *dto.UnifiedTask) error {
+		captured = append(captured, t)
+		return nil
+	})
+
+	r := newReconcilerForTest(t, db, owner, submitter)
+	processed, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+	require.Len(t, captured, 1)
+
+	got := captured[0]
+	require.Equal(t, consts.TaskTypeBuildDatapack, got.Type)
+	require.True(t, got.Immediate)
+	require.Equal(t, fix.traceID, got.TraceID)
+	require.NotNil(t, got.ParentTaskID)
+	require.Equal(t, fix.faultTaskID, *got.ParentTaskID)
+
+	// state + timestamps must have been written.
+	require.Equal(t, []injection.RuntimeUpdateInjectionStateReq{{
+		Name:  fix.injectionName,
+		State: consts.DatapackInjectSuccess,
+	}}, owner.stateUpdates)
+	require.Len(t, owner.timestampUpdates, 1)
+	require.Equal(t, fix.injectionName, owner.timestampUpdates[0].Name)
+}
+
+// TestReconciler_IsIdempotent simulates the CRD-success path racing the
+// reconciler: if a BuildDatapack child task already exists for the same
+// FaultInjection task, the reconciler must NOT submit a second one.
+func TestReconciler_IsIdempotent(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, 1, 30*time.Minute, false)
+
+	// The CRD-success path got there first.
+	require.NoError(t, db.Create(&model.Task{
+		ID:           uuid.NewString(),
+		Type:         consts.TaskTypeBuildDatapack,
+		TraceID:      fix.traceID,
+		ParentTaskID: &fix.faultTaskID,
+		Payload:      "{}",
+		State:        consts.TaskPending,
+		Status:       consts.CommonEnabled,
+	}).Error)
+
+	owner := newFakeInjectionOwner([]model.FaultInjection{
+		{ID: 1, Name: fix.injectionName, TaskID: &fix.faultTaskID},
+	})
+	called := 0
+	submitter := taskSubmitter(func(_ context.Context, _ *gorm.DB, _ *redis.Gateway, _ *dto.UnifiedTask) error {
+		called++
+		return nil
+	})
+	r := newReconcilerForTest(t, db, owner, submitter)
+	processed, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, processed)
+	require.Equal(t, 0, called)
+}
+
+// TestReconciler_RespectsStuckThreshold guards against the reconciler
+// stealing in-flight traces that are still inside their fault window.
+// updated_at within the stuck threshold must be left alone.
+func TestReconciler_RespectsStuckThreshold(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	// Fresh trace, only 10s old. Stuck threshold default is 600s.
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, 1, 10*time.Second, false)
+	_ = fix
+
+	owner := newFakeInjectionOwner(nil)
+	submitter := taskSubmitter(func(context.Context, *gorm.DB, *redis.Gateway, *dto.UnifiedTask) error {
+		t.Fatal("submit must not be called")
+		return nil
+	})
+	r := newReconcilerForTest(t, db, owner, submitter)
+	r.stuckThresholdSeconds = func() int { return 600 }
+	processed, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, processed)
+}
+
+// TestReconciler_HybridBatchRecoversWithoutBatchManager covers the
+// in-memory batchManager-race path: K_inner=2 with both leaves DB-resident
+// must still complete via the reconciler when the in-memory counter is
+// gone (worker restart or race-lost increment).
+func TestReconciler_HybridBatchRecoversWithoutBatchManager(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, 1, 30*time.Minute, true)
+
+	owner := newFakeInjectionOwner([]model.FaultInjection{
+		{ID: 1, Name: fix.injectionName, TaskID: &fix.faultTaskID},
+		{ID: 2, Name: fix.injectionName + "-leaf2", TaskID: &fix.faultTaskID},
+	})
+
+	var captured []*dto.UnifiedTask
+	submitter := taskSubmitter(func(_ context.Context, _ *gorm.DB, _ *redis.Gateway, t *dto.UnifiedTask) error {
+		captured = append(captured, t)
+		return nil
+	})
+	r := newReconcilerForTest(t, db, owner, submitter)
+	processed, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed, "hybrid batch must recover with exactly one BuildDatapack submit")
+	require.Len(t, captured, 1)
+}
+
+// TestReconciler_StuckAtFaultInjectionStartedRespectsDuration covers the
+// round-3 path: trace stuck at fault.injection.started because the worker
+// died before CRD-success ever fired. We must not finalize until
+// updated_at + max(guided.Duration) + grace is in the past.
+func TestReconciler_StuckAtFaultInjectionStartedRespectsDuration(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	// Trace stuck 3min ago, but guided duration is 5min — fault might
+	// still be running (no CRD-success means we trust duration).
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionStarted, 5, 3*time.Minute, false)
+	_ = fix
+
+	owner := newFakeInjectionOwner([]model.FaultInjection{})
+	submitter := taskSubmitter(func(context.Context, *gorm.DB, *redis.Gateway, *dto.UnifiedTask) error {
+		t.Fatal("submit must not be called: fault still inside duration window")
+		return nil
+	})
+	r := newReconcilerForTest(t, db, owner, submitter)
+	r.stuckThresholdSeconds = func() int { return 60 } // pull trace into scan
+	processed, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, processed)
+}
+
+// TestReconciler_StuckAtFaultInjectionStartedFinalizesAfterDuration is the
+// other half: once updated_at + duration + grace is in the past we
+// finalize the trace and submit BuildDatapack.
+func TestReconciler_StuckAtFaultInjectionStartedFinalizesAfterDuration(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	// Trace stuck 30min ago, guided duration 1min — well past the
+	// duration + grace window.
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionStarted, 1, 30*time.Minute, false)
+
+	owner := newFakeInjectionOwner([]model.FaultInjection{
+		{ID: 1, Name: fix.injectionName, TaskID: &fix.faultTaskID},
+	})
+	var captured []*dto.UnifiedTask
+	submitter := taskSubmitter(func(_ context.Context, _ *gorm.DB, _ *redis.Gateway, t *dto.UnifiedTask) error {
+		captured = append(captured, t)
+		return nil
+	})
+	r := newReconcilerForTest(t, db, owner, submitter)
+	r.stuckThresholdSeconds = func() int { return 60 }
+	processed, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+	require.Len(t, captured, 1)
+}
+
+// TestReconciler_TolersatesStateUpdateError verifies the reconciler does not
+// fail closed when the injection state update fails — postProcess in
+// k8s_handler.go uses errCtx.Warn for this exact case, so we must mirror.
+func TestReconciler_TolersatesStateUpdateError(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, 1, 30*time.Minute, false)
+
+	owner := newFakeInjectionOwner([]model.FaultInjection{
+		{ID: 1, Name: fix.injectionName, TaskID: &fix.faultTaskID},
+	})
+	owner.stateReturnErr = context.DeadlineExceeded // any error
+
+	var captured []*dto.UnifiedTask
+	submitter := taskSubmitter(func(_ context.Context, _ *gorm.DB, _ *redis.Gateway, t *dto.UnifiedTask) error {
+		captured = append(captured, t)
+		return nil
+	})
+	r := newReconcilerForTest(t, db, owner, submitter)
+	processed, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, processed, "state-update warning must not block BuildDatapack submission")
+	require.Len(t, captured, 1)
+}
+
+// TestMaxGuidedDurationMinutes_PicksLargest pins the helper that controls
+// the "is this fault still running?" gate: K_inner>=2 batches with mixed
+// durations must use the longest one.
+func TestMaxGuidedDurationMinutes_PicksLargest(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]any
+		want    int
+	}{
+		{
+			name:    "missing guided_configs falls back to 5",
+			payload: map[string]any{},
+			want:    5,
+		},
+		{
+			name: "single duration",
+			payload: map[string]any{
+				consts.InjectGuidedConfigs: []guidedcli.GuidedConfig{{Duration: intPtr(3)}},
+			},
+			want: 3,
+		},
+		{
+			name: "max of multiple",
+			payload: map[string]any{
+				consts.InjectGuidedConfigs: []guidedcli.GuidedConfig{
+					{Duration: intPtr(2)},
+					{Duration: intPtr(7)},
+					{Duration: intPtr(4)},
+				},
+			},
+			want: 7,
+		},
+		{
+			name: "all-nil falls back to 5",
+			payload: map[string]any{
+				consts.InjectGuidedConfigs: []guidedcli.GuidedConfig{{}, {}},
+			},
+			want: 5,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := maxGuidedDurationMinutes(tc.payload)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #293. The chaos-mesh CRD informer is currently the only thing that submits the post-fault `BuildDatapack` task. A worker restart between CRD-success and `SubmitTaskWithDB`, an in-memory `batchManager` race for `K_inner>=2` hybrid batches, or a silently early-returning `postProcess` closure leaves the trace pinned at `last_event=fault.injection.{started,completed}` with no downstream task — and the K-ramp campaign on the byte-cluster (issue #293's timeline) lost 28+ traces across 3 rounds via this gap. Notably, **round 2 stuck without a worker restart**, which rules out the simpler "informer drops events on rolling restart" hypothesis as the only failure mode.

This PR adds a periodic DB-driven sweep that runs alongside the chaos-mesh CRD informer in the controller lifecycle and re-fires the equivalent of `postProcess` for stuck traces. It is idempotent and replicates safely.

## Changes

### `AegisLab/src/service/consumer/stuck_trace_reconciler.go` (new)

`StuckTraceReconciler.Run` ticks on the configured interval (default 60s) and per tick:

1. Scans `traces` for `state=Running` AND `last_event IN ('fault.injection.started','fault.injection.completed')` AND `updated_at < now() - stuck_threshold`.
2. For each candidate, finds the `TaskTypeFaultInjection` task + its `FaultInjection` row(s) by `task_id`.
3. **Idempotency guard** (the safe replication seam): if a `TaskTypeBuildDatapack` task already exists with `parent_task_id = <fault_injection_task_id>`, bail out — the CRD-success path raced us. This means N runtime-worker replicas can run the reconciler concurrently without coordination.
4. **In-window gate**: if `FaultInjection.EndTime` is populated and not yet past `endTime + 2-min grace`, OR if `EndTime` is nil and `UpdatedAt + max(guided_configs[].Duration) + grace` is still in the future, skip — the fault may still be running.
5. Reconstructs the `BuildDatapack` payload from the stored `FaultInjection` task payload (benchmark + namespace), invokes `updateInjectionState` + `updateInjectionTimestamp` the same way `postProcess` does, and submits via `common.SubmitTaskWithDB` (the same path the CRD callback uses).

For hybrid `K_inner>=2` batches: the reconciler queries the DB for all `FaultInjection` rows tied to the FaultInjection task — bypassing the in-memory `FaultBatchManager` counter entirely. Even if both leaves' callbacks raced and the in-memory counter is wrong, the DB-side check completes the batch correctly.

### `AegisLab/src/service/consumer/stuck_trace_reconciler_test.go` (new)

Six tests against an in-memory sqlite DB + fake injection owner / env-var lister:

- `TestReconciler_RecoversTraceStuckAtFaultInjectionCompleted` — primary success path: stuck at `fault.injection.completed`, BuildDatapack submitted with `parent_task_id=<fault_injection_task_id>` and the right benchmark.
- `TestReconciler_IsIdempotent` — when a BuildDatapack child task already exists, no new task is submitted (covers the CRD-success-race scenario).
- `TestReconciler_RespectsStuckThreshold` — fresh trace inside the threshold is left alone.
- `TestReconciler_HybridBatchRecoversWithoutBatchManager` — covers issue #293's batchManager-race hypothesis: K_inner=2 with both leaves DB-resident still completes via exactly one BuildDatapack submit.
- `TestReconciler_StuckAtFaultInjectionStartedRespectsDuration` — guards against finalizing a fault still inside its `(updated_at + duration + grace)` window when CRD-success never fired.
- `TestReconciler_StuckAtFaultInjectionStartedFinalizesAfterDuration` — the other half: after the duration window, BuildDatapack is submitted.
- `TestReconciler_TolersatesStateUpdateError` — a state-update warning (matching `postProcess`'s `errCtx.Warn` semantics) does not block the BuildDatapack submission.
- `TestMaxGuidedDurationMinutes_PicksLargest` — pins the helper that picks the longest guided duration for the in-window gate.

The "worker restart between fault.injection.completed and SubmitTaskWithDB" scenario is exactly what `TestReconciler_RecoversTraceStuckAtFaultInjectionCompleted` simulates — the trace is in DB with `last_event=fault.injection.completed`, no BuildDatapack task exists, and the next reconciler tick fires it.

### `AegisLab/src/interface/controller/module.go`

Wire `StartStuckTraceReconciler` into the controller lifecycle so it starts alongside the chaos-mesh CRD informer.

### `AegisLab/src/consts/consts.go`

Two new etcd config keys mirroring the existing `rate_limiting.*` pattern (handler reads `config.GetInt` on every tick, so `aegisctl etcd put` applies without a backend rebuild):

| Key | Default | Purpose |
|-----|---------|---------|
| `rate_limiting.stuck_trace_reconcile_interval_seconds` | 60 | Reconciler tick cadence |
| `rate_limiting.stuck_trace_reconcile_stuck_threshold_seconds` | 600 | How long past `updated_at` before a trace is considered stuck |

## Out of scope

- The trace state machine event-priority logic (`selectBestLastEvent`) is not touched.
- The freshness probe (PR #290) is not touched.
- The post-BuildDatapack `RunAlgorithm` queueing path could in principle have similar failure modes, but the byte-cluster timeline has not surfaced them — kept scope tight per issue #293's "fix the fault-injection-completion path" bound. Open a follow-up if a future incident lands on the same root cause downstream.

## Test plan

- [x] `go test ./service/consumer/ -count=1 -timeout 60s` — all consumer tests pass (including the 8 new ones).
- [x] `go vet ./...` — clean.
- [x] `go build -tags duckdb_arrow -o /dev/null ./main.go` — clean.
- [x] `golangci-lint run ./service/consumer/...` — no new issues attributable to this change (3 pre-existing `unused` warnings in `monitor.go` / `monitor_test.go` are unchanged).

## Manual verification (byte-cluster)

After deploying:

1. Submit a `K_outer=4` campaign with `K_inner=1` against any registered system (e.g. `ts`).
2. Mid-fault-window (around the time `last_event=fault.injection.started`), `kubectl rollout restart deploy/rcabench-runtime-worker-service`.
3. Confirm via `aegisctl trace list -o json` that all 4 traces still reach `state=Completed` with `last_event=datapack.build.succeed` (or further) within `reconcile_interval + stuck_threshold` of the fault end time.
4. To exercise the hybrid path: same drill with `K_inner=2`, kill the worker between the two leaves' CRD-success events.
5. To exercise the non-restart path: just leave a campaign running on a busy cluster — the reconciler logs `stuck trace reconcile tick recovered N trace(s)` whenever it picks up a trace the informer dropped on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)