### PR TITLE
fix(byte-cluster/ts.yaml): drop redundant image overrides — seed handles them, registry composed wrong

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/ts.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/ts.yaml
@@ -1,22 +1,15 @@
 global:
+  # Tag for ts-* service images. Seed only overrides global.image.repository
+  # (pair-cn-shanghai mirror), not the tag, so v1.2.9 lives here.
   image:
-    repository: pair-diag-cn-guangzhou.cr.volces.com/pair
     tag: "v1.2.9"
   security:
     allowInsecureImages: true
 
-mysql:
-  image:
-    repository: pair-diag-cn-guangzhou.cr.volces.com/pair/mysql
-
-rabbitmq:
-  image:
-    registry: pair-diag-cn-guangzhou.cr.volces.com/pair
-    repository: rabbitmq
-
-loadgenerator:
-  image:
-    repository: pair-diag-cn-guangzhou.cr.volces.com/pair/loadgenerator
-    tag: "023"
-  initContainer:
-    image: pair-diag-cn-guangzhou.cr.volces.com/pair/netshoot:v0.14
+# NOTE: mysql / rabbitmq / loadgenerator image overrides removed — they're now
+# in data.yaml's ts@1.0.6 helm_config.values (#326). Keeping them here was
+# DOUBLE-SETTING the values: seed overrode `repository`, but the legacy
+# `rabbitmq.image.registry: pair-diag.../pair` in this file silently composed
+# with seed's repository to produce the broken
+# `pair-diag/pair/pair-cn-shanghai/opspai/rabbitmq` ImagePullBackOff on every
+# new ts ns.


### PR DESCRIPTION
## Bug

ts8 (and presumably every newly allocated ts ns since #326 reseed) had \`rabbitmq-0\` stuck in ImagePullBackOff with image:

\`pair-diag-cn-guangzhou.cr.volces.com/pair/pair-cn-shanghai.cr.volces.com/opspai/rabbitmq:4.0.7-debian-12-r0\`

That's two registry prefixes spliced together. ts8 readiness then blocked at the 25-min warming timeout, which jammed the runtime-worker queue and stranded 8 pending algo task dispatches.

## Root cause

The byte-cluster \`ts.yaml\` overlay (used by backend RP via \`--set-file initialDataFiles.ts_yaml\`) carried legacy mysql / rabbitmq / loadgenerator image blocks from the pre-seed era. Since #326 the seed (data.yaml's \`ts@1.0.5/1.0.6\` \`helm_config.values\`) handles them.

For mysql / loadgenerator, "double-setting" the same key was harmless — seed wins, repository is a single field. But for **rabbitmq**, the Bitnami subchart composes \`<registry>/<repository>\`. Seed only overrode \`image.repository\`; the legacy \`image.registry: pair-diag-cn-guangzhou.cr.volces.com/pair\` stayed and got prepended.

## Fix

Drop the mysql / rabbitmq / loadgenerator blocks from \`ts.yaml\`. Keep \`global.image.tag: v1.2.9\` (seed doesn't set tag) and \`global.security.allowInsecureImages: true\` (defensive duplicate).

## Apply plan (post-merge)

1. \`kubectl create cm rcabench-initial-data --from-file=...\` to update the in-cluster CM
2. \`kubectl rollout restart deploy/rcabench-api-gateway\` (re-mount CM)
3. \`helm uninstall + kubectl delete ns\` for every existing ts namespace (their live helm release still has the bad \`rabbitmq.image.registry\` baked in; \`helm upgrade --reuse-values\` won't drop unset keys, only fresh install will)
4. Wait for ts loop to re-allocate ns; verify \`kubectl -n tsN get pods rabbitmq-0 -o jsonpath='{.spec.containers[0].image}'\` is \`pair-cn-shanghai.cr.volces.com/opspai/rabbitmq:4.0.7-debian-12-r0\` (single, clean)

## Test plan

- [ ] CM apply + api-gw restart
- [ ] Fresh ts ns rabbitmq-0 image string has only ONE registry prefix
- [ ] ts ns reaches Ready within 5 min (no 25-min warming timeout)
- [ ] Pending algo task dispatches resume