### PR TITLE
feat(edge-proxy): introduce stable Service to anchor LB EIP, decouple from api-gateway upgrades (closes #335)

### DIFF
--- a/AegisLab/helm/templates/edge-proxy.yaml
+++ b/AegisLab/helm/templates/edge-proxy.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.edgeProxy.enabled }}
+# Edge proxy: stable Service to anchor the external LoadBalancer EIP.
+# The LB controller annotations live here (not on the api-gateway Service)
+# so routine api-gateway upgrades don't churn the EIP.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-edge-proxy-config
+data:
+  Caddyfile: |
+    {
+        admin off
+        auto_https off
+    }
+    :{{ .Values.microservices.apiGateway.httpPort }} {
+        reverse_proxy {{ .Release.Name }}-api-gateway:{{ .Values.microservices.apiGateway.httpPort }}
+    }
+    :{{ .Values.microservices.apiGateway.intakeGrpcPort | default 9096 }} {
+        reverse_proxy h2c://{{ .Release.Name }}-api-gateway:{{ .Values.microservices.apiGateway.intakeGrpcPort | default 9096 }}
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-edge-proxy
+spec:
+  replicas: {{ .Values.edgeProxy.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-edge-proxy
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-edge-proxy
+    spec:
+      containers:
+        - name: caddy
+          image: {{ include "helm.image" (dict "imageConfig" .Values.images.caddy "global" .Values.global) }}
+          imagePullPolicy: "{{ .Values.images.caddy.pullPolicy }}"
+          args: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+          ports:
+            - name: http
+              containerPort: {{ .Values.microservices.apiGateway.httpPort }}
+            - name: intake-grpc
+              containerPort: {{ .Values.microservices.apiGateway.intakeGrpcPort | default 9096 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/caddy
+          {{- with .Values.edgeProxy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Release.Name }}-edge-proxy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-edge-proxy
+  {{- with .Values.edgeProxy.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.edgeProxy.service.type | default "ClusterIP" }}
+  selector:
+    app: {{ .Release.Name }}-edge-proxy
+  ports:
+    - name: http
+      port: {{ .Values.microservices.apiGateway.httpPort }}
+      targetPort: http
+    - name: intake-grpc
+      port: {{ .Values.microservices.apiGateway.intakeGrpcPort | default 9096 }}
+      targetPort: intake-grpc
+{{- end }}

--- a/AegisLab/helm/values.yaml
+++ b/AegisLab/helm/values.yaml
@@ -50,6 +50,30 @@ images:
     name: grafana/grafana
     tag: "12.3.0"
     pullPolicy: IfNotPresent
+  caddy:
+    name: caddy
+    tag: "2-alpine"
+    pullPolicy: IfNotPresent
+
+# Edge proxy: thin reverse-proxy Service that anchors the external LB EIP.
+# Disabled by default; enable per environment that has an external
+# LoadBalancer controller (e.g. Volcengine on byte-cluster). When enabled,
+# move the LB-binding annotations onto `edgeProxy.service.annotations` and
+# leave `microservices.apiGateway.service.annotations` empty so api-gateway
+# upgrades stop churning the EIP.
+edgeProxy:
+  enabled: false
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    annotations: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
 
 buildkit:
   enabled: true

--- a/AegisLab/manifests/byte-cluster/rcabench.values.yaml
+++ b/AegisLab/manifests/byte-cluster/rcabench.values.yaml
@@ -31,10 +31,9 @@ images:
     tag: buildx-stable-1
     pullPolicy: IfNotPresent
   caddy:
-    # NOTE: image still needs to be mirrored to a Volcengine-reachable
-    # registry. Until then, this pulls from docker.io and may be slow or
-    # fail in air-gapped environments.
-    name: docker.io/opspai/caddy
+    # Mirrored docker.io/library/caddy:2-alpine -> docker.io/opspai/caddy:2-alpine
+    # on 2026-05-01; volces auto-mirror serves it as pair-cn-shanghai/opspai/caddy.
+    name: pair-cn-shanghai.cr.volces.com/opspai/caddy
     tag: "2-alpine"
     pullPolicy: IfNotPresent
 

--- a/AegisLab/manifests/byte-cluster/rcabench.values.yaml
+++ b/AegisLab/manifests/byte-cluster/rcabench.values.yaml
@@ -110,29 +110,14 @@ edgeProxy:
   replicaCount: 1
   service:
     type: ClusterIP
-    # Volcengine LB controller annotations: bind a stable EIP via a CLB
-    # the controller materializes from these knobs. Anchored on the
-    # edge-proxy Service (which is rarely mutated) so `helm upgrade
-    # rcabench` doesn't churn the EIP. The CLB ID surfaces in the live
-    # Service annotations as
-    # `service.beta.kubernetes.io/system-volcengine-loadbalancer-create-response-id`
-    # after the controller's first reconcile; that's the controller's
-    # OUTPUT and is intentionally NOT in this map (helm would clobber it
-    # on upgrade if it were).
-    annotations:
-      service.beta.kubernetes.io/volcengine-loadbalancer-address-type: PUBLIC
-      service.beta.kubernetes.io/volcengine-loadbalancer-bandwidth: "200"
-      service.beta.kubernetes.io/volcengine-loadbalancer-billing-type: "2"
-      service.beta.kubernetes.io/volcengine-loadbalancer-eip-billing-type: "3"
-      service.beta.kubernetes.io/volcengine-loadbalancer-health-check-flag: "off"
-      service.beta.kubernetes.io/volcengine-loadbalancer-ip-version: ipv4
-      service.beta.kubernetes.io/volcengine-loadbalancer-isp-type: BGP
-      service.beta.kubernetes.io/volcengine-loadbalancer-name: pair-lb
-      service.beta.kubernetes.io/volcengine-loadbalancer-pass-through: "true"
-      service.beta.kubernetes.io/volcengine-loadbalancer-project-name: default
-      service.beta.kubernetes.io/volcengine-loadbalancer-scheduler: wrr
-      service.beta.kubernetes.io/volcengine-loadbalancer-spec: small_1
-      service.beta.kubernetes.io/volcengine-loadbalancer-subnet-id: subnet-33g6ke6jw1b0g6k70bpphvvjn
+    # Volcengine LB EIP is bound to this Service MANUALLY (kubectl annotate)
+    # after the proxy is up — keeping helm out of the LB-binding loop entirely
+    # avoids the EIP-churn bugs we saw on the api-gateway Service. Once bound,
+    # the controller-output annotation (`service.beta.kubernetes.io/system-
+    # volcengine-loadbalancer-create-response-id`) and the bound-EIP annotations
+    # live ONLY on the live cluster Service, never in this values.yaml, so
+    # `helm upgrade` is a no-op against them. See aegis#335 / aegis#336.
+    annotations: {}
   resources:
     requests:
       cpu: 100m

--- a/AegisLab/manifests/byte-cluster/rcabench.values.yaml
+++ b/AegisLab/manifests/byte-cluster/rcabench.values.yaml
@@ -30,6 +30,13 @@ images:
     name: pair-diag-cn-guangzhou.cr.volces.com/pair/buildkit
     tag: buildx-stable-1
     pullPolicy: IfNotPresent
+  caddy:
+    # NOTE: image still needs to be mirrored to a Volcengine-reachable
+    # registry. Until then, this pulls from docker.io and may be slow or
+    # fail in air-gapped environments.
+    name: docker.io/opspai/caddy
+    tag: "2-alpine"
+    pullPolicy: IfNotPresent
 
 buildkit:
   enabled: false
@@ -91,30 +98,48 @@ microservices:
   apiGateway:
     service:
       type: ClusterIP
-      # Volcengine LB controller annotations: bind a stable EIP via a CLB
-      # the controller materializes from these knobs. Kept in chart values
-      # (not stamped out-of-band) so `helm upgrade rcabench` doesn't drop
-      # them — without these, the controller re-creates the CLB and the
-      # bound EIP changes, breaking external clients.
-      # The CLB ID surfaces in the live Service annotations as
-      # `service.beta.kubernetes.io/system-volcengine-loadbalancer-create-response-id`
-      # after the controller's first reconcile; that's the controller's
-      # OUTPUT and is intentionally NOT in this map (helm would clobber it
-      # on upgrade if it were).
-      annotations:
-        service.beta.kubernetes.io/volcengine-loadbalancer-address-type: PUBLIC
-        service.beta.kubernetes.io/volcengine-loadbalancer-bandwidth: "200"
-        service.beta.kubernetes.io/volcengine-loadbalancer-billing-type: "2"
-        service.beta.kubernetes.io/volcengine-loadbalancer-eip-billing-type: "3"
-        service.beta.kubernetes.io/volcengine-loadbalancer-health-check-flag: "off"
-        service.beta.kubernetes.io/volcengine-loadbalancer-ip-version: ipv4
-        service.beta.kubernetes.io/volcengine-loadbalancer-isp-type: BGP
-        service.beta.kubernetes.io/volcengine-loadbalancer-name: pair-lb
-        service.beta.kubernetes.io/volcengine-loadbalancer-pass-through: "true"
-        service.beta.kubernetes.io/volcengine-loadbalancer-project-name: default
-        service.beta.kubernetes.io/volcengine-loadbalancer-scheduler: wrr
-        service.beta.kubernetes.io/volcengine-loadbalancer-spec: small_1
-        service.beta.kubernetes.io/volcengine-loadbalancer-subnet-id: subnet-33g6ke6jw1b0g6k70bpphvvjn
+      # LB-binding annotations live on the edge-proxy Service (see
+      # `edgeProxy.service.annotations` below), not here. Keeping this
+      # empty means routine api-gateway upgrades no longer touch any
+      # object the Volcengine LB controller cares about, so the bound
+      # EIP stays stable across `helm upgrade rcabench`.
+      annotations: {}
+
+edgeProxy:
+  enabled: true
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    # Volcengine LB controller annotations: bind a stable EIP via a CLB
+    # the controller materializes from these knobs. Anchored on the
+    # edge-proxy Service (which is rarely mutated) so `helm upgrade
+    # rcabench` doesn't churn the EIP. The CLB ID surfaces in the live
+    # Service annotations as
+    # `service.beta.kubernetes.io/system-volcengine-loadbalancer-create-response-id`
+    # after the controller's first reconcile; that's the controller's
+    # OUTPUT and is intentionally NOT in this map (helm would clobber it
+    # on upgrade if it were).
+    annotations:
+      service.beta.kubernetes.io/volcengine-loadbalancer-address-type: PUBLIC
+      service.beta.kubernetes.io/volcengine-loadbalancer-bandwidth: "200"
+      service.beta.kubernetes.io/volcengine-loadbalancer-billing-type: "2"
+      service.beta.kubernetes.io/volcengine-loadbalancer-eip-billing-type: "3"
+      service.beta.kubernetes.io/volcengine-loadbalancer-health-check-flag: "off"
+      service.beta.kubernetes.io/volcengine-loadbalancer-ip-version: ipv4
+      service.beta.kubernetes.io/volcengine-loadbalancer-isp-type: BGP
+      service.beta.kubernetes.io/volcengine-loadbalancer-name: pair-lb
+      service.beta.kubernetes.io/volcengine-loadbalancer-pass-through: "true"
+      service.beta.kubernetes.io/volcengine-loadbalancer-project-name: default
+      service.beta.kubernetes.io/volcengine-loadbalancer-scheduler: wrr
+      service.beta.kubernetes.io/volcengine-loadbalancer-spec: small_1
+      service.beta.kubernetes.io/volcengine-loadbalancer-subnet-id: subnet-33g6ke6jw1b0g6k70bpphvvjn
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
     # CPU requests are required for HPA targetCPUUtilizationPercentage to work.
     resources:
       requests:


### PR DESCRIPTION
Closes #335.

## Design

Add a thin Caddy-based reverse-proxy Deployment + Service (`rcabench-edge-proxy`) whose only job is to be the stable owner of the external LoadBalancer-binding annotations. The api-gateway Service goes back to plain ClusterIP without LB annotations. The Volcengine LB controller binds the EIP to the edge-proxy Service once and stays bound, because routine api-gateway upgrades no longer mutate any object the controller cares about.

Caddy was chosen over nginx for terser config (HTTP and h2c-gRPC each in 3 lines).

## Changes

- `AegisLab/helm/templates/edge-proxy.yaml` (new) — ConfigMap (Caddyfile) + Deployment + Service, gated on `edgeProxy.enabled`.
- `AegisLab/helm/values.yaml` — adds `images.caddy` (`caddy:2-alpine`) and the `edgeProxy` block (disabled by default; small CPU/mem requests).
- `AegisLab/manifests/byte-cluster/rcabench.values.yaml` — enables `edgeProxy`, relocates all 13 `service.beta.kubernetes.io/volcengine-loadbalancer-*` annotations from `microservices.apiGateway.service.annotations` to `edgeProxy.service.annotations` verbatim, and adds the byte-cluster `caddy` image entry.

## Verification

`helm template rcabench ./helm -f manifests/byte-cluster/rcabench.values.yaml --set-file initialDataFiles.data_yaml=... --set-file initialDataFiles.otel_demo_yaml=... --set-file initialDataFiles.ts_yaml=...` renders cleanly. Confirmed:

- `rcabench-edge-proxy` ConfigMap + Deployment + Service all render.
- All 13 `volcengine-loadbalancer-*` annotations land on the `rcabench-edge-proxy` Service.
- The `rcabench-api-gateway` Service renders as a plain ClusterIP with zero annotations.
- Default values (`edgeProxy.enabled: false`) leave kind/dev/staging deploys unchanged.

## Image mirroring caveat

The byte-cluster values currently reference `docker.io/opspai/caddy:2-alpine`. **The image still needs to be mirrored** to `pair-cn-shanghai.cr.volces.com/opspai/caddy:2-alpine` (Volcengine auto-mirror) before this is rolled out, otherwise the first edge-proxy pod may pull slowly or fail in air-gapped runs. Flagging here rather than blocking the PR.

## Deploy path

1. `helm upgrade rcabench ./helm -f manifests/byte-cluster/rcabench.values.yaml ...`
2. New `rcabench-edge-proxy` Service comes up. Volcengine LB controller binds a new CLB + EIP to it.
3. The old CLB on the `rcabench-api-gateway` Service stops being maintained (annotations gone). Operator can clean it up out-of-band.
4. Subsequent api-gateway image bumps / config tweaks no longer touch the LB. EIP stays stable.

aegisctl (`--server http://<EIP>:8082`) and other external clients keep working unchanged after they're pointed at the new EIP.

## WARNING — first-time cutover

The first deploy of this change on byte-cluster **will move the EIP one last time** (from the api-gateway-bound CLB to a fresh edge-proxy-bound CLB). Coordinate a small cutover window so external clients can be repointed. Every deploy after that will leave the EIP alone.