### PR TITLE
fix(byte-cluster/seed): bump otel-demo 0.1.7→0.1.8 to use chart 0.1.7 (parallel ClusterRole fix)

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -87,16 +87,18 @@ containers:
     is_public: true
     status: 1
     versions:
-      # Bumped 0.1.6 → 0.1.7 to retarget OTel exporter to the per-system
-      # otel-demo collector (#303 step 2b). The wrapper otel-collector inside
-      # the demo chart forwards to `global.clusterCollector.service`, which
-      # we now point at the dedicated single-pod deployment-otel-demo
-      # collector instead of the shared deployment-collector.
-      - name: 0.1.7
+      # Bumped 0.1.7 → 0.1.8 to pick up otel-demo-aegis chart 0.1.7 which
+      # disables ALL ClusterRole-triggering presets (clusterMetrics,
+      # kubeletMetrics, kubernetesEvents, annotationDiscovery.*, plus
+      # clusterRole.create=false) — fixes the parallel-install collision
+      # where every otel-demoN beyond the first failed with "ClusterRole
+      # otel-collector exists, invalid ownership metadata". Previous chart
+      # 0.1.6 only disabled kubernetesAttributes which was insufficient.
+      - name: 0.1.8
         github_link: open-telemetry/opentelemetry-demo
         status: 1
         helm_config:
-          version: 0.1.6
+          version: 0.1.7
           chart_name: otel-demo-aegis
           repo_name: opspai
           repo_url: oci://pair-cn-shanghai.cr.volces.com/opspai


### PR DESCRIPTION
## Why

otel-demo-aegis chart 0.1.6 only disabled the \`kubernetesAttributes\` preset; the opentelemetry-collector subchart's \`clusterrole.yaml\` still rendered a cluster-scoped ClusterRole \`otel-collector\` because \`clusterMetrics\` / \`kubeletMetrics\` / \`kubernetesEvents\` / \`annotationDiscovery.*\` were left at their upstream defaults (\`true\`).

Live byte-cluster impact: every \`helm install otel-demoN\` after the first failed with:

\`\`\`
ClusterRole "otel-collector" exists and cannot be imported into the current release:
  invalid ownership metadata; annotation validation error:
    key "meta.helm.sh/release-name" must equal "otel-demoN": current value is "otel-demo0"
\`\`\`

Result: otel-demo K=12 loop completed Round 1 codex submit, but only ns 0 successfully provisioned. ns 1-11 all failed at RestartPedestal, the loop produced zero useful datapacks for hours.

## What

- container_version: 0.1.7 → 0.1.8
- helm_config.version (chart): 0.1.6 → **0.1.7** (the upstream fix in OperationsPAI/benchmark-charts#6)

Reseed honors the immutability contract on existing rows, so bumping the container_version is the only way to make the DB pick up the new chart.

## Companion PR

OperationsPAI/benchmark-charts#6 — publishes \`otel-demo-aegis 0.1.7\` to \`oci://pair-cn-shanghai.cr.volces.com/opspai\` with all ClusterRole-triggering presets disabled. Already pushed and verified mirrored.

This PR depends on that one being merged + chart visible at the OCI registry.

## Operational deploy steps after merge

1. \`kubectl create configmap rcabench-initial-data --from-file=data.yaml=... --dry-run=client -o yaml | kubectl apply -f -\`
2. \`kubectl rollout restart deploy/rcabench-api-gateway -n exp\`
3. \`aegisctl system reseed --apply\` — creates otel-demo 0.1.8 row
4. (one-time, already done on live cluster) \`kubectl delete clusterrole otel-collector && kubectl delete clusterrolebinding otel-collector\` — clears the otel-demo0 leftover

After that, otel-demo loop's RestartPedestal resolves to chart 0.1.7 and parallel installs no longer collide on the cluster-scoped role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)