### PR TITLE
fix(reconciler): exclude stuck traces that already have a BuildDatapack child from candidate query

### DIFF
--- a/AegisLab/src/service/consumer/stuck_trace_reconciler.go
+++ b/AegisLab/src/service/consumer/stuck_trace_reconciler.go
@@ -186,6 +186,18 @@ func (r *StuckTraceReconciler) tick(ctx context.Context) (int, int, error) {
 	}
 	cutoff := r.now().Add(-time.Duration(stuckSecs) * time.Second)
 
+	// Anti-join out traces that already have a non-deleted BuildDatapack
+	// task. Without this filter the candidate set is starved on busy
+	// clusters: any trace whose last_event was never advanced past
+	// fault.injection.* (e.g. BD ran and failed but the trace-state-update
+	// silently dropped — see follow-up to #305) keeps reappearing in the
+	// oldest-first scan, fills the LIMIT 50 budget every tick, and the
+	// per-row idempotency check inside recoverTrace returns (false, nil)
+	// for all of them. Newer genuinely-stuck traces (no BD child) are
+	// ordered by updated_at ASC after the broken-state old rows and never
+	// surface. The recoverTrace idempotency check stays as a defensive
+	// race-condition guard but should never fire in practice once this
+	// filter is in place.
 	var traces []model.Trace
 	err := r.db.WithContext(ctx).
 		Model(&model.Trace{}).
@@ -194,6 +206,14 @@ func (r *StuckTraceReconciler) tick(ctx context.Context) (int, int, error) {
 			[]consts.EventType{consts.EventFaultInjectionStarted, consts.EventFaultInjectionCompleted},
 			cutoff,
 			consts.CommonDeleted,
+		).
+		Where("NOT EXISTS (?)",
+			r.db.Model(&model.Task{}).
+				Select("1").
+				Where("tasks.trace_id = traces.id AND tasks.type = ? AND tasks.status != ?",
+					consts.TaskTypeBuildDatapack,
+					consts.CommonDeleted,
+				),
 		).
 		Order("updated_at ASC").
 		Order("id ASC").

--- a/AegisLab/src/service/consumer/stuck_trace_reconciler_test.go
+++ b/AegisLab/src/service/consumer/stuck_trace_reconciler_test.go
@@ -298,6 +298,74 @@ func TestReconciler_IsIdempotent(t *testing.T) {
 	require.Equal(t, 0, called)
 }
 
+// TestReconciler_DoesNotStarveNewCandidatesByOldHaveBDRows is the regression
+// guard for the byte-cluster K=12 ts loop incident: when ≥ maxBatchPerTick
+// traces are stuck at last_event=fault.injection.* AND already have a
+// BuildDatapack child (BD ran and failed/cancelled but trace.last_event was
+// never advanced), the LIMIT-50 oldest-first SELECT used to fill its budget
+// entirely with these "data-corrupt" rows. Every recoverTrace then bailed
+// out via the per-row idempotency check, brand-new genuinely-stuck traces
+// (no BD child) ordered after them by updated_at ASC and never surfaced —
+// the reconciler reported "candidates=50, processed=0" indefinitely while
+// recoverable traces piled up.
+//
+// Pre-fix: this test sees candidates == 50, processed == 0, the 5 fresh
+// traces are starved.
+// Post-fix: the SQL anti-join filters the 50 have-BD rows out of the SELECT,
+// candidates == 5, processed == 5.
+func TestReconciler_DoesNotStarveNewCandidatesByOldHaveBDRows(t *testing.T) {
+	db := newReconcilerTestDB(t)
+
+	// 50 traces with a non-deleted BuildDatapack child task already
+	// present. They match the WHERE clause (state=Running, last_event
+	// matches, past threshold, status active) but should be filtered out
+	// by the anti-join. updated_at on these is set further in the past
+	// than the fresh traces below so the ASC ordering would surface them
+	// first if they weren't filtered.
+	for i := 0; i < 50; i++ {
+		fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, 1, 60*time.Minute, false)
+		require.NoError(t, db.Create(&model.Task{
+			ID:           uuid.NewString(),
+			Type:         consts.TaskTypeBuildDatapack,
+			TraceID:      fix.traceID,
+			ParentTaskID: &fix.faultTaskID,
+			Payload:      "{}",
+			State:        consts.TaskError,
+			Status:       consts.CommonEnabled,
+		}).Error)
+	}
+
+	// 5 fresh genuinely-stuck traces with NO BuildDatapack child — these
+	// are the rows the reconciler must surface. updated_at is more recent
+	// than the 50 above so they would otherwise sort after them under
+	// "ORDER BY updated_at ASC".
+	freshTraceIDs := make(map[string]bool, 5)
+	for i := 0; i < 5; i++ {
+		fix := makeStuckFixture(t, db, consts.EventFaultInjectionCompleted, 1, 30*time.Minute, false)
+		freshTraceIDs[fix.traceID] = true
+	}
+
+	owner := newFakeInjectionOwner(nil)
+	var captured []*dto.UnifiedTask
+	submitter := taskSubmitter(func(_ context.Context, _ *gorm.DB, _ *redis.Gateway, t *dto.UnifiedTask) error {
+		captured = append(captured, t)
+		return nil
+	})
+	r := newReconcilerForTest(t, db, owner, submitter)
+	processed, candidates, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 5, candidates,
+		"candidate query must exclude traces that already have a non-deleted BuildDatapack child; "+
+			"got candidates=%d (would be 50 under pre-fix starvation)", candidates)
+	require.Equal(t, 5, processed, "all 5 fresh stuck traces must be recovered")
+	require.Len(t, captured, 5)
+	for _, ct := range captured {
+		require.True(t, freshTraceIDs[ct.TraceID],
+			"recovered trace %s must be one of the fresh no-BD-child traces; "+
+				"submitting against a have-BD trace would be the pre-fix bug", ct.TraceID)
+	}
+}
+
 // TestReconciler_RespectsStuckThreshold guards against the reconciler
 // stealing in-flight traces that are still inside their fault window.
 // updated_at within the stuck threshold must be left alone.


### PR DESCRIPTION
## Symptom

Follow-up to #305. Observed in the byte-cluster K=12 ts loop:

The reconciler reported \`tick: 50 candidates, 0 processed\` indefinitely while 96 actually-recoverable stuck traces piled up. Manual workaround applied (one-shot \`UPDATE traces SET state=3, last_event='trace.cancelled' WHERE state=1 AND last_event IN (...) AND have-BD-child\`) cleared 51 rows and the next tick recovered 50 traces.

### Root mechanic

\`tick()\` selects:

\`\`\`go
.Where("state = ? AND last_event IN ? AND updated_at < ? AND status != ?", ...)
.Order("updated_at ASC").Order("id ASC").Limit(50)
\`\`\`

Then \`recoverTrace()\` runs a per-row idempotency check: if a non-deleted BuildDatapack child already exists for this trace's FaultInjection task, return \`(false, nil)\`.

When ≥50 traces accumulate in \`state=Running\` + \`last_event=fault.injection.{started,completed}\` that **already have a non-deleted BuildDatapack child task** (because BD ran and failed/cancelled but \`trace.last_event\` was never advanced — separate trace-state-update bug, see follow-up below), every reconciler tick:

1. Selects those 50 oldest "data-corrupt" rows.
2. Each \`recoverTrace\` returns \`(false, nil)\` via the idempotency check.
3. Genuinely stuck new traces (no BD child) — ordered by \`updated_at ASC\` after the broken-state old rows — **never make it into the LIMIT-50 selection**.

This is unbounded starvation; the new traces never surface unless someone manually intervenes on the corrupt rows.

## Fix

Extend the candidate query with a \`NOT EXISTS\` anti-join keyed on \`tasks.trace_id = traces.id AND tasks.type = 'BuildDatapack' AND tasks.status != deleted\`. Traces that already have a non-deleted BD child are now invisible to the reconciler at the SELECT layer.

The per-row idempotency check inside \`recoverTrace\` is **kept** as a defensive race-condition guard (CRD-success path racing the reconciler within the same tick window) — it should never fire in practice once the SELECT filter is in place, and the in-tx recheck under \`submitIfNoChild\` still serializes concurrent reconciler replicas.

### Why not (b) mark-and-skip?

The alternative was: when \`recoverTrace\` observes \`existingDatapackCount > 0\`, advance the trace state in the same transaction (call \`updateTraceState\` so \`last_event\` is re-derived from current task state). This would fix the **underlying data corruption** rather than just stop ignoring it. Rejected:

- Bigger scope — \`updateTraceState\` is a goroutine-launched path elsewhere; calling it inline from the reconciler risks racing with concurrent writers.
- Higher blast radius — the reconciler today is read-mostly (only writes via the well-tested \`submitIfNoChild\` tx); folding state advancement into it widens the surface area substantially.
- The root cause (why those 51 traces had \`last_event\` not advancing when their BD task failed) is **a separate bug** — \`HandleJobFailed\` / cancel paths must publish trace-state events for the parent task, and clearly something dropped silently. Worth a dedicated PR with its own regression suite.

## Regression test

\`TestReconciler_DoesNotStarveNewCandidatesByOldHaveBDRows\`:

- Seeds 50 traces matching the WHERE clause that **already have** a BuildDatapack child task (\`State=TaskError\`, simulating "BD ran and failed but last_event never advanced") with older \`updated_at\`.
- Seeds 5 fresh genuinely-stuck traces with **no BD child** and newer \`updated_at\`.
- Pre-fix: \`candidates=50, processed=0\`, fresh traces starved (verified by running the test against pre-fix code: \`expected: 5, actual: 50\`).
- Post-fix: \`candidates=5, processed=5\`, all five fresh traces submitted. ✅

## Out of scope / follow-up

The 51 corrupt rows didn't appear by themselves — something on the \`HandleJobFailed\` / BD-task-cancel path failed to publish the trace-state-update event that should advance \`last_event\` past \`fault.injection.completed\` when the BD child enters Error/Cancelled. That should be tracked as a separate bug; this PR makes the reconciler resilient to it but doesn't prevent the corrupt rows from being created.

## Build / tests

- \`cd src && go build -tags duckdb_arrow -o /dev/null ./main.go\` — clean
- \`go test ./service/consumer/...\` — all pass (15/15 reconciler cases including the new one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)