### PR TITLE
chore(byte-cluster/seed): bump ts 1.0.5 → 1.0.6 to pick up trainticket chart 0.2.1 (closes #332 followup)

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -78,11 +78,20 @@ containers:
       # dockerhub (volces auto-mirrors docker.io/opspai/* to the pair-cn-
       # shanghai path), then pinned the new mirror paths via the four extra
       # helm values below.
-      - name: 1.0.5
+      #
+      # Bumped 1.0.5 → 1.0.6 to pick up trainticket chart 0.2.1
+      # (OperationsPAI/train-ticket#23) which honors `services.<svc>.type=
+      # ClusterIP` overrides by skipping the `nodePort:` field. Without it,
+      # our `services.tsUiDashboard.type=ClusterIP` seed override (#332) was
+      # silently broken — chart 0.2.0 still emitted nodePort:30080, k8s
+      # rejected the Service, ts-ui-dashboard never came up. Reseed honors
+      # the immutability contract on existing 1.0.5; new container_versions
+      # row picks up chart 0.2.1.
+      - name: 1.0.6
         github_link: OperationsPAI/train-ticket
         status: 1
         helm_config:
-          version: 0.2.0
+          version: 0.2.1
           chart_name: trainticket
           repo_name: train-ticket
           repo_url: https://operationspai.github.io/train-ticket


### PR DESCRIPTION
## Why

OperationsPAI/train-ticket#23 (merged today) makes the chart honor `services.<svc>.type=ClusterIP` by skipping the `nodePort:` field that k8s would otherwise reject.

Without that chart fix, our `services.tsUiDashboard.type=ClusterIP` seed override from PR #332 was a no-op — chart 0.2.0 still emitted `nodePort: 30080`, k8s rejected the Service, **ts-ui-dashboard never came up** on freshly-installed ts namespaces (verified live today on ts1/ts2/ts3).

## Diff

Single-line: ts pedestal_version 1.0.5 → 1.0.6, helm_config.version 0.2.0 → 0.2.1.

## Reseed plan

1. `aegisctl system reseed --apply` — creates a 1.0.6 `container_versions` row pinned to chart 0.2.1.
2. `helm uninstall tsN -n tsN && kubectl delete ns tsN` for each existing ts ns (their existing helm release is on chart 0.2.0 and `helm upgrade --reuse-values` won't re-render the broken nodePort field).
3. Restart ts loop — backend RP on fresh slots will install chart 0.2.1.

## Test plan

- [ ] reseed shows `new helm_config for new version` for ts@1.0.6
- [ ] After ts ns recreated, `kubectl -n tsN get svc ts-ui-dashboard` returns a ClusterIP Service (not NotFound)
- [ ] No nodePort allocation on tsN ts-ui-dashboard Service