### PR TITLE
feat(otel): per-system collectors for the remaining 6 systems (#303 step 2b)

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -87,7 +87,12 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.6
+      # Bumped 0.1.6 → 0.1.7 to retarget OTel exporter to the per-system
+      # otel-demo collector (#303 step 2b). The wrapper otel-collector inside
+      # the demo chart forwards to `global.clusterCollector.service`, which
+      # we now point at the dedicated single-pod deployment-otel-demo
+      # collector instead of the shared deployment-collector.
+      - name: 0.1.7
         github_link: open-telemetry/opentelemetry-demo
         status: 1
         helm_config:
@@ -95,6 +100,13 @@ containers:
           chart_name: otel-demo-aegis
           repo_name: opspai
           repo_url: oci://pair-cn-shanghai.cr.volces.com/opspai
+          values:
+            - key: global.clusterCollector.service
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: opentelemetry-kube-stack-deployment-otel-demo-collector.monitoring.svc.cluster.local
+              overridable: true
           status: 1
   - type: 2
     name: ob
@@ -131,7 +143,10 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 1.1.2
+      # Bumped 1.1.2 → 1.1.3 to retarget OTel exporter and Instrumentation
+      # CR at the per-system sockshop collector (#303 step 2b). Reseed honors
+      # the immutability contract on already-seeded versions.
+      - name: 1.1.3
         github_link: LGU-SE-Internal/coherence-helidon-sockshop-sample
         status: 1
         # Chart is now self-hosted in the fork's gh-pages site. For the Byte
@@ -171,13 +186,13 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: monitoring/opentelemetry-kube-stack
+              default_value: monitoring/otel-instr-sockshop
               overridable: true
             - key: otel.collectorEndpoint
               type: 0
               category: 1
               value_type: 0
-              default_value: http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317
+              default_value: http://opentelemetry-kube-stack-deployment-sockshop-collector.monitoring.svc.cluster.local:4317
               overridable: true
           status: 1
     # issue #115: sockshop's coherence-helidon variant requires the
@@ -208,7 +223,9 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.3
+      # Bumped 0.1.3 → 0.1.4 to retarget `global.otel.endpoint` at the
+      # per-system hs collector (#303 step 2b).
+      - name: 0.1.4
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
@@ -239,7 +256,7 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4318
+              default_value: opentelemetry-kube-stack-deployment-hs-collector.monitoring.svc.cluster.local:4318
               overridable: true
           status: 1
   - type: 2
@@ -247,7 +264,9 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.4
+      # Bumped 0.1.4 → 0.1.5 to retarget `global.otel.endpoint` at the
+      # per-system sn collector (#303 step 2b).
+      - name: 0.1.5
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
@@ -278,7 +297,7 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4318
+              default_value: opentelemetry-kube-stack-deployment-sn-collector.monitoring.svc.cluster.local:4318
               overridable: true
           status: 1
   - type: 2
@@ -286,7 +305,9 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.4
+      # Bumped 0.1.4 → 0.1.5 to retarget `global.otel.endpoint` at the
+      # per-system media collector (#303 step 2b).
+      - name: 0.1.5
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
@@ -317,7 +338,7 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4318
+              default_value: opentelemetry-kube-stack-deployment-media-collector.monitoring.svc.cluster.local:4318
               overridable: true
           status: 1
   - type: 2
@@ -325,7 +346,10 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.5
+      # Bumped 0.1.5 → 0.1.6 to retarget OTel exporter and Instrumentation
+      # CR at the per-system teastore collector (#303 step 2b). Reseed honors
+      # the immutability contract on already-seeded versions.
+      - name: 0.1.6
         github_link: LGU-SE-Internal/TeaStore
         status: 1
         helm_config:
@@ -350,7 +374,7 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: http://opentelemetry-kube-stack-deployment-collector.monitoring.svc.cluster.local:4317
+              default_value: http://opentelemetry-kube-stack-deployment-teastore-collector.monitoring.svc.cluster.local:4317
               overridable: true
             # 0.1.1 parameterizes the inject-<language> annotation from these
             # two values (previously hardcoded to "monitoring/opentelemetry-kube-stack").
@@ -365,7 +389,7 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: opentelemetry-kube-stack
+              default_value: otel-instr-teastore
               overridable: true
             # 0.1.2 makes the busybox image used by jmeter's wait-for-registry
             # init container configurable (LGU-SE-Internal/TeaStore#8). The Byte

--- a/AegisLab/manifests/byte-cluster/otel-kube-stack.values.yaml
+++ b/AegisLab/manifests/byte-cluster/otel-kube-stack.values.yaml
@@ -698,6 +698,712 @@ collectors:
             processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
             receivers: [otlp]
 
+  # Per-system collector for the otel-demo benchmark (#303 step 2b).
+  # See deploy-ts above for the rationale (single pod, no HPA, 64Gi mem).
+  # otel-demo wraps its components behind an in-namespace `otel-collector`
+  # Service that forwards upstream; the seed retargets
+  # `global.clusterCollector.service` to this per-system collector.
+  deploy-otel-demo:
+    suffix: deployment-otel-demo
+    mode: deployment
+    enabled: true
+    replicas: 1
+    resources:
+      limits:
+        cpu: 8000m
+        memory: 98304Mi
+      requests:
+        cpu: 2000m
+        memory: 65536Mi
+    config:
+      exporters:
+        clickhouse:
+          endpoint: tcp://clickstack-clickhouse-clickhouse-headless.monitoring.svc.cluster.local:9000?dial_timeout=10s&compress=lz4&username=default
+          database: otel
+          ttl: 72h
+          logs_table_name: otel_logs
+          traces_table_name: otel_traces
+          metrics_table_name: otel_metrics
+          timeout: 5s
+          retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_interval: 30s
+            max_elapsed_time: 300s
+      processors:
+        batch:
+          timeout: 5s
+          send_batch_size: 2000
+          send_batch_max_size: 4000
+        memory_limiter:
+          check_interval: 1s
+          limit_percentage: 75
+          spike_limit_percentage: 15
+        k8sattributes:
+          auth_type: serviceAccount
+          passthrough: false
+          extract:
+            metadata:
+              - k8s.pod.name
+              - k8s.pod.uid
+              - k8s.deployment.name
+              - k8s.namespace.name
+              - k8s.node.name
+              - k8s.pod.start_time
+              - service.name
+              - service.version
+              - service.instance.id
+            labels:
+              - tag_name: app.label.component
+                key: app.kubernetes.io/component
+                from: pod
+              - tag_name: service.name
+                key: app.kubernetes.io/name
+                from: pod
+              - tag_name: service.name
+                key: app
+                from: pod
+              - tag_name: service.name
+                key: name
+                from: pod
+            otel_annotations: true
+          pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.ip
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.uid
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
+            - sources:
+                - from: connection
+        transform/service_namespace:
+          trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+          metric_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+          log_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+      connectors:
+        spanmetrics: {}
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+      service:
+        pipelines:
+          logs:
+            exporters: [clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp]
+          metrics:
+            exporters: [clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp, spanmetrics]
+          traces:
+            exporters: [spanmetrics, clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp]
+
+  # Per-system collector for the hotel-reservation (hs) DSB benchmark (#303 step 2b).
+  deploy-hs:
+    suffix: deployment-hs
+    mode: deployment
+    enabled: true
+    replicas: 1
+    resources:
+      limits:
+        cpu: 8000m
+        memory: 98304Mi
+      requests:
+        cpu: 2000m
+        memory: 65536Mi
+    config:
+      exporters:
+        clickhouse:
+          endpoint: tcp://clickstack-clickhouse-clickhouse-headless.monitoring.svc.cluster.local:9000?dial_timeout=10s&compress=lz4&username=default
+          database: otel
+          ttl: 72h
+          logs_table_name: otel_logs
+          traces_table_name: otel_traces
+          metrics_table_name: otel_metrics
+          timeout: 5s
+          retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_interval: 30s
+            max_elapsed_time: 300s
+      processors:
+        batch:
+          timeout: 5s
+          send_batch_size: 2000
+          send_batch_max_size: 4000
+        memory_limiter:
+          check_interval: 1s
+          limit_percentage: 75
+          spike_limit_percentage: 15
+        k8sattributes:
+          auth_type: serviceAccount
+          passthrough: false
+          extract:
+            metadata:
+              - k8s.pod.name
+              - k8s.pod.uid
+              - k8s.deployment.name
+              - k8s.namespace.name
+              - k8s.node.name
+              - k8s.pod.start_time
+              - service.name
+              - service.version
+              - service.instance.id
+            labels:
+              - tag_name: app.label.component
+                key: app.kubernetes.io/component
+                from: pod
+              - tag_name: service.name
+                key: app.kubernetes.io/name
+                from: pod
+              - tag_name: service.name
+                key: app
+                from: pod
+              - tag_name: service.name
+                key: name
+                from: pod
+            otel_annotations: true
+          pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.ip
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.uid
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
+            - sources:
+                - from: connection
+        transform/service_namespace:
+          trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+          metric_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+          log_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+      connectors:
+        spanmetrics: {}
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+      service:
+        pipelines:
+          logs:
+            exporters: [clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp]
+          metrics:
+            exporters: [clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp, spanmetrics]
+          traces:
+            exporters: [spanmetrics, clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp]
+
+  # Per-system collector for the social-network (sn) DSB benchmark (#303 step 2b).
+  deploy-sn:
+    suffix: deployment-sn
+    mode: deployment
+    enabled: true
+    replicas: 1
+    resources:
+      limits:
+        cpu: 8000m
+        memory: 98304Mi
+      requests:
+        cpu: 2000m
+        memory: 65536Mi
+    config:
+      exporters:
+        clickhouse:
+          endpoint: tcp://clickstack-clickhouse-clickhouse-headless.monitoring.svc.cluster.local:9000?dial_timeout=10s&compress=lz4&username=default
+          database: otel
+          ttl: 72h
+          logs_table_name: otel_logs
+          traces_table_name: otel_traces
+          metrics_table_name: otel_metrics
+          timeout: 5s
+          retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_interval: 30s
+            max_elapsed_time: 300s
+      processors:
+        batch:
+          timeout: 5s
+          send_batch_size: 2000
+          send_batch_max_size: 4000
+        memory_limiter:
+          check_interval: 1s
+          limit_percentage: 75
+          spike_limit_percentage: 15
+        k8sattributes:
+          auth_type: serviceAccount
+          passthrough: false
+          extract:
+            metadata:
+              - k8s.pod.name
+              - k8s.pod.uid
+              - k8s.deployment.name
+              - k8s.namespace.name
+              - k8s.node.name
+              - k8s.pod.start_time
+              - service.name
+              - service.version
+              - service.instance.id
+            labels:
+              - tag_name: app.label.component
+                key: app.kubernetes.io/component
+                from: pod
+              - tag_name: service.name
+                key: app.kubernetes.io/name
+                from: pod
+              - tag_name: service.name
+                key: app
+                from: pod
+              - tag_name: service.name
+                key: name
+                from: pod
+            otel_annotations: true
+          pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.ip
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.uid
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
+            - sources:
+                - from: connection
+        transform/service_namespace:
+          trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+          metric_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+          log_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+      connectors:
+        spanmetrics: {}
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+      service:
+        pipelines:
+          logs:
+            exporters: [clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp]
+          metrics:
+            exporters: [clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp, spanmetrics]
+          traces:
+            exporters: [spanmetrics, clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp]
+
+  # Per-system collector for the media-microservices (media) DSB benchmark
+  # (#303 step 2b). System name in the seed is `media`; chart name is
+  # `media-microservices`.
+  deploy-media:
+    suffix: deployment-media
+    mode: deployment
+    enabled: true
+    replicas: 1
+    resources:
+      limits:
+        cpu: 8000m
+        memory: 98304Mi
+      requests:
+        cpu: 2000m
+        memory: 65536Mi
+    config:
+      exporters:
+        clickhouse:
+          endpoint: tcp://clickstack-clickhouse-clickhouse-headless.monitoring.svc.cluster.local:9000?dial_timeout=10s&compress=lz4&username=default
+          database: otel
+          ttl: 72h
+          logs_table_name: otel_logs
+          traces_table_name: otel_traces
+          metrics_table_name: otel_metrics
+          timeout: 5s
+          retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_interval: 30s
+            max_elapsed_time: 300s
+      processors:
+        batch:
+          timeout: 5s
+          send_batch_size: 2000
+          send_batch_max_size: 4000
+        memory_limiter:
+          check_interval: 1s
+          limit_percentage: 75
+          spike_limit_percentage: 15
+        k8sattributes:
+          auth_type: serviceAccount
+          passthrough: false
+          extract:
+            metadata:
+              - k8s.pod.name
+              - k8s.pod.uid
+              - k8s.deployment.name
+              - k8s.namespace.name
+              - k8s.node.name
+              - k8s.pod.start_time
+              - service.name
+              - service.version
+              - service.instance.id
+            labels:
+              - tag_name: app.label.component
+                key: app.kubernetes.io/component
+                from: pod
+              - tag_name: service.name
+                key: app.kubernetes.io/name
+                from: pod
+              - tag_name: service.name
+                key: app
+                from: pod
+              - tag_name: service.name
+                key: name
+                from: pod
+            otel_annotations: true
+          pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.ip
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.uid
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
+            - sources:
+                - from: connection
+        transform/service_namespace:
+          trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+          metric_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+          log_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+      connectors:
+        spanmetrics: {}
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+      service:
+        pipelines:
+          logs:
+            exporters: [clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp]
+          metrics:
+            exporters: [clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp, spanmetrics]
+          traces:
+            exporters: [spanmetrics, clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp]
+
+  # Per-system collector for the sockshop benchmark (#303 step 2b).
+  # Coherence/Helidon Java workloads use operator-injected instrumentation
+  # via the `otel-instr-sockshop` Instrumentation CR (see extraObjects below).
+  deploy-sockshop:
+    suffix: deployment-sockshop
+    mode: deployment
+    enabled: true
+    replicas: 1
+    resources:
+      limits:
+        cpu: 8000m
+        memory: 98304Mi
+      requests:
+        cpu: 2000m
+        memory: 65536Mi
+    config:
+      exporters:
+        clickhouse:
+          endpoint: tcp://clickstack-clickhouse-clickhouse-headless.monitoring.svc.cluster.local:9000?dial_timeout=10s&compress=lz4&username=default
+          database: otel
+          ttl: 72h
+          logs_table_name: otel_logs
+          traces_table_name: otel_traces
+          metrics_table_name: otel_metrics
+          timeout: 5s
+          retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_interval: 30s
+            max_elapsed_time: 300s
+      processors:
+        batch:
+          timeout: 5s
+          send_batch_size: 2000
+          send_batch_max_size: 4000
+        memory_limiter:
+          check_interval: 1s
+          limit_percentage: 75
+          spike_limit_percentage: 15
+        k8sattributes:
+          auth_type: serviceAccount
+          passthrough: false
+          extract:
+            metadata:
+              - k8s.pod.name
+              - k8s.pod.uid
+              - k8s.deployment.name
+              - k8s.namespace.name
+              - k8s.node.name
+              - k8s.pod.start_time
+              - service.name
+              - service.version
+              - service.instance.id
+            labels:
+              - tag_name: app.label.component
+                key: app.kubernetes.io/component
+                from: pod
+              - tag_name: service.name
+                key: app.kubernetes.io/name
+                from: pod
+              - tag_name: service.name
+                key: app
+                from: pod
+              - tag_name: service.name
+                key: name
+                from: pod
+            otel_annotations: true
+          pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.ip
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.uid
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
+            - sources:
+                - from: connection
+        transform/service_namespace:
+          trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+          metric_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+          log_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+      connectors:
+        spanmetrics: {}
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+      service:
+        pipelines:
+          logs:
+            exporters: [clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp]
+          metrics:
+            exporters: [clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp, spanmetrics]
+          traces:
+            exporters: [spanmetrics, clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp]
+
+  # Per-system collector for the teastore benchmark (#303 step 2b).
+  # Java workloads use operator-injected instrumentation via the
+  # `otel-instr-teastore` Instrumentation CR (see extraObjects below).
+  deploy-teastore:
+    suffix: deployment-teastore
+    mode: deployment
+    enabled: true
+    replicas: 1
+    resources:
+      limits:
+        cpu: 8000m
+        memory: 98304Mi
+      requests:
+        cpu: 2000m
+        memory: 65536Mi
+    config:
+      exporters:
+        clickhouse:
+          endpoint: tcp://clickstack-clickhouse-clickhouse-headless.monitoring.svc.cluster.local:9000?dial_timeout=10s&compress=lz4&username=default
+          database: otel
+          ttl: 72h
+          logs_table_name: otel_logs
+          traces_table_name: otel_traces
+          metrics_table_name: otel_metrics
+          timeout: 5s
+          retry_on_failure:
+            enabled: true
+            initial_interval: 5s
+            max_interval: 30s
+            max_elapsed_time: 300s
+      processors:
+        batch:
+          timeout: 5s
+          send_batch_size: 2000
+          send_batch_max_size: 4000
+        memory_limiter:
+          check_interval: 1s
+          limit_percentage: 75
+          spike_limit_percentage: 15
+        k8sattributes:
+          auth_type: serviceAccount
+          passthrough: false
+          extract:
+            metadata:
+              - k8s.pod.name
+              - k8s.pod.uid
+              - k8s.deployment.name
+              - k8s.namespace.name
+              - k8s.node.name
+              - k8s.pod.start_time
+              - service.name
+              - service.version
+              - service.instance.id
+            labels:
+              - tag_name: app.label.component
+                key: app.kubernetes.io/component
+                from: pod
+              - tag_name: service.name
+                key: app.kubernetes.io/name
+                from: pod
+              - tag_name: service.name
+                key: app
+                from: pod
+              - tag_name: service.name
+                key: name
+                from: pod
+            otel_annotations: true
+          pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.ip
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.uid
+            - sources:
+                - from: resource_attribute
+                  name: k8s.pod.name
+                - from: resource_attribute
+                  name: k8s.namespace.name
+            - sources:
+                - from: connection
+        transform/service_namespace:
+          trace_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+          metric_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+          log_statements:
+            - context: resource
+              statements:
+                - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+      connectors:
+        spanmetrics: {}
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+      service:
+        pipelines:
+          logs:
+            exporters: [clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp]
+          metrics:
+            exporters: [clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp, spanmetrics]
+          traces:
+            exporters: [spanmetrics, clickhouse]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            receivers: [otlp]
+
 clusterRole:
   enabled: true
   annotations: {}
@@ -771,3 +1477,108 @@ instrumentation:
     env:
       - name: OTEL_EXPORTER_OTLP_ENDPOINT
         value: http://opentelemetry-kube-stack-deployment-collector.monitoring:4318
+
+# Per-system Instrumentation CRs for operator-injected workloads (#303 step 2b).
+#
+# sockshop and teastore charts use the OpenTelemetry Operator's `Instrumentation`
+# CR via pod annotations (`instrumentation.opentelemetry.io/inject-java`, etc.).
+# Each CR mirrors the global `instrumentation:` block above but retargets every
+# language exporter at the matching per-system collector Service so traces are
+# routed off the shared `deployment-collector`. Kept beside the chart's
+# `extraObjects` so a single `helm upgrade` against this values file lands
+# both the per-system collectors and the per-system Instrumentation CRs in one
+# step.
+extraObjects:
+  - apiVersion: opentelemetry.io/v1alpha1
+    kind: Instrumentation
+    metadata:
+      name: otel-instr-sockshop
+      namespace: monitoring
+    spec:
+      exporter:
+        endpoint: http://opentelemetry-kube-stack-deployment-sockshop-collector.monitoring:4317
+      resource:
+        addK8sUIDAttributes: true
+      propagators:
+        - tracecontext
+        - baggage
+        - b3
+        - b3multi
+        - jaeger
+        - xray
+        - ottrace
+      env:
+        - name: OTEL_TRACES_EXPORTER
+          value: otlp
+        - name: OTEL_METRICS_EXPORTER
+          value: otlp
+        - name: OTEL_LOGS_EXPORTER
+          value: otlp
+        - name: OTEL_EXPORTER_OTLP_SPAN_INSECURE
+          value: '"true"'
+      java:
+        image: pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-operator-autoinstrumentation-java:2.23.0
+        env:
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://opentelemetry-kube-stack-deployment-sockshop-collector.monitoring:4317
+      python:
+        env:
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://opentelemetry-kube-stack-deployment-sockshop-collector.monitoring:4318
+          - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
+            value: 'true'
+      dotnet:
+        env:
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://opentelemetry-kube-stack-deployment-sockshop-collector.monitoring:4318
+      go:
+        env:
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://opentelemetry-kube-stack-deployment-sockshop-collector.monitoring:4318
+
+  - apiVersion: opentelemetry.io/v1alpha1
+    kind: Instrumentation
+    metadata:
+      name: otel-instr-teastore
+      namespace: monitoring
+    spec:
+      exporter:
+        endpoint: http://opentelemetry-kube-stack-deployment-teastore-collector.monitoring:4317
+      resource:
+        addK8sUIDAttributes: true
+      propagators:
+        - tracecontext
+        - baggage
+        - b3
+        - b3multi
+        - jaeger
+        - xray
+        - ottrace
+      env:
+        - name: OTEL_TRACES_EXPORTER
+          value: otlp
+        - name: OTEL_METRICS_EXPORTER
+          value: otlp
+        - name: OTEL_LOGS_EXPORTER
+          value: otlp
+        - name: OTEL_EXPORTER_OTLP_SPAN_INSECURE
+          value: '"true"'
+      java:
+        image: pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-operator-autoinstrumentation-java:2.23.0
+        env:
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://opentelemetry-kube-stack-deployment-teastore-collector.monitoring:4317
+      python:
+        env:
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://opentelemetry-kube-stack-deployment-teastore-collector.monitoring:4318
+          - name: OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED
+            value: 'true'
+      dotnet:
+        env:
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://opentelemetry-kube-stack-deployment-teastore-collector.monitoring:4318
+      go:
+        env:
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: http://opentelemetry-kube-stack-deployment-teastore-collector.monitoring:4318


### PR DESCRIPTION
## Summary

Fans out the per-system collector pattern validated in Step 2a (#304, ts only) to the remaining 6 benchmark systems: **otel-demo, hs, sn, media, sockshop, teastore**. Each system gets its own dedicated single-pod collector and corresponding seed retarget, so every benchmark exports OTLP to its own collector instead of sharing the HPA-managed `deployment-collector` pool that motivated #300.

This is **chart + seed changes only — not deployed to the cluster**. The operator picks up the new collectors and `Instrumentation` CRs on the next `helm upgrade opentelemetry-kube-stack`, and the new seed values land in MySQL on the next reseed; both are operational steps that will run separately once this lands.

## Per-chart instrumentation pattern

Each system's exporter env was retargeted at the matching per-system collector Service:

| System    | Chart key(s) retargeted | Transport |
|-----------|--------------------------|-----------|
| otel-demo | `global.clusterCollector.service` (wrapper `otel-collector` forwards upstream) | gRPC/4317 |
| hs        | `global.otel.endpoint` (DSB chart) | HTTP/4318 |
| sn        | `global.otel.endpoint` (DSB chart) | HTTP/4318 |
| media     | `global.otel.endpoint` (DSB chart) | HTTP/4318 |
| sockshop  | `otel.collectorEndpoint` + `otel.instrumentation` = `monitoring/otel-instr-sockshop` | gRPC/4317 |
| teastore  | `opentelemetry.otlpEndpoint` + `opentelemetry.instrumentationName` = `otel-instr-teastore` | gRPC/4317 |

`sockshop` and `teastore` use the OpenTelemetry Operator's `Instrumentation` CR (operator-injected auto-instrumentation), so this PR also adds two new `Instrumentation` CRs — `otel-instr-sockshop` and `otel-instr-teastore` — via the chart's `extraObjects:` array. Each mirrors the global `instrumentation:` block but retargets every language exporter at the matching per-system collector Service.

Java endpoints stay on **gRPC :4317** (the HTTP/4318 + `dns:///` path was rolled back in #304's first commit because caddy at the otel-demo entrance defaults to gRPC and silently dropped all entrance traces). Python / .NET / Go stay on **HTTP :4318** (operator defaults per language).

## Per-system collector budget

Each new collector: `replicas: 1`, `resources.requests.memory: 65536Mi`, `resources.limits.memory: 98304Mi`, `cpu: 2000m / 8000m`. Full `config:` block is identical to `deploy-ts:` — same OTLP-in / ClickHouse-out / spanmetrics / k8sattributes / transform/service_namespace pipeline. `presets.kubernetesEvents` and `presets.clusterMetrics` stay on the shared `deploy:` collector since they're leader-elected cluster-wide concerns.

Total fan-out cost: 7 systems x 1 x 64Gi = 448Gi. Cluster has 36 x 120Gi nodes (~4.3TB allocatable, currently 28-36% used) — fits comfortably.

## Seed version bumps

Reseed honors the immutability contract on already-seeded versions, so the new endpoints would not propagate to the DB without bumping the version name:

| System    | Old   | New   |
|-----------|-------|-------|
| otel-demo | 0.1.6 | 0.1.7 |
| hs        | 0.1.3 | 0.1.4 |
| sn        | 0.1.4 | 0.1.5 |
| media     | 0.1.4 | 0.1.5 |
| sockshop  | 1.1.2 | 1.1.3 |
| teastore  | 0.1.5 | 0.1.6 |

DB live-cluster updates will be a separate operational step; this PR only changes the source-of-truth manifests.

## Stacked on #304

This branch is built on `fix/per-system-otel-collectors-303` (PR #304, the Step 2a branch). It will rebase cleanly onto `main` once #304 merges.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — both `otel-kube-stack.values.yaml` and `data.yaml` parse
- [x] `helm template opentelemetry-kube-stack open-telemetry/opentelemetry-kube-stack --version 0.14.12 -f manifests/byte-cluster/otel-kube-stack.values.yaml -n monitoring` renders 9 `OpenTelemetryCollector`s (daemon + deploy + 7 per-system: ts/otel-demo/hs/sn/media/sockshop/teastore) and 3 `Instrumentation` CRs (default + per-system sockshop/teastore)
- [ ] After merge: `helm upgrade opentelemetry-kube-stack` against byte-cluster — pods come up healthy
- [ ] After merge: aegisctl reseed — DB picks up new `*` versions; injection on each system flows traces through its dedicated collector
- [ ] Validate end-to-end on each of the 6 systems with one fault injection round and one successful BuildDatapack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>