### PR TITLE
feat(reason): add filter-clean command for prefiltering dirty datapacks

### DIFF
--- a/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
+++ b/rcabench-platform/src/rcabench_platform/v3/internal/reasoning/cli.py
@@ -1181,5 +1181,128 @@ def batch(
     return 0
 
 
+_FILTER_REQUIRED_PARQUETS = (
+    "abnormal_traces.parquet",
+    "normal_traces.parquet",
+    "abnormal_metrics.parquet",
+    "abnormal_metrics_histogram.parquet",
+    "abnormal_metrics_sum.parquet",
+)
+_FILTER_EXTERNAL_SERVICES = {"mysql", "redis", "postgres", "mongodb", "kafka", "rabbitmq"}
+
+
+def _classify_case(
+    case_dir: Path,
+    min_services: int,
+    max_gap_seconds: float,
+) -> tuple[str, str]:
+    """Return (verdict, detail). verdict ∈ {clean, missing_parquet, no_engine_config,
+    loadgen_only, gt_no_spans, large_gap, read_error}."""
+    inj_path = case_dir / "injection.json"
+    if not inj_path.exists():
+        return ("missing_parquet", "injection.json")
+    missing = [f for f in _FILTER_REQUIRED_PARQUETS if not (case_dir / f).exists()]
+    if missing:
+        return ("missing_parquet", missing[0])
+
+    import json as _json
+
+    import polars as pl
+
+    try:
+        inj = _json.loads(inj_path.read_text())
+    except Exception as exc:
+        return ("read_error", f"injection.json: {type(exc).__name__}")
+
+    eng = inj.get("engine_config") or inj.get("engine_config_summary") or []
+    if not eng:
+        return ("no_engine_config", "")
+
+    try:
+        ab = pl.read_parquet(case_dir / "abnormal_traces.parquet")
+        nm = pl.read_parquet(case_dir / "normal_traces.parquet")
+    except Exception as exc:
+        return ("read_error", f"traces: {type(exc).__name__}")
+
+    ab_svcs = set(ab["service_name"].unique().to_list()) if len(ab) else set()
+    if len(ab_svcs) < min_services:
+        return ("loadgen_only", f"{len(ab_svcs)} services")
+
+    gt: set[str] = set()
+    for entry in inj.get("ground_truth", []) or []:
+        for s in entry.get("service", []) or []:
+            gt.add(s)
+    gt_internal = (gt - _FILTER_EXTERNAL_SERVICES) or gt
+    missing_gt = [s for s in gt_internal if s not in ab_svcs]
+    if missing_gt:
+        return ("gt_no_spans", ",".join(missing_gt))
+
+    if len(nm) and len(ab):
+        from datetime import datetime as _dt
+
+        ab_min = ab["time"].min()
+        nm_max = nm["time"].max()
+        if isinstance(ab_min, _dt) and isinstance(nm_max, _dt):
+            gap = (ab_min - nm_max).total_seconds()
+            if gap > max_gap_seconds:
+                return ("large_gap", f"{gap:.0f}s")
+
+    return ("clean", "")
+
+
+@app.command()
+def filter_clean(
+    data_base_dir: str = typer.Option(..., help="Base directory containing case folders"),
+    min_services: int = typer.Option(3, help="Minimum distinct services in abnormal_traces"),
+    max_gap_seconds: float = typer.Option(30.0, help="Max normal_end → abnormal_start gap (seconds)"),
+    output: str = typer.Option("-", help="Output path for clean case names ('-' = stdout)"),
+    summary: bool = typer.Option(True, help="Print dirty-reason breakdown to stderr"),
+) -> int:
+    """Filter datapacks by data quality. Prints clean case names (one per line).
+
+    Reject criteria: missing required parquet, no engine_config, fewer than
+    `min_services` distinct services in abnormal_traces, any GT internal
+    service with zero spans in abnormal_traces, or normal-to-abnormal time
+    gap > max_gap_seconds.
+    """
+    import sys
+    from collections import Counter
+
+    base_path = Path(data_base_dir)
+    if not base_path.is_dir():
+        typer.echo(f"error: {base_path} is not a directory", err=True)
+        raise typer.Exit(2)
+
+    clean: list[str] = []
+    reasons: Counter[str] = Counter()
+    details: list[tuple[str, str, str]] = []
+
+    for case_dir in sorted(base_path.iterdir()):
+        if not case_dir.is_dir():
+            continue
+        verdict, detail = _classify_case(case_dir, min_services, max_gap_seconds)
+        if verdict == "clean":
+            clean.append(case_dir.name)
+        else:
+            reasons[verdict] += 1
+            details.append((case_dir.name, verdict, detail))
+
+    out_stream = sys.stdout if output == "-" else open(output, "w")
+    try:
+        for name in clean:
+            out_stream.write(name + "\n")
+    finally:
+        if out_stream is not sys.stdout:
+            out_stream.close()
+
+    if summary:
+        total = len(clean) + sum(reasons.values())
+        print(f"clean: {len(clean)}/{total}", file=sys.stderr)
+        for reason, n in reasons.most_common():
+            print(f"  {n:4} {reason}", file=sys.stderr)
+
+    return 0
+
+
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
## Summary
- New CLI command `reason filter-clean` that prints clean datapack names to stdout (one per line) and a dirty-reason breakdown to stderr, making it pipeable into `batch --stdin` / `xargs` / `comm`.
- Reject criteria are intentionally strict and additive: any one trip rejects the datapack.

## Why
On a 151-case ts hybrid corpus, ~70% of datapacks were unusable for reasoning evaluation: GT services with zero spans (66), partial parquet downloads (20), loadgen-only traces (17), normal/abnormal time gaps that the `inject_time` gate cannot tolerate (3), parquet truncation (2). Running `batch` over them produced `AssertionError`, `FileNotFoundError`, `no_paths`, or root-cause sets that miss services the reasoner never had a graph node for. None of these failures are fixable in the reasoner itself — they are upstream data quality.

Measured: on the clean 43-case subset, reasoner `hit_all` (all GT internal services in `root_causes`) is 100%.

## Reject criteria (`_classify_case`)
| verdict | trigger |
|---|---|
| `missing_parquet` | injection.json or any of abnormal/normal traces / metrics / metrics_histogram / metrics_sum absent |
| `read_error` | parquet present but unreadable (truncated, no PAR1 footer) |
| `no_engine_config` | injection.json has empty `engine_config` and `engine_config_summary` |
| `loadgen_only` | abnormal_traces has fewer than `--min-services` distinct services (default 3) |
| `gt_no_spans` | any GT internal service has zero spans in abnormal_traces |
| `large_gap` | `abnormal_traces.time.min() - normal_traces.time.max() > --max-gap-seconds` (default 30s) |

External services (mysql, redis, postgres, …) are excluded from the GT internal set so a missing mysql doesn't disqualify a case.

## Usage
```
# print clean case names
aegisctl reason filter-clean --data-base-dir /path/to/cases

# pipe into batch (drop .valid markers on dirty cases first)
DIR=/path/to/cases
aegisctl reason filter-clean --data-base-dir "$DIR" > /tmp/clean.txt
comm -23 <(ls "$DIR" | sort) /tmp/clean.txt | xargs -I{} rm -f "$DIR/{}/.valid"
aegisctl reason batch --data-base-dir "$DIR" --force
```

Knobs:
- `--min-services` (default 3)
- `--max-gap-seconds` (default 30)
- `--output -` (stdout, default) or path
- `--no-summary` for pure stdout output

## Test plan
- [x] `aegisctl reason filter-clean --help` renders all options
- [x] Smoke test on a 151-case directory — yields 43 clean, expected dirty breakdown
- [x] Repeat run after fix is idempotent (no side effects on disk)
- [x] `just lint` introduces no new pyright errors in the new code (5 pre-existing errors remain in unrelated files)
- [ ] Verify `reason batch` happily consumes a directory with mixed clean/dirty cases when `.valid` is removed for dirty ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)