### PR TITLE
chore(byte-cluster/seed): bump hs 0.1.4 → 0.1.5 to pick up hotel-reservation chart 0.1.5 (closes #353)

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -446,11 +446,19 @@ containers:
     versions:
       # Bumped 0.1.3 → 0.1.4 to retarget `global.otel.endpoint` at the
       # per-system hs collector (#303 step 2b).
-      - name: 0.1.4
+      #
+      # Bumped 0.1.4 → 0.1.5 to pick up hotel-reservation chart 0.1.5
+      # (LGU-SE-Internal/DeathStarBench#56 + #57): adds wait-for-consul
+      # init container to all 9 Go service Deployments using
+      # `global.infraDockerRegistry` (already set to pair-cn-shanghai
+      # opspai mirror below). Resolves the cold-start CrashLoopBackOff
+      # surfaced by aegis#353 — services no longer crash on consul DNS
+      # lookup before kube-dns picks up the consul Service.
+      - name: 0.1.5
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
-          version: 0.1.3
+          version: 0.1.5
           chart_name: hotel-reservation
           repo_name: lgu-dsb
           repo_url: https://lgu-se-internal.github.io/DeathStarBench


### PR DESCRIPTION
## Why

DSB chart 0.1.5 (DeathStarBench#56 + #57 both merged) adds a `wait-for-consul` init container to all 9 Go service Deployments. Init image composed from `global.infraDockerRegistry` which our seed already sets to `pair-cn-shanghai.cr.volces.com/opspai` — so byte-cluster pulls cleanly without per-key override.

Resolves cold-start CrashLoopBackOff documented in #353.

## Diff

Single hop: hs pedestal 0.1.4 → 0.1.5, helm_config.version 0.1.3 → 0.1.5.

## Reseed plan

1. `aegisctl system reseed --apply` creates new container_versions row at 0.1.5
2. Nuke existing hs ns + helm release (chart 0.1.3 baked in)
3. Restart hs loop — backend RP installs 0.1.5 with wait-for-consul

## Test plan

- [ ] Fresh hsN install: every Go service pod has `wait-for-consul` init container
- [ ] No CrashLoopBackOff on cold-start RP
- [ ] Faster RP-to-FaultInjection transition (no 3-9 restart wait)