### PR TITLE
fix(byte-cluster/seed): bump ts 1.0.2→1.0.4 — bake allowInsecureImages + loadgen 024 + per-system collector defaults into seed

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -44,11 +44,28 @@ containers:
     is_public: true
     status: 1
     versions:
-      # Bumped 1.0.1 → 1.0.2 to retarget OTel exporter to the per-system
-      # ts collector (#303). Reseed honors the immutability contract on
-      # already-seeded versions, so the values below would not propagate
-      # to the DB without bumping the version name.
-      - name: 1.0.2
+      # Bumped 1.0.2 → 1.0.4 to consolidate three out-of-band defaults that
+      # ts ns previously got via per-namespace `helm upgrade --set` but which
+      # weren't in the DB seed (so any RestartPedestal flow that re-installed
+      # the chart from the seed alone would miss them):
+      #   1. global.security.allowInsecureImages=true — the upstream Bitnami
+      #      rabbitmq subchart bundled by trainticket@0.2.0 hardcodes an
+      #      "image recognition" check (NOTES.txt:165) that fails helm
+      #      install with `Original containers have been substituted for
+      #      unrecognized ones` whenever the rabbitmq image is anything
+      #      other than the bitnami official set. Our cluster pulls the
+      #      mirrored image from pair-diag-cn-guangzhou.cr.volces.com/pair/
+      #      so the check ALWAYS fires unless explicitly bypassed. The
+      #      bypass is safe — image is known-good (rabbitmq pods ran fine
+      #      under the previous out-of-band overrides for weeks).
+      #   2. loadgenerator.image.tag=024 — built from
+      #      OperationsPAI/loadgenerator main HEAD (sync notes in earlier
+      #      ts seed bumps).
+      #   3. loadgenerator.image.repository=pair-cn-shanghai.cr.volces.com/
+      #      opspai/loadgenerator — volces shanghai mirror so byte-cluster
+      #      pulls don't egress to docker.io.
+      # Plus carries forward the per-system collector retargeting from #303.
+      - name: 1.0.4
         github_link: OperationsPAI/train-ticket
         status: 1
         helm_config:
@@ -63,6 +80,14 @@ containers:
               value_type: 1
               template_string: 31%03d
               overridable: false
+            # Skip the Bitnami rabbitmq subchart's image-recognition check
+            # so helm install proceeds with the mirrored rabbitmq image.
+            - key: global.security.allowInsecureImages
+              type: 0
+              category: 1
+              value_type: 2
+              default_value: "true"
+              overridable: true
             # Per-system collector (#303): all ts workloads (Java services
             # + Go loadgen + caddy ui-dashboard) export to the dedicated
             # `opentelemetry-kube-stack-deployment-ts-collector` Service
@@ -80,6 +105,18 @@ containers:
               category: 1
               value_type: 0
               default_value: opentelemetry-kube-stack-deployment-ts-collector.monitoring:4317
+              overridable: true
+            - key: loadgenerator.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/loadgenerator
+              overridable: true
+            - key: loadgenerator.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "024"
               overridable: true
           status: 1
   - type: 2


### PR DESCRIPTION
## Why

Three values that ts namespaces previously got via per-namespace \`helm upgrade --set\` were lost from the DB seed and silently regressed every time RestartPedestal fresh-installed the trainticket chart:

| # | Key | Why it matters |
|---|---|---|
| 1 | \`global.security.allowInsecureImages: true\` | Bitnami rabbitmq subchart bundled by trainticket@0.2.0 hardcodes an image-recognition check at \`templates/NOTES.txt:165\` that fails helm install with **"Original containers have been substituted for unrecognized ones"** whenever \`rabbitmq.image\` isn't on the bitnami official allow-list. Our cluster pulls from \`pair-diag-cn-guangzhou.cr.volces.com/pair/\` so the check **always** fires. Without the bypass, every ts namespace install fails at the helm template stage. |
| 2 | \`loadgenerator.image.tag: "024"\` | Rebuilt from \`OperationsPAI/loadgenerator\` main HEAD (5743f13). |
| 3 | \`loadgenerator.image.repository: pair-cn-shanghai.cr.volces.com/opspai/loadgenerator\` | Volces shanghai mirror so byte-cluster doesn't egress to docker.io. |

Live impact: ts loop's RestartPedestal hit **60% failure rate over 12h** — 277 of 469 RP attempts failed with \`execution error at (trainticket/charts/rabbitmq/templates/NOTES.txt:165:4)\`. ts produced ~50 useful datapacks instead of the ~336 expected from 28 codex rounds × K=12.

## What

ts container_version: **1.0.2 → 1.0.4** with all three values baked into helm_config_values:

\`\`\`yaml
- name: 1.0.4
  helm_config:
    version: 0.2.0
    chart_name: trainticket
    values:
      - key: services.tsUiDashboard.nodePort           # unchanged
      - key: global.security.allowInsecureImages       # NEW
        default_value: "true"
      - key: global.otelcollector                      # carries forward (#303)
      - key: loadgenerator.opentelemetry.endpoint      # carries forward (#303)
      - key: loadgenerator.image.repository            # NEW (was out-of-band)
      - key: loadgenerator.image.tag                   # NEW (was out-of-band)
\`\`\`

Skipping 1.0.3 because that container_version exists in the live DB only — created by ad-hoc reseed during incident debugging when items 2+3 were edited locally but never PR'd. 1.0.4 makes the seed consistent with the live state plus item 1.

## Other systems audit

Ran \`helm template\` on every system's chart with default values:

| System | Bitnami subcharts | Template errors | Needs allowInsecureImages |
|---|---|---|---|
| **ts (trainticket)** | rabbitmq, mysql | ❌ | ✅ this PR |
| sockshop | none | ✓ | no |
| teastore | none | ✓ | no |
| hs (hotel-reservation) | none | ✓ | no |
| sn (social-network) | bitnami present but old chart, check disabled | ✓ | no |
| media (media-microservices) | none | ✓ | no |
| otel-demo (otel-demo-aegis) | none | ✓ | no (separate fix in OperationsPAI/benchmark-charts#6) |

Only ts trips the Bitnami security check. This PR scope is correct as ts-only.

## Verification

\`\`\`
helm template t train-ticket/trainticket --version 0.2.0
# default: ❌ NOTES.txt:165 error

helm template t train-ticket/trainticket --version 0.2.0 \\
  --set global.security.allowInsecureImages=true
# ✓ renders cleanly
\`\`\`

## Operational deploy after merge

1. Update \`rcabench-initial-data\` ConfigMap from this data.yaml.
2. \`kubectl rollout restart deploy/rcabench-api-gateway -n exp\`
3. \`aegisctl system reseed --apply\` to write the ts 1.0.4 row.
4. ts loop's next round → RestartPedestal uses chart 0.2.0 with the new values → helm install succeeds → ts ns enters Ready cycle as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)