### PR TITLE
[codex] fix byte-cluster otel-demo seed mirror overrides

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -213,13 +213,18 @@ containers:
     is_public: true
     status: 1
     versions:
-      # Bumped 0.1.8 → 0.1.9 to pick up otel-demo-aegis chart 0.1.8 which
-      # mirrors busybox + kafka images via docker.io/opspai/* so the volces
-      # auto-mirror can serve them on byte-cluster nodes that can't reach
-      # docker.io / ghcr.io directly. Without this, every otel-demoN namespace
-      # had wait-for-kafka init containers stuck in ImagePullBackOff and the
-      # kafka pod itself failed to pull, blocking accounting/cart/checkout/
-      # fraud-detection from ever starting.
+      # Bumped 0.1.8 -> 0.1.9 to pick up otel-demo-aegis chart 0.1.8 and to
+      # seed the byte-cluster image-rewrite overrides in DB, not just in the
+      # sidecar values file. Before this fix the live DB only carried
+      # `global.clusterCollector.service`, so RestartPedestal re-installs
+      # merged a stale value_file with almost no helm_config_values and fell
+      # back to bad defaults / dead image refs:
+      #   - app images resolved to pair-diag `pair/open-telemetry-demo:*`,
+      #     but the 2.2.0-* tags are not published there;
+      #   - kafka resolved to docker.io/opspai/otel-demo-kafka:2.2.0, which
+      #     byte-cluster nodes cannot reach directly.
+      # Keep the collector retargeting override, and pin the verified byte-
+      # cluster mirrors for app images, kafka, and the in-namespace collector.
       - name: 0.1.9
         github_link: open-telemetry/opentelemetry-demo
         status: 1
@@ -234,6 +239,102 @@ containers:
               category: 1
               value_type: 0
               default_value: opentelemetry-kube-stack-deployment-otel-demo-collector.monitoring.svc.cluster.local
+              overridable: true
+            - key: opentelemetry-demo.default.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/open-telemetry-demo
+              overridable: true
+            - key: opentelemetry-demo.components.accounting.initContainers[0].image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+              overridable: true
+            - key: opentelemetry-demo.components.cart.initContainers[0].image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+              overridable: true
+            - key: opentelemetry-demo.components.checkout.initContainers[0].image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+              overridable: true
+            - key: opentelemetry-demo.components.fraud-detection.initContainers[0].image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+              overridable: true
+            - key: opentelemetry-demo.components.kafka.imageOverride.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/otel-demo-kafka
+              overridable: true
+            - key: opentelemetry-demo.components.kafka.imageOverride.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "2.2.0"
+              overridable: true
+            - key: opentelemetry-demo.components.flagd.imageOverride.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/flagd
+              overridable: true
+            - key: opentelemetry-demo.components.flagd.imageOverride.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: v0.12.9
+              overridable: true
+            - key: opentelemetry-demo.components.flagd.initContainers[0].image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+              overridable: true
+            - key: opentelemetry-demo.components.postgresql.imageOverride.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/postgres
+              overridable: true
+            - key: opentelemetry-demo.components.postgresql.imageOverride.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "17.6"
+              overridable: true
+            - key: opentelemetry-demo.components.valkey-cart.imageOverride.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/valkey
+              overridable: true
+            - key: opentelemetry-demo.components.valkey-cart.imageOverride.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 9.0.1-alpine3.23
+              overridable: true
+            - key: opentelemetry-demo.opentelemetry-collector.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/otel-demo-opentelemetry-collector-contrib
+              overridable: true
+            - key: opentelemetry-demo.opentelemetry-collector.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "0.135.0"
               overridable: true
           status: 1
   - type: 2

--- a/AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml
@@ -21,23 +21,65 @@ opentelemetry-demo:
     image:
       repository: pair-cn-shanghai.cr.volces.com/opspai/open-telemetry-demo
 
-  # NOTE: `components.{accounting,cart,checkout,fraud-detection,flagd}.initContainers`
-  # are deliberately NOT set here. Chart otel-demo-aegis 0.1.8 already pins
-  # them to docker.io/opspai/busybox:latest (PR benchmark-charts#7). Adding
-  # an override here would silently take precedence and re-introduce the
-  # old broken pair-diag/busybox:1.35 path.
   components:
+    accounting:
+      initContainers:
+        - name: wait-for-kafka
+          image: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+          command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
+
+    cart:
+      initContainers:
+        - name: wait-for-valkey-cart
+          image: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+          command: ["sh", "-c", "until nc -z -v -w30 valkey-cart 6379; do echo waiting for valkey-cart; sleep 2; done;"]
+
+    checkout:
+      initContainers:
+        - name: wait-for-kafka
+          image: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+          command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
+
+    fraud-detection:
+      initContainers:
+        - name: wait-for-kafka
+          image: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+          command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
+
+    kafka:
+      imageOverride:
+        repository: pair-cn-shanghai.cr.volces.com/opspai/otel-demo-kafka
+        tag: "2.2.0"
+      initContainers: []
+
     flagd:
       # flagd main image — chart leaves this at upstream `ghcr.io/open-feature/flagd`.
-      # Mirrored to opspai on 2026-05-01.
+      # Mirrored to opspai on 2026-05-01, and now available via the
+      # pair-cn-shanghai mirror.
       imageOverride:
         repository: pair-cn-shanghai.cr.volces.com/opspai/flagd
+        tag: "v0.12.9"
+      initContainers:
+        - name: init-config
+          image: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+          command: ["sh", "-c", "cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json"]
+          volumeMounts:
+            - mountPath: /config-ro
+              name: config-ro
+            - mountPath: /config-rw
+              name: config-rw
 
     valkey-cart:
       # valkey-cart subchart's main image — chart upstream uses bitnami; we
       # mirror upstream valkey to opspai for byte-cluster reachability.
       imageOverride:
         repository: pair-cn-shanghai.cr.volces.com/opspai/valkey
+        tag: "9.0.1-alpine3.23"
+
+    postgresql:
+      imageOverride:
+        repository: pair-cn-shanghai.cr.volces.com/opspai/postgres
+        tag: "17.6"
 
   opentelemetry-collector:
     image:


### PR DESCRIPTION
## What changed

This updates the byte-cluster `otel-demo` seed data so RestartPedestal installs no longer fall back to broken default image locations.

Specifically:
- add explicit `helm_config.values` overrides for `otel-demo@0.1.9` in `AegisLab/manifests/byte-cluster/initial-data/data.yaml`
- update `AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml` to point app, kafka, busybox init containers, flagd, valkey, postgres, and the in-namespace collector at the Shanghai `opspai` mirror

## Why

On the live byte cluster, `otel-demo` traces were failing in `restart.pedestal` because the DB seed only carried `global.clusterCollector.service` for `otel-demo@0.1.9`.

That left Helm re-installs merging a stale values file with almost no DB-side dynamic overrides, so image resolution fell back to bad defaults:
- app images resolved to `pair-diag-cn-guangzhou.cr.volces.com/pair/open-telemetry-demo:2.2.0-*`, where those tags are not published
- kafka resolved to `docker.io/opspai/otel-demo-kafka:2.2.0`
- postgresql resolved to `postgres:17.6`
- busybox init containers still resolved to non-mirrored refs

The result was widespread `ImagePullBackOff` in `otel-demoN` namespaces and `restart.pedestal.failed` task failures.

## Impact

- future byte-cluster installs will materialize the correct mirrored image refs from seed
- future `otel-demo@0.1.9` reseeds will populate the missing DB-side overrides instead of only the collector endpoint
- this aligns the sidecar values file and DB seed so RestartPedestal uses the same image sources in both paths

## Validation

- validated YAML parses for both modified files
- verified the missing upstream-default images exist after pushing them to `docker.io/opspai/*` and waiting for the Shanghai mirror:
  - `opspai/flagd:v0.12.9`
  - `opspai/valkey:9.0.1-alpine3.23`
  - `opspai/postgres:17.6`
- applied the same seed fix on the live cluster and confirmed `aegisctl pedestal helm reseed --container-version-id 147 --apply` inserted the expected DB overrides for `otel-demo@0.1.9`
