### PR TITLE
fix(byte-cluster/seed): bump ts/sockshop/teastore versions to propagate #301 OTel fix to DB

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -44,7 +44,11 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 1.0.0
+      # Bumped 1.0.0 → 1.0.1 for #300 fix (Java OTLP gRPC :4317 → HTTP :4318
+      # + loadgenerator gRPC dns:///headless). Reseed honors the immutability
+      # contract on already-seeded versions, so the values below would not
+      # propagate to the DB without bumping the version name.
+      - name: 1.0.1
         github_link: OperationsPAI/train-ticket
         status: 1
         helm_config:
@@ -135,7 +139,10 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 1.1.1
+      # Bumped 1.1.1 → 1.1.2 for #300 fix (Coherence/Helidon Java OTLP
+      # gRPC :4317 → HTTP :4318). Reseed honors the immutability contract
+      # on already-seeded versions.
+      - name: 1.1.2
         github_link: LGU-SE-Internal/coherence-helidon-sockshop-sample
         status: 1
         # Chart is now self-hosted in the fork's gh-pages site. For the Byte
@@ -334,7 +341,10 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.4
+      # Bumped 0.1.4 → 0.1.5 for #300 fix (TeaStore Java OTLP
+      # gRPC :4317 → HTTP :4318). Reseed honors the immutability contract
+      # on already-seeded versions.
+      - name: 0.1.5
         github_link: LGU-SE-Internal/TeaStore
         status: 1
         helm_config:


### PR DESCRIPTION
## Summary

PR #301 updated the OTel exporter URL in the seed (`global.otelcollector`, `otel.collectorEndpoint`, `opentelemetry.otlpEndpoint` → `:4318`, plus a new `loadgenerator.opentelemetry.endpoint` for the Go gRPC client-side LB), but **`aegisctl system reseed` honors an immutability contract on already-seeded versions** — drift on the existing container_version is reported but never applied.

So after PR #301 merged, three things ended up out of sync:

1. **Live helm releases** (ts0-ts33, sockshop0-N, teastore0-N) — were patched via `helm upgrade --set` during the live deployment. They have the new `:4318` env vars in their pod specs.
2. **DB seed** (`container_versions` + `helm_config_values` rows for `ts@1.0.0`, etc.) — *unchanged*, still points at the old `:4317`.
3. **--auto namespace allocator** — would create the next ts namespace (ts34) using the DB seed → regress to the old `:4317` → re-introduce the gRPC HPA-churn deadlock (#300) silently.

This PR closes the gap by bumping version_name on the affected systems, which makes reseed write the new values into a fresh `container_version` row (preserving the history of 1.0.0 / 1.1.1 / 0.1.4 unchanged for any existing release pinned to them).

## Bumps

| System | Old version | New version |
| --- | --- | --- |
| ts | 1.0.0 | 1.0.1 |
| sockshop | 1.1.1 | 1.1.2 |
| teastore | 0.1.4 | 0.1.5 |

The actual seed values themselves were already correct in main (PR #301). This PR just bumps the version_name so reseed propagates them.

## Verified on byte-cluster

After bumping, ran:

```bash
# 1. ConfigMap rcabench-initial-data refreshed with the new data.yaml
kubectl create configmap rcabench-initial-data -n exp \
  --from-file=data.yaml=AegisLab/manifests/byte-cluster/initial-data/data.yaml \
  --dry-run=client -o yaml | kubectl apply -f -

# 2. Restart api-gateway so the in-process seed cache is invalidated
kubectl rollout restart deploy/rcabench-api-gateway -n exp

# 3. Apply reseed
aegisctl system reseed --apply
```

Reseed output (relevant lines):

```
helm_config_values  ts        ts@1.0.1:global.otelcollector             default="http://...:4318"             applied
helm_config_values  ts        ts@1.0.1:loadgenerator.opentelemetry...   default="dns:///...headless:4317"     applied
helm_config_values  sockshop  sockshop@1.1.2:otel.collectorEndpoint     default="http://...:4318"             applied
helm_config_values  teastore  teastore@0.1.5:opentelemetry.otlpEndpoint default="http://...:4318"             applied
helm_configs        ts        1.0.1                                     chart=trainticket version=0.2.0       applied
helm_configs        sockshop  1.1.2                                     chart=sockshop version=1.1.1          applied
helm_configs        teastore  0.1.5                                     chart=teastore version=0.1.4          applied
Summary: new_versions=6 defaults_updated=4 etcd_published=0 preserved_overrides=8
```

DB now has both versions (DESCRIBE container_versions on cv joined with containers):
- `ts`: `1.0.0` (existing) + `1.0.1` (new)
- `sockshop`: `0.1.1`, `1.1.1` (existing) + `1.1.2` (new)
- `teastore`: `0.1.0`, `0.1.1` (existing) + `0.1.5` (new)

## Operator caveat: ConfigMap refresh + api-gateway restart needed

The reseed flow reads `/app/data/initial_data/data.yaml` mounted from the `rcabench-initial-data` ConfigMap. Just merging this PR isn't enough — an operator must also:

1. Re-render the ConfigMap from the merged file (the `helm` chart for `rcabench` does this on `helm install/upgrade`; a `kubectl create configmap --dry-run=client | kubectl apply` is the manual equivalent).
2. Roll the api-gateway pods so the in-process cache picks up the new file content.
3. Run `aegisctl system reseed --apply`.

Document those steps in the byte-cluster README in a follow-up if this is a recurring pattern.

## Out of scope

- Doesn't touch `hs`, `sn`, `media`, or `otel-demo` versions — those didn't change in PR #301 (their existing data.yaml entries were already correct, just unseeded historically; reseed picked them up as a side effect).
- Doesn't touch the live ts0-ts33 / sockshop / teastore helm releases — they remain pinned to the old version names, with their env vars already live-patched.

## Related

- Issue #300 — original "empty abnormal_traces.parquet" bug.
- PR #301 — the seed/values changes whose DB propagation this PR completes.