### PR TITLE
chore(byte-cluster): bump rcabench image tag to byte-20260501-groundtruth-fix

### DIFF
--- a/AegisLab/manifests/byte-cluster/rcabench.values.yaml
+++ b/AegisLab/manifests/byte-cluster/rcabench.values.yaml
@@ -4,7 +4,7 @@ global:
 images:
   rcabench:
     name: pair-cn-shanghai.cr.volces.com/opspai/rcabench
-    tag: byte-20260501-duration-fix
+    tag: byte-20260501-groundtruth-fix
     pullPolicy: IfNotPresent
   jaeger:
     name: pair-diag-cn-guangzhou.cr.volces.com/pair/jaeger


### PR DESCRIPTION
## Why

Picks up #333 (groundtruth uses spec.Namespace + FI-time re-capture so GT.Pod stays accurate after RestartPedestal pod rename, plus the parseInjection / buildNode / isNonActionField review fixes from the same PR).

## Image already published

Built + pushed to `docker.io/opspai/rcabench:byte-20260501-groundtruth-fix` from main HEAD (5b49ba7).

## Test plan

- [ ] helm upgrade rolls api-gateway + runtime-worker to new image
- [ ] CLI guided submit returns trace_id (no Interval/PreDuration 400; no fallback to hs0 GT)
- [ ] After RP pod rename, injection row's GT.Pod reflects the post-rename name