### PR TITLE
fix(byte-cluster/seed): pin ts mysql Service to ClusterIP

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -166,6 +166,20 @@ containers:
               value_type: 0
               default_value: "024"
               overridable: true
+            # Pin mysql Service to ClusterIP. trainticket@0.2.0 chart default
+            # is `NodePort` with no `nodePort` value, so kubernetes auto-assigns
+            # a random port from 30000-32767 per release. With ~12 ts ns running
+            # in parallel, that range frequently collides with the deterministic
+            # `services.tsUiDashboard.nodePort=31%03d` allocation (range 31000-
+            # 31099): observed `ts7` mysql at 31003 blocking `ts3` ts-ui-dashboard
+            # install. mysql has no out-of-cluster consumers anyway, so ClusterIP
+            # is the right type.
+            - key: mysql.service.type
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: ClusterIP
+              overridable: true
           status: 1
   - type: 2
     name: otel-demo


### PR DESCRIPTION
## Symptom

trainticket@0.2.0 chart defaults \`mysql.service.type\` to **NodePort with no \`nodePort\` value**, so kubernetes auto-assigns a random port from 30000-32767 per release. With ~12 ts namespaces running in parallel, the random allocation frequently collides with \`services.tsUiDashboard.nodePort\` which is **deterministically** assigned \`31%03d\` (range 31000-31099).

## Live evidence today

\`\`\`
ts7 mysql: NodePort 3306:31003/TCP        <-- random k8s allocation
ts3 ts-ui-dashboard install: failed
    Service "ts-ui-dashboard" is invalid:
    spec.ports[0].nodePort: Invalid value: 31003:
    provided port is already allocated
\`\`\`

This blocks every \`ts*\` RestartPedestal where the random mysql port lands in 31000-31099.

## Fix

Add seed override \`mysql.service.type=ClusterIP\` to ts@1.0.5. mysql is consumed only in-cluster by the ts service pods; the NodePort is gratuitous.

## Reseed plan

This adds a new \`helm_config_values\` row to existing \`ts@1.0.5\`. Reseed backfills it (verified pattern from sn/media earlier today) without bumping the container_version. After merge:
1. \`aegisctl system reseed --apply\`
2. \`helm uninstall ts7 -n ts7\` (release the stuck 31003)
3. Restart ts loop — new \`helm install\` will use ClusterIP mysql

## Test plan

- [ ] reseed shows \`backfilled helm value on existing helm_config\` for \`ts@1.0.5:mysql.service.type\`
- [ ] Fresh ts ns install shows \`kubectl -n tsN get svc mysql\` as type=ClusterIP
- [ ] No nodePort collision in subsequent ts loop rounds