### PR TITLE
fix(byte-cluster/seed): pin ts-ui-dashboard Service to ClusterIP (drop deterministic 31xxx NodePort)

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -87,12 +87,23 @@ containers:
           repo_name: train-ticket
           repo_url: https://operationspai.github.io/train-ticket
           values:
-            - key: services.tsUiDashboard.nodePort
-              type: 1
+            # Pin ts-ui-dashboard to ClusterIP. Chart default is
+            # `NodePort` with `nodePort: 30080`; we previously templated a
+            # per-namespace `31%03d` to spread allocations across ts0..ts99,
+            # but with mysql also defaulted to NodePort (now pinned to
+            # ClusterIP above), the deterministic 31xxx range collided with
+            # mysql's randomly-assigned NodePort whenever k8s happened to land
+            # mysql in 31000-31099 (e.g. ts7 mysql at 31003 blocked ts3
+            # ts-ui-dashboard install). Easiest: drop the NodePort entirely —
+            # ts-ui-dashboard has no out-of-cluster consumers in the
+            # benchmark loop (RP queries it via in-cluster DNS), and external
+            # access can be done with `kubectl port-forward` if ever needed.
+            - key: services.tsUiDashboard.type
+              type: 0
               category: 1
-              value_type: 1
-              template_string: 31%03d
-              overridable: false
+              value_type: 0
+              default_value: ClusterIP
+              overridable: true
             # Skip the Bitnami rabbitmq subchart's image-recognition check
             # so helm install proceeds with the mirrored rabbitmq image.
             - key: global.security.allowInsecureImages


### PR DESCRIPTION
## Companion to #331

#331 pinned mysql to ClusterIP. ts-ui-dashboard's deterministic \`services.tsUiDashboard.nodePort=31%03d\` template was a workaround for the mysql random-NodePort collision problem — with mysql off NodePort, the dashboard NodePort can also go away.

## Why drop instead of keep

- ts-ui-dashboard has no out-of-cluster consumers in the benchmark loop (RP queries it via in-cluster DNS).
- Keeping the deterministic NodePort costs us a kube nodePort allocation per ts ns (12-40 of them), wasting the 30000-32767 range.
- External access is still possible via \`kubectl port-forward svc/ts-ui-dashboard 8080:8080\` if ever needed (chart NOTES.txt:13 already documents this).

## Diff

- Drop \`services.tsUiDashboard.nodePort\` template entry (was \`31%03d\`).
- Add \`services.tsUiDashboard.type=ClusterIP\` override.

## Reseed plan

Reseed backfills on existing ts@1.0.5 (no version bump needed). Existing ts ns helm releases need to be uninstalled + reinstalled for the change to take effect — \`helm upgrade --reuse-values\` won't drop the old NodePort field, only fresh install will.

## Test plan

- [ ] reseed shows \`backfilled helm value\` for \`ts@1.0.5:services.tsUiDashboard.type\`
- [ ] Fresh ts ns install shows \`kubectl -n tsN get svc ts-ui-dashboard\` as type=ClusterIP, no NodePort