### PR TITLE
fix(injection): pin duration unconditionally instead of rejecting nil

### DIFF
--- a/AegisLab/src/module/injection/api_types.go
+++ b/AegisLab/src/module/injection/api_types.go
@@ -468,19 +468,6 @@ func (req *SubmitInjectionReq) Validate() error {
 			if strings.TrimSpace(spec.ChaosType) == "" {
 				return fmt.Errorf("specs[%d][%d].chaos_type is required", i, j)
 			}
-			// Backend pins the abnormal window. We deliberately overwrite
-			// any caller-supplied `duration` rather than rejecting it, so
-			// existing CLI bodies keep working while loop agents lose the
-			// ability to drift it. A nil pointer here would still indicate
-			// the chaos-experiment resolver bailed out before normalizing
-			// the rest of the config (issue #176), so keep that diagnostic.
-			if spec.Duration == nil {
-				return fmt.Errorf(
-					"specs[%d][%d].duration is missing for chaos_type=%q — the chaos-experiment guided resolver typically default-fills duration on success, "+
-						"so a missing duration usually means the resolver hit a builder error (missing required field, JVM method not in cache, mem_type decode failure, ...) "+
-						"and shipped an un-normalized config; re-run the guided session and check the resolver's `errors` field",
-					i, j, strings.TrimSpace(spec.ChaosType))
-			}
 			fixed := consts.FixedAbnormalWindowMinutes
 			spec.Duration = &fixed
 			req.Specs[i][j] = *spec

--- a/AegisLab/src/module/injection/guided_submit_test.go
+++ b/AegisLab/src/module/injection/guided_submit_test.go
@@ -3,7 +3,6 @@ package injection
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"aegis/consts"
@@ -79,40 +78,25 @@ func TestSubmitInjectionReqValidateRejectsEmptyBatch(t *testing.T) {
 	require.ErrorContains(t, err, "must contain at least one guided config")
 }
 
-// TestSubmitInjectionReqValidateRejectsMissingDuration is the issue-#176
-// defense-in-depth assertion: when the resolver fails to default-fill
-// Duration (i.e. the chaos-experiment builder errored and shipped an
-// un-normalized config), the validator must point at the resolver as the
-// likely cause, NOT regurgitate the generic "duration > 0" message.
-func TestSubmitInjectionReqValidateRejectsMissingDuration(t *testing.T) {
-	req := validSubmitInjectionReq()
-	req.Specs[0][0].Duration = nil
-	req.Specs[0][0].ChaosType = "JVMMemoryStress"
-
-	err := req.Validate()
-	require.Error(t, err)
-	msg := err.Error()
-	require.Contains(t, msg, "duration is missing")
-	require.Contains(t, msg, "JVMMemoryStress")
-	require.Contains(t, msg, "guided resolver")
-	// Crucially: must NOT say "must be greater than 0" for the nil case —
-	// that's the misleading message that issue #176 traced to.
-	require.NotContains(t, msg, "duration must be greater than 0")
-}
-
-// TestSubmitInjectionReqValidateOverridesCallerSuppliedDuration is the
-// hardcoded-time-window guarantee: any non-nil per-spec duration shipped by
-// the caller (loop agent, manual curl, ...) is silently overwritten with
-// consts.FixedAbnormalWindowMinutes so external clients can't drift the
-// abnormal window. The chaos-experiment resolver's own default-fill keeps
-// the legacy code path producing a non-nil pointer even when the CLI used
-// to set --duration explicitly.
-func TestSubmitInjectionReqValidateOverridesCallerSuppliedDuration(t *testing.T) {
-	for _, in := range []int{0, 1, 9999} {
-		t.Run(fmt.Sprintf("input=%d", in), func(t *testing.T) {
+// TestSubmitInjectionReqValidatePinsDuration is the hardcoded-time-window
+// guarantee: any per-spec duration (including nil from a resolver that
+// errored before normalizing) is silently pinned to
+// consts.FixedAbnormalWindowMinutes. Issue #321: rejecting nil broke
+// guided submits whenever the chaos-experiment builder errored.
+func TestSubmitInjectionReqValidatePinsDuration(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *int
+	}{
+		{"nil", nil},
+		{"zero", guidedDurationPtr(0)},
+		{"one", guidedDurationPtr(1)},
+		{"large", guidedDurationPtr(9999)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			req := validSubmitInjectionReq()
-			v := in
-			req.Specs[0][0].Duration = &v
+			req.Specs[0][0].Duration = tc.in
 
 			require.NoError(t, req.Validate())
 			require.NotNil(t, req.Specs[0][0].Duration)


### PR DESCRIPTION
## Summary

Closes #321. `SubmitInjectionReq.Validate()` rejected guided specs with `Duration == nil`, but the very next lines overwrote `Duration` with `consts.FixedAbnormalWindowMinutes` regardless of what the caller sent — so the nil-check was vestigial and broke every guided submit whose `chaos-experiment` resolver hit a builder error and shipped an un-normalized `GuidedConfig` (`JVMRuntimeMutator`, `DNSError`, likely other JVM*/HTTP variants).

This blocked `aegisctl inject guided --apply --batch --auto` campaigns at submit time with a 400 — all 12 ts-loop slots failed in the most recent reproduction.

## Before

```go
if spec.Duration == nil {
    return fmt.Errorf("specs[%d][%d].duration is missing for chaos_type=%q — ...", i, j, ...)
}
fixed := consts.FixedAbnormalWindowMinutes
spec.Duration = &fixed
req.Specs[i][j] = *spec
```

## After

```go
fixed := consts.FixedAbnormalWindowMinutes
spec.Duration = &fixed
req.Specs[i][j] = *spec
```

The pin always runs. The contract was already "backend pins the abnormal window; caller-supplied values are discarded" — there was no information in `cfg.Duration` we used, so a `nil` should not have been treated differently than e.g. `5`.

## Tests

`TestSubmitInjectionReqValidateRejectsMissingDuration` codified the bug (asserted nil → error) and was deleted. The existing `TestSubmitInjectionReqValidateOverridesCallerSuppliedDuration` was widened to a table test that also covers the `nil` case (renamed `TestSubmitInjectionReqValidatePinsDuration`).

`PreDuration` and `Interval` were checked for the same anti-pattern; they are not in `SubmitInjectionReq.Validate`'s code path, so no other changes needed.

## Test plan

- [x] `go test -tags duckdb_arrow -run 'TestSubmitInjectionReq|TestGuidedSpec|TestParseBatchGuided' ./module/injection/...` passes
- [ ] Re-run a `JVMRuntimeMutator` guided submit on a live cluster and confirm it no longer 400s

Fixes #321