### PR TITLE
fix(byte-cluster/seed): bump ts 1.0.4→1.0.5 to mirror chart 0.2.0 docker.io defaults

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -65,7 +65,20 @@ containers:
       #      opspai/loadgenerator — volces shanghai mirror so byte-cluster
       #      pulls don't egress to docker.io.
       # Plus carries forward the per-system collector retargeting from #303.
-      - name: 1.0.4
+      #
+      # Bumped 1.0.4 → 1.0.5 to redirect every chart-default docker.io image
+      # through the volces shanghai mirror (`pair-cn-shanghai.cr.volces.com/
+      # opspai/*`). byte-cluster nodes can NOT egress to docker.io, so the
+      # chart's defaults — `global.image.repository=docker.io/opspai`,
+      # `mysql.image.repository=docker.io/library/mysql`, `rabbitmq.image.
+      # repository=bitnamilegacy/rabbitmq`, and the loadgen `wait-for-
+      # services` init container `docker.io/nicolaka/netshoot:v0.14` — all
+      # ImagePullBackOff'd on every newly allocated ts namespace after
+      # backend RP triggered helm install. Manually mirrored to opspai
+      # dockerhub (volces auto-mirrors docker.io/opspai/* to the pair-cn-
+      # shanghai path), then pinned the new mirror paths via the four extra
+      # helm values below.
+      - name: 1.0.5
         github_link: OperationsPAI/train-ticket
         status: 1
         helm_config:
@@ -87,6 +100,41 @@ containers:
               category: 1
               value_type: 2
               default_value: "true"
+              overridable: true
+            # Repository for ts-* service images and the chart's
+            # `init-otel-agent` (autoinstrumentation-java) initContainer.
+            # Chart default `docker.io/opspai` is unreachable from byte-
+            # cluster nodes; the volces shanghai mirror is.
+            - key: global.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            # mysql + rabbitmq subcharts: chart defaults reach docker.io
+            # directly. Mirror both to opspai (manually pulled + pushed
+            # 2026-05-01: docker.io/library/mysql:5.7 and docker.io/
+            # bitnamilegacy/rabbitmq:4.0.7-debian-12-r0).
+            - key: mysql.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/mysql
+              overridable: true
+            - key: rabbitmq.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/rabbitmq
+              overridable: true
+            # loadgen `wait-for-services` init container — chart hardcodes
+            # docker.io/nicolaka/netshoot:v0.14 in values.yaml:394. Mirror
+            # pushed to opspai/netshoot:v0.14 on 2026-05-01.
+            - key: loadgenerator.initContainer.image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/netshoot:v0.14
               overridable: true
             # Per-system collector (#303): all ts workloads (Java services
             # + Go loadgen + caddy ui-dashboard) export to the dedicated


### PR DESCRIPTION
## Symptom

After full rebuild + reseed today (#322 + #324 + #325 merged), the ts loop's new RP rounds left every ts namespace with **48 pods in ImagePullBackOff**. Five distinct chart defaults all reach docker.io, which byte-cluster nodes cannot egress to:

| Image | Where in chart 0.2.0 |
|---|---|
| `docker.io/opspai/ts-*-service:latest` | every service deployment via `global.image.repository` |
| `docker.io/opspai/autoinstrumentation-java:elastic` | `init-otel-agent` initContainer on every Java service |
| `docker.io/library/mysql:5.7` | mysql subchart |
| `docker.io/bitnamilegacy/rabbitmq:4.0.7-debian-12-r0` | rabbitmq subchart |
| `docker.io/nicolaka/netshoot:v0.14` | loadgen `wait-for-services` initContainer (chart values.yaml:394) |

Manual `AegisLab/manifests/byte-cluster/initial-data/ts.yaml` overrides only apply for README-step-6 standalone helm installs; **backend RP only reads `helm_config.values` from the seed**, so it shipped chart defaults straight to the cluster.

## Fix

1. Mirrored the four upstream images to `docker.io/opspai/*` (volces auto-mirrors to `pair-cn-shanghai.cr.volces.com/opspai/*`):
   - `opspai/netshoot:v0.14`
   - `opspai/mysql:5.7`
   - `opspai/rabbitmq:4.0.7-debian-12-r0`
   - (autoinstrumentation-java was already on docker.io/opspai, pulled via the same mirror once `global.image.repository` is overridden)
2. Bumped ts `1.0.4 → 1.0.5` and added 4 new `helm_config.values` entries pinning each to the mirror path. Honors immutability contract — existing 1.0.4 rows stay intact, reseed picks up 1.0.5.

## Test plan

- [ ] aegisctl reseed --apply produces a 1.0.5 row
- [ ] Tear down all ts namespaces, restart loop, verify next RP `helm install` reaches 1/1 ready on every service deployment
- [ ] No ImagePullBackOff in `kubectl -n ts0 get pods` after RP completes