### PR TITLE
fix(seed): drop http:// prefix from LGU global.otel.endpoint

### DIFF
--- a/AegisLab/data/initial_data/prod/data.yaml
+++ b/AegisLab/data/initial_data/prod/data.yaml
@@ -199,7 +199,14 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.0
+      # Bumped 0.1.0 → 0.1.1 to drop the `http://` scheme from the OTel
+      # endpoint (DSB Go SDK auto-prefixes `http://`, double-prefix kills
+      # all spans) and to swap from the dead seed key
+      # `global.services.environments.OTEL_EXPORTER_OTLP_ENDPOINT` (which
+      # the upstream hotel-reservation chart ignores) to the chart's
+      # actual `global.otel.endpoint` knob. Closes #323. Reseed honors
+      # the immutability contract on already-seeded versions.
+      - name: 0.1.1
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
@@ -220,11 +227,11 @@ containers:
               value_type: 0
               default_value: 20260423-61074ea
               overridable: true
-            - key: global.services.environments.OTEL_EXPORTER_OTLP_ENDPOINT
+            - key: global.otel.endpoint
               type: 0
               category: 1
               value_type: 0
-              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              default_value: otel-collector.otel.svc.cluster.local:4318
               overridable: true
           status: 1
   - type: 2
@@ -232,7 +239,10 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.0
+      # Bumped 0.1.0 → 0.1.1 to drop the `http://` scheme from the OTel
+      # endpoint (DSB Go SDK auto-prefixes `http://`, double-prefix kills
+      # all spans). Closes #323.
+      - name: 0.1.1
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
@@ -257,7 +267,7 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              default_value: otel-collector.otel.svc.cluster.local:4318
               overridable: true
           status: 1
   - type: 2
@@ -265,7 +275,10 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.0
+      # Bumped 0.1.0 → 0.1.1 to drop the `http://` scheme from the OTel
+      # endpoint (DSB Go SDK auto-prefixes `http://`, double-prefix kills
+      # all spans). Closes #323.
+      - name: 0.1.1
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
@@ -290,7 +303,7 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              default_value: otel-collector.otel.svc.cluster.local:4318
               overridable: true
           status: 1
   - type: 2

--- a/AegisLab/data/initial_data/staging/data.yaml
+++ b/AegisLab/data/initial_data/staging/data.yaml
@@ -173,7 +173,13 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.0
+      # Bumped 0.1.0 → 0.1.1 to drop the `http://` scheme from the OTel
+      # endpoint (DSB Go SDK auto-prefixes `http://`, double-prefix kills
+      # all spans) and to swap from the dead seed key
+      # `global.services.environments.OTEL_EXPORTER_OTLP_ENDPOINT` (which
+      # the upstream hotel-reservation chart ignores) to the chart's
+      # actual `global.otel.endpoint` knob. Closes #323.
+      - name: 0.1.1
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
@@ -194,11 +200,11 @@ containers:
               value_type: 0
               default_value: 20260423-61074ea
               overridable: true
-            - key: global.services.environments.OTEL_EXPORTER_OTLP_ENDPOINT
+            - key: global.otel.endpoint
               type: 0
               category: 1
               value_type: 0
-              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              default_value: otel-collector.otel.svc.cluster.local:4318
               overridable: true
           status: 1
   - type: 2
@@ -206,7 +212,10 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.0
+      # Bumped 0.1.0 → 0.1.1 to drop the `http://` scheme from the OTel
+      # endpoint (DSB Go SDK auto-prefixes `http://`, double-prefix kills
+      # all spans). Closes #323.
+      - name: 0.1.1
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
@@ -231,7 +240,7 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              default_value: otel-collector.otel.svc.cluster.local:4318
               overridable: true
           status: 1
   - type: 2
@@ -239,7 +248,10 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 0.1.0
+      # Bumped 0.1.0 → 0.1.1 to drop the `http://` scheme from the OTel
+      # endpoint (DSB Go SDK auto-prefixes `http://`, double-prefix kills
+      # all spans). Closes #323.
+      - name: 0.1.1
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
@@ -264,7 +276,7 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: http://otel-collector.otel.svc.cluster.local:4318
+              default_value: otel-collector.otel.svc.cluster.local:4318
               overridable: true
           status: 1
   - type: 2


### PR DESCRIPTION
## Summary

- Strips the `http://` scheme from `global.otel.endpoint` defaults for hs / sn / media (and hotelreservation in staging) in `data/initial_data/{prod,staging}/data.yaml`. The DSB Go OTel SDK in the upstream LGU charts auto-prefixes `http://`, so passing `http://...` produces `http://http://...` and the exporter drops every span on fresh deploy.
- Swaps the dead seed key `global.services.environments.OTEL_EXPORTER_OTLP_ENDPOINT` on the hs / hotelreservation pedestals to the chart's actual `global.otel.endpoint` knob — the upstream `hotel-reservation` chart ignores the old key entirely. Dead config removed rather than left to mislead future readers.
- Bumps each affected pedestal version name `0.1.0 -> 0.1.1` so the reseeder picks up the new container_versions row (immutability contract on already-seeded names). `helm_config.version` stays pinned to upstream 0.1.0.
- Byte-cluster overlay was already corrected in #303 (no http://, per-ns collector form) and is left untouched.

Fixes #323

## Test plan

- [ ] `aegisctl system reseed --apply` writes the new `0.1.1` rows to staging and prod DB.
- [ ] Fresh `helm install` of `lgu-dsb/social-network` against the new seed renders `OTEL_EXPORTER_OTLP_ENDPOINT` as `http://otel-collector.otel.svc.cluster.local:4318` (single prefix), spans land in ClickHouse `otel.otel_traces`.
- [ ] Fresh hs deploy now uses `global.otel.endpoint` (verified by `helm template ... --set global.otel.endpoint=...` honoring it instead of the chart's `\$(NODE_IP)` fallback).

Generated with Claude Code