### PR TITLE
fix(byte-cluster/otel-demo): redirect overlay to opspai mirror + drop redundant init overrides

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml
@@ -11,50 +11,33 @@ global:
 
 opentelemetry-demo:
   default:
+    # The 18 demo service images (accounting/ad/cart/checkout/...) all use
+    # this repo with `:2.2.0-<component>` tags. Chart upstream defaults to
+    # ghcr.io/open-telemetry/demo which byte-cluster nodes can't reach;
+    # `pair-diag-cn-guangzhou.cr.volces.com/pair/open-telemetry-demo` (the
+    # previous override) doesn't actually have the 2.2.0-* tags published.
+    # Re-mirrored every component to opspai dockerhub on 2026-05-01 so the
+    # volces auto-mirror serves them via this pair-cn-shanghai path.
     image:
-      repository: pair-diag-cn-guangzhou.cr.volces.com/pair/open-telemetry-demo
+      repository: pair-cn-shanghai.cr.volces.com/opspai/open-telemetry-demo
 
+  # NOTE: `components.{accounting,cart,checkout,fraud-detection,flagd}.initContainers`
+  # are deliberately NOT set here. Chart otel-demo-aegis 0.1.8 already pins
+  # them to docker.io/opspai/busybox:latest (PR benchmark-charts#7). Adding
+  # an override here would silently take precedence and re-introduce the
+  # old broken pair-diag/busybox:1.35 path.
   components:
-    accounting:
-      initContainers:
-        - name: wait-for-kafka
-          image: pair-diag-cn-guangzhou.cr.volces.com/pair/busybox:1.35
-          command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
-
-    cart:
-      initContainers:
-        - name: wait-for-valkey-cart
-          image: pair-diag-cn-guangzhou.cr.volces.com/pair/busybox:1.35
-          command: ["sh", "-c", "until nc -z -v -w30 valkey-cart 6379; do echo waiting for valkey-cart; sleep 2; done;"]
-
-    checkout:
-      initContainers:
-        - name: wait-for-kafka
-          image: pair-diag-cn-guangzhou.cr.volces.com/pair/busybox:1.35
-          command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
-
-    fraud-detection:
-      initContainers:
-        - name: wait-for-kafka
-          image: pair-diag-cn-guangzhou.cr.volces.com/pair/busybox:1.35
-          command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
-
     flagd:
+      # flagd main image — chart leaves this at upstream `ghcr.io/open-feature/flagd`.
+      # Mirrored to opspai on 2026-05-01.
       imageOverride:
-        repository: pair-diag-cn-guangzhou.cr.volces.com/pair/flagd
-      initContainers:
-        - name: init-config
-          image: pair-diag-cn-guangzhou.cr.volces.com/pair/busybox:1.35
-          command: ["sh", "-c", "cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json"]
-          volumeMounts:
-            - mountPath: /config-ro
-              name: config-ro
-            - mountPath: /config-rw
-              name: config-rw
+        repository: pair-cn-shanghai.cr.volces.com/opspai/flagd
 
     valkey-cart:
+      # valkey-cart subchart's main image — chart upstream uses bitnami; we
+      # mirror upstream valkey to opspai for byte-cluster reachability.
       imageOverride:
-        repository: pair-diag-cn-guangzhou.cr.volces.com/pair/valkey
+        repository: pair-cn-shanghai.cr.volces.com/opspai/valkey
 
   opentelemetry-collector:
     image:


### PR DESCRIPTION
## Two fixes in one overlay rewrite

### 1. `default.image.repository` redirected to a mirror that has the tags

Previous overlay pointed at `pair-diag-cn-guangzhou.cr.volces.com/pair/open-telemetry-demo`. That repo has no \`2.2.0-*\` tags. Every otel-demoN ns landed with 18 pods in ImagePullBackOff after the recent chart 0.1.7 → 0.1.8 bump (which carried upstream demo to 2.2.0).

Mirrored all 18 components from \`ghcr.io/open-telemetry/demo:2.2.0-{accounting,ad,cart,checkout,currency,email,flagd,fraud-detection,frontend,frontend-proxy,image-provider,kafka,load-generator,payment,product-catalog,quote,recommendation,shipping}\` to \`docker.io/opspai/open-telemetry-demo:2.2.0-*\` so the volces auto-mirror serves them via the pair-cn-shanghai path.

### 2. Dropped redundant init container overrides that were undoing benchmark-charts#7

The overlay had \`components.{accounting,cart,checkout,fraud-detection,flagd}.initContainers\` blocks that pinned busybox to \`pair-diag-cn-guangzhou.cr.volces.com/pair/busybox:1.35\`. Chart \`otel-demo-aegis@0.1.8\` already pins those same init containers to \`docker.io/opspai/busybox:latest\` (benchmark-charts#7). The overlay was silently overriding the chart fix.

### 3. Mirrored flagd + valkey for the two `imageOverride` sites
- \`flagd\`: ghcr.io/open-feature/flagd:v0.12.4 → docker.io/opspai/flagd:latest
- \`valkey-cart\`: docker.io/valkey/valkey:8.0-alpine → docker.io/opspai/valkey:latest

## No seed bump

Overlay loads via \`--set-file initialDataFiles.otel_demo_yaml\` — a \`helm upgrade rcabench\` picks up the new content. No container_versions row needs bumping.

## Test plan

- [ ] helm upgrade rcabench
- [ ] Nuke + re-allocate otel-demoN ns, verify backend RP install reaches all-pods-Running on at least one ns
- [ ] No ImagePullBackOff in \`kubectl -n otel-demo0 get pods\`