### PR TITLE
fix(container): add id DESC tie-breaker so pedestal selector picks latest by id when name fields tie

### DIFF
--- a/AegisLab/src/module/container/repository.go
+++ b/AegisLab/src/module/container/repository.go
@@ -122,7 +122,7 @@ func (r *Repository) batchGetContainerVersions(containerType consts.ContainerTyp
 	query := r.db.Table("container_versions cv").
 		Preload("Container").
 		Where("cv.status = ?", consts.CommonEnabled).
-		Order("cv.container_id DESC, cv.name_major DESC, cv.name_minor DESC, cv.name_patch DESC")
+		Order("cv.container_id DESC, cv.name_major DESC, cv.name_minor DESC, cv.name_patch DESC, cv.id DESC")
 
 	query = query.Joins("INNER JOIN containers c ON c.id = cv.container_id").
 		Where("c.type = ? AND c.name IN (?) AND c.status = ?", containerType, containerNames, consts.CommonEnabled)

--- a/AegisLab/src/module/container/repository_test.go
+++ b/AegisLab/src/module/container/repository_test.go
@@ -1,0 +1,86 @@
+package container
+
+import (
+	"testing"
+
+	"aegis/consts"
+	"aegis/model"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestBatchGetContainerVersions_TieBreakerByID guards against issue #328:
+// when two container_versions rows share (name_major, name_minor, name_patch)
+// — the legacy 0/0/0 case where pre-semver rows were never reseeded — the
+// selector must deterministically prefer the row with the highest id. Without
+// the trailing `id DESC`, MySQL returned an implementation-defined row and
+// pedestal version resolution would silently pick stale chart configs.
+func TestBatchGetContainerVersions_TieBreakerByID(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{TranslateError: true})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&model.Container{}, &model.ContainerVersion{}); err != nil {
+		t.Skipf("sqlite AutoMigrate unsupported: %v", err)
+	}
+
+	container := &model.Container{
+		Name:     "legacy-bench",
+		Type:     consts.ContainerTypeBenchmark,
+		IsPublic: true,
+		Status:   consts.CommonEnabled,
+	}
+	if err := db.Omit(containerCommonOmitFields).Create(container).Error; err != nil {
+		t.Fatalf("seed container: %v", err)
+	}
+
+	// Insert two versions with identical (0,0,0) semver fields — the case
+	// produced by legacy seed rows — using SkipHooks so BeforeCreate doesn't
+	// re-derive major/minor/patch from Name.
+	older := &model.ContainerVersion{
+		Name:        "legacy-old",
+		NameMajor:   0,
+		NameMinor:   0,
+		NamePatch:   0,
+		ContainerID: container.ID,
+		Tag:         "old",
+		Repository:  "opspai/legacy",
+		Status:      consts.CommonEnabled,
+	}
+	newer := &model.ContainerVersion{
+		Name:        "legacy-new",
+		NameMajor:   0,
+		NameMinor:   0,
+		NamePatch:   0,
+		ContainerID: container.ID,
+		Tag:         "new",
+		Repository:  "opspai/legacy",
+		Status:      consts.CommonEnabled,
+	}
+	tx := db.Session(&gorm.Session{SkipHooks: true}).Omit("active_version_key")
+	if err := tx.Create(older).Error; err != nil {
+		t.Fatalf("seed older version: %v", err)
+	}
+	if err := tx.Create(newer).Error; err != nil {
+		t.Fatalf("seed newer version: %v", err)
+	}
+	if newer.ID <= older.ID {
+		t.Fatalf("expected newer.ID > older.ID, got older=%d newer=%d", older.ID, newer.ID)
+	}
+
+	repo := NewRepository(db)
+	versions, err := repo.batchGetContainerVersions(consts.ContainerTypeBenchmark, []string{"legacy-bench"}, 0)
+	if err != nil {
+		t.Fatalf("batchGetContainerVersions: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("expected 2 versions, got %d", len(versions))
+	}
+	// ResolveContainerVersions consumes flatMap[name][0] when no explicit
+	// version is requested, so the FIRST row from the ORDER BY must be the
+	// one with the higher id.
+	if versions[0].ID != newer.ID {
+		t.Fatalf("tie-break failed: want id=%d (newer) first, got id=%d", newer.ID, versions[0].ID)
+	}
+}


### PR DESCRIPTION
## Summary

- `batchGetContainerVersions` (`AegisLab/src/module/container/repository.go`) ordered by `container_id, name_major, name_minor, name_patch` — all DESC — but lacked a terminal `id DESC`. Legacy rows where `name_major/minor/patch` are all 0 (pre-semver seed data) tie on every sort key, so MySQL returned an implementation-defined row and `ResolveContainerVersions` silently picked stale chart configs.
- Adds `cv.id DESC` as the final ORDER BY column, matching the existing `chaossystem/repository.go:150` (`GetPedestalHelmConfigByName`) convention.
- Legacy 0/0/0 rows should still be reseeded so semver reflects reality, but this fix unblocks them in the meantime.

Fixes #328

## Test plan

- [x] New regression test `TestBatchGetContainerVersions_TieBreakerByID` inserts two `container_versions` rows with identical `(0,0,0)` semver — the higher `id` must win. Verified the test FAILS without the fix and PASSES with it.
- [x] `cd AegisLab/src && go build -tags duckdb_arrow -o /dev/null ./main.go` succeeds.
- [x] `cd AegisLab/src && go test -tags duckdb_arrow ./module/container/...` passes (`ok aegis/module/container 0.078s`).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>