### PR TITLE
chore(byte-cluster/otel-demo): disable llm + product-reviews components

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml
@@ -83,6 +83,15 @@ opentelemetry-demo:
         # round-trips it as float and chart schema rejects it.
         tag: 17.6-bookworm
 
+    # Disable optional LLM + product-reviews components. They were added
+    # in upstream otel-demo 2.2.0 and chart 0.1.8 enables them by default.
+    # We don't run AI/LLM workloads in the RCA benchmark — keeping them off
+    # avoids two extra mirrored images and two extra Pods per ns.
+    llm:
+      enabled: false
+    product-reviews:
+      enabled: false
+
   opentelemetry-collector:
     image:
       repository: pair-cn-shanghai.cr.volces.com/opspai/otel-demo-opentelemetry-collector-contrib


### PR DESCRIPTION
## Why

Upstream otel-demo 2.2.0 added `llm` (Python LLM client demo) and `product-reviews` (calls llm via dummy OPENAI_API_KEY). Chart 0.1.8 enables both by default.

These bring zero value for RCA injection (no DB / network fan-out worth perturbing) and require maintaining two extra mirrored images:
- `pair-cn-shanghai.cr.volces.com/opspai/open-telemetry-demo:2.2.0-llm`
- `pair-cn-shanghai.cr.volces.com/opspai/open-telemetry-demo:2.2.0-product-reviews`

## Diff

```yaml
opentelemetry-demo:
  components:
    llm:
      enabled: false
    product-reviews:
      enabled: false
```

## Test plan

- [ ] CM apply + worker re-mount picks up new overlay
- [ ] Fresh otel-demoN ns: no `llm-*`, no `product-reviews-*` Pods
- [ ] Other otel-demo components still install correctly