### PR TITLE
chore(byte-cluster): bump rcabench image tag to byte-20260501-system

### DIFF
--- a/AegisLab/manifests/byte-cluster/rcabench.values.yaml
+++ b/AegisLab/manifests/byte-cluster/rcabench.values.yaml
@@ -4,7 +4,7 @@ global:
 images:
   rcabench:
     name: pair-cn-shanghai.cr.volces.com/opspai/rcabench
-    tag: byte-20260501-groundtruth-fix
+    tag: byte-20260501-system
     pullPolicy: IfNotPresent
   jaeger:
     name: pair-diag-cn-guangzhou.cr.volces.com/pair/jaeger


### PR DESCRIPTION
## Why

Picks up #339: backend now sets `BENCHMARK_SYSTEM` env when dispatching the detector k8s Job. Paired with the detector image bump in #340, this lets the entrypoint pass `--system $pedestal` instead of silently defaulting to `ts`.

**Without this backend bump**, even with the new detector image deployed, `BENCHMARK_SYSTEM` won't be on the Job spec and the entrypoint exits 2.

## Image already published

Built + pushed to `docker.io/opspai/rcabench:byte-20260501-system` from main HEAD (`be15481`).

## Test plan

- [ ] helm upgrade rolls api-gateway + runtime-worker to new image
- [ ] Next algo task pod ENV includes `BENCHMARK_SYSTEM=<pedestal>`
- [ ] hs/otel-demo algo tasks complete (verify with #340 detector seed merged + reseed)