### PR TITLE
fix(consumer): unsilence BuildDatapack chain — startup log + tick heartbeat + hybrid-batch progress (#305)

### DIFF
--- a/AegisLab/src/service/consumer/fault_injection.go
+++ b/AegisLab/src/service/consumer/fault_injection.go
@@ -75,6 +75,18 @@ func (bm *FaultBatchManager) isFinished(batchID string) bool {
 	return count >= len(injectionNames)
 }
 
+// snapshotBatchProgress returns (count, expected) for batchID under read
+// lock. Used by HandleCRDSucceeded to log per-leaf progress so a hybrid
+// batch stuck waiting on a leaf whose CRD informer never fires (issue
+// #305) is observable rather than silent.
+func (bm *FaultBatchManager) snapshotBatchProgress(batchID string) (int, int) {
+	bm.mu.RLock()
+	defer bm.mu.RUnlock()
+	count := bm.batchCounts[batchID]
+	expected := len(bm.batchInjections[batchID])
+	return count, expected
+}
+
 func (bm *FaultBatchManager) setBatchInjections(batchID string, injectionNames []string) {
 	bm.mu.Lock()
 	defer bm.mu.Unlock()

--- a/AegisLab/src/service/consumer/k8s_handler.go
+++ b/AegisLab/src/service/consumer/k8s_handler.go
@@ -365,6 +365,7 @@ func (h *k8sHandler) HandleCRDSucceeded(namespace, pod, name string, startTime, 
 	}
 
 	if !parsedLabels.IsHybrid {
+		logEntry.WithField("crd_name", name).Info("HandleCRDSucceeded: single-leaf, submitting BuildDatapack")
 		postProcess(name)
 	} else {
 		bm := h.batchManager
@@ -373,10 +374,27 @@ func (h *k8sHandler) HandleCRDSucceeded(namespace, pod, name string, startTime, 
 			return
 		}
 		bm.incrementBatchCount(parsedLabels.batchID)
+		count, expected := bm.snapshotBatchProgress(parsedLabels.batchID)
+		batchEntry := logEntry.WithFields(logrus.Fields{
+			"batch_id":      parsedLabels.batchID,
+			"crd_name":      name,
+			"batch_count":   count,
+			"batch_size":    expected,
+			"batch_finished": bm.isFinished(parsedLabels.batchID),
+		})
 
 		if bm.isFinished(parsedLabels.batchID) {
 			bm.deleteBatch(parsedLabels.batchID)
+			batchEntry.Info("HandleCRDSucceeded: hybrid batch complete, submitting BuildDatapack")
 			postProcess(parsedLabels.batchID)
+		} else {
+			// Hybrid batch incomplete: log progress so we can see _which_
+			// leaf CRD callbacks landed and which are still outstanding.
+			// The silent failure mode in #305 was a hybrid batch where
+			// one leaf's CRD informer never fired (RuntimeMutatorChaos
+			// missing from chaos-experiment GetCRDMapping), so we'd sit
+			// here forever with no visibility.
+			batchEntry.Info("HandleCRDSucceeded: hybrid batch leaf received, awaiting more")
 		}
 	}
 }

--- a/AegisLab/src/service/consumer/stuck_trace_reconciler.go
+++ b/AegisLab/src/service/consumer/stuck_trace_reconciler.go
@@ -93,25 +93,53 @@ func NewStuckTraceReconciler(
 // Interval changes pushed via etcd at runtime are picked up at the next tick
 // by re-reading r.intervalSeconds() and calling ticker.Reset when the value
 // has changed — no worker restart required.
+//
+// A startup INFO log + per-tick heartbeat (issue #305) makes a silent
+// reconciler immediately visible in worker logs — previously the only
+// signal was "tick recovered N" which logs only when N>0, so a quiet
+// reconciler was indistinguishable from a never-launched goroutine.
 func (r *StuckTraceReconciler) Run(ctx context.Context) {
 	if r == nil || r.db == nil {
 		logrus.Warn("StuckTraceReconciler.Run skipped: missing db")
 		return
 	}
 	currentInterval := r.resolveInterval()
+	stuckSecs := r.stuckThresholdSeconds()
+	if stuckSecs <= 0 {
+		stuckSecs = consts.DefaultStuckTraceReconcileStuckSecs
+	}
+	logrus.WithFields(logrus.Fields{
+		"interval_seconds":        int(currentInterval / time.Second),
+		"stuck_threshold_seconds": stuckSecs,
+		"max_batch_per_tick":      r.maxBatchPerTick,
+	}).Info("StuckTraceReconciler started")
 	ticker := time.NewTicker(currentInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
+			logrus.Info("StuckTraceReconciler stopping: context cancelled")
 			return
 		case <-ticker.C:
 		}
-		processed, err := r.tick(ctx)
-		if err != nil {
-			logrus.WithError(err).Warn("stuck trace reconcile tick failed")
-		} else if processed > 0 {
-			logrus.Infof("stuck trace reconcile tick recovered %d trace(s)", processed)
+		processed, candidates, err := r.runTickSafely(ctx)
+		fields := logrus.Fields{
+			"candidates": candidates,
+			"processed":  processed,
+		}
+		switch {
+		case err != nil:
+			logrus.WithFields(fields).WithError(err).Warn("stuck trace reconcile tick failed")
+		case processed > 0:
+			logrus.WithFields(fields).Infof("stuck trace reconcile tick recovered %d trace(s)", processed)
+		case candidates > 0:
+			// Candidates existed but none recovered (all skipped by
+			// threshold/idempotency check). Surface as INFO so the
+			// "reconciler quiet but stuck candidates exist" failure
+			// mode (issue #305) is immediately visible.
+			logrus.WithFields(fields).Info("stuck trace reconcile tick: no recoveries")
+		default:
+			logrus.WithFields(fields).Debug("stuck trace reconcile tick: no candidates")
 		}
 		if r.tickHook != nil {
 			r.tickHook(processed, err)
@@ -123,6 +151,20 @@ func (r *StuckTraceReconciler) Run(ctx context.Context) {
 	}
 }
 
+// runTickSafely wraps tick() so a panic during recovery doesn't kill the
+// reconciler goroutine for the rest of the worker's lifetime (issue #305:
+// a silent reconciler is a worse failure than a noisy one).
+func (r *StuckTraceReconciler) runTickSafely(ctx context.Context) (processed, candidates int, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			logrus.WithField("panic", rec).Error("StuckTraceReconciler.tick panicked, continuing loop")
+			err = fmt.Errorf("tick panic: %v", rec)
+		}
+	}()
+	processed, candidates, err = r.tick(ctx)
+	return
+}
+
 func (r *StuckTraceReconciler) resolveInterval() time.Duration {
 	v := time.Duration(r.intervalSeconds()) * time.Second
 	if v <= 0 {
@@ -131,9 +173,13 @@ func (r *StuckTraceReconciler) resolveInterval() time.Duration {
 	return v
 }
 
-// tick runs one reconcile sweep and returns the number of traces it
-// successfully recovered.
-func (r *StuckTraceReconciler) tick(ctx context.Context) (int, error) {
+// tick runs one reconcile sweep and returns (processed, candidates, err).
+// processed = traces for which a BuildDatapack was actually submitted;
+// candidates = stuck-trace rows the SELECT returned. Reporting both lets
+// the heartbeat distinguish "no rows match" from "rows match but were
+// skipped" — without that, a silent reconciler with stuck rows in the DB
+// looks identical to a working one with nothing to do (issue #305).
+func (r *StuckTraceReconciler) tick(ctx context.Context) (int, int, error) {
 	stuckSecs := r.stuckThresholdSeconds()
 	if stuckSecs <= 0 {
 		stuckSecs = consts.DefaultStuckTraceReconcileStuckSecs
@@ -154,7 +200,7 @@ func (r *StuckTraceReconciler) tick(ctx context.Context) (int, error) {
 		Limit(r.maxBatchPerTick).
 		Find(&traces).Error
 	if err != nil {
-		return 0, fmt.Errorf("query stuck traces: %w", err)
+		return 0, 0, fmt.Errorf("query stuck traces: %w", err)
 	}
 
 	processed := 0
@@ -171,7 +217,7 @@ func (r *StuckTraceReconciler) tick(ctx context.Context) (int, error) {
 			processed++
 		}
 	}
-	return processed, nil
+	return processed, len(traces), nil
 }
 
 // recoverTrace handles a single stuck trace. Returns (true, nil) iff a

--- a/AegisLab/src/service/consumer/stuck_trace_reconciler_test.go
+++ b/AegisLab/src/service/consumer/stuck_trace_reconciler_test.go
@@ -244,7 +244,7 @@ func TestReconciler_RecoversTraceStuckAtFaultInjectionCompleted(t *testing.T) {
 	})
 
 	r := newReconcilerForTest(t, db, owner, submitter)
-	processed, err := r.tick(context.Background())
+	processed, _, err := r.tick(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, processed)
 	require.Len(t, captured, 1)
@@ -292,7 +292,7 @@ func TestReconciler_IsIdempotent(t *testing.T) {
 		return nil
 	})
 	r := newReconcilerForTest(t, db, owner, submitter)
-	processed, err := r.tick(context.Background())
+	processed, _, err := r.tick(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 0, processed)
 	require.Equal(t, 0, called)
@@ -314,9 +314,40 @@ func TestReconciler_RespectsStuckThreshold(t *testing.T) {
 	})
 	r := newReconcilerForTest(t, db, owner, submitter)
 	r.stuckThresholdSeconds = func() int { return 600 }
-	processed, err := r.tick(context.Background())
+	processed, _, err := r.tick(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 0, processed)
+}
+
+// TestReconciler_TickReportsCandidateCount pins the observability contract
+// that closes issue #305. Before this change, tick returned only `processed`
+// — when stuck candidates existed but every one was skipped (threshold not
+// yet hit, idempotency win, etc.) the reconciler logged nothing and was
+// indistinguishable from a goroutine that never started. The heartbeat in
+// Run() depends on tick reporting the candidate count truthfully.
+func TestReconciler_TickReportsCandidateCount(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	// Fresh trace inside the threshold window: it is a candidate per the
+	// SQL filter (state=Running, last_event matches, status active) only
+	// AFTER the threshold has elapsed. With a 10-second age and a 1-second
+	// threshold, the SELECT picks it up; the per-row threshold check then
+	// keeps it (CreatedAt + duration is far in the future).
+	fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, 60, 10*time.Second, false)
+	_ = fix
+
+	owner := newFakeInjectionOwner([]model.FaultInjection{
+		{ID: 1, Name: fix.injectionName, TaskID: &fix.faultTaskID, PreDuration: 1},
+	})
+	submitter := taskSubmitter(func(context.Context, *gorm.DB, *redis.Gateway, *dto.UnifiedTask) error {
+		t.Fatal("submit must not be called for fresh in-window trace")
+		return nil
+	})
+	r := newReconcilerForTest(t, db, owner, submitter)
+	r.stuckThresholdSeconds = func() int { return 1 }
+	processed, candidates, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, processed, "in-window trace must not be processed")
+	require.Equal(t, 1, candidates, "candidate count must report the SELECT row count, not just submits — silent reconciler regression guard for #305")
 }
 
 // TestReconciler_HybridBatchRecoversWithoutBatchManager covers the
@@ -338,7 +369,7 @@ func TestReconciler_HybridBatchRecoversWithoutBatchManager(t *testing.T) {
 		return nil
 	})
 	r := newReconcilerForTest(t, db, owner, submitter)
-	processed, err := r.tick(context.Background())
+	processed, _, err := r.tick(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, processed, "hybrid batch must recover with exactly one BuildDatapack submit")
 	require.Len(t, captured, 1)
@@ -362,7 +393,7 @@ func TestReconciler_StuckAtFaultInjectionStartedRespectsDuration(t *testing.T) {
 	})
 	r := newReconcilerForTest(t, db, owner, submitter)
 	r.stuckThresholdSeconds = func() int { return 60 } // pull trace into scan
-	processed, err := r.tick(context.Background())
+	processed, _, err := r.tick(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 0, processed)
 }
@@ -386,7 +417,7 @@ func TestReconciler_StuckAtFaultInjectionStartedFinalizesAfterDuration(t *testin
 	})
 	r := newReconcilerForTest(t, db, owner, submitter)
 	r.stuckThresholdSeconds = func() int { return 60 }
-	processed, err := r.tick(context.Background())
+	processed, _, err := r.tick(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, processed)
 	require.Len(t, captured, 1)
@@ -429,7 +460,7 @@ func TestReconciler_StuckAtFaultInjectionCompletedDoesNotReadvanceParent(t *test
 	})
 	r := newReconcilerForTest(t, db, owner, submitter)
 	r.stuckThresholdSeconds = func() int { return 60 }
-	processed, err := r.tick(context.Background())
+	processed, _, err := r.tick(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, processed)
 
@@ -457,7 +488,7 @@ func TestReconciler_ToleratesStateUpdateError(t *testing.T) {
 		return nil
 	})
 	r := newReconcilerForTest(t, db, owner, submitter)
-	processed, err := r.tick(context.Background())
+	processed, _, err := r.tick(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, processed, "state-update warning must not block BuildDatapack submission")
 	require.Len(t, captured, 1)
@@ -541,7 +572,7 @@ func TestReconciler_SynthesizesAbnormalWindowForward(t *testing.T) {
 		return nil
 	})
 	r := newReconcilerForTest(t, db, owner, submitter)
-	processed, err := r.tick(context.Background())
+	processed, _, err := r.tick(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, processed)
 
@@ -578,7 +609,7 @@ func TestReconciler_PrefersStoredTimestampsOverSynthesis(t *testing.T) {
 		return nil
 	})
 	r := newReconcilerForTest(t, db, owner, submitter)
-	processed, err := r.tick(context.Background())
+	processed, _, err := r.tick(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, processed)
 
@@ -633,7 +664,8 @@ func TestReconciler_ConcurrentTicksSubmitOnce(t *testing.T) {
 	tickOnce := func() (int, error) {
 		owner := newFakeInjectionOwner([]model.FaultInjection{rowSnapshot})
 		r := newReconcilerForTest(t, db, owner, persistChild)
-		return r.tick(context.Background())
+		processed, _, err := r.tick(context.Background())
+		return processed, err
 	}
 
 	var wg sync.WaitGroup
@@ -747,7 +779,7 @@ func TestReconciler_GatesAndSynthesisIgnoreUpdatedAtBumps(t *testing.T) {
 	})
 
 	r := newReconcilerForTest(t, db, owner, submitter)
-	processed, err := r.tick(context.Background())
+	processed, _, err := r.tick(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, processed,
 		"duration gate anchored to CreatedAt must let the trace finalize: "+


### PR DESCRIPTION
## Summary

Closes #305.

The two paths that submit a BuildDatapack task after a fault injection
completes (CRD-success in `HandleCRDSucceeded` and the DB sweep in
`StuckTraceReconciler` from PR #294) were **both silent** in production
on 2026-04-30 after the worker restarted at 14:14+08. Round 7+ ts traces
sat at `last_event=fault.injection.completed` with `bd_count=0` for
30+ minutes, no `stuck trace reconcile tick recovered` log line, no
`HandleCRDSucceeded`-side BD-submit log line.

## Root cause

**Confirmed root cause A** (the live incident): hybrid (K_inner=2)
batches whose second leaf is a `JVMRuntimeMutator` never receive a
CRD-success callback. The chaos-experiment library's `GetCRDMapping`
([client/kubernetes.go:235](https://github.com/OperationsPAI/chaos-experiment/blob/main/client/kubernetes.go#L235))
omits `runtimemutatorchaos` from the watched GVR set, so the
controller-runtime informer never fires for those CRDs.
`HandleCRDSucceeded` fires for the first leaf, increments the in-memory
batch counter to `1/2`, and `isFinished` returns false — the worker
sits forever waiting for the second leaf event that will never land.

This isn't actually a Round 7 regression — Round 6 had it too
(`SELECT id, bd_count FROM ... WHERE created_at BETWEEN '2026-04-30 12:50' AND '2026-04-30 13:05'`
shows 50% of hybrid traces with `bd_count=0`). Round 7 just tipped
the loop's success rate visibly under threshold.

**Confirmed root cause B** (why the backstop didn't fire visibly):
the reconciler is in fact running — but its only INFO log was a
conditional `"tick recovered N"` emitted only when N>0. With every
candidate hitting the threshold-not-yet check (or the future-EndTime
check, etc.), `processed=0` every tick, no log. The reconciler was
indistinguishable in logs from a goroutine that never started, so the
real failure mode (CRD-success silence) was invisible too.

## Fix

`src/service/consumer/stuck_trace_reconciler.go`:
- `Run` emits a startup INFO with `interval / stuck_threshold / max_batch_per_tick`.
- `tick` now returns `(processed, candidates, err)`. The candidate count
  is the SELECT row count; the heartbeat distinguishes "no rows match"
  from "rows match but every one was skipped".
- Per-tick heartbeat: INFO when recoveries happened, INFO when
  candidates existed but all were skipped, DEBUG when no candidates,
  WARN on error.
- `runTickSafely` wraps `tick` in a panic-recovery shim so a per-row
  crash can't permanently kill the loop.
- Tests updated for the new `tick` signature; new
  `TestReconciler_TickReportsCandidateCount` pins the candidate-count
  contract so a future regression to the pre-fix silent shape gets
  caught.

`src/service/consumer/k8s_handler.go`:
- `HandleCRDSucceeded` emits `"single-leaf, submitting BuildDatapack"`
  on the non-hybrid path and per-leaf progress (`batch_id, batch_count,
  batch_size, batch_finished`) on the hybrid path. A batch stuck on a
  missing CRD callback now surfaces as repeated `"leaf received,
  awaiting more"` entries with stable `count<expected`.

`src/service/consumer/fault_injection.go`:
- `FaultBatchManager.snapshotBatchProgress` — read-locked progress
  snapshot used by the new HandleCRDSucceeded fields.

## Out of scope (will be filed separately)

- Adding `runtimemutatorchaos` to chaos-experiment `GetCRDMapping` is
  the upstream fix for root cause A. Cannot land in this repo.
- Hardening `FaultBatchManager.isFinished` against the worker-restart
  edge case (returns `true` when `batchInjections[batchID]` doesn't
  exist, which can fire `postProcess` prematurely on the first CRD
  callback after restart) is a separate concern from this incident
  and is left to a follow-up.

## Test plan

- [x] `cd src && go build -tags duckdb_arrow -o /dev/null ./main.go` passes.
- [x] `go test ./service/consumer/...` — all pass including the new test.
- [ ] Live deploy to byte-cluster: confirm the startup log
  `"StuckTraceReconciler started"` appears once per worker; confirm
  per-tick `"stuck trace reconcile tick: no recoveries"` heartbeat
  appears every 60s while stuck candidates exist; confirm
  `HandleCRDSucceeded: hybrid batch leaf received, awaiting more`
  appears for partially-completed batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)