### PR TITLE
fix(detector): pass pedestal name as --system to algo job (default-ts hardcode silently failed all non-ts runs)

### DIFF
--- a/AegisLab/src/dto/injection.go
+++ b/AegisLab/src/dto/injection.go
@@ -13,6 +13,10 @@ type InjectionItem struct {
 	PreDuration int       `json:"pre_duration"`
 	StartTime   time.Time `json:"start_time,omitempty"`
 	EndTime     time.Time `json:"end_time,omitempty"`
+	// Pedestal is the benchmark system code (e.g. "ts", "hs", "otel-demo") that
+	// produced this datapack. Empty when the FaultInjection has no pedestal
+	// association (manual uploads) or when the pedestal relation was not preloaded.
+	Pedestal string `json:"pedestal,omitempty"`
 }
 
 func NewInjectionItem(injection *model.FaultInjection) InjectionItem {
@@ -27,6 +31,9 @@ func NewInjectionItem(injection *model.FaultInjection) InjectionItem {
 	}
 	if injection.EndTime != nil {
 		item.EndTime = *injection.EndTime
+	}
+	if injection.Pedestal != nil && injection.Pedestal.Container != nil {
+		item.Pedestal = injection.Pedestal.Container.Name
 	}
 
 	return item

--- a/AegisLab/src/module/dataset/repository.go
+++ b/AegisLab/src/module/dataset/repository.go
@@ -381,7 +381,7 @@ func (r *Repository) clearDatasetVersionInjections(datasetVersionIDs []int, inje
 }
 
 func (r *Repository) ListInjectionsByDatasetVersionID(versionID int, includeLabels bool) ([]model.FaultInjection, error) {
-	query := r.db.Model(&model.FaultInjection{})
+	query := r.db.Model(&model.FaultInjection{}).Preload("Pedestal.Container")
 	if includeLabels {
 		query = query.Preload("Labels")
 	}

--- a/AegisLab/src/module/injection/repository.go
+++ b/AegisLab/src/module/injection/repository.go
@@ -36,7 +36,7 @@ func (r *Repository) loadInjection(id int) (*model.FaultInjection, error) {
 }
 
 func (r *Repository) findInjectionByName(name string, preload bool) (*model.FaultInjection, error) {
-	query := r.db
+	query := r.db.Preload("Pedestal.Container")
 	if preload {
 		query = query.Preload("Labels")
 	}

--- a/AegisLab/src/service/consumer/algo_execution.go
+++ b/AegisLab/src/service/consumer/algo_execution.go
@@ -315,6 +315,14 @@ func getAlgoJobEnvVars(taskID string, executionID int, datapackPathPrefix, expPa
 		{Name: "EXECUTION_ID", Value: strconv.Itoa(executionID)},
 	}
 
+	// BENCHMARK_SYSTEM is consumed by the detector entrypoint to choose the
+	// pedestal-specific entrance service. Without this, the detector silently
+	// defaults to "ts" and fails on every non-train-ticket datapack with
+	// "No entrance traffic found in normal or abnormal trace data".
+	if payload.datapack.Pedestal != "" {
+		jobEnvVars = append(jobEnvVars, corev1.EnvVar{Name: "BENCHMARK_SYSTEM", Value: payload.datapack.Pedestal})
+	}
+
 	envNameIndexMap := make(map[string]int, len(jobEnvVars))
 	for index, jobEnvVar := range jobEnvVars {
 		envNameIndexMap[jobEnvVar.Name] = index

--- a/AegisLab/src/service/consumer/algo_execution_test.go
+++ b/AegisLab/src/service/consumer/algo_execution_test.go
@@ -1,0 +1,70 @@
+package consumer
+
+import (
+	"testing"
+	"time"
+
+	"aegis/dto"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetAlgoJobEnvVars_PassesPedestalAsBenchmarkSystem locks in the contract
+// that the algo Job receives BENCHMARK_SYSTEM=<pedestal> when the datapack
+// has a pedestal. The detector entrypoint reads this env var to pick the
+// pedestal-specific entrance service; if it's missing the detector silently
+// defaults to "ts" and fails every non-train-ticket run with
+// "No entrance traffic found in normal or abnormal trace data".
+func TestGetAlgoJobEnvVars_PassesPedestalAsBenchmarkSystem(t *testing.T) {
+	now := time.Now()
+	payload := &executionPayload{
+		algorithm: dto.ContainerVersionItem{
+			ID:            1,
+			Name:          "1.0.0",
+			ContainerName: "detector",
+		},
+		datapack: dto.InjectionItem{
+			ID:        42,
+			Name:      "batch-hs-001",
+			StartTime: now.Add(-10 * time.Minute),
+			EndTime:   now,
+			Pedestal:  "hs",
+		},
+	}
+
+	envVars, err := getAlgoJobEnvVars("task-1", 7, "/data", "/exp", payload)
+	assert.NoError(t, err)
+
+	got := map[string]string{}
+	for _, e := range envVars {
+		got[e.Name] = e.Value
+	}
+	assert.Equal(t, "hs", got["BENCHMARK_SYSTEM"],
+		"detector job must receive pedestal name as BENCHMARK_SYSTEM; missing/wrong value silently mis-routes non-ts datapacks")
+}
+
+// TestGetAlgoJobEnvVars_OmitsBenchmarkSystemWhenPedestalUnknown verifies that
+// when the datapack has no pedestal association (manual upload), the env var
+// is left unset rather than defaulting to a misleading value. The detector
+// entrypoint will then fail-fast with a clear error instead of silently
+// running against the wrong pedestal.
+func TestGetAlgoJobEnvVars_OmitsBenchmarkSystemWhenPedestalUnknown(t *testing.T) {
+	now := time.Now()
+	payload := &executionPayload{
+		algorithm: dto.ContainerVersionItem{ID: 1, Name: "1.0.0", ContainerName: "detector"},
+		datapack: dto.InjectionItem{
+			ID:        99,
+			Name:      "manual-upload-1",
+			StartTime: now.Add(-1 * time.Minute),
+			EndTime:   now,
+		},
+	}
+
+	envVars, err := getAlgoJobEnvVars("task-2", 8, "/data", "/exp", payload)
+	assert.NoError(t, err)
+
+	for _, e := range envVars {
+		assert.NotEqual(t, "BENCHMARK_SYSTEM", e.Name,
+			"BENCHMARK_SYSTEM must not be set when pedestal is unknown")
+	}
+}

--- a/rcabench-platform/cli/detector.py
+++ b/rcabench-platform/cli/detector.py
@@ -877,10 +877,23 @@ def platform_convert(
 def run(
     in_p: Path | None = None,
     ou_p: Path | None = None,
-    system: str = "ts",
+    system: str | None = None,
     convert: bool = False,
     online: bool = False,
 ) -> AnalysisResult | None:
+    # Resolve pedestal from --system, then BENCHMARK_SYSTEM env var. Refuse to
+    # silently default to "ts": doing so mis-routes every non-train-ticket
+    # datapack (hs / otel-demo / sn / media / sockshop / teastore) to the
+    # ts-ui-dashboard entrance-service check and emits a misleading
+    # "No entrance traffic found" failure.
+    if system is None:
+        system = os.environ.get("BENCHMARK_SYSTEM") or ""
+    if not system:
+        raise ValueError(
+            "detector run: pedestal system not provided. "
+            "Pass --system <name> or set BENCHMARK_SYSTEM env var "
+            "(e.g. ts, hs, otel-demo)."
+        )
     start_time = datetime.now()
     input_path, output_path = setup_paths_and_validation(in_p, ou_p)
     _, is_valid = valid(input_path)

--- a/rcabench-platform/cli/tests/test_detector_system_required.py
+++ b/rcabench-platform/cli/tests/test_detector_system_required.py
@@ -1,0 +1,57 @@
+"""Regression test: detector `run` must refuse to silently default to system='ts'.
+
+Before this fix, every non-train-ticket datapack (hs, otel-demo, sn, media,
+sockshop, teastore) failed inside the detector with a misleading
+"No entrance traffic found in normal or abnormal trace data" error, because
+the entrypoint shipped with `--system ts` baked in. We now require the
+pedestal to be provided either by `--system` or via the `BENCHMARK_SYSTEM`
+env var, and fail-fast otherwise so the dispatch bug is loud.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BENCHMARK_SYSTEM", raising=False)
+
+
+def _import_run():
+    # Imported lazily so pytest collection does not pull in heavy detector deps
+    # when the suite is run for unrelated reasons.
+    from cli.detector import run  # type: ignore[import-not-found]
+
+    return run
+
+
+def test_run_refuses_to_default_to_ts_when_system_not_provided(tmp_path: Path) -> None:
+    run = _import_run()
+    with pytest.raises(ValueError) as excinfo:
+        run(in_p=tmp_path, ou_p=tmp_path, system=None)
+    msg = str(excinfo.value)
+    assert "BENCHMARK_SYSTEM" in msg or "system" in msg.lower(), msg
+
+
+def test_run_reads_benchmark_system_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Sanity-check the env-var plumbing: BENCHMARK_SYSTEM must reach the run()
+    body. We can't execute the full pipeline (needs parquet inputs), so we just
+    assert the early-validation path no longer raises the missing-system error.
+    A different error from setup_paths_and_validation is acceptable -- it means
+    we passed the system-required gate."""
+    monkeypatch.setenv("BENCHMARK_SYSTEM", "hs")
+    run = _import_run()
+    try:
+        run(in_p=tmp_path, ou_p=tmp_path, system=None)
+    except ValueError as e:
+        assert "BENCHMARK_SYSTEM" not in str(e), (
+            f"system gate still tripped despite BENCHMARK_SYSTEM=hs: {e}"
+        )
+    except Exception:
+        # Any non-ValueError or downstream ValueError is fine -- it means the
+        # system-required gate accepted the env var and execution proceeded.
+        pass

--- a/rcabench-platform/docker/detector/entrypoint.sh
+++ b/rcabench-platform/docker/detector/entrypoint.sh
@@ -1,4 +1,15 @@
 #!/bin/bash -ex
 cd /app
-echo "Running ts-anomaly-detector"
-LOGURU_COLORIZE=0 .venv/bin/python cli/detector.py run --convert --online
+
+if [ -z "${BENCHMARK_SYSTEM:-}" ]; then
+    echo "ERROR: BENCHMARK_SYSTEM env var is not set." >&2
+    echo "The detector cannot infer which pedestal (ts/hs/otel-demo/...) the" >&2
+    echo "datapack came from, and silently defaulting to 'ts' fails on every" >&2
+    echo "non-train-ticket run. The aegis backend must set BENCHMARK_SYSTEM" >&2
+    echo "to the pedestal name when dispatching the detector job." >&2
+    exit 2
+fi
+
+echo "Running anomaly-detector for system=${BENCHMARK_SYSTEM}"
+LOGURU_COLORIZE=0 .venv/bin/python cli/detector.py run \
+    --system "${BENCHMARK_SYSTEM}" --convert --online


### PR DESCRIPTION
## Summary

The detector container entrypoint shipped with `cli/detector.py run --convert --online` -- no `--system` flag -- and the typer command defaulted to `system='ts'`. Every non-train-ticket datapack (hs / otel-demo / sn / media / sockshop / teastore) silently mis-routed through the train-ticket pedestal and failed inside the entrance-service check.

**Live evidence** (byte-cluster, today):

```
Pedestal 'ts' declared entrance_service='ts-ui-dashboard' ...
Available services: ['attractions', 'frontend', 'geo', 'profile',
                     'rate', 'recommendation', 'reservation', 'search', 'user']
ValueError: No entrance traffic found in normal or abnormal trace data
```

43/43 hs algorithm tasks in a 10-minute window in ns `hs38` (datapack `batch-01KQH9V2WGN459JY7J7PJRH24B` and siblings) ended in `state=-1` because of this.

## Fix

- Backend (`consumer/algo_execution.go`): emit `BENCHMARK_SYSTEM=<pedestal>` env var on the algo Job, sourced from `FaultInjection.Pedestal.Container.Name`.
- DTO (`dto/injection.go`): add `Pedestal` field on `InjectionItem` so the value rides with the task payload.
- Repos: preload `Pedestal.Container` on `findInjectionByName` and `ListInjectionsByDatasetVersionID` (both feed `ResolveDatapacks` for `TaskTypeRunAlgorithm`).
- Detector entrypoint (`docker/detector/entrypoint.sh`): require `BENCHMARK_SYSTEM`, pass it as `--system`, fail-fast (exit 2) when unset.
- Detector CLI (`cli/detector.py`): drop the `system: str = "ts"` default; resolve from `--system` then env, raise `ValueError` if neither is set. The silent ts-default was the bug.

## Out of scope

- Detector image rebuild + push (would require docker build / push of `opspai/detector:latest`).
- The hs BD `abnormal_traces.parquet` empty issue is a separate bug being tracked elsewhere.

## Test plan

- [x] `go test -run TestGetAlgoJobEnvVars ./service/consumer/ -v` passes (asserts env var presence + absence-when-no-pedestal)
- [x] `pytest cli/tests/test_detector_system_required.py -v` passes (asserts `run()` refuses to default to `ts`, accepts `BENCHMARK_SYSTEM` env)
- [x] `go build -tags duckdb_arrow ./main.go` clean
- [ ] After image rebuild: re-run a hs algorithm task and confirm detector log shows `system=hs` and entrance-service check resolves to `frontend`.