### PR TITLE
fix(byte-cluster/seed): use non-numeric postgres tag (17.6-bookworm) so backend yaml render keeps it a string

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -309,11 +309,18 @@ containers:
               value_type: 0
               default_value: pair-cn-shanghai.cr.volces.com/opspai/postgres
               overridable: true
+            # NOTE: tag must NOT be a YAML float (e.g. "17.6") because the
+            # backend's seed→helm-values renderer Go-yaml-marshals string
+            # values back, and `17.6` round-trips as float, then Helm's
+            # opentelemetry-demo schema rejects it with
+            # `'/components/postgresql/imageOverride/tag': got number, want string`.
+            # Use a non-numeric tag suffix (`-bookworm`) so the value stays a
+            # string through the render path.
             - key: opentelemetry-demo.components.postgresql.imageOverride.tag
               type: 0
               category: 1
               value_type: 0
-              default_value: "17.6"
+              default_value: 17.6-bookworm
               overridable: true
             - key: opentelemetry-demo.components.valkey-cart.imageOverride.repository
               type: 0

--- a/AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml
@@ -79,7 +79,9 @@ opentelemetry-demo:
     postgresql:
       imageOverride:
         repository: pair-cn-shanghai.cr.volces.com/opspai/postgres
-        tag: "17.6"
+        # See data.yaml: must be non-numeric or backend's yaml renderer
+        # round-trips it as float and chart schema rejects it.
+        tag: 17.6-bookworm
 
   opentelemetry-collector:
     image:


### PR DESCRIPTION
## Bug

Every otel-demoN helm install fails today with:

```
values don't meet the specifications of the schema(s) in the following chart(s):
opentelemetry-demo:
- at '/components/postgresql/imageOverride/tag': got number, want string
```

## Root cause

Seed yaml has `default_value: "17.6"` (quoted string). DB stores it as plain string `17.6` (HEX 31372E36). But the backend's seed→helm-values renderer Go-yaml-marshals string values back when constructing helm install args, and YAML auto-coerces `17.6` to float. Helm's opentelemetry-demo JSON schema then rejects the install.

Other tags in the same seed survive because they're already non-numeric (kafka `2.2.0` has two dots so YAML keeps as string; flagd `v0.12.9`, valkey `9.0.1-alpine3.23` have non-digit chars).

## Fix

Switch postgres tag to `17.6-bookworm` (non-numeric, YAML must parse as string). Mirrored `docker.io/library/postgres:17.6-bookworm` → `docker.io/opspai/postgres:17.6-bookworm` (volces auto-mirror).

Both data.yaml seed and otel-demo.yaml overlay updated.

## Real fix (out of scope)

Backend's seed render path should preserve the declared `value_type` (0=string) instead of letting YAML auto-coerce. Open an issue for follow-up if not already tracked.

## Test plan

- [ ] Reseed picks up the new tag
- [ ] Fresh otel-demoN namespace install completes (no schema error)
- [ ] postgres pod runs with image `pair-cn-shanghai.cr.volces.com/opspai/postgres:17.6-bookworm`
EOF
)