### PR TITLE
fix(consumer): emit trace event when BuildDatapack task fails so trace.last_event advances (closes #312)

### DIFF
--- a/AegisLab/src/service/consumer/trace.go
+++ b/AegisLab/src/service/consumer/trace.go
@@ -185,7 +185,25 @@ func tryUpdateTraceStateCore(redisGateway *redis.Gateway, ctx context.Context, d
 	// the explicit streamEvent.EventName so the trace reflects that the
 	// child task has actually been attempted; trace state classification
 	// (Failed/Completed) is left to inferTraceState.
-	if newState == consts.TaskRescheduled && streamEvent != nil && streamEvent.EventName != "" {
+	//
+	// Race guard (Copilot review on #313): updateTraceState runs in a
+	// goroutine, so a stale TaskRescheduled call can land *after* a
+	// later Running/Completed call wrote a terminal event. Without the
+	// guard, the late-arriving stale event would overwrite a completed
+	// trace's last_event with no.token.available — strictly worse than
+	// the original bug. Three checks:
+	//   1. updatedTask.State == TaskRescheduled — DB still says
+	//      rescheduled, so the override reflects current persisted state.
+	//   2. streamEvent.TaskID == taskID — the streamEvent describes the
+	//      same task transition we're processing, not a separate event
+	//      that happens to ride the same channel.
+	//   3. streamEvent.TaskType == updatedTask.Type — defensive consistency
+	//      check; should always hold but cheap to enforce.
+	if newState == consts.TaskRescheduled &&
+		updatedTask.State == consts.TaskRescheduled &&
+		streamEvent != nil && streamEvent.EventName != "" &&
+		streamEvent.TaskID == taskID &&
+		streamEvent.TaskType == updatedTask.Type {
 		inferredEventType = streamEvent.EventName
 		logEntry.Debugf("using explicit event from rescheduled %s task: %s",
 			consts.GetTaskTypeName(updatedTask.Type), inferredEventType)

--- a/AegisLab/src/service/consumer/trace.go
+++ b/AegisLab/src/service/consumer/trace.go
@@ -172,6 +172,25 @@ func tryUpdateTraceStateCore(redisGateway *redis.Gateway, ctx context.Context, d
 		}
 	}
 
+	// Issue #312: when a task transitions to TaskRescheduled (e.g.
+	// BuildDatapack waiting for a token / ClickHouse freshness, or
+	// RestartPedestal waiting for a free namespace), inferTraceState
+	// counts the task as Pending and falls through to Priority 4, which
+	// re-asserts the *previous* leaf event (e.g. fault.injection.completed)
+	// as last_event. Without this surface, a trace whose BD child has been
+	// rescheduling for many minutes still reports last_event=
+	// fault.injection.completed and is indistinguishable from a trace
+	// whose CRD-success path never submitted BD at all (which is what
+	// the stuck-trace reconciler from #309 is meant to repair). Prefer
+	// the explicit streamEvent.EventName so the trace reflects that the
+	// child task has actually been attempted; trace state classification
+	// (Failed/Completed) is left to inferTraceState.
+	if newState == consts.TaskRescheduled && streamEvent != nil && streamEvent.EventName != "" {
+		inferredEventType = streamEvent.EventName
+		logEntry.Debugf("using explicit event from rescheduled %s task: %s",
+			consts.GetTaskTypeName(updatedTask.Type), inferredEventType)
+	}
+
 	logEntry.Debugf("inferred trace state: %s, event: %s (triggered by task %s: %s)",
 		consts.GetTraceStateName(inferredState),
 		inferredEventType,

--- a/AegisLab/src/service/consumer/trace_test.go
+++ b/AegisLab/src/service/consumer/trace_test.go
@@ -158,3 +158,71 @@ func TestTryUpdateTraceStateCore_BDFailureAdvancesLastEvent(t *testing.T) {
 	require.NoError(t, db.First(&got, "id = ?", traceID).Error)
 	require.Equal(t, consts.EventDatapackBuildFailed, got.LastEvent)
 }
+
+// TestTryUpdateTraceStateCore_StaleRescheduleDoesNotOverwriteTerminal pins
+// the race-guard added per Copilot review on PR #313. Setup: BD task has
+// already advanced to TaskCompleted in the DB (a later updateTraceState
+// goroutine wrote the terminal state), but a stale TaskRescheduled call is
+// arriving late on the same channel with newState=TaskRescheduled and a
+// reschedule streamEvent. Without the guard, the override would overwrite
+// the trace's terminal last_event with no.token.available — strictly
+// worse than the original #312 corruption. With the guard, the persisted
+// task state (TaskCompleted) wins and inferTraceState's normal path
+// produces the correct terminal event.
+func TestTryUpdateTraceStateCore_StaleRescheduleDoesNotOverwriteTerminal(t *testing.T) {
+	db := newTraceStateTestDB(t)
+
+	traceID := uuid.NewString()
+	faultTaskID := uuid.NewString()
+	bdTaskID := uuid.NewString()
+	now := time.Now()
+
+	require.NoError(t, db.Create(&model.Trace{
+		ID:        traceID,
+		Type:      consts.TraceTypeFullPipeline,
+		LastEvent: consts.EventFaultInjectionCompleted,
+		State:     consts.TraceRunning,
+		Status:    consts.CommonEnabled,
+		LeafNum:   1,
+		StartTime: now.Add(-15 * time.Minute),
+		UpdatedAt: now.Add(-5 * time.Minute),
+	}).Error)
+	require.NoError(t, db.Create(&model.Task{
+		ID:       faultTaskID,
+		Type:     consts.TaskTypeFaultInjection,
+		TraceID:  traceID,
+		Payload:  "{}",
+		State:    consts.TaskCompleted,
+		Status:   consts.CommonEnabled,
+		Level:    1,
+		Sequence: 0,
+	}).Error)
+	// BD persisted as TaskCompleted — the later goroutine has already won.
+	require.NoError(t, db.Create(&model.Task{
+		ID:       bdTaskID,
+		Type:     consts.TaskTypeBuildDatapack,
+		TraceID:  traceID,
+		Payload:  "{}",
+		State:    consts.TaskCompleted,
+		Status:   consts.CommonEnabled,
+		Level:    2,
+		Sequence: 0,
+	}).Error)
+
+	staleStreamEvent := &dto.TraceStreamEvent{
+		TaskID:    bdTaskID,
+		TaskType:  consts.TaskTypeBuildDatapack,
+		EventName: consts.EventNoTokenAvailable,
+	}
+
+	// Late-arriving stale reschedule call — newState input still says
+	// TaskRescheduled because that was the value at goroutine spawn.
+	err := tryUpdateTraceStateCore(nil, context.Background(), db, traceID, bdTaskID,
+		consts.TaskRescheduled, staleStreamEvent)
+	require.NoError(t, err)
+
+	var got model.Trace
+	require.NoError(t, db.First(&got, "id = ?", traceID).Error)
+	require.NotEqual(t, consts.EventNoTokenAvailable, got.LastEvent,
+		"stale reschedule event must not overwrite a trace whose BD task already persisted as TaskCompleted")
+}

--- a/AegisLab/src/service/consumer/trace_test.go
+++ b/AegisLab/src/service/consumer/trace_test.go
@@ -1,0 +1,160 @@
+package consumer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"aegis/consts"
+	"aegis/dto"
+	"aegis/model"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// newTraceStateTestDB builds an in-memory SQLite DB with the Trace + Task
+// schema. Mirrors newReconcilerTestDB / newK8sHandlerTestDB so test setup
+// stays consistent across consumer tests.
+func newTraceStateTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&model.Trace{}, &model.Task{}))
+	return db
+}
+
+// TestTryUpdateTraceStateCore_BDRescheduleAdvancesLastEvent is the issue
+// #312 regression guard. Setup mirrors the byte-cluster K=12 ts campaign
+// Round 12 corruption: a FullPipeline trace whose level-1 FaultInjection
+// completed and whose level-2 BuildDatapack child has just been moved to
+// TaskRescheduled (the rate-limit-token-timeout / freshness-deferred path
+// in rescheduleBuildDatapackTask). Pre-fix, inferTraceState counted the
+// rescheduled task as Pending, fell through to Priority 4, and re-asserted
+// EventFaultInjectionCompleted as the trace's last_event — leaving the
+// trace permanently stuck while BD retried in the background. Post-fix,
+// the explicit streamEvent.EventName from rescheduleBuildDatapackTask
+// surfaces to traces.last_event.
+func TestTryUpdateTraceStateCore_BDRescheduleAdvancesLastEvent(t *testing.T) {
+	db := newTraceStateTestDB(t)
+
+	traceID := uuid.NewString()
+	faultTaskID := uuid.NewString()
+	bdTaskID := uuid.NewString()
+	now := time.Now()
+
+	require.NoError(t, db.Create(&model.Trace{
+		ID:        traceID,
+		Type:      consts.TraceTypeFullPipeline,
+		LastEvent: consts.EventFaultInjectionCompleted,
+		State:     consts.TraceRunning,
+		Status:    consts.CommonEnabled,
+		LeafNum:   1,
+		StartTime: now.Add(-10 * time.Minute),
+		UpdatedAt: now.Add(-5 * time.Minute),
+	}).Error)
+	require.NoError(t, db.Create(&model.Task{
+		ID:       faultTaskID,
+		Type:     consts.TaskTypeFaultInjection,
+		TraceID:  traceID,
+		Payload:  "{}",
+		State:    consts.TaskCompleted,
+		Status:   consts.CommonEnabled,
+		Level:    1,
+		Sequence: 0,
+	}).Error)
+	require.NoError(t, db.Create(&model.Task{
+		ID:       bdTaskID,
+		Type:     consts.TaskTypeBuildDatapack,
+		TraceID:  traceID,
+		Payload:  "{}",
+		State:    consts.TaskRescheduled,
+		Status:   consts.CommonEnabled,
+		Level:    2,
+		Sequence: 0,
+	}).Error)
+
+	streamEvent := &dto.TraceStreamEvent{
+		TaskID:    bdTaskID,
+		TaskType:  consts.TaskTypeBuildDatapack,
+		EventName: consts.EventNoTokenAvailable,
+	}
+
+	err := tryUpdateTraceStateCore(nil, context.Background(), db, traceID, bdTaskID,
+		consts.TaskRescheduled, streamEvent)
+	require.NoError(t, err)
+
+	var got model.Trace
+	require.NoError(t, db.First(&got, "id = ?", traceID).Error)
+	require.Equal(t, consts.EventNoTokenAvailable, got.LastEvent,
+		"BD reschedule must advance trace.last_event off fault.injection.completed")
+	require.Equal(t, consts.TraceRunning, got.State,
+		"reschedule must not flip the trace to a terminal state on its own")
+}
+
+// TestTryUpdateTraceStateCore_BDFailureAdvancesLastEvent guards the
+// k8s-job-failure path (HandleJobFailed) for the same trace shape.
+// The job-failed path emits EventDatapackBuildFailed and moves the BD
+// task to TaskError; inferTraceState's Priority 1 (all-failed at this
+// level) should already produce EventDatapackBuildFailed via
+// selectBestLastEvent's TaskError fallback. This test pins that
+// behavior so a future refactor of the reschedule branch above doesn't
+// silently regress the genuine-job-failure case.
+func TestTryUpdateTraceStateCore_BDFailureAdvancesLastEvent(t *testing.T) {
+	db := newTraceStateTestDB(t)
+
+	traceID := uuid.NewString()
+	faultTaskID := uuid.NewString()
+	bdTaskID := uuid.NewString()
+	now := time.Now()
+
+	require.NoError(t, db.Create(&model.Trace{
+		ID:        traceID,
+		Type:      consts.TraceTypeFullPipeline,
+		LastEvent: consts.EventFaultInjectionCompleted,
+		State:     consts.TraceRunning,
+		Status:    consts.CommonEnabled,
+		LeafNum:   1,
+		StartTime: now.Add(-10 * time.Minute),
+		UpdatedAt: now.Add(-5 * time.Minute),
+	}).Error)
+	require.NoError(t, db.Create(&model.Task{
+		ID:       faultTaskID,
+		Type:     consts.TaskTypeFaultInjection,
+		TraceID:  traceID,
+		Payload:  "{}",
+		State:    consts.TaskCompleted,
+		Status:   consts.CommonEnabled,
+		Level:    1,
+		Sequence: 0,
+	}).Error)
+	require.NoError(t, db.Create(&model.Task{
+		ID:       bdTaskID,
+		Type:     consts.TaskTypeBuildDatapack,
+		TraceID:  traceID,
+		Payload:  "{}",
+		State:    consts.TaskError,
+		Status:   consts.CommonEnabled,
+		Level:    2,
+		Sequence: 0,
+	}).Error)
+
+	streamEvent := &dto.TraceStreamEvent{
+		TaskID:    bdTaskID,
+		TaskType:  consts.TaskTypeBuildDatapack,
+		EventName: consts.EventDatapackBuildFailed,
+	}
+
+	err := tryUpdateTraceStateCore(nil, context.Background(), db, traceID, bdTaskID,
+		consts.TaskError, streamEvent)
+	require.NoError(t, err)
+
+	var got model.Trace
+	require.NoError(t, db.First(&got, "id = ?", traceID).Error)
+	require.Equal(t, consts.EventDatapackBuildFailed, got.LastEvent)
+}


### PR DESCRIPTION
## Investigation

**Symptom (issue #312):** byte-cluster K=12 ts campaign Round 12 — 12 traces stuck at `last_event=fault.injection.completed` with `bd.updated_at > t.updated_at`, BD task in `TaskRescheduled` (state=1), retrying repeatedly while the trace never advances.

**Where the gap is:** NOT in `HandleJobFailed` — that path correctly emits `EventDatapackBuildFailed` (`src/service/consumer/k8s_handler.go:550, 610`). The gap is in `tryUpdateTraceStateCore` (`src/service/consumer/trace.go:125-185`), specifically in the interaction between `rescheduleBuildDatapackTask` and `inferTraceState`:

- `rescheduleBuildDatapackTask` moves the task to `TaskRescheduled` and emits an explicit `EventNoTokenAvailable` streamEvent (`src/service/consumer/build_datapack.go:340-348`).
- `inferTraceState` counts `TaskRescheduled` as `Pending` in `buildLevelStatistics` (`trace.go:252-253`).
- For a FullPipeline trace with FI completed (level 1) and BD rescheduled (level 2, counted as Pending), `inferTraceState` skips Priority 1 (no all-failed level), Priority 2 (leaf not completed), Priority 3 (no Running task), and falls to **Priority 4** which re-asserts the latest completed task's event = `EventFaultInjectionCompleted` (`trace.go:475-494`).
- The reschedule's explicit `streamEvent.EventName` was discarded — only the CollectResult special-case at `trace.go:161-173` honored streamEvent.

Diff between success and failure paths boils down to: success → `TaskCompleted` (leaf-completed wins via Priority 2 + `selectBestLastEvent`); k8s-job-failure → `TaskError` (Priority 1 all-failed wins); reschedule → `TaskRescheduled` (counted as Pending, falls through, streamEvent ignored).

## Fix

`src/service/consumer/trace.go`: mirror the existing CollectResult special-case — when a task transitions to `TaskRescheduled` and the streamEvent has a non-empty EventName, prefer the explicit streamEvent.EventName over the inferred event. State classification (Failed/Completed) is left to `inferTraceState`; only `last_event` is overridden, so the change stays scoped to the corruption symptom.

**Alternative considered (rejected):** adding `TaskRescheduled` mappings to `traceTaskEventMap` for BD/RestartPedestal/Algorithm and reworking `inferTraceState` so Priority 4's "latest task" tie-breaker considers rescheduled tasks. Rejected because it would change which events flow into traces for any non-rescheduled run that happens to have an active reschedule mid-trace, broadening the blast radius beyond the reported corruption.

## Other task types audited

- **Looked at and confirmed correct:**
  - FaultInjection failure → `HandleCRDFailed` → `TaskError` + `EventFaultInjectionFailed` (`k8s_handler.go:225`). Inference Priority 1 catches it.
  - RunAlgorithm failure → `HandleJobFailed` → `TaskError` + `EventAlgoRunFailed` (`k8s_handler.go:585`). Same path as BD failure, works.
  - RestartPedestal failure → `restart_pedestal.go:394, 438, 483, 505` emits `EventRestartPedestalFailed` on `TaskError`. Works.
  - BuildDatapack k8s-job-failure (`HandleJobFailed`, `k8s_handler.go:550`) — works (covered by `TestTryUpdateTraceStateCore_BDFailureAdvancesLastEvent`).

- **Same gap, follow-up worth filing (NOT fixed in this PR per #312 scope guidance):**
  - RunAlgorithm reschedule (`rescheduleAlgoExecutionTask`) emits `EventNoTokenAvailable` — the streamEvent-discard fix in this PR also covers this path, but no live regression has been reported, so no follow-up filed yet.
  - RestartPedestal reschedule (`rescheduleRestartPedestalTask`) emits `EventNoNamespaceAvailable` — same shape, also covered transitively by this fix.

## Regression test

`TestTryUpdateTraceStateCore_BDRescheduleAdvancesLastEvent` in `src/service/consumer/trace_test.go`. Reproduces the byte-cluster K=12 corruption: FI completed (level 1) + BD rescheduled (level 2) + streamEvent `EventNoTokenAvailable`. Asserts `trace.last_event == EventNoTokenAvailable` (not `EventFaultInjectionCompleted`) and trace state stays `TraceRunning`.

**Confirmed the test fails on the unfixed code.** Output without the fix:

```
Error:      Not equal:
            expected: "no.token.available"
            actual  : "fault.injection.completed"
```

`TestTryUpdateTraceStateCore_BDFailureAdvancesLastEvent` is added alongside as a defensive guard so a future refactor of the reschedule branch can't silently regress the genuine-job-failure path.

## #309 compatibility

The reconciler's `NOT EXISTS` filter (`stuck_trace_reconciler.go:204-217`) is unaffected:
- Filters on `last_event IN [fault.injection.started, fault.injection.completed]`.
- After this fix, BD-rescheduled traces have `last_event = no.token.available`, so they are correctly excluded from reconciler candidates (which is desired — BD task already exists).
- All `TestReconciler_*` tests pass unchanged.

## Build / lint

```
cd src && go build -tags duckdb_arrow -o /dev/null ./main.go    # OK
cd src && golangci-lint run ./service/consumer/...              # no new issues on touched files
cd src && go test -tags duckdb_arrow ./service/consumer/        # all pass
```

## Operational note

This unblocks the stuck-trace reconciler from manual SQL cleanup. The workaround `UPDATE traces SET last_event='datapack.build.failed', state=3 WHERE ...` is no longer needed; BD reschedule events now flow naturally to `trace.last_event`, removing the indistinguishability between "CRD-success-failed" traces (which the reconciler should repair) and "BD-rescheduled" traces (which should be left alone).