### PR TITLE
feat(helm): track api-gateway Service annotations so helm upgrade preserves Volcengine EIP binding

### DIFF
--- a/AegisLab/helm/templates/service.yaml
+++ b/AegisLab/helm/templates/service.yaml
@@ -165,6 +165,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-api-gateway
+  {{- with .Values.microservices.apiGateway.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if eq .Values.configmap.system.env_mode "staging" }}
   type: NodePort

--- a/AegisLab/helm/values.yaml
+++ b/AegisLab/helm/values.yaml
@@ -211,6 +211,15 @@ microservices:
     service:
       type: ClusterIP
       nodePort: 32082
+      # Annotations rendered onto the api-gateway Service. Kept in chart
+      # values (not just stamped out-of-band) so `helm upgrade` doesn't
+      # silently drop them — on byte-cluster the Volcengine LB controller
+      # uses these to bind a stable EIP to the underlying CLB; if helm
+      # reapplies the Service without them the controller re-creates the
+      # CLB and the EIP changes, breaking external clients. Override per
+      # environment; empty `{}` for environments without external LB
+      # (kind, dev). See manifests/byte-cluster/values.yaml.
+      annotations: {}
     httpPort: 8082
     # Port for the runtime-intake gRPC server (runtime-worker -> api-gateway).
     intakeGrpcPort: 9096

--- a/AegisLab/manifests/byte-cluster/rcabench.values.yaml
+++ b/AegisLab/manifests/byte-cluster/rcabench.values.yaml
@@ -91,6 +91,30 @@ microservices:
   apiGateway:
     service:
       type: ClusterIP
+      # Volcengine LB controller annotations: bind a stable EIP via a CLB
+      # the controller materializes from these knobs. Kept in chart values
+      # (not stamped out-of-band) so `helm upgrade rcabench` doesn't drop
+      # them — without these, the controller re-creates the CLB and the
+      # bound EIP changes, breaking external clients.
+      # The CLB ID surfaces in the live Service annotations as
+      # `service.beta.kubernetes.io/system-volcengine-loadbalancer-create-response-id`
+      # after the controller's first reconcile; that's the controller's
+      # OUTPUT and is intentionally NOT in this map (helm would clobber it
+      # on upgrade if it were).
+      annotations:
+        service.beta.kubernetes.io/volcengine-loadbalancer-address-type: PUBLIC
+        service.beta.kubernetes.io/volcengine-loadbalancer-bandwidth: "200"
+        service.beta.kubernetes.io/volcengine-loadbalancer-billing-type: "2"
+        service.beta.kubernetes.io/volcengine-loadbalancer-eip-billing-type: "3"
+        service.beta.kubernetes.io/volcengine-loadbalancer-health-check-flag: "off"
+        service.beta.kubernetes.io/volcengine-loadbalancer-ip-version: ipv4
+        service.beta.kubernetes.io/volcengine-loadbalancer-isp-type: BGP
+        service.beta.kubernetes.io/volcengine-loadbalancer-name: pair-lb
+        service.beta.kubernetes.io/volcengine-loadbalancer-pass-through: "true"
+        service.beta.kubernetes.io/volcengine-loadbalancer-project-name: default
+        service.beta.kubernetes.io/volcengine-loadbalancer-scheduler: wrr
+        service.beta.kubernetes.io/volcengine-loadbalancer-spec: small_1
+        service.beta.kubernetes.io/volcengine-loadbalancer-subnet-id: subnet-33g6ke6jw1b0g6k70bpphvvjn
     # CPU requests are required for HPA targetCPUUtilizationPercentage to work.
     resources:
       requests:


### PR DESCRIPTION
## Why

The byte-cluster api-gateway Service has a stable EIP bound via a Volcengine CLB that the cloud controller materializes from `service.beta.kubernetes.io/volcengine-loadbalancer-*` annotations. These annotations were previously stamped on the live Service out-of-band — **helm doesn't know about them**.

Risk: any \`helm upgrade rcabench\` (e.g. for a chart structural change unrelated to the gateway) would three-way-merge the Service template (which has no annotations) against the live state and strip them. The Volcengine controller would then re-evaluate, re-create the CLB, and the bound EIP would change — breaking external clients that hardcode the EIP.

Image-only updates already avoid this (we use \`kubectl set image deploy/rcabench-api-gateway api-gateway=<new>\` which only patches the Deployment's PodTemplateSpec, never touches the Service). But any future \`helm upgrade\` is a landmine.

## What

- \`helm/values.yaml\`: new \`microservices.apiGateway.service.annotations\` (default \`{}\`) + comment explaining why it lives in chart values.
- \`helm/templates/service.yaml\`: render the annotations onto the api-gateway Service.
- \`manifests/byte-cluster/rcabench.values.yaml\`: populate the byte-cluster overlay with all 13 Volcengine LB annotations from the live Service (\`address-type\`, \`bandwidth\`, \`billing-type\`, \`eip-billing-type\`, \`ipv4\`, \`BGP\`, \`pair-lb\` name, \`pass-through\`, \`default\` project, \`wrr\` scheduler, \`small_1\` spec, subnet-id).

Two annotations deliberately NOT in this map:
- \`system-volcengine-loadbalancer-create-response-id\` — the CLB ID (controller's OUTPUT, written after first reconcile). If helm templated it, helm would clobber it on upgrade.
- \`apps.vke.volcengine.com/updated\` — controller's reconcile timestamp, same reason.

After this PR + a one-time \`helm upgrade rcabench\`, helm fully owns the input annotations and reapplies them identically on every subsequent upgrade — no diff, no re-create, EIP stable.

## Verification

\`\`\`bash
helm template rcabench helm/ -f manifests/byte-cluster/rcabench.values.yaml \\
  | awk '/^kind: Service$/{flag=1} flag && /name: rcabench-api-gateway/{p=1} p; /^---/{if(p){exit}}'
\`\`\`

Output: \`rcabench-api-gateway\` Service rendered with all 13 input annotations under \`metadata.annotations\`.

For non-byte environments (kind, dev) the default empty \`{}\` keeps prior behavior — no annotations rendered.

## Operational note

After merge, the byte-cluster operator should run a single \`helm upgrade rcabench helm/ -f manifests/byte-cluster/rcabench.values.yaml -n exp\` to bring the live Service under helm's tracking with the annotations now in the chart values. Volcengine controller will see no diff (annotations match), no CLB churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)