### PR TITLE
fix(handler): groundtruth uses spec.Namespace (caller's ns), falls back to system pool head only when unset

### DIFF
--- a/AegisLab/src/service/consumer/fault_injection.go
+++ b/AegisLab/src/service/consumer/fault_injection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -163,6 +164,37 @@ func executeFaultInjection(ctx context.Context, task *dto.UnifiedTask, deps Runt
 			groundtruths = append(groundtruths, *model.NewDBGroundtruth(&chaosGroundtruth))
 		}
 
+		// Re-capture groundtruth right before applying CRDs. The first pass
+		// above runs at the top of the FI handler — by the time annotations,
+		// labels, and the batch ID are wired up, RestartPedestal's helm-upgrade
+		// may have rolled the targeted pod and renamed it (the chaos-mesh CRD
+		// selector is label-based so the FI still lands, but the DB-recorded
+		// GT.Pod was the OLD name). Re-resolving here pins fresh pod / container
+		// names without changing the action-space (service-level groundtruth is
+		// expected to be stable; a service mismatch is logged but we proceed
+		// with the fresh values — the CRD is what's actually about to run).
+		for i, conf := range injectionConfs {
+			confCopy := conf
+			fresh, mismatch, err := recaptureGroundtruth(childCtx, func(ctx context.Context) (chaos.Groundtruth, error) {
+				return confCopy.GetGroundtruth(ctx)
+			}, groundtruths[i])
+			if err != nil {
+				return handleExecutionError(span, logEntry, fmt.Sprintf("failed to re-capture groundtruth for guided config %d", i), err)
+			}
+			if mismatch {
+				logEntry.WithFields(logrus.Fields{
+					"index":           i,
+					"prior_service":   groundtruths[i].Service,
+					"fresh_service":   fresh.Service,
+					"prior_pod":       groundtruths[i].Pod,
+					"fresh_pod":       fresh.Pod,
+					"prior_container": groundtruths[i].Container,
+					"fresh_container": fresh.Container,
+				}).Warn("groundtruth service set changed between submit and CRD apply; persisting fresh values")
+			}
+			groundtruths[i] = fresh
+		}
+
 		// Marshal display config as array
 		displayData, err := json.Marshal(displayMaps)
 		if err != nil {
@@ -245,6 +277,63 @@ func executeFaultInjection(ctx context.Context, task *dto.UnifiedTask, deps Runt
 		toReleased = false
 		return nil
 	})
+}
+
+// recaptureGroundtruth re-invokes getter at fault-injection time and returns
+// the freshly-resolved groundtruth plus a serviceMismatch flag. Callers persist
+// the fresh value; mismatch only signals that the action's service set changed
+// between the early loop-time call and CRD apply (a known-bad sign that one of
+// the layers below — pod-listing, container-name resolution — saw a different
+// state). The chaos-mesh selector is label-based so the CRD still lands; the
+// fresh GT is what consumers like the datapack builder should record.
+//
+// Extracted as a getter-typed helper so unit tests can drive both passes
+// without standing up a real cluster (the K8s-touching work all lives inside
+// the spec's GetGroundtruth).
+func recaptureGroundtruth(ctx context.Context, getter func(context.Context) (chaos.Groundtruth, error), prior model.Groundtruth) (model.Groundtruth, bool, error) {
+	fresh, err := getter(ctx)
+	if err != nil {
+		return model.Groundtruth{}, false, err
+	}
+	freshDB := *model.NewDBGroundtruth(&fresh)
+	return freshDB, !sameStringSet(prior.Service, freshDB.Service), nil
+}
+
+// sameStringSet returns true when a and b contain the same elements ignoring
+// order and duplicates. Used by recaptureGroundtruth to detect cross-pass
+// service-set drift (which is structural, not a pod-rename).
+func sameStringSet(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	as := append([]string(nil), a...)
+	bs := append([]string(nil), b...)
+	sort.Strings(as)
+	sort.Strings(bs)
+	as = dedupSorted(as)
+	bs = dedupSorted(bs)
+	if len(as) != len(bs) {
+		return false
+	}
+	for i := range as {
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func dedupSorted(s []string) []string {
+	if len(s) < 2 {
+		return s
+	}
+	out := s[:1]
+	for _, v := range s[1:] {
+		if v != out[len(out)-1] {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 // parseInjectionPayload extracts and validates the guided-config payload from

--- a/AegisLab/src/service/consumer/fault_injection_test.go
+++ b/AegisLab/src/service/consumer/fault_injection_test.go
@@ -1,11 +1,15 @@
 package consumer
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"aegis/consts"
 	"aegis/dto"
+	"aegis/model"
 
+	chaos "github.com/OperationsPAI/chaos-experiment/handler"
 	"github.com/OperationsPAI/chaos-experiment/pkg/guidedcli"
 	"github.com/stretchr/testify/require"
 )
@@ -55,4 +59,59 @@ func TestParseInjectionPayloadRejectsLegacyNodes(t *testing.T) {
 
 	_, err := parseInjectionPayload(payload)
 	require.ErrorContains(t, err, consts.InjectGuidedConfigs)
+}
+
+// TestRecaptureGroundtruth_OverwritesPodNameWhenServiceMatches pins the
+// RestartPedestal pod-rename fix: when the loop-time GT recorded pod
+// `ts-order-service-7d6b-aaaa` and the helm-upgrade in between rolled it to
+// `ts-order-service-7d6b-bbbb`, recapture must surface the new name without
+// flagging a service mismatch (label-stable workloads keep the same service).
+func TestRecaptureGroundtruth_OverwritesPodNameWhenServiceMatches(t *testing.T) {
+	prior := model.Groundtruth{
+		Service:   []string{"ts-order-service"},
+		Pod:       []string{"ts-order-service-7d6b-aaaa"},
+		Container: []string{"ts-order-service"},
+	}
+	getter := func(_ context.Context) (chaos.Groundtruth, error) {
+		return chaos.Groundtruth{
+			Service:   []string{"ts-order-service"},
+			Pod:       []string{"ts-order-service-7d6b-bbbb"},
+			Container: []string{"ts-order-service"},
+		}, nil
+	}
+
+	fresh, mismatch, err := recaptureGroundtruth(context.Background(), getter, prior)
+	require.NoError(t, err)
+	require.False(t, mismatch, "service set is identical; mismatch flag must be false")
+	require.Equal(t, []string{"ts-order-service-7d6b-bbbb"}, fresh.Pod, "pod name must reflect the post-recapture value, not the loop-time stale one")
+	require.Equal(t, []string{"ts-order-service"}, fresh.Service)
+	require.Equal(t, []string{"ts-order-service"}, fresh.Container)
+}
+
+// TestRecaptureGroundtruth_FlagsServiceMismatchAndStillReturnsFresh covers the
+// pathological case where the spec resolves to a different service the second
+// time (e.g. cache invalidation between calls). The fresh GT is what the CRD
+// will actually target, so we persist it and let the caller log a warning.
+func TestRecaptureGroundtruth_FlagsServiceMismatchAndStillReturnsFresh(t *testing.T) {
+	prior := model.Groundtruth{Service: []string{"ts-order-service"}, Pod: []string{"a"}}
+	getter := func(_ context.Context) (chaos.Groundtruth, error) {
+		return chaos.Groundtruth{Service: []string{"ts-travel-service"}, Pod: []string{"b"}}, nil
+	}
+
+	fresh, mismatch, err := recaptureGroundtruth(context.Background(), getter, prior)
+	require.NoError(t, err)
+	require.True(t, mismatch, "service set differs; mismatch flag must be true")
+	require.Equal(t, []string{"ts-travel-service"}, fresh.Service)
+	require.Equal(t, []string{"b"}, fresh.Pod)
+}
+
+func TestRecaptureGroundtruth_PropagatesGetterError(t *testing.T) {
+	prior := model.Groundtruth{Service: []string{"x"}}
+	want := errors.New("kube list timeout")
+	getter := func(_ context.Context) (chaos.Groundtruth, error) {
+		return chaos.Groundtruth{}, want
+	}
+
+	_, _, err := recaptureGroundtruth(context.Background(), getter, prior)
+	require.ErrorIs(t, err, want)
 }

--- a/chaos-experiment/handler/consts.go
+++ b/chaos-experiment/handler/consts.go
@@ -12,6 +12,7 @@ const (
 
 const (
 	keySystem      = "System"
+	keyNamespace   = "Namespace"
 	keyApp         = "AppIdx"
 	keyMethod      = "MethodIdx"
 	keyTarget      = "MutatorTargetIdx"

--- a/chaos-experiment/handler/dns_chaos.go
+++ b/chaos-experiment/handler/dns_chaos.go
@@ -15,6 +15,8 @@ type DNSErrorSpec struct {
 	Duration       int `range:"1-60" description:"Time Unit Minute"`
 	System         int `range:"0-0" dynamic:"true" description:"String"`
 	DNSEndpointIdx int `range:"0-0" dynamic:"true" description:"DNS Endpoint Index"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *DNSErrorSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -58,6 +60,8 @@ type DNSRandomSpec struct {
 	Duration       int `range:"1-60" description:"Time Unit Minute"`
 	System         int `range:"0-0" dynamic:"true" description:"String"`
 	DNSEndpointIdx int `range:"0-0" dynamic:"true" description:"DNS Endpoint Index"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *DNSRandomSpec) Create(cli cli.Client, opts ...Option) (string, error) {

--- a/chaos-experiment/handler/groundtruth.go
+++ b/chaos-experiment/handler/groundtruth.go
@@ -62,6 +62,17 @@ type Groundtruth struct {
 	Span      []string `json:"span,omitempty"`
 }
 
+// resolveSpecNamespace returns the per-spec namespace if set by the builder,
+// otherwise falls back to the system pool head. The fallback preserves the
+// pre-PR behavior for callers (e.g. legacy tests, JSON payloads from older
+// pipelines) that construct specs without the Namespace field.
+func resolveSpecNamespace(system systemconfig.SystemType, specNamespace string) (string, error) {
+	if specNamespace != "" {
+		return specNamespace, nil
+	}
+	return systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+}
+
 // GetGroundtruthFromAppIdx returns a Groundtruth object for a given app index
 func GetGroundtruthFromAppIdx(ctx context.Context, system systemconfig.SystemType, namespace string, appIdx int) (Groundtruth, error) {
 	systemCache := resourcelookup.GetSystemCache(system)
@@ -390,7 +401,7 @@ func GetGroundtruthFromDatabaseIdx(ctx context.Context, system systemconfig.Syst
 
 func (s *PodFailureSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -399,7 +410,7 @@ func (s *PodFailureSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error
 
 func (s *PodKillSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -408,7 +419,7 @@ func (s *PodKillSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 
 func (s *ContainerKillSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -417,7 +428,7 @@ func (s *ContainerKillSpec) GetGroundtruth(ctx context.Context) (Groundtruth, er
 
 func (s *MemoryStressChaosSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -432,7 +443,7 @@ func (s *MemoryStressChaosSpec) GetGroundtruth(ctx context.Context) (Groundtruth
 
 func (s *CPUStressChaosSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -447,7 +458,7 @@ func (s *CPUStressChaosSpec) GetGroundtruth(ctx context.Context) (Groundtruth, e
 
 func (s *TimeSkewSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -456,7 +467,7 @@ func (s *TimeSkewSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) 
 
 func (s *DNSErrorSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -465,7 +476,7 @@ func (s *DNSErrorSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) 
 
 func (s *DNSRandomSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -474,7 +485,7 @@ func (s *DNSRandomSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error)
 
 func (s *HTTPRequestAbortSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -483,7 +494,7 @@ func (s *HTTPRequestAbortSpec) GetGroundtruth(ctx context.Context) (Groundtruth,
 
 func (s *HTTPResponseAbortSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -492,7 +503,7 @@ func (s *HTTPResponseAbortSpec) GetGroundtruth(ctx context.Context) (Groundtruth
 
 func (s *HTTPRequestDelaySpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -507,7 +518,7 @@ func (s *HTTPRequestDelaySpec) GetGroundtruth(ctx context.Context) (Groundtruth,
 
 func (s *HTTPResponseDelaySpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -522,7 +533,7 @@ func (s *HTTPResponseDelaySpec) GetGroundtruth(ctx context.Context) (Groundtruth
 
 func (s *HTTPResponseReplaceBodySpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -531,7 +542,7 @@ func (s *HTTPResponseReplaceBodySpec) GetGroundtruth(ctx context.Context) (Groun
 
 func (s *HTTPResponsePatchBodySpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -540,7 +551,7 @@ func (s *HTTPResponsePatchBodySpec) GetGroundtruth(ctx context.Context) (Groundt
 
 func (s *HTTPRequestReplacePathSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -549,7 +560,7 @@ func (s *HTTPRequestReplacePathSpec) GetGroundtruth(ctx context.Context) (Ground
 
 func (s *HTTPRequestReplaceMethodSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -558,7 +569,7 @@ func (s *HTTPRequestReplaceMethodSpec) GetGroundtruth(ctx context.Context) (Grou
 
 func (s *HTTPResponseReplaceCodeSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -567,7 +578,7 @@ func (s *HTTPResponseReplaceCodeSpec) GetGroundtruth(ctx context.Context) (Groun
 
 func (s *NetworkDelaySpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -582,7 +593,7 @@ func (s *NetworkDelaySpec) GetGroundtruth(ctx context.Context) (Groundtruth, err
 
 func (s *NetworkLossSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -591,7 +602,7 @@ func (s *NetworkLossSpec) GetGroundtruth(ctx context.Context) (Groundtruth, erro
 
 func (s *NetworkDuplicateSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -600,7 +611,7 @@ func (s *NetworkDuplicateSpec) GetGroundtruth(ctx context.Context) (Groundtruth,
 
 func (s *NetworkCorruptSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -609,7 +620,7 @@ func (s *NetworkCorruptSpec) GetGroundtruth(ctx context.Context) (Groundtruth, e
 
 func (s *NetworkBandwidthSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -618,7 +629,7 @@ func (s *NetworkBandwidthSpec) GetGroundtruth(ctx context.Context) (Groundtruth,
 
 func (s *NetworkPartitionSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -628,7 +639,7 @@ func (s *NetworkPartitionSpec) GetGroundtruth(ctx context.Context) (Groundtruth,
 // JVM chaos GetGroundtruth implementations
 func (s *JVMLatencySpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -643,7 +654,7 @@ func (s *JVMLatencySpec) GetGroundtruth(ctx context.Context) (Groundtruth, error
 
 func (s *JVMReturnSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -652,7 +663,7 @@ func (s *JVMReturnSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error)
 
 func (s *JVMExceptionSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -661,7 +672,7 @@ func (s *JVMExceptionSpec) GetGroundtruth(ctx context.Context) (Groundtruth, err
 
 func (s *JVMGCSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -670,7 +681,7 @@ func (s *JVMGCSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 
 func (s *JVMCPUStressSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -685,7 +696,7 @@ func (s *JVMCPUStressSpec) GetGroundtruth(ctx context.Context) (Groundtruth, err
 
 func (s *JVMMemoryStressSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -700,7 +711,7 @@ func (s *JVMMemoryStressSpec) GetGroundtruth(ctx context.Context) (Groundtruth, 
 
 func (s *JVMMySQLLatencySpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -715,7 +726,7 @@ func (s *JVMMySQLLatencySpec) GetGroundtruth(ctx context.Context) (Groundtruth, 
 
 func (s *JVMMySQLExceptionSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}
@@ -724,7 +735,7 @@ func (s *JVMMySQLExceptionSpec) GetGroundtruth(ctx context.Context) (Groundtruth
 
 func (s *JVMRuntimeMutatorSpec) GetGroundtruth(ctx context.Context) (Groundtruth, error) {
 	system := systemconfig.GetAllSystemTypes()[s.System]
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	namespace, err := resolveSpecNamespace(system, s.Namespace)
 	if err != nil {
 		return Groundtruth{}, err
 	}

--- a/chaos-experiment/handler/groundtruth_test.go
+++ b/chaos-experiment/handler/groundtruth_test.go
@@ -85,6 +85,36 @@ func TestSelectContainerByIndex_NegativeIndexHandled(t *testing.T) {
 	}
 }
 
+// TestResolveSpecNamespace_PrefersSpecNamespace pins the regression where every
+// *Spec.GetGroundtruth used GetNamespaceByIndex(system, defaultStartIndex)
+// instead of the caller-provided namespace. Guided submits with --namespace hs28
+// (or any non-zero pool slot) used to fail with "no containers found ... in
+// namespace hs0" because the spec dropped the operator's namespace on the floor.
+func TestResolveSpecNamespace_PrefersSpecNamespace(t *testing.T) {
+	got, err := resolveSpecNamespace(systemconfig.SystemHotelReservation, "hs28")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "hs28" {
+		t.Errorf("got %q, want %q (the spec's per-call namespace, not the pool head)", got, "hs28")
+	}
+}
+
+func TestResolveSpecNamespace_FallsBackToPoolHeadWhenUnset(t *testing.T) {
+	// Legacy callers that build specs without setting Namespace must keep working.
+	got, err := resolveSpecNamespace(systemconfig.SystemHotelReservation, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want, err := systemconfig.GetNamespaceByIndex(systemconfig.SystemHotelReservation, defaultStartIndex)
+	if err != nil {
+		t.Fatalf("unexpected error from pool head: %v", err)
+	}
+	if got != want {
+		t.Errorf("fallback got %q, want %q", got, want)
+	}
+}
+
 func TestSelectContainerByIndex_ValidIndexReturnsEntry(t *testing.T) {
 	containers := []resourcelookup.ContainerInfo{
 		{PodName: "p1", AppLabel: "front-end", ContainerName: "front-end"},

--- a/chaos-experiment/handler/handler.go
+++ b/chaos-experiment/handler/handler.go
@@ -473,15 +473,26 @@ func parseInjection(ctx context.Context, instance Injection) (map[string]any, er
 		}
 	}
 
-	namespace, err := systemconfig.GetNamespaceByIndex(system, defaultStartIndex)
+	var specNamespace string
+	for i := range instanceValue.NumField() {
+		if instanceType.Field(i).Name == keyNamespace {
+			f := instanceValue.Field(i)
+			if f.Kind() == reflect.String {
+				specNamespace = f.String()
+			}
+			break
+		}
+	}
+
+	namespace, err := resolveSpecNamespace(system, specNamespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get namespace for system %s: %v", system, err)
+		return nil, fmt.Errorf("failed to resolve namespace for system %s: %v", system, err)
 	}
 
 	systemCache := resourcelookup.GetSystemCache(system)
 
 	for i := range instanceValue.NumField() {
-		// Skip non-numeric fields (e.g. the per-spec Namespace string used by
+		// Skip non-action fields (e.g. the per-spec Namespace string used by
 		// GetGroundtruth). They aren't part of the action-space the display config
 		// surfaces.
 		if isNonActionField(instanceType.Field(i).Type) {

--- a/chaos-experiment/handler/handler.go
+++ b/chaos-experiment/handler/handler.go
@@ -481,6 +481,13 @@ func parseInjection(ctx context.Context, instance Injection) (map[string]any, er
 	systemCache := resourcelookup.GetSystemCache(system)
 
 	for i := range instanceValue.NumField() {
+		// Skip non-numeric fields (e.g. the per-spec Namespace string used by
+		// GetGroundtruth). They aren't part of the action-space the display config
+		// surfaces.
+		if isNonActionField(instanceType.Field(i).Type) {
+			continue
+		}
+
 		key := utils.ToSnakeCase(instanceType.Field(i).Name)
 
 		index, err := getIntValue(instanceValue.Field(i))

--- a/chaos-experiment/handler/http_chaos.go
+++ b/chaos-experiment/handler/http_chaos.go
@@ -17,6 +17,8 @@ type HTTPRequestAbortSpec struct {
 	Duration    int `range:"1-60" description:"Time Unit Minute"`
 	System      int `range:"0-0" dynamic:"true" description:"String"`
 	EndpointIdx int `range:"0-0" dynamic:"true" description:"Flattened HTTP Endpoint Index"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *HTTPRequestAbortSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -77,6 +79,8 @@ type HTTPResponseAbortSpec struct {
 	Duration    int `range:"1-60" description:"Time Unit Minute"`
 	System      int `range:"0-0" dynamic:"true" description:"String"`
 	EndpointIdx int `range:"0-0" dynamic:"true" description:"Flattened HTTP Endpoint Index"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *HTTPResponseAbortSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -138,6 +142,8 @@ type HTTPRequestDelaySpec struct {
 	System        int `range:"0-0" dynamic:"true" description:"String"`
 	EndpointIdx   int `range:"0-0" dynamic:"true" description:"Flattened HTTP Endpoint Index"`
 	DelayDuration int `range:"10-5000" description:"Delay in milliseconds"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *HTTPRequestDelaySpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -199,6 +205,8 @@ type HTTPResponseDelaySpec struct {
 	System        int `range:"0-0" dynamic:"true" description:"String"`
 	EndpointIdx   int `range:"0-0" dynamic:"true" description:"Flattened HTTP Endpoint Index"`
 	DelayDuration int `range:"10-5000" description:"Delay in milliseconds"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *HTTPResponseDelaySpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -268,6 +276,8 @@ type HTTPResponseReplaceBodySpec struct {
 	System      int             `range:"0-0" dynamic:"true" description:"Namespace Index (0-based)"`
 	EndpointIdx int             `range:"0-0" dynamic:"true" description:"Flattened HTTP Endpoint Index"`
 	BodyType    ReplaceBodyType `range:"0-1" description:"Body Type (0=Empty, 1=Random)"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *HTTPResponseReplaceBodySpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -333,6 +343,8 @@ type HTTPResponsePatchBodySpec struct {
 	Duration    int `range:"1-60" description:"Time Unit Minute"`
 	System      int `range:"0-0" dynamic:"true" description:"String"`
 	EndpointIdx int `range:"0-0" dynamic:"true" description:"Flattened HTTP Endpoint Index"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *HTTPResponsePatchBodySpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -392,6 +404,8 @@ type HTTPRequestReplacePathSpec struct {
 	Duration    int `range:"1-60" description:"Time Unit Minute"`
 	System      int `range:"0-0" dynamic:"true" description:"String"`
 	EndpointIdx int `range:"0-0" dynamic:"true" description:"Flattened HTTP Endpoint Index"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *HTTPRequestReplacePathSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -453,6 +467,8 @@ type HTTPRequestReplaceMethodSpec struct {
 	System        int `range:"0-0" dynamic:"true" description:"Namespace Index (0-based)"`
 	EndpointIdx   int `range:"0-0" dynamic:"true" description:"Flattened HTTP Endpoint Index"`
 	ReplaceMethod int `range:"0-6" description:"HTTP Method index (filtered, excluding original method)"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *HTTPRequestReplaceMethodSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -517,6 +533,8 @@ type HTTPResponseReplaceCodeSpec struct {
 	System      int            `range:"0-0" dynamic:"true" description:"Namespace Index (0-based)"`
 	EndpointIdx int            `range:"0-0" dynamic:"true" description:"Flattened HTTP Endpoint Index"`
 	StatusCode  HTTPStatusCode `range:"0-9" description:"HTTP Status Code to replace with"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *HTTPResponseReplaceCodeSpec) Create(cli cli.Client, opts ...Option) (string, error) {

--- a/chaos-experiment/handler/jvm_chaos.go
+++ b/chaos-experiment/handler/jvm_chaos.go
@@ -36,6 +36,8 @@ type JVMLatencySpec struct {
 	System          int `range:"0-0" dynamic:"true" description:"String"`
 	MethodIdx       int `range:"0-0" dynamic:"true" description:"Flattened app+method index"`
 	LatencyDuration int `range:"1-5000" description:"Latency in ms"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *JVMLatencySpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -90,6 +92,8 @@ type JVMReturnSpec struct {
 	MethodIdx      int           `range:"0-0" dynamic:"true" description:"Flattened app+method index"`
 	ReturnType     JVMReturnType `range:"1-2" description:"Return Type (1=String, 2=Int)"`
 	ReturnValueOpt int           `range:"0-1" description:"Return value option (0=Default, 1=Random)"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *JVMReturnSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -158,6 +162,8 @@ type JVMExceptionSpec struct {
 	System       int `range:"0-0" dynamic:"true" description:"String"`
 	MethodIdx    int `range:"0-0" dynamic:"true" description:"Flattened app+method index"`
 	ExceptionOpt int `range:"0-1" description:"Exception option (0=Default, 1=Random)"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *JVMExceptionSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -225,6 +231,8 @@ type JVMGCSpec struct {
 	Duration int `range:"1-60" description:"Time Unit Minute"`
 	System   int `range:"0-0" dynamic:"true" description:"String"`
 	AppIdx   int `range:"0-0" dynamic:"true" description:"App Index"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *JVMGCSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -268,6 +276,8 @@ type JVMCPUStressSpec struct {
 	System    int `range:"0-0" dynamic:"true" description:"String"`
 	MethodIdx int `range:"0-0" dynamic:"true" description:"Flattened app+method index"`
 	CPUCount  int `range:"1-8" description:"Number of CPU cores to stress"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *JVMCPUStressSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -321,6 +331,8 @@ type JVMMemoryStressSpec struct {
 	System    int           `range:"0-0" dynamic:"true" description:"Namespace Index (0-based)"`
 	MethodIdx int           `range:"0-0" dynamic:"true" description:"Flattened app+method index"`
 	MemType   JVMMemoryType `range:"1-2" description:"Memory Type (1=Heap, 2=Stack)"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *JVMMemoryStressSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -399,6 +411,8 @@ type JVMMySQLLatencySpec struct {
 	System      int `range:"0-0" dynamic:"true" description:"String"`
 	DatabaseIdx int `range:"0-0" dynamic:"true" description:"Flattened app+database+table index"`
 	LatencyMs   int `range:"10-5000" description:"Latency in ms"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *JVMMySQLLatencySpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -452,6 +466,8 @@ type JVMMySQLExceptionSpec struct {
 	Duration    int `range:"1-60" description:"Time Unit Minute"`
 	System      int `range:"0-0" dynamic:"true" description:"String"`
 	DatabaseIdx int `range:"0-0" dynamic:"true" description:"Flattened app+database+table index"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *JVMMySQLExceptionSpec) Create(cli cli.Client, opts ...Option) (string, error) {

--- a/chaos-experiment/handler/jvm_runtime_mutator.go
+++ b/chaos-experiment/handler/jvm_runtime_mutator.go
@@ -16,6 +16,8 @@ type JVMRuntimeMutatorSpec struct {
 	Duration         int `range:"1-60" description:"Time Unit Minute"`
 	System           int `range:"0-0" dynamic:"true" description:"System Index"`
 	MutatorTargetIdx int `range:"0-0" dynamic:"true" description:"Flattened valid runtime mutator injection index"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *JVMRuntimeMutatorSpec) Create(cli cli.Client, opts ...Option) (string, error) {

--- a/chaos-experiment/handler/model.go
+++ b/chaos-experiment/handler/model.go
@@ -232,6 +232,13 @@ func buildNode(rt reflect.Type, fieldName string, rootNode *Node) (*Node, error)
 		for i := range rt.NumField() {
 			field := rt.Field(i)
 
+			// Skip non-numeric fields (e.g. the per-spec Namespace string used by
+			// GetGroundtruth). The action-space serializer is index/range-based and
+			// only meaningful for numeric fields.
+			if isNonActionField(field.Type) {
+				continue
+			}
+
 			child, err := buildFieldNode(field, rootNode)
 			if err != nil {
 				return nil, err
@@ -512,6 +519,16 @@ func getValueRange(field reflect.StructField, rootNode *Node) (int, int, error) 
 	}
 
 	return start, end, err
+}
+
+// isNonActionField reports whether a struct field belongs to the action-space
+// (numeric range) or is metadata threaded through to GetGroundtruth such as
+// the per-spec Namespace.
+func isNonActionField(t reflect.Type) bool {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t.Kind() == reflect.String
 }
 
 func parseRangeTag(tag string) (int, int, error) {

--- a/chaos-experiment/handler/model.go
+++ b/chaos-experiment/handler/model.go
@@ -222,8 +222,7 @@ func buildNode(rt reflect.Type, fieldName string, rootNode *Node) (*Node, error)
 	}
 
 	node := &Node{
-		Name:  typeName(rt, fieldName),
-		Range: []int{0, rt.NumField() - 1},
+		Name: typeName(rt, fieldName),
 	}
 
 	node.Children = make(map[string]*Node)
@@ -232,9 +231,9 @@ func buildNode(rt reflect.Type, fieldName string, rootNode *Node) (*Node, error)
 		for i := range rt.NumField() {
 			field := rt.Field(i)
 
-			// Skip non-numeric fields (e.g. the per-spec Namespace string used by
+			// Skip non-action fields (e.g. the per-spec Namespace string used by
 			// GetGroundtruth). The action-space serializer is index/range-based and
-			// only meaningful for numeric fields.
+			// only meaningful for integer fields.
 			if isNonActionField(field.Type) {
 				continue
 			}
@@ -246,6 +245,16 @@ func buildNode(rt reflect.Type, fieldName string, rootNode *Node) (*Node, error)
 
 			node.Children[strconv.Itoa(i)] = child
 		}
+	}
+
+	// Range bounds the chooser's selection to indices that actually have a
+	// child entry. Skipped fields (Namespace, future metadata) must not be
+	// reachable, so derive the upper bound from the included child count
+	// rather than rt.NumField()-1.
+	if len(node.Children) > 0 {
+		node.Range = []int{0, len(node.Children) - 1}
+	} else {
+		node.Range = []int{0, 0}
 	}
 
 	return node, nil
@@ -521,14 +530,23 @@ func getValueRange(field reflect.StructField, rootNode *Node) (int, int, error) 
 	return start, end, err
 }
 
-// isNonActionField reports whether a struct field belongs to the action-space
-// (numeric range) or is metadata threaded through to GetGroundtruth such as
-// the per-spec Namespace.
+// isNonActionField reports whether a struct field should be excluded from the
+// action-space machinery. Only integer-typed fields participate in the
+// action-space; metadata such as the per-spec Namespace and any other
+// non-integer scalar kinds do not. Nested struct fields (InjectionConf's
+// chaos-type pointers) are intentionally NOT excluded -- they recurse into
+// buildNode/buildFieldNode where their own children get filtered.
 func isNonActionField(t reflect.Type) bool {
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}
-	return t.Kind() == reflect.String
+	switch t.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Struct:
+		return false
+	default:
+		return true
+	}
 }
 
 func parseRangeTag(tag string) (int, int, error) {

--- a/chaos-experiment/handler/network_chaos.go
+++ b/chaos-experiment/handler/network_chaos.go
@@ -32,6 +32,8 @@ type NetworkPartitionSpec struct {
 	System         int `range:"0-0" dynamic:"true" description:"String"`
 	NetworkPairIdx int `range:"0-0" dynamic:"true" description:"Flattened network pair index"`
 	Direction      int `range:"1-3" description:"Direction (1=to, 2=from, 3=both)"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *NetworkPartitionSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -87,6 +89,8 @@ type NetworkDelaySpec struct {
 	Correlation    int `range:"0-100" description:"Correlation percentage"`
 	Jitter         int `range:"0-1000" description:"Jitter in milliseconds"`
 	Direction      int `range:"1-3" description:"Direction (1=to, 2=from, 3=both)"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *NetworkDelaySpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -146,6 +150,8 @@ type NetworkLossSpec struct {
 	Loss           int `range:"1-100" description:"Packet loss percentage"`
 	Correlation    int `range:"0-100" description:"Correlation percentage"`
 	Direction      int `range:"1-3" description:"Direction (1=to, 2=from, 3=both)"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *NetworkLossSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -204,6 +210,8 @@ type NetworkDuplicateSpec struct {
 	Duplicate      int `range:"1-100" description:"Packet duplication percentage"`
 	Correlation    int `range:"0-100" description:"Correlation percentage"`
 	Direction      int `range:"1-3" description:"Direction (1=to, 2=from, 3=both)"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *NetworkDuplicateSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -262,6 +270,8 @@ type NetworkCorruptSpec struct {
 	Corrupt        int `range:"1-100" description:"Packet corruption percentage"`
 	Correlation    int `range:"0-100" description:"Correlation percentage"`
 	Direction      int `range:"1-3" description:"Direction (1=to, 2=from, 3=both)"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *NetworkCorruptSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -321,6 +331,8 @@ type NetworkBandwidthSpec struct {
 	Limit          int `range:"1-10000" description:"Number of bytes that can be queued"`
 	Buffer         int `range:"1-10000" description:"Maximum amount of bytes available instantaneously"`
 	Direction      int `range:"1-3" description:"Direction (1=to, 2=from, 3=both)"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *NetworkBandwidthSpec) Create(cli cli.Client, opts ...Option) (string, error) {

--- a/chaos-experiment/handler/pod_chaos.go
+++ b/chaos-experiment/handler/pod_chaos.go
@@ -14,6 +14,9 @@ type PodFailureSpec struct {
 	Duration int `range:"1-60" description:"Time Unit Minute"`
 	System   int `range:"0-0" dynamic:"true" description:"String"`
 	AppIdx   int `range:"0-0" dynamic:"true" description:"App Index"`
+	// Namespace is the caller-resolved Kubernetes namespace (e.g. "hs28"). When
+	// empty, GetGroundtruth falls back to the system pool head for back-compat.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *PodFailureSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -55,6 +58,8 @@ type PodKillSpec struct {
 	Duration int `range:"1-60" description:"Time Unit Minute"`
 	System   int `range:"0-0" dynamic:"true" description:"String"`
 	AppIdx   int `range:"0-0" dynamic:"true" description:"App Index"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *PodKillSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -95,6 +100,8 @@ type ContainerKillSpec struct {
 	Duration     int `range:"1-60" description:"Time Unit Minute"`
 	System       int `range:"0-0" dynamic:"true" description:"String"`
 	ContainerIdx int `range:"0-0" dynamic:"true" description:"Container Index"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *ContainerKillSpec) Create(cli cli.Client, opts ...Option) (string, error) {

--- a/chaos-experiment/handler/stress_chaos.go
+++ b/chaos-experiment/handler/stress_chaos.go
@@ -15,6 +15,8 @@ type CPUStressChaosSpec struct {
 	ContainerIdx int `range:"0-0" dynamic:"true" description:"Container Index"`
 	CPULoad      int `range:"1-100" description:"CPU Load Percentage"`
 	CPUWorker    int `range:"1-3" description:"CPU Stress Threads"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *CPUStressChaosSpec) Create(cli cli.Client, opts ...Option) (string, error) {
@@ -63,6 +65,8 @@ type MemoryStressChaosSpec struct {
 	ContainerIdx int `range:"0-0" dynamic:"true" description:"Container Index"`
 	MemorySize   int `range:"1-1024" description:"Memory Size Unit MB"`
 	MemWorker    int `range:"1-4" description:"Memory Stress Threads"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *MemoryStressChaosSpec) Create(cli cli.Client, opts ...Option) (string, error) {

--- a/chaos-experiment/handler/time_chaos.go
+++ b/chaos-experiment/handler/time_chaos.go
@@ -15,6 +15,8 @@ type TimeSkewSpec struct {
 	System       int `range:"0-0" dynamic:"true"`
 	ContainerIdx int `range:"0-0" dynamic:"true" description:"Container Index"`
 	TimeOffset   int `range:"-600-600" description:"Time offset in seconds"`
+	// Namespace: see PodFailureSpec.Namespace.
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s *TimeSkewSpec) Create(cli cli.Client, opts ...Option) (string, error) {

--- a/chaos-experiment/pkg/guidedcli/builders.go
+++ b/chaos-experiment/pkg/guidedcli/builders.go
@@ -16,7 +16,7 @@ func buildPodKill(ctx context.Context, cfg GuidedConfig, systemType systemconfig
 		return handler.InjectionConf{}, nil, err
 	}
 
-	spec := &handler.PodKillSpec{Duration: duration, System: systemIdx, AppIdx: appIdx}
+	spec := &handler.PodKillSpec{Duration: duration, System: systemIdx, AppIdx: appIdx, Namespace: cfg.Namespace}
 	return handler.InjectionConf{PodKill: spec}, payload("PodKill", map[string]any{
 		"Duration": duration,
 		"System":   systemIdx,
@@ -30,7 +30,7 @@ func buildPodFailure(ctx context.Context, cfg GuidedConfig, systemType systemcon
 		return handler.InjectionConf{}, nil, err
 	}
 
-	spec := &handler.PodFailureSpec{Duration: duration, System: systemIdx, AppIdx: appIdx}
+	spec := &handler.PodFailureSpec{Duration: duration, System: systemIdx, AppIdx: appIdx, Namespace: cfg.Namespace}
 	return handler.InjectionConf{PodFailure: spec}, payload("PodFailure", map[string]any{
 		"Duration": duration,
 		"System":   systemIdx,
@@ -44,7 +44,7 @@ func buildJVMGarbageCollector(ctx context.Context, cfg GuidedConfig, systemType 
 		return handler.InjectionConf{}, nil, err
 	}
 
-	spec := &handler.JVMGCSpec{Duration: duration, System: systemIdx, AppIdx: appIdx}
+	spec := &handler.JVMGCSpec{Duration: duration, System: systemIdx, AppIdx: appIdx, Namespace: cfg.Namespace}
 	return handler.InjectionConf{JVMGarbageCollector: spec}, payload("JVMGarbageCollector", map[string]any{
 		"Duration": duration,
 		"System":   systemIdx,
@@ -58,7 +58,7 @@ func buildContainerKill(ctx context.Context, cfg GuidedConfig, systemType system
 		return handler.InjectionConf{}, nil, err
 	}
 
-	spec := &handler.ContainerKillSpec{Duration: duration, System: systemIdx, ContainerIdx: containerIdx}
+	spec := &handler.ContainerKillSpec{Duration: duration, System: systemIdx, ContainerIdx: containerIdx, Namespace: cfg.Namespace}
 	return handler.InjectionConf{ContainerKill: spec}, payload("ContainerKill", map[string]any{
 		"Duration":     duration,
 		"System":       systemIdx,
@@ -82,6 +82,7 @@ func buildCPUStress(ctx context.Context, cfg GuidedConfig, systemType systemconf
 		ContainerIdx: containerIdx,
 		CPULoad:      *cfg.CPULoad,
 		CPUWorker:    *cfg.CPUWorker,
+		Namespace:    cfg.Namespace,
 	}
 	return handler.InjectionConf{CPUStress: spec}, payload("CPUStress", map[string]any{
 		"Duration":     duration,
@@ -108,6 +109,7 @@ func buildMemoryStress(ctx context.Context, cfg GuidedConfig, systemType systemc
 		ContainerIdx: containerIdx,
 		MemorySize:   *cfg.MemorySize,
 		MemWorker:    *cfg.MemWorker,
+		Namespace:    cfg.Namespace,
 	}
 	return handler.InjectionConf{MemoryStress: spec}, payload("MemoryStress", map[string]any{
 		"Duration":     duration,
@@ -133,6 +135,7 @@ func buildTimeSkew(ctx context.Context, cfg GuidedConfig, systemType systemconfi
 		System:       systemIdx,
 		ContainerIdx: containerIdx,
 		TimeOffset:   *cfg.TimeOffset,
+		Namespace:    cfg.Namespace,
 	}
 	return handler.InjectionConf{TimeSkew: spec}, payload("TimeSkew", map[string]any{
 		"Duration":     duration,
@@ -148,7 +151,7 @@ func buildHTTPRequestAbort(ctx context.Context, cfg GuidedConfig, systemType sys
 		return handler.InjectionConf{}, nil, err
 	}
 
-	spec := &handler.HTTPRequestAbortSpec{Duration: duration, System: systemIdx, EndpointIdx: endpointIdx}
+	spec := &handler.HTTPRequestAbortSpec{Duration: duration, System: systemIdx, EndpointIdx: endpointIdx, Namespace: cfg.Namespace}
 	return handler.InjectionConf{HTTPRequestAbort: spec}, payload("HTTPRequestAbort", map[string]any{
 		"Duration":    duration,
 		"System":      systemIdx,
@@ -162,7 +165,7 @@ func buildHTTPResponseAbort(ctx context.Context, cfg GuidedConfig, systemType sy
 		return handler.InjectionConf{}, nil, err
 	}
 
-	spec := &handler.HTTPResponseAbortSpec{Duration: duration, System: systemIdx, EndpointIdx: endpointIdx}
+	spec := &handler.HTTPResponseAbortSpec{Duration: duration, System: systemIdx, EndpointIdx: endpointIdx, Namespace: cfg.Namespace}
 	return handler.InjectionConf{HTTPResponseAbort: spec}, payload("HTTPResponseAbort", map[string]any{
 		"Duration":    duration,
 		"System":      systemIdx,
@@ -185,6 +188,7 @@ func buildHTTPRequestDelay(ctx context.Context, cfg GuidedConfig, systemType sys
 		System:        systemIdx,
 		EndpointIdx:   endpointIdx,
 		DelayDuration: *cfg.DelayDuration,
+		Namespace:     cfg.Namespace,
 	}
 	return handler.InjectionConf{HTTPRequestDelay: spec}, payload("HTTPRequestDelay", map[string]any{
 		"Duration":      duration,
@@ -209,6 +213,7 @@ func buildHTTPResponseDelay(ctx context.Context, cfg GuidedConfig, systemType sy
 		System:        systemIdx,
 		EndpointIdx:   endpointIdx,
 		DelayDuration: *cfg.DelayDuration,
+		Namespace:     cfg.Namespace,
 	}
 	return handler.InjectionConf{HTTPResponseDelay: spec}, payload("HTTPResponseDelay", map[string]any{
 		"Duration":      duration,
@@ -237,6 +242,7 @@ func buildHTTPResponseReplaceBody(ctx context.Context, cfg GuidedConfig, systemT
 		System:      systemIdx,
 		EndpointIdx: endpointIdx,
 		BodyType:    handler.ReplaceBodyType(bodyType),
+		Namespace:   cfg.Namespace,
 	}
 	return handler.InjectionConf{HTTPResponseReplaceBody: spec}, payload("HTTPResponseReplaceBody", map[string]any{
 		"Duration":    duration,
@@ -252,7 +258,7 @@ func buildHTTPResponsePatchBody(ctx context.Context, cfg GuidedConfig, systemTyp
 		return handler.InjectionConf{}, nil, err
 	}
 
-	spec := &handler.HTTPResponsePatchBodySpec{Duration: duration, System: systemIdx, EndpointIdx: endpointIdx}
+	spec := &handler.HTTPResponsePatchBodySpec{Duration: duration, System: systemIdx, EndpointIdx: endpointIdx, Namespace: cfg.Namespace}
 	return handler.InjectionConf{HTTPResponsePatchBody: spec}, payload("HTTPResponsePatchBody", map[string]any{
 		"Duration":    duration,
 		"System":      systemIdx,
@@ -266,7 +272,7 @@ func buildHTTPRequestReplacePath(ctx context.Context, cfg GuidedConfig, systemTy
 		return handler.InjectionConf{}, nil, err
 	}
 
-	spec := &handler.HTTPRequestReplacePathSpec{Duration: duration, System: systemIdx, EndpointIdx: endpointIdx}
+	spec := &handler.HTTPRequestReplacePathSpec{Duration: duration, System: systemIdx, EndpointIdx: endpointIdx, Namespace: cfg.Namespace}
 	return handler.InjectionConf{HTTPRequestReplacePath: spec}, payload("HTTPRequestReplacePath", map[string]any{
 		"Duration":    duration,
 		"System":      systemIdx,
@@ -294,6 +300,7 @@ func buildHTTPRequestReplaceMethod(ctx context.Context, cfg GuidedConfig, system
 		System:        systemIdx,
 		EndpointIdx:   endpointIdx,
 		ReplaceMethod: methodCode,
+		Namespace:     cfg.Namespace,
 	}
 	return handler.InjectionConf{HTTPRequestReplaceMethod: spec}, payload("HTTPRequestReplaceMethod", map[string]any{
 		"Duration":      duration,
@@ -323,6 +330,7 @@ func buildHTTPResponseReplaceCode(ctx context.Context, cfg GuidedConfig, systemT
 		System:      systemIdx,
 		EndpointIdx: endpointIdx,
 		StatusCode:  handler.HTTPStatusCode(statusCode),
+		Namespace:   cfg.Namespace,
 	}
 	return handler.InjectionConf{HTTPResponseReplaceCode: spec}, payload("HTTPResponseReplaceCode", map[string]any{
 		"Duration":    duration,
@@ -338,7 +346,7 @@ func buildDNSError(ctx context.Context, cfg GuidedConfig, systemType systemconfi
 		return handler.InjectionConf{}, nil, err
 	}
 
-	spec := &handler.DNSErrorSpec{Duration: duration, System: systemIdx, DNSEndpointIdx: dnsIdx}
+	spec := &handler.DNSErrorSpec{Duration: duration, System: systemIdx, DNSEndpointIdx: dnsIdx, Namespace: cfg.Namespace}
 	return handler.InjectionConf{DNSError: spec}, payload("DNSError", map[string]any{
 		"Duration":       duration,
 		"System":         systemIdx,
@@ -352,7 +360,7 @@ func buildDNSRandom(ctx context.Context, cfg GuidedConfig, systemType systemconf
 		return handler.InjectionConf{}, nil, err
 	}
 
-	spec := &handler.DNSRandomSpec{Duration: duration, System: systemIdx, DNSEndpointIdx: dnsIdx}
+	spec := &handler.DNSRandomSpec{Duration: duration, System: systemIdx, DNSEndpointIdx: dnsIdx, Namespace: cfg.Namespace}
 	return handler.InjectionConf{DNSRandom: spec}, payload("DNSRandom", map[string]any{
 		"Duration":       duration,
 		"System":         systemIdx,
@@ -375,6 +383,7 @@ func buildNetworkPartition(ctx context.Context, cfg GuidedConfig, systemType sys
 		System:         systemIdx,
 		NetworkPairIdx: pairIdx,
 		Direction:      direction,
+		Namespace:      cfg.Namespace,
 	}
 	return handler.InjectionConf{NetworkPartition: spec}, payload("NetworkPartition", map[string]any{
 		"Duration":       duration,
@@ -402,6 +411,7 @@ func buildNetworkDelay(ctx context.Context, cfg GuidedConfig, systemType systemc
 		Correlation:    *cfg.Correlation,
 		Jitter:         *cfg.Jitter,
 		Direction:      direction,
+		Namespace:      cfg.Namespace,
 	}
 	return handler.InjectionConf{NetworkDelay: spec}, payload("NetworkDelay", map[string]any{
 		"Duration":       duration,
@@ -430,6 +440,7 @@ func buildNetworkLoss(ctx context.Context, cfg GuidedConfig, systemType systemco
 		Loss:           *cfg.Loss,
 		Correlation:    *cfg.Correlation,
 		Direction:      direction,
+		Namespace:      cfg.Namespace,
 	}
 	return handler.InjectionConf{NetworkLoss: spec}, payload("NetworkLoss", map[string]any{
 		"Duration":       duration,
@@ -458,6 +469,7 @@ func buildNetworkDuplicate(ctx context.Context, cfg GuidedConfig, systemType sys
 		Duplicate:      *cfg.Duplicate,
 		Correlation:    *cfg.Correlation,
 		Direction:      direction,
+		Namespace:      cfg.Namespace,
 	}
 	return handler.InjectionConf{NetworkDuplicate: spec}, payload("NetworkDuplicate", map[string]any{
 		"Duration":       duration,
@@ -486,6 +498,7 @@ func buildNetworkCorrupt(ctx context.Context, cfg GuidedConfig, systemType syste
 		Corrupt:        *cfg.Corrupt,
 		Correlation:    *cfg.Correlation,
 		Direction:      direction,
+		Namespace:      cfg.Namespace,
 	}
 	return handler.InjectionConf{NetworkCorrupt: spec}, payload("NetworkCorrupt", map[string]any{
 		"Duration":       duration,
@@ -515,6 +528,7 @@ func buildNetworkBandwidth(ctx context.Context, cfg GuidedConfig, systemType sys
 		Limit:          *cfg.Limit,
 		Buffer:         *cfg.Buffer,
 		Direction:      direction,
+		Namespace:      cfg.Namespace,
 	}
 	return handler.InjectionConf{NetworkBandwidth: spec}, payload("NetworkBandwidth", map[string]any{
 		"Duration":       duration,
@@ -542,6 +556,7 @@ func buildJVMLatency(ctx context.Context, cfg GuidedConfig, systemType systemcon
 		System:          systemIdx,
 		MethodIdx:       methodIdx,
 		LatencyDuration: *cfg.LatencyDuration,
+		Namespace:       cfg.Namespace,
 	}
 	return handler.InjectionConf{JVMLatency: spec}, payload("JVMLatency", map[string]any{
 		"Duration":        duration,
@@ -576,6 +591,7 @@ func buildJVMReturn(ctx context.Context, cfg GuidedConfig, systemType systemconf
 		MethodIdx:      methodIdx,
 		ReturnType:     handler.JVMReturnType(returnType),
 		ReturnValueOpt: returnValueOpt,
+		Namespace:      cfg.Namespace,
 	}
 	return handler.InjectionConf{JVMReturn: spec}, payload("JVMReturn", map[string]any{
 		"Duration":       duration,
@@ -606,6 +622,7 @@ func buildJVMException(ctx context.Context, cfg GuidedConfig, systemType systemc
 		System:       systemIdx,
 		MethodIdx:    methodIdx,
 		ExceptionOpt: exceptionOpt,
+		Namespace:    cfg.Namespace,
 	}
 	return handler.InjectionConf{JVMException: spec}, payload("JVMException", map[string]any{
 		"Duration":     duration,
@@ -629,6 +646,7 @@ func buildJVMCPUStress(ctx context.Context, cfg GuidedConfig, systemType systemc
 		System:    systemIdx,
 		MethodIdx: methodIdx,
 		CPUCount:  *cfg.CPUCount,
+		Namespace: cfg.Namespace,
 	}
 	return handler.InjectionConf{JVMCPUStress: spec}, payload("JVMCPUStress", map[string]any{
 		"Duration":  duration,
@@ -658,6 +676,7 @@ func buildJVMMemoryStress(ctx context.Context, cfg GuidedConfig, systemType syst
 		System:    systemIdx,
 		MethodIdx: methodIdx,
 		MemType:   handler.JVMMemoryType(memType),
+		Namespace: cfg.Namespace,
 	}
 	return handler.InjectionConf{JVMMemoryStress: spec}, payload("JVMMemoryStress", map[string]any{
 		"Duration":  duration,
@@ -682,6 +701,7 @@ func buildJVMMySQLLatency(ctx context.Context, cfg GuidedConfig, systemType syst
 		System:      systemIdx,
 		DatabaseIdx: databaseIdx,
 		LatencyMs:   *cfg.LatencyMs,
+		Namespace:   cfg.Namespace,
 	}
 	return handler.InjectionConf{JVMMySQLLatency: spec}, payload("JVMMySQLLatency", map[string]any{
 		"Duration":    duration,
@@ -701,6 +721,7 @@ func buildJVMMySQLException(ctx context.Context, cfg GuidedConfig, systemType sy
 		Duration:    duration,
 		System:      systemIdx,
 		DatabaseIdx: databaseIdx,
+		Namespace:   cfg.Namespace,
 	}
 	return handler.InjectionConf{JVMMySQLException: spec}, payload("JVMMySQLException", map[string]any{
 		"Duration":    duration,
@@ -719,7 +740,7 @@ func buildJVMRuntimeMutator(ctx context.Context, cfg GuidedConfig, systemType sy
 		return handler.InjectionConf{}, nil, err
 	}
 
-	spec := &handler.JVMRuntimeMutatorSpec{Duration: duration, System: systemIdx, MutatorTargetIdx: targetIdx}
+	spec := &handler.JVMRuntimeMutatorSpec{Duration: duration, System: systemIdx, MutatorTargetIdx: targetIdx, Namespace: cfg.Namespace}
 	return handler.InjectionConf{JVMRuntimeMutator: spec}, payload("JVMRuntimeMutator", map[string]any{
 		"Duration":         duration,
 		"System":           systemIdx,


### PR DESCRIPTION
## Summary
- Every `*Spec.GetGroundtruth()` in `chaos-experiment/handler/groundtruth.go` was calling `systemconfig.GetNamespaceByIndex(system, defaultStartIndex)`, hardcoding the first namespace from the system pool (e.g. `hs0`) instead of using the operator-provided namespace.
- Live evidence: guided submits with `--namespace hsN` (N>0) returned 500 from the backend with `no containers found for system X in namespace hs0` whenever `hs0` was empty/torn-down, even though pods existed under `hsN`.
- Fix: each Spec struct now carries an optional `Namespace string`, populated from `cfg.Namespace` by the guidedcli builders. `GetGroundtruth` resolves it via a single helper, falling back to the system pool head when unset so legacy callers / older JSON payloads keep working unchanged.
- Action-space reflection paths (`StructToNode`, `parseInjection`, `GetDisplayConfig`) now skip non-numeric fields so the new `Namespace` string doesn't pollute the index/range machinery they were built for.

## Test plan
- [x] `cd chaos-experiment && go build ./...`
- [x] `cd chaos-experiment && go test ./handler/... ./pkg/guidedcli/...` (only pre-existing flaky/cluster-dependent failures: `TestGenerateRandomAction`, `TestGetAppLabelByIndexUsesInjectableOrdering`, `TestHandler2`, `TestValidate` -- all reproduce on `main`)
- [x] `cd AegisLab/src && go build -tags duckdb_arrow -o /dev/null ./main.go`
- [x] `cd AegisLab/src && go test -tags duckdb_arrow ./module/injection/...`
- [x] New regression: `TestResolveSpecNamespace_PrefersSpecNamespace` proves a spec with `Namespace: "hs28"` resolves to `hs28`, not `hs0`. Companion test asserts the empty-namespace fallback still hits the pool head.
- [ ] Re-run the failing guided submit (`aegisctl inject ... --namespace hs28`) end-to-end on a cluster where `hs0` is absent.