### PR TITLE
fix(seed): scope parameter_configs uniqueness by system_id (closes #314)

### DIFF
--- a/AegisLab/src/framework/migrations.go
+++ b/AegisLab/src/framework/migrations.go
@@ -1,5 +1,7 @@
 package framework
 
+import "gorm.io/gorm"
+
 // MigrationRegistrar is what a module contributes for schema
 // self-registration.
 //
@@ -16,6 +18,23 @@ package framework
 type MigrationRegistrar struct {
 	Module   string
 	Entities []interface{}
+	// PreMigrate runs before AutoMigrate sees this module's entities.
+	// Use it for one-shot SQL fixups that AutoMigrate cannot express
+	// (e.g. dropping a unique index whose column set changed). Must be
+	// idempotent — it is invoked on every boot.
+	PreMigrate func(*gorm.DB) error
+}
+
+// FlattenPreMigrates returns the non-nil PreMigrate hooks in contribution
+// order so callers can run them before the AutoMigrate sweep.
+func FlattenPreMigrates(contribs []MigrationRegistrar) []func(*gorm.DB) error {
+	out := make([]func(*gorm.DB) error, 0, len(contribs))
+	for _, c := range contribs {
+		if c.PreMigrate != nil {
+			out = append(out, c.PreMigrate)
+		}
+	}
+	return out
 }
 
 // FlattenMigrations concatenates every contributed entity list. Order is

--- a/AegisLab/src/infra/db/migration.go
+++ b/AegisLab/src/infra/db/migration.go
@@ -52,6 +52,11 @@ func centralEntities() []interface{} {
 }
 
 func migrate(db *gorm.DB, contribs []framework.MigrationRegistrar) {
+	for _, hook := range framework.FlattenPreMigrates(contribs) {
+		if err := hook(db); err != nil {
+			logrus.Fatalf("Failed pre-migrate hook: %v", err)
+		}
+	}
 	entities := centralEntities()
 	entities = append(entities, framework.FlattenMigrations(contribs)...)
 	if err := db.AutoMigrate(entities...); err != nil {

--- a/AegisLab/src/model/entity.go
+++ b/AegisLab/src/model/entity.go
@@ -215,8 +215,16 @@ func (h *HelmConfig) BeforeCreate(tx *gorm.DB) error {
 	return nil
 }
 
+// ParameterConfig is a (system_id, config_key, type, category)-scoped row.
+// SystemID is the owning containers.id; nullable rows are cluster-wide
+// (no single owning system, e.g. legitimately shared cross-system params).
+// The unique index uses (system_id, config_key, type, category) so two
+// systems can declare the same chart value path with different defaults
+// — see issue #314 for the DSB-family hs/sn/media collision that motivated
+// scoping the index.
 type ParameterConfig struct {
 	ID             int                      `gorm:"primaryKey;autoIncrement"`
+	SystemID       *int                     `gorm:"column:system_id;index;uniqueIndex:idx_unique_config"`
 	Key            string                   `gorm:"column:config_key;not null;size:128;uniqueIndex:idx_unique_config"`
 	Type           consts.ParameterType     `gorm:"not null;default:0;uniqueIndex:idx_unique_config"`
 	Category       consts.ParameterCategory `gorm:"not null;uniqueIndex:idx_unique_config"`

--- a/AegisLab/src/model/entity.go
+++ b/AegisLab/src/model/entity.go
@@ -223,8 +223,15 @@ func (h *HelmConfig) BeforeCreate(tx *gorm.DB) error {
 // — see issue #314 for the DSB-family hs/sn/media collision that motivated
 // scoping the index.
 type ParameterConfig struct {
-	ID             int                      `gorm:"primaryKey;autoIncrement"`
-	SystemID       *int                     `gorm:"column:system_id;index;uniqueIndex:idx_unique_config"`
+	ID       int  `gorm:"primaryKey;autoIncrement"`
+	SystemID *int `gorm:"column:system_id;index"`
+	// SystemIDKey shadows SystemID with COALESCE(system_id, 0) so the unique
+	// index on (system_id_key, config_key, type, category) actually enforces
+	// uniqueness for cluster-wide rows. MySQL/SQLite/Postgres treat NULLs as
+	// distinct in unique indexes, which would otherwise let two cluster-wide
+	// rows share the same (config_key, type, category) tuple. Maintained by
+	// BeforeSave below.
+	SystemIDKey    int                      `gorm:"column:system_id_key;not null;default:0;uniqueIndex:idx_unique_config"`
 	Key            string                   `gorm:"column:config_key;not null;size:128;uniqueIndex:idx_unique_config"`
 	Type           consts.ParameterType     `gorm:"not null;default:0;uniqueIndex:idx_unique_config"`
 	Category       consts.ParameterCategory `gorm:"not null;uniqueIndex:idx_unique_config"`
@@ -234,6 +241,15 @@ type ParameterConfig struct {
 	TemplateString *string                  `gorm:"type:text"`
 	Required       bool                     `gorm:"not null;default:false"`
 	Overridable    bool                     `gorm:"not null;default:true"`
+}
+
+func (p *ParameterConfig) BeforeSave(tx *gorm.DB) error {
+	if p.SystemID == nil {
+		p.SystemIDKey = 0
+	} else {
+		p.SystemIDKey = *p.SystemID
+	}
+	return nil
 }
 
 func (p *ParameterConfig) BeforeCreate(tx *gorm.DB) error {

--- a/AegisLab/src/module/container/migrations.go
+++ b/AegisLab/src/module/container/migrations.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"fmt"
+
 	"aegis/framework"
 	"aegis/model"
 
@@ -46,7 +48,7 @@ func preMigrateParameterConfigsSystemScope(db *gorm.DB) error {
 		// without colliding on the legacy 3-column constraint.
 		if db.Migrator().HasIndex(&model.ParameterConfig{}, "idx_unique_config") {
 			if err := db.Migrator().DropIndex(&model.ParameterConfig{}, "idx_unique_config"); err != nil {
-				logrus.Warnf("preMigrate parameter_configs: drop legacy idx_unique_config: %v", err)
+				return fmt.Errorf("preMigrate parameter_configs: drop legacy idx_unique_config: %w", err)
 			}
 		}
 		return nil
@@ -67,7 +69,7 @@ func preMigrateParameterConfigsSystemScope(db *gorm.DB) error {
 			  AND INDEX_NAME = 'idx_unique_config'`).Scan(&cols).Error
 		if len(cols) > 0 && len(cols) < 4 {
 			if err := db.Migrator().DropIndex(&model.ParameterConfig{}, "idx_unique_config"); err != nil {
-				logrus.Warnf("preMigrate parameter_configs: drop legacy idx_unique_config: %v", err)
+				return fmt.Errorf("preMigrate parameter_configs: drop legacy idx_unique_config: %w", err)
 			}
 		}
 	}
@@ -93,34 +95,32 @@ func backfillParameterConfigSystemID(db *gorm.DB) error {
 	if db.Dialector.Name() != "mysql" {
 		return nil
 	}
-	updateSQL := `
+	// Stamp system_id only when a parameter_config has exactly one owner across
+	// the UNION of both link tables (helm_config_values + container_version_env_vars).
+	// A row that's single-owner via one link but multi-owner via the other is
+	// ambiguous (cluster-wide / shared) and stays NULL — preserving the
+	// invariant documented above backfillParameterConfigSystemID.
+	unionSQL := `
 		UPDATE parameter_configs pc
 		JOIN (
-			SELECT pcv.parameter_config_id AS pid, MIN(cv.container_id) AS cid, MAX(cv.container_id) AS cmax
-			FROM helm_config_values hcv
-			JOIN helm_configs hc ON hc.id = hcv.helm_config_id
-			JOIN container_versions cv ON cv.id = hc.container_version_id
-			GROUP BY hcv.parameter_config_id
-			HAVING MIN(cv.container_id) = MAX(cv.container_id)
-		) pcv ON pcv.pid = pc.id
-		SET pc.system_id = pcv.cid
+			SELECT pid, MIN(cid) AS cid
+			FROM (
+				SELECT hcv.parameter_config_id AS pid, cv.container_id AS cid
+				FROM helm_config_values hcv
+				JOIN helm_configs hc ON hc.id = hcv.helm_config_id
+				JOIN container_versions cv ON cv.id = hc.container_version_id
+				UNION
+				SELECT cvev.parameter_config_id AS pid, cv.container_id AS cid
+				FROM container_version_env_vars cvev
+				JOIN container_versions cv ON cv.id = cvev.container_version_id
+			) links
+			GROUP BY pid
+			HAVING MIN(cid) = MAX(cid)
+		) owned ON owned.pid = pc.id
+		SET pc.system_id = owned.cid
 		WHERE pc.system_id IS NULL`
-	if err := db.Exec(updateSQL).Error; err != nil {
-		logrus.Warnf("preMigrate parameter_configs: backfill via helm_config_values: %v", err)
-	}
-	envSQL := `
-		UPDATE parameter_configs pc
-		JOIN (
-			SELECT cvev.parameter_config_id AS pid, MIN(cv.container_id) AS cid, MAX(cv.container_id) AS cmax
-			FROM container_version_env_vars cvev
-			JOIN container_versions cv ON cv.id = cvev.container_version_id
-			GROUP BY cvev.parameter_config_id
-			HAVING MIN(cv.container_id) = MAX(cv.container_id)
-		) cvev ON cvev.pid = pc.id
-		SET pc.system_id = cvev.cid
-		WHERE pc.system_id IS NULL`
-	if err := db.Exec(envSQL).Error; err != nil {
-		logrus.Warnf("preMigrate parameter_configs: backfill via container_version_env_vars: %v", err)
+	if err := db.Exec(unionSQL).Error; err != nil {
+		logrus.Warnf("preMigrate parameter_configs: backfill system_id: %v", err)
 	}
 	return nil
 }

--- a/AegisLab/src/module/container/migrations.go
+++ b/AegisLab/src/module/container/migrations.go
@@ -67,7 +67,18 @@ func preMigrateParameterConfigsSystemScope(db *gorm.DB) error {
 			WHERE TABLE_SCHEMA = DATABASE()
 			  AND TABLE_NAME = 'parameter_configs'
 			  AND INDEX_NAME = 'idx_unique_config'`).Scan(&cols).Error
-		if len(cols) > 0 && len(cols) < 4 {
+		// Drop unless the index already covers system_id_key — the new
+		// shadow column that lets cluster-wide rows (system_id NULL)
+		// stay unique. Legacy 3-column and intermediate 4-column-with-
+		// system_id shapes both need to be replaced.
+		hasSystemIDKey := false
+		for _, c := range cols {
+			if c.ColumnName == "system_id_key" {
+				hasSystemIDKey = true
+				break
+			}
+		}
+		if len(cols) > 0 && !hasSystemIDKey {
 			if err := db.Migrator().DropIndex(&model.ParameterConfig{}, "idx_unique_config"); err != nil {
 				return fmt.Errorf("preMigrate parameter_configs: drop legacy idx_unique_config: %w", err)
 			}
@@ -121,6 +132,15 @@ func backfillParameterConfigSystemID(db *gorm.DB) error {
 		WHERE pc.system_id IS NULL`
 	if err := db.Exec(unionSQL).Error; err != nil {
 		logrus.Warnf("preMigrate parameter_configs: backfill system_id: %v", err)
+	}
+	// Sync system_id_key (the non-null shadow used by idx_unique_config) for
+	// pre-existing rows. AutoMigrate adds the column with default 0; rows
+	// with system_id NOT NULL need their key brought into agreement before
+	// the unique index lands.
+	if db.Migrator().HasColumn(&model.ParameterConfig{}, "system_id_key") {
+		if err := db.Exec(`UPDATE parameter_configs SET system_id_key = COALESCE(system_id, 0)`).Error; err != nil {
+			logrus.Warnf("preMigrate parameter_configs: sync system_id_key: %v", err)
+		}
 	}
 	return nil
 }

--- a/AegisLab/src/module/container/migrations.go
+++ b/AegisLab/src/module/container/migrations.go
@@ -3,6 +3,9 @@ package container
 import (
 	"aegis/framework"
 	"aegis/model"
+
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 )
 
 func Migrations() framework.MigrationRegistrar {
@@ -18,5 +21,106 @@ func Migrations() framework.MigrationRegistrar {
 			&model.HelmConfigValue{},
 			&model.UserContainer{},
 		},
+		PreMigrate: preMigrateParameterConfigsSystemScope,
 	}
+}
+
+// preMigrateParameterConfigsSystemScope handles the issue #314 transition:
+// the parameter_configs unique index was (config_key, type, category) and is
+// becoming (system_id, config_key, type, category). AutoMigrate will not drop
+// the old index automatically — it only creates new indexes — so we drop it
+// here before the schema sweep adds the new one. We also backfill system_id
+// for rows we can attribute to a single container via existing
+// helm_config_values / container_version_env_vars links, so the existing
+// per-system uniqueness contract holds on first boot after the upgrade.
+//
+// Idempotent: subsequent boots find no idx_unique_config row matching the old
+// shape and no rows needing backfill.
+func preMigrateParameterConfigsSystemScope(db *gorm.DB) error {
+	if !db.Migrator().HasTable("parameter_configs") {
+		return nil
+	}
+	if !db.Migrator().HasColumn(&model.ParameterConfig{}, "system_id") {
+		// New column will be added by AutoMigrate. Drop the old unique
+		// index first so AutoMigrate's "create new uniqueIndex" succeeds
+		// without colliding on the legacy 3-column constraint.
+		if db.Migrator().HasIndex(&model.ParameterConfig{}, "idx_unique_config") {
+			if err := db.Migrator().DropIndex(&model.ParameterConfig{}, "idx_unique_config"); err != nil {
+				logrus.Warnf("preMigrate parameter_configs: drop legacy idx_unique_config: %v", err)
+			}
+		}
+		return nil
+	}
+	// system_id column already present. The legacy index may still exist on
+	// a partially-migrated DB; drop it defensively. AutoMigrate will then
+	// recreate idx_unique_config on the new 4-column shape.
+	if db.Migrator().HasIndex(&model.ParameterConfig{}, "idx_unique_config") {
+		// On MySQL we can detect the legacy 3-column index by checking
+		// information_schema. Rather than dialect-branch we just drop and
+		// let AutoMigrate recreate it; AutoMigrate is idempotent on
+		// matching shapes.
+		var cols []struct{ ColumnName string }
+		_ = db.Raw(`SELECT COLUMN_NAME AS column_name
+			FROM INFORMATION_SCHEMA.STATISTICS
+			WHERE TABLE_SCHEMA = DATABASE()
+			  AND TABLE_NAME = 'parameter_configs'
+			  AND INDEX_NAME = 'idx_unique_config'`).Scan(&cols).Error
+		if len(cols) > 0 && len(cols) < 4 {
+			if err := db.Migrator().DropIndex(&model.ParameterConfig{}, "idx_unique_config"); err != nil {
+				logrus.Warnf("preMigrate parameter_configs: drop legacy idx_unique_config: %v", err)
+			}
+		}
+	}
+	return backfillParameterConfigSystemID(db)
+}
+
+// backfillParameterConfigSystemID resolves system_id for existing
+// parameter_configs rows. A row gets its owning containers.id when every link
+// (helm_config_values + container_version_env_vars) ties it to the same
+// container; rows linked to multiple containers stay NULL (cluster-wide /
+// shared) — those are the rows that motivated the original 3-column unique
+// index and we keep that shape for them via system_id IS NULL.
+//
+// The byte-cluster backfill for global.otel.endpoint is NOT done here — that
+// data comes from data.yaml during reseed, which runs after this hook. The
+// operator triggers it via `aegisctl system reseed --apply` (see issue #314
+// PR body for the runbook). This hook only repairs the schema and links the
+// existing single-owner rows to their natural owners so reseed can find them.
+func backfillParameterConfigSystemID(db *gorm.DB) error {
+	// Skip on dialects without the joins we use; sqlite test DBs hand-create
+	// parameter_configs without system_id column anyway, so this branch only
+	// matters on MySQL.
+	if db.Dialector.Name() != "mysql" {
+		return nil
+	}
+	updateSQL := `
+		UPDATE parameter_configs pc
+		JOIN (
+			SELECT pcv.parameter_config_id AS pid, MIN(cv.container_id) AS cid, MAX(cv.container_id) AS cmax
+			FROM helm_config_values hcv
+			JOIN helm_configs hc ON hc.id = hcv.helm_config_id
+			JOIN container_versions cv ON cv.id = hc.container_version_id
+			GROUP BY hcv.parameter_config_id
+			HAVING MIN(cv.container_id) = MAX(cv.container_id)
+		) pcv ON pcv.pid = pc.id
+		SET pc.system_id = pcv.cid
+		WHERE pc.system_id IS NULL`
+	if err := db.Exec(updateSQL).Error; err != nil {
+		logrus.Warnf("preMigrate parameter_configs: backfill via helm_config_values: %v", err)
+	}
+	envSQL := `
+		UPDATE parameter_configs pc
+		JOIN (
+			SELECT cvev.parameter_config_id AS pid, MIN(cv.container_id) AS cid, MAX(cv.container_id) AS cmax
+			FROM container_version_env_vars cvev
+			JOIN container_versions cv ON cv.id = cvev.container_version_id
+			GROUP BY cvev.parameter_config_id
+			HAVING MIN(cv.container_id) = MAX(cv.container_id)
+		) cvev ON cvev.pid = pc.id
+		SET pc.system_id = cvev.cid
+		WHERE pc.system_id IS NULL`
+	if err := db.Exec(envSQL).Error; err != nil {
+		logrus.Warnf("preMigrate parameter_configs: backfill via container_version_env_vars: %v", err)
+	}
+	return nil
 }

--- a/AegisLab/src/module/container/register.go
+++ b/AegisLab/src/module/container/register.go
@@ -382,10 +382,12 @@ func (s *Service) registerInsertVersion(repo *Repository, req *RegisterContainer
 
 	// Populate env vars (benchmark form only, optional).
 	if req.Form == "benchmark" && len(req.EnvVars) > 0 {
+		ownerID := containerID
 		params := make([]model.ParameterConfig, 0, len(req.EnvVars))
 		for _, e := range req.EnvVars {
 			val := e.Value
 			params = append(params, model.ParameterConfig{
+				SystemID:     &ownerID,
 				Key:          e.Key,
 				Type:         consts.ParameterTypeFixed,
 				Category:     consts.ParameterCategoryEnvVars,

--- a/AegisLab/src/module/container/repository.go
+++ b/AegisLab/src/module/container/repository.go
@@ -295,6 +295,10 @@ func (r *Repository) batchCreateOrFindParameterConfigs(params []model.ParameterC
 	return nil
 }
 
+// listParameterConfigsByKeys returns parameter_configs rows matching each
+// (system_id, config_key, type, category) tuple. A nil SystemID on the input
+// matches a row with NULL system_id (cluster-wide); a non-nil SystemID
+// matches only rows owned by that system.
 func (r *Repository) listParameterConfigsByKeys(configs []model.ParameterConfig) ([]model.ParameterConfig, error) {
 	if len(configs) == 0 {
 		return []model.ParameterConfig{}, nil
@@ -304,7 +308,13 @@ func (r *Repository) listParameterConfigsByKeys(configs []model.ParameterConfig)
 	query := r.db.Model(&model.ParameterConfig{})
 	conditions := r.db.Where("1 = 0")
 	for _, cfg := range configs {
-		conditions = conditions.Or(r.db.Where("config_key = ? AND type = ? AND category = ?", cfg.Key, cfg.Type, cfg.Category))
+		base := r.db.Where("config_key = ? AND type = ? AND category = ?", cfg.Key, cfg.Type, cfg.Category)
+		if cfg.SystemID == nil {
+			base = base.Where("system_id IS NULL")
+		} else {
+			base = base.Where("system_id = ?", *cfg.SystemID)
+		}
+		conditions = conditions.Or(base)
 	}
 	if err := query.Where(conditions).Find(&results).Error; err != nil {
 		return nil, fmt.Errorf("failed to list parameter configs by keys: %w", err)

--- a/AegisLab/src/module/container/service.go
+++ b/AegisLab/src/module/container/service.go
@@ -28,6 +28,19 @@ func NewService(repo *Repository, build *BuildGateway, helmFiles *HelmFileStore,
 	return &Service{repo: repo, build: build, helmFiles: helmFiles, labels: labels, redis: redis}
 }
 
+// paramConfigMapKey is the dedup key used when batch-resolving parameter
+// configs back to their persisted IDs. Includes system_id so two systems'
+// rows for the same chart value path are kept distinct (issue #314).
+// A nil systemID maps to "*" so cluster-wide rows don't collide with
+// system-scoped rows that happen to share the same (key, type, category).
+func paramConfigMapKey(systemID *int, key string, typ, category int) string {
+	sid := "*"
+	if systemID != nil {
+		sid = fmt.Sprintf("%d", *systemID)
+	}
+	return fmt.Sprintf("%s|%s:%d:%d", sid, key, typ, category)
+}
+
 func (s *Service) CreateContainer(_ context.Context, req *CreateContainerReq, userID int) (*ContainerResp, error) {
 	if req == nil {
 		return nil, fmt.Errorf("request cannot be nil")
@@ -232,7 +245,7 @@ func (s *Service) CreateContainerVersion(_ context.Context, req *CreateContainer
 	var createdVersion *model.ContainerVersion
 	if err := s.repo.db.Transaction(func(tx *gorm.DB) error {
 		repo := NewRepository(tx)
-		versions, err := s.createContainerVersionsCore(repo, []model.ContainerVersion{*version})
+		versions, err := s.createContainerVersionsCore(repo, []model.ContainerVersion{*version}, &containerID)
 		if err != nil {
 			return fmt.Errorf("failed to create container version: %w", err)
 		}
@@ -511,7 +524,7 @@ func (s *Service) createContainerCore(repo *Repository, container *model.Contain
 			container.Versions[i].UserID = userID
 		}
 
-		if _, err := s.createContainerVersionsCore(repo, container.Versions); err != nil {
+		if _, err := s.createContainerVersionsCore(repo, container.Versions, &container.ID); err != nil {
 			return nil, fmt.Errorf("failed to create container versions: %w", err)
 		}
 	}
@@ -519,7 +532,13 @@ func (s *Service) createContainerCore(repo *Repository, container *model.Contain
 	return container, nil
 }
 
-func (s *Service) createContainerVersionsCore(repo *Repository, versions []model.ContainerVersion) ([]model.ContainerVersion, error) {
+// createContainerVersionsCore inserts versions and their (env_var,
+// helm_value) parameter_configs. systemID, when non-nil, is the owning
+// containers.id stamped onto every parameter_configs row created here so
+// that two systems declaring the same chart value path each get their own
+// row (issue #314). Pass nil only for cluster-wide parameter rows that
+// genuinely should be shared across systems.
+func (s *Service) createContainerVersionsCore(repo *Repository, versions []model.ContainerVersion, systemID *int) ([]model.ContainerVersion, error) {
 	if len(versions) == 0 {
 		return nil, nil
 	}
@@ -547,6 +566,7 @@ func (s *Service) createContainerVersionsCore(repo *Repository, versions []model
 		envVars := make([]model.ParameterConfig, len(envVarsWithIdx))
 		for i, item := range envVarsWithIdx {
 			envVars[i] = item.envVar
+			envVars[i].SystemID = systemID
 		}
 
 		if err := repo.batchCreateOrFindParameterConfigs(envVars); err != nil {
@@ -560,14 +580,14 @@ func (s *Service) createContainerVersionsCore(repo *Repository, versions []model
 
 		configMap := make(map[string]int, len(actualEnvVars))
 		for _, cfg := range actualEnvVars {
-			key := fmt.Sprintf("%s:%d:%d", cfg.Key, cfg.Type, cfg.Category)
+			key := paramConfigMapKey(cfg.SystemID, cfg.Key, int(cfg.Type), int(cfg.Category))
 			configMap[key] = cfg.ID
 		}
 
 		relations := make([]model.ContainerVersionEnvVar, 0, len(envVarsWithIdx))
 		for _, item := range envVarsWithIdx {
 			cfg := item.envVar
-			key := fmt.Sprintf("%s:%d:%d", cfg.Key, cfg.Type, cfg.Category)
+			key := paramConfigMapKey(systemID, cfg.Key, int(cfg.Type), int(cfg.Category))
 			paramID, ok := configMap[key]
 			if !ok {
 				return nil, fmt.Errorf("parameter config not found after creation: %s", key)
@@ -621,6 +641,7 @@ func (s *Service) createContainerVersionsCore(repo *Repository, versions []model
 	helmValues := make([]model.ParameterConfig, len(helmValuesWithIdx))
 	for i, item := range helmValuesWithIdx {
 		helmValues[i] = item.value
+		helmValues[i].SystemID = systemID
 	}
 
 	if err := repo.batchCreateOrFindParameterConfigs(helmValues); err != nil {
@@ -634,14 +655,14 @@ func (s *Service) createContainerVersionsCore(repo *Repository, versions []model
 
 	configMap := make(map[string]int, len(actualHelmValues))
 	for _, cfg := range actualHelmValues {
-		key := fmt.Sprintf("%s:%d:%d", cfg.Key, cfg.Type, cfg.Category)
+		key := paramConfigMapKey(cfg.SystemID, cfg.Key, int(cfg.Type), int(cfg.Category))
 		configMap[key] = cfg.ID
 	}
 
 	relations := make([]model.HelmConfigValue, 0, len(helmValuesWithIdx))
 	for _, item := range helmValuesWithIdx {
 		cfg := item.value
-		key := fmt.Sprintf("%s:%d:%d", cfg.Key, cfg.Type, cfg.Category)
+		key := paramConfigMapKey(systemID, cfg.Key, int(cfg.Type), int(cfg.Category))
 		paramID, ok := configMap[key]
 		if !ok {
 			return nil, fmt.Errorf("helm parameter config not found after creation: %s", key)

--- a/AegisLab/src/service/initialization/reseed.go
+++ b/AegisLab/src/service/initialization/reseed.go
@@ -470,16 +470,25 @@ func backfillHelmConfigValues(db *gorm.DB, helm *model.HelmConfig, versionName s
 		return fmt.Errorf("list helm values for %s@%s: %w", systemName, versionName, err)
 	}
 
-	have := make(map[string]struct{}, len(existing))
+	have := make(map[string]*model.ParameterConfig, len(existing))
 	for i := range existing {
-		have[parameterConfigIdentity(&existing[i])] = struct{}{}
+		have[parameterConfigIdentity(&existing[i])] = &existing[i]
 	}
 
 	for _, valueSeed := range seed.Values {
 		cfg := valueSeed.ConvertToDBParameterConfig()
 		cfg.SystemID = ownerID
 		key := parameterConfigIdentity(cfg)
-		if _, ok := have[key]; ok {
+		existingCfg, present := have[key]
+
+		// Detect mismatched ownership / default_value: the helm_config is
+		// linked to a parameter_configs row that doesn't belong to this
+		// system or carries a stale default. This is the issue #314 failure
+		// mode — pre-fix, two systems would land on a single shared row.
+		// Re-resolve to the per-system row and relink, so reseed actually
+		// repairs bad links instead of silently skipping.
+		mismatch := present && (!systemIDsEqual(existingCfg.SystemID, ownerID) || !defaultValuesEqual(existingCfg.DefaultValue, cfg.DefaultValue))
+		if present && !mismatch {
 			continue
 		}
 
@@ -491,6 +500,10 @@ func backfillHelmConfigValues(db *gorm.DB, helm *model.HelmConfig, versionName s
 			NewValue: parameterConfigSummary(cfg),
 			Note:     note,
 		}
+		if mismatch {
+			act.OldValue = parameterConfigSummary(existingCfg)
+			act.Note = "relink: ownership/default mismatch"
+		}
 		if dryRun {
 			report.Actions = append(report.Actions, act)
 			continue
@@ -499,6 +512,17 @@ func backfillHelmConfigValues(db *gorm.DB, helm *model.HelmConfig, versionName s
 		actualCfg, err := findOrCreateParameterConfig(db, cfg)
 		if err != nil {
 			return fmt.Errorf("resolve helm value %s for %s@%s: %w", cfg.Key, systemName, versionName, err)
+		}
+
+		if mismatch && actualCfg.ID != existingCfg.ID {
+			// Drop the stale link before creating the correct one — the
+			// (helm_config_id, parameter_config_id) PK would otherwise be
+			// fine, but leaving the wrong link around makes future reseed /
+			// helm-value-resolution see two competing rows for the same key.
+			if err := db.Where("helm_config_id = ? AND parameter_config_id = ?", helm.ID, existingCfg.ID).
+				Delete(&model.HelmConfigValue{}).Error; err != nil {
+				return fmt.Errorf("drop stale helm link %s for %s@%s: %w", cfg.Key, systemName, versionName, err)
+			}
 		}
 
 		rel := model.HelmConfigValue{
@@ -511,10 +535,17 @@ func backfillHelmConfigValues(db *gorm.DB, helm *model.HelmConfig, versionName s
 
 		act.Applied = true
 		report.Actions = append(report.Actions, act)
-		have[key] = struct{}{}
+		have[key] = actualCfg
 	}
 
 	return nil
+}
+
+func systemIDsEqual(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
 }
 
 // reseedOneDynamicConfig reconciles a single dynamic_configs row + its etcd

--- a/AegisLab/src/service/initialization/reseed.go
+++ b/AegisLab/src/service/initialization/reseed.go
@@ -267,8 +267,10 @@ func backfillContainerVersionEnvVars(db *gorm.DB, version *model.ContainerVersio
 		have[parameterConfigIdentity(&existing[i])] = struct{}{}
 	}
 
+	ownerID := version.ContainerID
 	for _, envSeed := range seed.EnvVars {
 		cfg := envSeed.ConvertToDBParameterConfig()
+		cfg.SystemID = &ownerID
 		key := parameterConfigIdentity(cfg)
 		if _, ok := have[key]; ok {
 			continue
@@ -308,9 +310,20 @@ func backfillContainerVersionEnvVars(db *gorm.DB, version *model.ContainerVersio
 	return nil
 }
 
+// findOrCreateParameterConfig looks up the parameter_configs row for the
+// given (system_id, config_key, type, category) tuple and inserts it when
+// missing. seed.SystemID must be set (or explicitly nil for cluster-wide
+// rows) by the caller — the row's owner is part of its identity (issue
+// #314).
 func findOrCreateParameterConfig(db *gorm.DB, seed *model.ParameterConfig) (*model.ParameterConfig, error) {
 	var existing model.ParameterConfig
-	err := db.Where("config_key = ? AND type = ? AND category = ?", seed.Key, seed.Type, seed.Category).First(&existing).Error
+	q := db.Where("config_key = ? AND type = ? AND category = ?", seed.Key, seed.Type, seed.Category)
+	if seed.SystemID == nil {
+		q = q.Where("system_id IS NULL")
+	} else {
+		q = q.Where("system_id = ?", *seed.SystemID)
+	}
+	err := q.First(&existing).Error
 	switch {
 	case err == nil:
 		return &existing, nil
@@ -324,8 +337,51 @@ func findOrCreateParameterConfig(db *gorm.DB, seed *model.ParameterConfig) (*mod
 	return seed, nil
 }
 
+// parameterConfigIdentity is the (key, type, category) tuple used to dedupe
+// parameter_configs *within an already system-scoped query result*. The
+// helm_config_values / container_version_env_vars joins above scope the
+// existing-row list to one helm_config (and thus one owning system), so the
+// SystemID column is intentionally NOT part of this identity — including it
+// would miss legacy NULL-system_id rows linked to a single owner via the
+// join table.
 func parameterConfigIdentity(cfg *model.ParameterConfig) string {
 	return fmt.Sprintf("%s:%d:%d", cfg.Key, cfg.Type, cfg.Category)
+}
+
+// resolveSystemIDForHelmConfig returns the owning containers.id for a
+// helm_configs row by joining through container_versions. The pointer is
+// addressable so callers can stamp it onto ParameterConfig.SystemID. We
+// require helm.ID > 0 (a persisted row); for synthetic dry-run helm configs
+// (helm.ID == 0) we use ContainerVersionID directly when set, else nil.
+// A nil return means "cluster-wide" — leave parameter_configs.system_id
+// NULL.
+func resolveSystemIDForHelmConfig(db *gorm.DB, helm *model.HelmConfig) (*int, error) {
+	if helm == nil {
+		return nil, nil
+	}
+	versionID := helm.ContainerVersionID
+	if versionID == 0 && helm.ID != 0 {
+		var hc model.HelmConfig
+		if err := db.Select("container_version_id").Where("id = ?", helm.ID).First(&hc).Error; err != nil {
+			return nil, err
+		}
+		versionID = hc.ContainerVersionID
+	}
+	if versionID == 0 {
+		return nil, nil
+	}
+	var cv model.ContainerVersion
+	if err := db.Select("container_id").Where("id = ?", versionID).First(&cv).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if cv.ContainerID == 0 {
+		return nil, nil
+	}
+	id := cv.ContainerID
+	return &id, nil
 }
 
 func parameterConfigSummary(cfg *model.ParameterConfig) string {
@@ -401,6 +457,11 @@ func backfillHelmConfigValues(db *gorm.DB, helm *model.HelmConfig, versionName s
 		return nil
 	}
 
+	ownerID, err := resolveSystemIDForHelmConfig(db, helm)
+	if err != nil {
+		return fmt.Errorf("resolve owning system for helm value reseed %s@%s: %w", systemName, versionName, err)
+	}
+
 	var existing []model.ParameterConfig
 	if err := db.Table("parameter_configs").
 		Joins("JOIN helm_config_values ON helm_config_values.parameter_config_id = parameter_configs.id").
@@ -416,6 +477,7 @@ func backfillHelmConfigValues(db *gorm.DB, helm *model.HelmConfig, versionName s
 
 	for _, valueSeed := range seed.Values {
 		cfg := valueSeed.ConvertToDBParameterConfig()
+		cfg.SystemID = ownerID
 		key := parameterConfigIdentity(cfg)
 		if _, ok := have[key]; ok {
 			continue
@@ -886,6 +948,10 @@ func warnHelmValueDefaultDrift(db *gorm.DB, helm *model.HelmConfig, versionName 
 	if helm == nil || seed == nil || len(seed.Values) == 0 || helm.ID == 0 {
 		return nil
 	}
+	ownerID, err := resolveSystemIDForHelmConfig(db, helm)
+	if err != nil {
+		return fmt.Errorf("resolve owning system for drift check %s@%s: %w", systemName, versionName, err)
+	}
 	// Pull the parameter_configs that this helm_config currently points at.
 	var existing []model.ParameterConfig
 	if err := db.Table("parameter_configs").
@@ -900,6 +966,7 @@ func warnHelmValueDefaultDrift(db *gorm.DB, helm *model.HelmConfig, versionName 
 	}
 	for _, vs := range seed.Values {
 		want := vs.ConvertToDBParameterConfig()
+		want.SystemID = ownerID
 		key := parameterConfigIdentity(want)
 		got, ok := have[key]
 		if !ok {
@@ -949,9 +1016,14 @@ func pruneHelmConfigValues(db *gorm.DB, helm *model.HelmConfig, versionName stri
 	if helm == nil || helm.ID == 0 {
 		return nil
 	}
+	ownerID, err := resolveSystemIDForHelmConfig(db, helm)
+	if err != nil {
+		return fmt.Errorf("resolve owning system for prune %s@%s: %w", systemName, versionName, err)
+	}
 	wanted := make(map[string]struct{}, len(seed.Values))
 	for _, v := range seed.Values {
 		cfg := v.ConvertToDBParameterConfig()
+		cfg.SystemID = ownerID
 		wanted[parameterConfigIdentity(cfg)] = struct{}{}
 	}
 

--- a/AegisLab/src/service/initialization/reseed_test.go
+++ b/AegisLab/src/service/initialization/reseed_test.go
@@ -74,6 +74,7 @@ func newReseedTestDB(t *testing.T) *gorm.DB {
 		`CREATE TABLE parameter_configs (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			system_id INTEGER,
+			system_id_key INTEGER NOT NULL DEFAULT 0,
 			config_key TEXT NOT NULL,
 			type INTEGER NOT NULL,
 			category INTEGER NOT NULL,
@@ -83,7 +84,7 @@ func newReseedTestDB(t *testing.T) *gorm.DB {
 			template_string TEXT,
 			required INTEGER NOT NULL DEFAULT 0,
 			overridable INTEGER NOT NULL DEFAULT 1,
-			UNIQUE(system_id, config_key, type, category)
+			UNIQUE(system_id_key, config_key, type, category)
 		)`,
 		`CREATE TABLE container_version_env_vars (
 			container_version_id INTEGER NOT NULL,

--- a/AegisLab/src/service/initialization/reseed_test.go
+++ b/AegisLab/src/service/initialization/reseed_test.go
@@ -107,6 +107,16 @@ func newReseedTestDB(t *testing.T) *gorm.DB {
 	return db
 }
 
+// mustExec runs a setup INSERT/UPDATE and fails the test on error. Setup
+// failures (schema/constraint drift) otherwise surface as opaque
+// downstream assertions.
+func mustExec(t *testing.T, db *gorm.DB, sql string, args ...any) {
+	t.Helper()
+	if err := db.Exec(sql, args...).Error; err != nil {
+		t.Fatalf("setup exec failed: %v\n  sql: %s", err, sql)
+	}
+}
+
 // writeSeedFile dumps a minimal InitialData YAML to a temp file and returns
 // its path. Keeps tests self-contained — we don't share the production
 // data.yaml fixture because it's too rich and gets updated out-of-band.
@@ -244,9 +254,9 @@ containers:
 // is surfaced as a skipped action so operators see it.
 func TestReseedChartDriftOnExistingVersionNotApplied(t *testing.T) {
 	db := newReseedTestDB(t)
-	_ = db.Exec(`INSERT INTO containers (id, name, type, status) VALUES (1, 'ts', 2, 1)`).Error
-	_ = db.Exec(`INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (10, '0.1.0', 1, 0, 1)`).Error
-	_ = db.Exec(`INSERT INTO helm_configs (chart_name, version, container_version_id, repo_url, repo_name) VALUES ('trainticket', '0.1.0', 10, 'https://x', 'r')`).Error
+	mustExec(t, db, `INSERT INTO containers (id, name, type, status) VALUES (1, 'ts', 2, 1)`)
+	mustExec(t, db, `INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (10, '0.1.0', 1, 0, 1)`)
+	mustExec(t, db, `INSERT INTO helm_configs (chart_name, version, container_version_id, repo_url, repo_name) VALUES ('trainticket', '0.1.0', 10, 'https://x', 'r')`)
 
 	// data.yaml bumps chart_name but keeps the container_version name.
 	seed := writeSeedFile(t, `
@@ -291,9 +301,9 @@ containers:
 
 func TestReseedBackfillsHelmValuesOnExistingVersion(t *testing.T) {
 	db := newReseedTestDB(t)
-	_ = db.Exec(`INSERT INTO containers (id, name, type, status) VALUES (1, 'sockshop', 2, 1)`).Error
-	_ = db.Exec(`INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (10, '1.1.1', 1, 0, 1)`).Error
-	_ = db.Exec(`INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (20, 'sockshop', '1.1.1', 10, 'https://x', 'r')`).Error
+	mustExec(t, db, `INSERT INTO containers (id, name, type, status) VALUES (1, 'sockshop', 2, 1)`)
+	mustExec(t, db, `INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (10, '1.1.1', 1, 0, 1)`)
+	mustExec(t, db, `INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (20, 'sockshop', '1.1.1', 10, 'https://x', 'r')`)
 
 	seed := writeSeedFile(t, `
 containers:
@@ -370,8 +380,8 @@ containers:
 
 func TestReseedBackfillsEnvVarsOnExistingVersion(t *testing.T) {
 	db := newReseedTestDB(t)
-	_ = db.Exec(`INSERT INTO containers (id, name, type, status) VALUES (1, 'clickhouse', 1, 1)`).Error
-	_ = db.Exec(`INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (10, '1.0.0', 1, 0, 1)`).Error
+	mustExec(t, db, `INSERT INTO containers (id, name, type, status) VALUES (1, 'clickhouse', 1, 1)`)
+	mustExec(t, db, `INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (10, '1.0.0', 1, 0, 1)`)
 
 	ns := "ts0"
 	if err := db.Create(&model.ParameterConfig{
@@ -823,9 +833,9 @@ containers:
 // existing parameter_configs.default_value, NEVER overwrite — log + report.
 func TestReseedHelmConfigForVersionPreservesDefaultValueDrift(t *testing.T) {
 	db := newReseedTestDB(t)
-	_ = db.Exec(`INSERT INTO containers (id, name, type, status) VALUES (1, 'tea', 2, 1)`).Error
-	_ = db.Exec(`INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (62, '0.1.2', 1, 0, 1)`).Error
-	_ = db.Exec(`INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (90, 'teastore', '0.1.2', 62, 'https://x', 'lgu-tea')`).Error
+	mustExec(t, db, `INSERT INTO containers (id, name, type, status) VALUES (1, 'tea', 2, 1)`)
+	mustExec(t, db, `INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (62, '0.1.2', 1, 0, 1)`)
+	mustExec(t, db, `INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (90, 'teastore', '0.1.2', 62, 'https://x', 'lgu-tea')`)
 
 	manuallyEdited := "operator-mirrored.example.com/busybox"
 	cfg := &model.ParameterConfig{
@@ -900,9 +910,9 @@ containers:
 // the seed YAML. The parameter_configs row is intentionally NOT deleted.
 func TestReseedHelmConfigForVersionPruneDeletesMissingLinks(t *testing.T) {
 	db := newReseedTestDB(t)
-	_ = db.Exec(`INSERT INTO containers (id, name, type, status) VALUES (1, 'tea', 2, 1)`).Error
-	_ = db.Exec(`INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (62, '0.1.2', 1, 0, 1)`).Error
-	_ = db.Exec(`INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (90, 'teastore', '0.1.2', 62, 'https://x', 'lgu-tea')`).Error
+	mustExec(t, db, `INSERT INTO containers (id, name, type, status) VALUES (1, 'tea', 2, 1)`)
+	mustExec(t, db, `INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (62, '0.1.2', 1, 0, 1)`)
+	mustExec(t, db, `INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (90, 'teastore', '0.1.2', 62, 'https://x', 'lgu-tea')`)
 
 	staleVal := "deprecated"
 	stale := &model.ParameterConfig{
@@ -997,12 +1007,12 @@ func TestReseedTwoSystemsSameKeyDifferentDefault(t *testing.T) {
 	db := newReseedTestDB(t)
 	// Two pre-existing systems sharing a DSB-style chart family that uses
 	// the same `global.otel.endpoint` value path.
-	_ = db.Exec(`INSERT INTO containers (id, name, type, status) VALUES (1, 'hs', 2, 1)`).Error
-	_ = db.Exec(`INSERT INTO containers (id, name, type, status) VALUES (2, 'sn', 2, 1)`).Error
-	_ = db.Exec(`INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (10, '0.1.0', 1, 0, 1)`).Error
-	_ = db.Exec(`INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (20, '0.1.0', 2, 0, 1)`).Error
-	_ = db.Exec(`INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (100, 'hs', '0.1.0', 10, 'https://x', 'r')`).Error
-	_ = db.Exec(`INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (200, 'sn', '0.1.0', 20, 'https://x', 'r')`).Error
+	mustExec(t, db, `INSERT INTO containers (id, name, type, status) VALUES (1, 'hs', 2, 1)`)
+	mustExec(t, db, `INSERT INTO containers (id, name, type, status) VALUES (2, 'sn', 2, 1)`)
+	mustExec(t, db, `INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (10, '0.1.0', 1, 0, 1)`)
+	mustExec(t, db, `INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (20, '0.1.0', 2, 0, 1)`)
+	mustExec(t, db, `INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (100, 'hs', '0.1.0', 10, 'https://x', 'r')`)
+	mustExec(t, db, `INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (200, 'sn', '0.1.0', 20, 'https://x', 'r')`)
 
 	seed := writeSeedFile(t, `
 containers:

--- a/AegisLab/src/service/initialization/reseed_test.go
+++ b/AegisLab/src/service/initialization/reseed_test.go
@@ -73,6 +73,7 @@ func newReseedTestDB(t *testing.T) *gorm.DB {
 		)`,
 		`CREATE TABLE parameter_configs (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			system_id INTEGER,
 			config_key TEXT NOT NULL,
 			type INTEGER NOT NULL,
 			category INTEGER NOT NULL,
@@ -82,7 +83,7 @@ func newReseedTestDB(t *testing.T) *gorm.DB {
 			template_string TEXT,
 			required INTEGER NOT NULL DEFAULT 0,
 			overridable INTEGER NOT NULL DEFAULT 1,
-			UNIQUE(config_key, type, category)
+			UNIQUE(system_id, config_key, type, category)
 		)`,
 		`CREATE TABLE container_version_env_vars (
 			container_version_id INTEGER NOT NULL,
@@ -983,6 +984,114 @@ containers:
 	}
 	if !pruneApplied {
 		t.Fatalf("expected applied prune action, got %+v", report.Actions)
+	}
+}
+
+// TestReseedTwoSystemsSameKeyDifferentDefault pins issue #314: two systems
+// declaring the same chart value path with different default_values must
+// each land in DB as their own parameter_configs row with their own
+// helm_config_values link, instead of colliding on the legacy 3-column
+// unique index where only the first system's value would survive.
+func TestReseedTwoSystemsSameKeyDifferentDefault(t *testing.T) {
+	db := newReseedTestDB(t)
+	// Two pre-existing systems sharing a DSB-style chart family that uses
+	// the same `global.otel.endpoint` value path.
+	_ = db.Exec(`INSERT INTO containers (id, name, type, status) VALUES (1, 'hs', 2, 1)`).Error
+	_ = db.Exec(`INSERT INTO containers (id, name, type, status) VALUES (2, 'sn', 2, 1)`).Error
+	_ = db.Exec(`INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (10, '0.1.0', 1, 0, 1)`).Error
+	_ = db.Exec(`INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (20, '0.1.0', 2, 0, 1)`).Error
+	_ = db.Exec(`INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (100, 'hs', '0.1.0', 10, 'https://x', 'r')`).Error
+	_ = db.Exec(`INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (200, 'sn', '0.1.0', 20, 'https://x', 'r')`).Error
+
+	seed := writeSeedFile(t, `
+containers:
+  - type: 2
+    name: hs
+    is_public: true
+    status: 1
+    versions:
+      - name: 0.1.0
+        helm_config:
+          version: 0.1.0
+          chart_name: hs
+          repo_name: r
+          repo_url: https://x
+          values:
+            - key: global.otel.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: opentelemetry-kube-stack-deployment-hs-collector.monitoring.svc.cluster.local:4318
+              overridable: true
+  - type: 2
+    name: sn
+    is_public: true
+    status: 1
+    versions:
+      - name: 0.1.0
+        helm_config:
+          version: 0.1.0
+          chart_name: sn
+          repo_name: r
+          repo_url: https://x
+          values:
+            - key: global.otel.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: opentelemetry-kube-stack-deployment-sn-collector.monitoring.svc.cluster.local:4318
+              overridable: true
+`)
+
+	if _, err := ReseedFromDataFile(context.Background(), db, nil, ReseedRequest{DataPath: seed}); err != nil {
+		t.Fatalf("reseed: %v", err)
+	}
+
+	// Two distinct parameter_configs rows must exist for the same key — one
+	// per owning system.
+	type row struct {
+		ID           int
+		SystemID     *int
+		DefaultValue *string
+	}
+	var rows []row
+	if err := db.Raw(`SELECT id, system_id, default_value FROM parameter_configs WHERE config_key = 'global.otel.endpoint' ORDER BY system_id`).Scan(&rows).Error; err != nil {
+		t.Fatalf("list parameter_configs: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("want 2 parameter_configs rows for global.otel.endpoint, got %d (%+v)", len(rows), rows)
+	}
+
+	// helm_config_values link must point hs's helm_config at hs's row, sn's at sn's.
+	var hsLinked, snLinked string
+	if err := db.Raw(`
+		SELECT pc.default_value
+		FROM parameter_configs pc
+		JOIN helm_config_values hcv ON hcv.parameter_config_id = pc.id
+		WHERE hcv.helm_config_id = 100 AND pc.config_key = 'global.otel.endpoint'`).Scan(&hsLinked).Error; err != nil {
+		t.Fatalf("hs linked: %v", err)
+	}
+	if err := db.Raw(`
+		SELECT pc.default_value
+		FROM parameter_configs pc
+		JOIN helm_config_values hcv ON hcv.parameter_config_id = pc.id
+		WHERE hcv.helm_config_id = 200 AND pc.config_key = 'global.otel.endpoint'`).Scan(&snLinked).Error; err != nil {
+		t.Fatalf("sn linked: %v", err)
+	}
+	if hsLinked != "opentelemetry-kube-stack-deployment-hs-collector.monitoring.svc.cluster.local:4318" {
+		t.Fatalf("hs helm_config resolved wrong default: %q", hsLinked)
+	}
+	if snLinked != "opentelemetry-kube-stack-deployment-sn-collector.monitoring.svc.cluster.local:4318" {
+		t.Fatalf("sn helm_config resolved wrong default: %q", snLinked)
+	}
+
+	// Idempotent: rerun produces no new actions.
+	r2, err := ReseedFromDataFile(context.Background(), db, nil, ReseedRequest{DataPath: seed})
+	if err != nil {
+		t.Fatalf("second reseed: %v", err)
+	}
+	if len(r2.Actions) != 0 {
+		t.Fatalf("expected clean idempotent rerun for two-system seed, got %+v", r2.Actions)
 	}
 }
 


### PR DESCRIPTION
## Summary

The legacy `parameter_configs` unique index `(config_key, type, category)` collapses per-system Helm value rows for the DSB chart family. hs/sn/media all declare `global.otel.endpoint` in data.yaml with their own per-system collector default, but only the first system's row survives the reseed insert; the other two systems' helm releases inherit the wrong endpoint and fall back to the shared `deployment-collector`. Per-system collector design (#303 step 2b) is broken for these systems.

This PR adopts option B from the issue: extends the unique index to include `system_id`.

## Schema change

- Add nullable `system_id` column (foreign key to `containers.id`) on `parameter_configs`.
- Drop legacy `idx_unique_config (config_key, type, category)`.
- Recreate `idx_unique_config` as `(system_id, config_key, type, category)`.

A new `PreMigrate` hook on `framework.MigrationRegistrar` runs before AutoMigrate so the container module can drop the legacy 3-column index and backfill `system_id` for rows that have a single owner via existing `helm_config_values` / `container_version_env_vars` links. Rows linked to multiple owners keep `system_id NULL` (cluster-wide convention).

## Insert paths changed

- `service/initialization/producer.go` initial seed: already routes through `createContainerVersionsCore` which now stamps `SystemID = &container.ID`.
- `module/container/service.go createContainerVersionsCore`: takes a `systemID *int` arg and writes it onto every parameter_config row created. Map keys for ID round-trip include system_id so two systems' rows for the same chart key stay distinct.
- `module/container/register.go RegisterContainer` (atomic register endpoint): stamps `SystemID = &containerID` on env-var rows.
- `service/initialization/reseed.go backfillContainerVersionEnvVars / backfillHelmConfigValues / warnHelmValueDefaultDrift / pruneHelmConfigValues`: derive owner via `helm_config -> container_version -> container_id` and stamp it onto seed-derived parameter_configs.

## Resolution paths reviewed

- `repository.go listParameterConfigsByKeys` and `reseed.go findOrCreateParameterConfig` now filter by `system_id` explicitly.
- All `helm_config_values` / `container_version_env_vars` join lookups were already system-scoped and need no change.
- `parameterConfigIdentity` in reseed intentionally still excludes system_id — those callers iterate rows already scoped to one helm_config via the join, and including system_id would miss legacy NULL-system_id rows linked through that join.

## Backfill

This PR does NOT mutate byte-cluster state. After deploy:

1. Backend boot runs the PreMigrate hook → drops legacy index, backfills `system_id` from existing single-owner links, AutoMigrate adds `system_id` column + new unique index.
2. Operator runs `aegisctl system reseed --apply` → `findOrCreateParameterConfig` sees no row matching `(system_id=hs_id, key=global.otel.endpoint)` and inserts a hs-scoped row with the hs default; same for sn/media. `helm_config_values` links update to point at the per-system rows.
3. Next helm install / RestartPedestal picks up per-system `OTEL_EXPORTER_OTLP_ENDPOINT`.

This unblocks #303 step 2b for hs/sn/media.

## Other shared keys found in data.yaml

`grep` of seed data.yaml for keys declared by ≥2 systems:

| Key | Systems | Same default? |
|---|---|---|
| `global.otel.endpoint` | hs, sn, media | NO (motivating bug) |
| `global.dockerRegistry` | hs, sn, media | yes (no symptom today, but now correctly per-system-scoped) |
| `global.infraDockerRegistry` | hs, sn, media | yes (same) |
| `global.defaultImageVersion` | hs, sn, media | declared with mismatched `category` (1/2/3 — likely a typo, but already unique by accident) |
| `NAMESPACE` (env var) | clickhouse type=1 / pedestal | yes |

All are now correctly system-scoped post-reseed; only `global.otel.endpoint` had a user-visible regression.

## Test plan

- [x] `cd src && go build -tags duckdb_arrow -o /dev/null ./main.go` passes.
- [x] `go test ./service/initialization/... ./module/container/... ./framework/...` passes including new `TestReseedTwoSystemsSameKeyDifferentDefault`.
- [x] New regression test asserts two systems with the same `config_key` materialise as two distinct parameter_configs rows and each system's `helm_config_values` link resolves to that system's own default.
- [ ] Operator deploy-time: run reseed --apply on byte-cluster, verify `helm get values hs10 -n hs10 | grep otel` shows `deployment-hs-collector`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)