### PR TITLE
chore(byte-cluster): bump rcabench image tag to byte-20260501-duration-fix

### DIFF
--- a/AegisLab/manifests/byte-cluster/rcabench.values.yaml
+++ b/AegisLab/manifests/byte-cluster/rcabench.values.yaml
@@ -4,7 +4,7 @@ global:
 images:
   rcabench:
     name: pair-cn-shanghai.cr.volces.com/opspai/rcabench
-    tag: byte-20260423-otel013-valuesfix
+    tag: byte-20260501-duration-fix
     pullPolicy: IfNotPresent
   jaeger:
     name: pair-diag-cn-guangzhou.cr.volces.com/pair/jaeger


### PR DESCRIPTION
## Why

The cluster has been running on `pair-cn-shanghai.cr.volces.com/opspai/rcabench:byte-20260501-duration-fix` since today's manual `helm upgrade` (which deployed PR #324's fix for the JVMRuntimeMutator duration validator). Persist the tag in chart values so a fresh `helm upgrade --install` (disaster recovery / re-deploy) doesn't roll back to `byte-20260423-otel013-valuesfix` and re-introduce the duration-missing 400 errors.

## Image already published

The new image was built + pushed to `docker.io/opspai/rcabench:byte-20260501-duration-fix` earlier today and is already pulled by `kubectl -n exp get deploy rcabench-api-gateway`.

## Test plan

- [x] No-op against the live cluster (already running this image)
- [ ] Re-deploy from a clean clone of main + this PR pulls correct image