### PR TITLE
fix(byte-cluster/seed): drop initContainers[0].image overrides — helm --set replaces the array, breaks .name

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -249,30 +249,16 @@ containers:
               value_type: 0
               default_value: pair-cn-shanghai.cr.volces.com/opspai/open-telemetry-demo
               overridable: true
-            - key: opentelemetry-demo.components.accounting.initContainers[0].image
-              type: 0
-              category: 1
-              value_type: 0
-              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
-              overridable: true
-            - key: opentelemetry-demo.components.cart.initContainers[0].image
-              type: 0
-              category: 1
-              value_type: 0
-              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
-              overridable: true
-            - key: opentelemetry-demo.components.checkout.initContainers[0].image
-              type: 0
-              category: 1
-              value_type: 0
-              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
-              overridable: true
-            - key: opentelemetry-demo.components.fraud-detection.initContainers[0].image
-              type: 0
-              category: 1
-              value_type: 0
-              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
-              overridable: true
+            # NOTE: per-component `initContainers[0].image` overrides removed.
+            # Helm `--set` against an indexed array slot REPLACES the whole
+            # array (not field-merge), so setting only `[0].image` clears the
+            # `[0].name` and `[0].command` from the chart default, and k8s
+            # rejects every Deployment with
+            #   spec.template.spec.initContainers[0].name: Required value
+            # The sidecar overlay (`AegisLab/manifests/byte-cluster/initial-
+            # data/otel-demo.yaml`) carries the full init-container objects
+            # (name + image + command), so dropping these seed keys lets the
+            # overlay -f win, and the mirror image lands cleanly.
             - key: opentelemetry-demo.components.kafka.imageOverride.repository
               type: 0
               category: 1
@@ -297,12 +283,8 @@ containers:
               value_type: 0
               default_value: v0.12.9
               overridable: true
-            - key: opentelemetry-demo.components.flagd.initContainers[0].image
-              type: 0
-              category: 1
-              value_type: 0
-              default_value: pair-cn-shanghai.cr.volces.com/opspai/busybox:latest
-              overridable: true
+            # flagd init container override also removed — same reason as the
+            # accounting/cart/checkout/fraud-detection block above.
             - key: opentelemetry-demo.components.postgresql.imageOverride.repository
               type: 0
               category: 1


### PR DESCRIPTION
## Bug

Every otel-demoN install today fails with:

```
Deployment.apps "cart" is invalid:
  spec.template.spec.initContainers[0].name: Required value
... same for checkout / fraud-detection / accounting / flagd
```

## Root cause

Seed keys like `opentelemetry-demo.components.cart.initContainers[0].image` get rendered as `--set components.cart.initContainers[0].image=...`. Helm `--set` against an indexed array slot **REPLACES the whole array** (not field-merge), so setting only `[0].image` clears `[0].name` and `[0].command` from the chart default. k8s rejects every Deployment.

## Fix

Drop the 5 `initContainers[0].image` keys from seed. The sidecar overlay `otel-demo.yaml` already carries the full init-container objects (name + image + command), and overlay-via-`-f` does field-merge, so dropping the seed override lets the overlay win.

## Followup

Backend's seed→helm-values renderer should detect indexed-array overrides and bundle adjacent fields, or reject them at submit time, instead of letting helm silently truncate the array. Out of scope here.

## Test plan

- [ ] CM apply + worker restart picks up new data.yaml
- [ ] Reseed (no-op since drift is removal not addition; SQL DELETE may be needed)
- [ ] Fresh otel-demoN install: all Deployments admitted, init containers have full `name+image+command`