### PR TITLE
fix(chaos-experiment): include RuntimeMutatorChaos in GetCRDMapping

### DIFF
--- a/chaos-experiment/client/kubernetes.go
+++ b/chaos-experiment/client/kubernetes.go
@@ -231,16 +231,16 @@ func GetPodsByLabel(namespace, labelKey, labelValue string) ([]string, error) {
 	return podNames, nil
 }
 
-// TODO: 添加需要的类型
 func GetCRDMapping() map[schema.GroupVersionResource]client.Object {
 	return map[schema.GroupVersionResource]client.Object{
-		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "dnschaos"}:     &v1alpha1.DNSChaos{},
-		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "httpchaos"}:    &v1alpha1.HTTPChaos{},
-		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "jvmchaos"}:     &v1alpha1.JVMChaos{},
-		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "networkchaos"}: &v1alpha1.NetworkChaos{},
-		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "podchaos"}:     &v1alpha1.PodChaos{},
-		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "stresschaos"}:  &v1alpha1.StressChaos{},
-		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "timechaos"}:    &v1alpha1.TimeChaos{},
+		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "dnschaos"}:             &v1alpha1.DNSChaos{},
+		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "httpchaos"}:            &v1alpha1.HTTPChaos{},
+		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "jvmchaos"}:             &v1alpha1.JVMChaos{},
+		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "networkchaos"}:         &v1alpha1.NetworkChaos{},
+		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "podchaos"}:             &v1alpha1.PodChaos{},
+		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "stresschaos"}:          &v1alpha1.StressChaos{},
+		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "timechaos"}:            &v1alpha1.TimeChaos{},
+		{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "runtimemutatorchaos"}: &v1alpha1.RuntimeMutatorChaos{},
 	}
 }
 


### PR DESCRIPTION
## Why

`chaos-experiment/client/kubernetes.go::GetCRDMapping()` is the canonical list of chaos-mesh CRD types AegisLab watches via dynamic informers (`AegisLab/src/infra/k8s/controller.go:108-111` populates `chaosGVRs` from this map). The list omitted `runtimemutatorchaos`, so RuntimeMutatorChaos CRDs were created in-cluster but **no informer ever subscribed to their Phase transitions**.

Effect on the BD chain:

```
trace (K_inner=2 hybrid)
  ├── Leaf 1: JVMRuntimeMutator → CRD created, runs, finishes
  │             └── informer NOT subscribed → no callback fires
  └── Leaf 2: NetworkDelay → CRD created, runs, finishes
                └── HandleCRDSucceeded → batchManager.count = 1/2

batch.count never reaches 2/2 → postProcess never fires
                              → SubmitTask(BuildDatapack) never called
                              → trace stuck at fault.injection.completed forever
```

Manifested on byte-cluster K=12 ts campaign:
- Round 6: 50% of hybrid traces stuck (the half whose Leaf 1 was RuntimeMutator). Previously misdiagnosed as OTel HPA churn (#300).
- Round 7+ (loop config pinned every Leaf 1 to JVMRuntimeMutator): 100% of traces stuck. No new BuildDatapack tasks created for 3+ hours.

PR #306 lands the matching observability so silent batch-stalls become visible. This PR closes the underlying gap.

## What

One entry added:

\`\`\`go
{Group: "chaos-mesh.org", Version: "v1alpha1", Resource: "runtimemutatorchaos"}: &v1alpha1.RuntimeMutatorChaos{},
\`\`\`

Drops the now-resolved \`// TODO: 添加需要的类型\` comment.

## Test plan

- [x] \`cd chaos-experiment && go build ./...\` passes
- [x] \`cd AegisLab/src && go build -tags duckdb_arrow -o /dev/null ./main.go\` passes (uses the local replace directive on chaos-experiment)
- [ ] Once merged + image rebuilt: backend redeployed; new K_inner=2 hybrid batches with Leaf 1=JVMRuntimeMutator should progress past \`fault.injection.completed\` to \`datapack.build.*\` within ~5 min of CRD completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)