### PR TITLE
fix(byte-cluster/otel): widen deploy collector + headless gRPC for #300

### DIFF
--- a/AegisLab/manifests/byte-cluster/README.md
+++ b/AegisLab/manifests/byte-cluster/README.md
@@ -232,10 +232,15 @@ kubectl describe hpa -n monitoring opentelemetry-kube-stack-deployment-collector
 Expected:
 - one daemon collector per node (handles per-node pod prometheus scrape +
   kubelet/cAdvisor + filelog — sharded by node, no cross-replica duplication)
-- one deployment collector pool of `4–12` replicas (HPA bounded by
+- one deployment collector pool of `8–24` replicas (HPA bounded by
   `autoscaler.minReplicas`/`maxReplicas`; carries OTLP push + leader-elected
   k8s_cluster / k8sobjects only — no prometheus scrape, so memory pressure
-  no longer scales with cluster pod count)
+  no longer scales with cluster pod count). The previous 4–12 / 6 GiB
+  request was too tight: the pool sat permanently at maxReplicas with
+  memory 68%/60% target and HPA scaled a fresh pod every 20–90 minutes
+  under campaign load. Each scale event broke a long-lived OTLP gRPC
+  connection from a workload exporter pinned to the churned pod, and the
+  Go SDK's exporter goroutine deadlocked — see #300.
 - CPU and memory targets both present on the HPA
 
 History note: the deployment pool used to run prometheus pod scrape too, and

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -59,11 +59,30 @@ containers:
               value_type: 1
               template_string: 31%03d
               overridable: false
+            # Java services use the OTel Java agent which does NOT support
+            # the `dns:///` URL scheme (config metadata requires http/https).
+            # Keeping the regular ClusterIP Service URL here means each Java
+            # exporter pins one HTTP/2 connection to one collector pod, which
+            # is the failure mode behind #300. If/when the Java agent gains
+            # gRPC client-side LB support, switch this to
+            # `dns:///opentelemetry-kube-stack-deployment-collector-headless...`
+            # to match the loadgenerator override below.
             - key: global.otelcollector
               type: 0
               category: 1
               value_type: 0
               default_value: http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317
+              overridable: true
+            # Loadgenerator is a Go binary using the OTLP/gRPC SDK, which
+            # does support `dns:///` for client-side LB. Targeting the
+            # operator-rendered headless Service spreads the loadgen's
+            # exporter goroutines across all collector pods, so a single
+            # HPA churn cannot deadlock the loadgen the way it did in #300.
+            - key: loadgenerator.opentelemetry.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: dns:///opentelemetry-kube-stack-deployment-collector-headless.monitoring.svc.cluster.local:4317
               overridable: true
           status: 1
   - type: 2

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -59,19 +59,20 @@ containers:
               value_type: 1
               template_string: 31%03d
               overridable: false
-            # Java services use the OTel Java agent which does NOT support
-            # the `dns:///` URL scheme (config metadata requires http/https).
-            # Keeping the regular ClusterIP Service URL here means each Java
-            # exporter pins one HTTP/2 connection to one collector pod, which
-            # is the failure mode behind #300. If/when the Java agent gains
-            # gRPC client-side LB support, switch this to
-            # `dns:///opentelemetry-kube-stack-deployment-collector-headless...`
-            # to match the loadgenerator override below.
+            # Java services use the OTel Java agent v2.23.0, which rejects
+            # the `dns:///` URL scheme (config metadata requires http/https)
+            # — so the Go-SDK fix from #300 cannot be reused here. Instead
+            # switch the Java exporter from gRPC :4317 to HTTP/protobuf :4318:
+            # HTTP/1.1 has no long-lived multiplexed connection to deadlock
+            # when an HPA churn closes a single pod's socket, so the failure
+            # mode behind #300 cannot reproduce. The matching protocol env
+            # (`OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`) is set on the
+            # Instrumentation CR's java block in otel-kube-stack.values.yaml.
             - key: global.otelcollector
               type: 0
               category: 1
               value_type: 0
-              default_value: http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317
+              default_value: http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4318
               overridable: true
             # Loadgenerator is a Go binary using the OTLP/gRPC SDK, which
             # does support `dns:///` for client-side LB. Targeting the
@@ -176,11 +177,16 @@ containers:
               value_type: 0
               default_value: monitoring/opentelemetry-kube-stack
               overridable: true
+            # Coherence/Helidon Java OTel agent — switched to HTTP/protobuf
+            # :4318 to bypass the gRPC HPA-churn deadlock from #300 (the
+            # `dns:///` workaround used for the Go SDK is rejected by the
+            # Java agent v2.23.0). Protocol env injected by the
+            # Instrumentation CR java block.
             - key: otel.collectorEndpoint
               type: 0
               category: 1
               value_type: 0
-              default_value: http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317
+              default_value: http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4318
               overridable: true
           status: 1
     # issue #115: sockshop's coherence-helidon variant requires the
@@ -349,11 +355,16 @@ containers:
               value_type: 0
               default_value: 20260423-2b3fd43
               overridable: true
+            # TeaStore Java OTel agent — switched to HTTP/protobuf :4318 to
+            # bypass the gRPC HPA-churn deadlock from #300. Java agent v2.23.0
+            # rejects `dns:///`, so the Go-SDK approach used for the ts
+            # loadgenerator does not apply. Protocol env injected by the
+            # Instrumentation CR java block.
             - key: opentelemetry.otlpEndpoint
               type: 0
               category: 1
               value_type: 0
-              default_value: http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317
+              default_value: http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4318
               overridable: true
             # 0.1.1 parameterizes the inject-<language> annotation from these
             # two values (previously hardcoded to "monitoring/opentelemetry-kube-stack").

--- a/AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml
@@ -1,6 +1,13 @@
 global:
   clusterCollector:
-    service: opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local
+    # otel-demo deploys an in-namespace wrapper OTel Collector that forwards
+    # to this address (chart concatenates `:4317`). The wrapper is a Go OTel
+    # binary, so its OTLP gRPC exporter supports the `dns:///` scheme +
+    # round_robin balancer for client-side LB across the operator-rendered
+    # headless Service. Pointing here at the headless variant prevents the
+    # wrapper from pinning to a single deployment-collector pod that an HPA
+    # event could churn — the Go-SDK deadlock root-cause behind #300.
+    service: dns:///opentelemetry-kube-stack-deployment-collector-headless.monitoring.svc.cluster.local
 
 opentelemetry-demo:
   default:

--- a/AegisLab/manifests/byte-cluster/otel-kube-stack.values.yaml
+++ b/AegisLab/manifests/byte-cluster/otel-kube-stack.values.yaml
@@ -383,7 +383,7 @@ collectors:
     suffix: deployment
     mode: deployment
     enabled: true
-    replicas: 4
+    replicas: 8
     autoscaler:
       # History: this collector originally also ran prometheus pod/endpoints
       # scrape (kubernetes-pods + kubernetes-endpoints jobs in the receiver
@@ -398,22 +398,32 @@ collectors:
       # Pod scrape now lives in the daemon collector with a node-local
       # field selector, so deployment-mode collectors only carry OTLP
       # push (apps → here via Service load balancing), k8s_cluster, and
-      # k8sobjects (both leader-elected). With that load profile 4–12
-      # replicas is plenty; the previous 6/120 bounds were fighting the
-      # symptom, not the cause.
-      minReplicas: 4
-      maxReplicas: 12
+      # k8sobjects (both leader-elected).
+      #
+      # Bounds widened to 8–24 (from 4–12) and per-pod request doubled
+      # alongside #300: at 4–12 the pool sat permanently at maxReplicas
+      # with mem 68%/60% target, churning a fresh pod every 20–90 minutes
+      # under campaign load. Each churn broke the long-lived OTLP gRPC
+      # connection a workload exporter had pinned to that pod (ClusterIP
+      # Service + HTTP/2 multiplexing), and the Go SDK's exporter
+      # goroutine deadlocked on a closed socket — taking the whole
+      # namespace silent for 16–24 minutes. Doubling the request lifts
+      # absolute headroom so steady-state usage drops below the 60%
+      # target at min replicas; doubling max gives the HPA somewhere to
+      # go without re-pinning at the ceiling.
+      minReplicas: 8
+      maxReplicas: 24
       targetCPUUtilization: 55
       targetMemoryUtilization: 60
     podDisruptionBudget:
-      minAvailable: 4
+      minAvailable: 8
     resources:
       limits:
         cpu: 4000m
-        memory: 16000Mi
+        memory: 32000Mi
       requests:
         cpu: 1000m
-        memory: 6000Mi
+        memory: 12000Mi
     presets:
       kubernetesEvents:
         enabled: true

--- a/AegisLab/manifests/byte-cluster/otel-kube-stack.values.yaml
+++ b/AegisLab/manifests/byte-cluster/otel-kube-stack.values.yaml
@@ -608,14 +608,20 @@ instrumentation:
     - name: OTEL_EXPORTER_OTLP_SPAN_INSECURE
       value: '"true"'
 
-  # Java agent: OTLP gRPC to :4317 matches the exporter default above.
+  # Java agent: OTLP HTTP/protobuf to :4318. Switched off gRPC :4317 because
+  # the Java agent v2.23.0 rejects the `dns:///` URL scheme used to fix #300
+  # for the Go SDK (loadgenerator + otel-demo wrapper) -- so the
+  # client-side-LB workaround that lets a Go gRPC client survive HPA churn
+  # cannot be applied to Java. HTTP/1.1 instead has no multiplexed long-lived
+  # connection, so an HPA-driven pod churn on the deployment collector cannot
+  # deadlock a Java exporter in the way #300 documented for gRPC.
   java:
     image: pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-operator-autoinstrumentation-java:2.23.0
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: http://opentelemetry-kube-stack-deployment-collector.monitoring:4317
+        value: http://opentelemetry-kube-stack-deployment-collector.monitoring:4318
       - name: OTEL_EXPORTER_OTLP_PROTOCOL
-        value: grpc
+        value: http/protobuf
 
   nodejs: {}
 


### PR DESCRIPTION
## Summary

Fixes the OTel deployment-collector HPA-churn → workload deadlock root-cause documented in
https://github.com/OperationsPAI/aegis/issues/300#issuecomment-4344448144.

The pool was pinned at `maxReplicas=12` with memory `81%/60%` target — HPA scaled a
fresh pod every 20-90 minutes under campaign load. Each scale event broke a long-lived
OTLP gRPC connection a workload exporter had pinned to the churned pod (ClusterIP
Service + HTTP/2 multiplexing), and the Go SDK's exporter goroutine deadlocked on a
closed socket — taking the namespace silent for 16-24 minutes. The 4 of 12 K_inner=2
batches that ended at `datapack.build.failed` are the same ts namespaces whose loadgens
the second investigation comment caught process-alive but goroutine-deadlocked.

This PR addresses the two root-cause layers separately:

- **Layer 1 (mem + replica)**: bump request/limit/HPA bounds so the collector doesn't sit at the HPA target and churn pods.
- **Layer 2 (gRPC stream stickiness)**: Go SDK clients move to `dns:///<headless>` for client-side load balancing; Java agent clients (which reject `dns:///` URL scheme up to v2.23.0) instead switch to OTLP HTTP/protobuf on `:4318` — HTTP request-response has no long-lived stream to deadlock.

## Before / after

| Knob | Before | After |
| --- | --- | --- |
| `collectors.deploy.resources.requests.memory` | `6000Mi` | `12000Mi` |
| `collectors.deploy.resources.limits.memory`   | `16000Mi` | `32000Mi` |
| `collectors.deploy.replicas`                  | `4` | `8` |
| `collectors.deploy.autoscaler.minReplicas`    | `4` | `8` |
| `collectors.deploy.autoscaler.maxReplicas`    | `12` | `24` |
| `collectors.deploy.podDisruptionBudget.minAvailable` | `4` | `8` |
| ts loadgenerator OTLP URL (Go SDK) | `http://…-deployment-collector…:4317` (implicit) | `dns:///…-deployment-collector-headless…:4317` |
| otel-demo wrapper → cluster-collector URL | `…-deployment-collector…` | `dns:///…-deployment-collector-headless…` |
| ts/sockshop/teastore OTLP URL (Java agent) | gRPC `:4317` | **HTTP `:4318`** + `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` |
| OTel Operator `Instrumentation` CR `java` block | gRPC `:4317` | **HTTP `:4318`** + protocol env |
| hs/sn/media OTLP URL (HTTP/4318) | unchanged | unchanged — already on HTTP |
| Service type | unchanged | unchanged — OTel Operator already auto-renders both `*-collector` (ClusterIP) and `*-collector-headless` (clusterIP=None) for every CR |

## Why two different mitigations for gRPC vs Java agent

Investigation comment in #300 confirmed the deadlock is rooted in long-lived gRPC HTTP/2 streams that the Go SDK exporter goroutine waits on indefinitely after the underlying pod is killed. Two independent mitigations apply:

- **Go SDK + headless DNS** — works because Go's gRPC library natively supports `dns:///host:port` URLs, refreshing the resolver pool when DNS records change. `round_robin` is enabled by default in `configgrpc` since collector v0.103.0, so client-side load balancing engages without further config.
- **Java agent + HTTP/protobuf** — works because the Java OTel agent (≤ v2.23.0) rejects the `dns:///` scheme in `OTEL_EXPORTER_OTLP_ENDPOINT`. We switch protocol to `http/protobuf` on `:4318` instead. HTTP requests are short-lived, so even if a single export hits a churning pod, the next export reconnects (no goroutine deadlock state).

## Workloads / files changed

| Workload | Stack | Change |
| --- | --- | --- |
| ts main services | Java agent (Spring) | URL `:4317` → `:4318`, add `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` |
| sockshop | Coherence/Helidon Java | Same as ts |
| teastore | Java agent | Same as ts |
| ts loadgenerator | Go SDK | URL → `dns:///<headless>:4317` (gRPC) |
| otel-demo wrapper | Go otelcol-contrib | URL → `dns:///<headless>:4317` (gRPC) |
| `Instrumentation` CR `java` block | OTel Operator | URL `:4317` → `:4318` + protocol env |
| `Instrumentation` CR `python` / `dotnet` / `go` blocks | already on `:4318` | unchanged |
| hs / sn / media | HTTP/4318 | unchanged |

## Out of scope

- Kind / cn-mirror collector manifests (`AegisLab/manifests/cn_mirror/`, `AegisLab/manifests/otel-collector/`) — separate variant, not regressing here.
- Daemon collector — the deadlock is on the deployment collector only.
- HPA target percentages — changing only the request moves the absolute target; the percentage stays at 60%.
- Bumping the Java OTel agent past v2.23.0 (would unlock `dns:///` for the Java path); deferred until we have a reason to change agent version independently.

## Test plan

- [x] `helm template` renders the deployment OpenTelemetryCollector with `requests.memory: 12000Mi`, `limits.memory: 32000Mi`, `autoscaler: {minReplicas: 8, maxReplicas: 24}`, `podDisruptionBudget.minAvailable: 8`.
- [x] `helm template` renders ts/sockshop/teastore values with `OTEL_EXPORTER_OTLP_ENDPOINT=…:4318` and `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`.
- [x] `helm template` renders the `Instrumentation` CR java block with `:4318` endpoint + protocol env.
- [x] `git diff main` is YAML + README only (no Go, no test, no skill changes).
- [x] **Layer 1 deployed live** to byte-cluster (helm upgrade --reuse-values --set on mem/replica/HPA): mem utilization dropped 81% → 2%, 12 fresh collector pods 1/1 Running 0 restarts, HPA bounds 8-24 confirmed.
- [ ] Layer 2 deployment (headless + Java HTTP/4318): pending PR merge → `helm upgrade` with the merged values file → roll workload pods (ts loadgenerator, ts/sockshop/teastore main services) to pick up new env.
- [ ] Verify `kubectl get svc -n monitoring | grep deployment-collector` shows both regular and `-headless` Services.
- [ ] On byte-cluster: K_inner=2 hybrid batch failure rate drops well below the pre-fix ~47% (target ≤ 5% modulo other failure modes).

## Related

- Issue #300 — root failure-mode tracker (cold-namespace empty `abnormal_traces.parquet`).
- Issue #289 / PR #290 — earlier freshness probe partition-prune; orthogonal but related (both touch BuildDatapack reliability).
- Issue #292 — EIP rotation; loosely related (both about helm-upgrade-time blast radius).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>