### PR TITLE
chore(byte-cluster/seed): pin detector image to byte-20260501-system (drop :latest)

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -4,8 +4,15 @@ containers:
     is_public: true
     status: 1
     versions:
-      - name: 1.0.0
-        image_ref: pair-cn-shanghai.cr.volces.com/opspai/detector:latest
+      # Bumped 1.0.0 → 1.0.1 to pin a specific image tag (was floating on
+      # `:latest`). Tag `byte-20260501-system` ships #339: backend now sets
+      # BENCHMARK_SYSTEM env when dispatching the detector job, the
+      # entrypoint requires it and passes `--system $BENCHMARK_SYSTEM`,
+      # and the Python entrypoint refuses to default to `ts`. Without this
+      # combo, every non-ts datapack silently failed at "No entrance traffic"
+      # because the detector looked for ts-ui-dashboard everywhere.
+      - name: 1.0.1
+        image_ref: pair-cn-shanghai.cr.volces.com/opspai/detector:byte-20260501-system
         command: bash /entrypoint.sh
   - type: 0
     name: random


### PR DESCRIPTION
## Why

1. `:latest` is a moving target — every detector image rebuild flips the deployed version with no git audit trail.
2. The newly-pinned tag `byte-20260501-system` is the **first image** that ships the #339 fix (BENCHMARK_SYSTEM env-driven `--system` flag, entrypoint requires it, Python default removed). Without this seed bump, the deployed detector keeps running old `:latest` and defaults to `system=ts`, silently failing every hs/otel-demo/sn/media datapack at `No entrance traffic found`.

## Diff

Single line: detector pedestal 1.0.0 → 1.0.1 + image_ref pinned.

## Reseed plan

1. `aegisctl system reseed --apply` → creates 1.0.1 container_versions row
2. Backend RP picks up the new image on next algo task dispatch (no helm upgrade needed; detector is a per-task k8s Job)

## Followup

Lines 16/24/32/252 still use `:latest` for `random`, `traceback`, `clickhouse_dataset` (×2). Will pin per-image as rebuilds land — out of scope here.

## Test plan

- [ ] reseed shows `new version from data.yaml` for detector@1.0.1
- [ ] Next hs algo task pod ENV: `BENCHMARK_SYSTEM=hs`, log shows `Running anomaly-detector for system=hs`
- [ ] hs detector tasks complete without `No entrance traffic` error