### PR TITLE
fix(byte-cluster): align ts rabbitmq seed with mirrored images

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -213,13 +213,18 @@ containers:
     is_public: true
     status: 1
     versions:
-      # Bumped 0.1.8 → 0.1.9 to pick up otel-demo-aegis chart 0.1.8 which
-      # mirrors busybox + kafka images via docker.io/opspai/* so the volces
-      # auto-mirror can serve them on byte-cluster nodes that can't reach
-      # docker.io / ghcr.io directly. Without this, every otel-demoN namespace
-      # had wait-for-kafka init containers stuck in ImagePullBackOff and the
-      # kafka pod itself failed to pull, blocking accounting/cart/checkout/
-      # fraud-detection from ever starting.
+      # Bumped 0.1.8 -> 0.1.9 to pick up otel-demo-aegis chart 0.1.8 and to
+      # seed the byte-cluster image-rewrite overrides in DB, not just in the
+      # sidecar values file. Before this fix the live DB only carried
+      # `global.clusterCollector.service`, so RestartPedestal re-installs
+      # merged a stale value_file with almost no helm_config_values and fell
+      # back to bad defaults / dead image refs:
+      #   - app images resolved to pair-diag `pair/open-telemetry-demo:*`,
+      #     but the 2.2.0-* tags are not published there;
+      #   - kafka resolved to docker.io/opspai/otel-demo-kafka:2.2.0, which
+      #     byte-cluster nodes cannot reach directly.
+      # Keep the collector retargeting override, and pin the verified byte-
+      # cluster mirrors for app images, kafka, and the in-namespace collector.
       - name: 0.1.9
         github_link: open-telemetry/opentelemetry-demo
         status: 1
@@ -234,6 +239,102 @@ containers:
               category: 1
               value_type: 0
               default_value: opentelemetry-kube-stack-deployment-otel-demo-collector.monitoring.svc.cluster.local
+              overridable: true
+            - key: opentelemetry-demo.default.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/open-telemetry-demo
+              overridable: true
+            - key: opentelemetry-demo.components.accounting.initContainers[0].image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+              overridable: true
+            - key: opentelemetry-demo.components.cart.initContainers[0].image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+              overridable: true
+            - key: opentelemetry-demo.components.checkout.initContainers[0].image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+              overridable: true
+            - key: opentelemetry-demo.components.fraud-detection.initContainers[0].image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+              overridable: true
+            - key: opentelemetry-demo.components.kafka.imageOverride.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/otel-demo-kafka
+              overridable: true
+            - key: opentelemetry-demo.components.kafka.imageOverride.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "2.2.0"
+              overridable: true
+            - key: opentelemetry-demo.components.flagd.imageOverride.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/flagd
+              overridable: true
+            - key: opentelemetry-demo.components.flagd.imageOverride.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: v0.12.9
+              overridable: true
+            - key: opentelemetry-demo.components.flagd.initContainers[0].image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+              overridable: true
+            - key: opentelemetry-demo.components.postgresql.imageOverride.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/postgres
+              overridable: true
+            - key: opentelemetry-demo.components.postgresql.imageOverride.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "17.6"
+              overridable: true
+            - key: opentelemetry-demo.components.valkey-cart.imageOverride.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/valkey
+              overridable: true
+            - key: opentelemetry-demo.components.valkey-cart.imageOverride.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 9.0.1-alpine3.23
+              overridable: true
+            - key: opentelemetry-demo.opentelemetry-collector.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/otel-demo-opentelemetry-collector-contrib
+              overridable: true
+            - key: opentelemetry-demo.opentelemetry-collector.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "0.135.0"
               overridable: true
           status: 1
   - type: 2

--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -148,11 +148,14 @@ containers:
               value_type: 0
               default_value: pair-cn-shanghai.cr.volces.com/opspai/mysql
               overridable: true
+            # Keep this as a repository suffix because the chart also carries
+            # `rabbitmq.image.registry`. The final rendered image should be
+            # `pair-cn-shanghai.cr.volces.com/opspai/rabbitmq:<tag>`.
             - key: rabbitmq.image.repository
               type: 0
               category: 1
               value_type: 0
-              default_value: pair-cn-shanghai.cr.volces.com/opspai/rabbitmq
+              default_value: opspai/rabbitmq
               overridable: true
             # loadgen `wait-for-services` init container — chart hardcodes
             # docker.io/nicolaka/netshoot:v0.14 in values.yaml:394. Mirror

--- a/AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml
@@ -21,23 +21,65 @@ opentelemetry-demo:
     image:
       repository: pair-cn-shanghai.cr.volces.com/opspai/open-telemetry-demo
 
-  # NOTE: `components.{accounting,cart,checkout,fraud-detection,flagd}.initContainers`
-  # are deliberately NOT set here. Chart otel-demo-aegis 0.1.8 already pins
-  # them to docker.io/opspai/busybox:latest (PR benchmark-charts#7). Adding
-  # an override here would silently take precedence and re-introduce the
-  # old broken pair-diag/busybox:1.35 path.
   components:
+    accounting:
+      initContainers:
+        - name: wait-for-kafka
+          image: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+          command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
+
+    cart:
+      initContainers:
+        - name: wait-for-valkey-cart
+          image: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+          command: ["sh", "-c", "until nc -z -v -w30 valkey-cart 6379; do echo waiting for valkey-cart; sleep 2; done;"]
+
+    checkout:
+      initContainers:
+        - name: wait-for-kafka
+          image: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+          command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
+
+    fraud-detection:
+      initContainers:
+        - name: wait-for-kafka
+          image: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+          command: ["sh", "-c", "until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;"]
+
+    kafka:
+      imageOverride:
+        repository: pair-cn-shanghai.cr.volces.com/opspai/otel-demo-kafka
+        tag: "2.2.0"
+      initContainers: []
+
     flagd:
       # flagd main image — chart leaves this at upstream `ghcr.io/open-feature/flagd`.
-      # Mirrored to opspai on 2026-05-01.
+      # Mirrored to opspai on 2026-05-01, and now available via the
+      # pair-cn-shanghai mirror.
       imageOverride:
         repository: pair-cn-shanghai.cr.volces.com/opspai/flagd
+        tag: "v0.12.9"
+      initContainers:
+        - name: init-config
+          image: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
+          command: ["sh", "-c", "cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json"]
+          volumeMounts:
+            - mountPath: /config-ro
+              name: config-ro
+            - mountPath: /config-rw
+              name: config-rw
 
     valkey-cart:
       # valkey-cart subchart's main image — chart upstream uses bitnami; we
       # mirror upstream valkey to opspai for byte-cluster reachability.
       imageOverride:
         repository: pair-cn-shanghai.cr.volces.com/opspai/valkey
+        tag: "9.0.1-alpine3.23"
+
+    postgresql:
+      imageOverride:
+        repository: pair-cn-shanghai.cr.volces.com/opspai/postgres
+        tag: "17.6"
 
   opentelemetry-collector:
     image:

--- a/AegisLab/manifests/byte-cluster/initial-data/ts.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/ts.yaml
@@ -1,15 +1,22 @@
 global:
-  # Tag for ts-* service images. Seed only overrides global.image.repository
-  # (pair-cn-shanghai mirror), not the tag, so v1.2.9 lives here.
   image:
+    repository: pair-diag-cn-guangzhou.cr.volces.com/pair
     tag: "v1.2.9"
   security:
     allowInsecureImages: true
 
-# NOTE: mysql / rabbitmq / loadgenerator image overrides removed — they're now
-# in data.yaml's ts@1.0.6 helm_config.values (#326). Keeping them here was
-# DOUBLE-SETTING the values: seed overrode `repository`, but the legacy
-# `rabbitmq.image.registry: pair-diag.../pair` in this file silently composed
-# with seed's repository to produce the broken
-# `pair-diag/pair/pair-cn-shanghai/opspai/rabbitmq` ImagePullBackOff on every
-# new ts ns.
+mysql:
+  image:
+    repository: pair-diag-cn-guangzhou.cr.volces.com/pair/mysql
+
+rabbitmq:
+  image:
+    registry: pair-cn-shanghai.cr.volces.com
+    repository: opspai/rabbitmq
+
+loadgenerator:
+  image:
+    repository: pair-diag-cn-guangzhou.cr.volces.com/pair/loadgenerator
+    tag: "023"
+  initContainer:
+    image: pair-diag-cn-guangzhou.cr.volces.com/pair/netshoot:v0.14


### PR DESCRIPTION
## What
- align ts rabbitmq seed data with the mirrored image layout
- keep ts values and DB-side helm seed consistent so restart flows render `pair-cn-shanghai.cr.volces.com/opspai/rabbitmq`
- preserve the earlier otel-demo mirror overrides already on this branch

## Why
- ts restart flows were rendering a broken rabbitmq image ref by combining a registry override with a fully-qualified repository override
- that produced `pair-diag-cn-guangzhou.cr.volces.com/pair/pair-cn-shanghai...` in live namespaces and blocked `rabbitmq-0` startup

## Validation
- updated local seed files
- updated live DB override to `opspai/rabbitmq` during debugging
- verified `ts9` rabbitmq starts successfully with `pair-cn-shanghai.cr.volces.com/opspai/rabbitmq:4.0.7-debian-12-r0`