### PR TITLE
fix(reseed): re-snapshot helm value_file when CM overlay drifts (#360)

### DIFF
--- a/AegisLab/src/service/initialization/reseed.go
+++ b/AegisLab/src/service/initialization/reseed.go
@@ -1,6 +1,7 @@
 package initialization
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -179,6 +180,9 @@ func reseedContainerVersions(db *gorm.DB, seed *InitialDataContainer, valuesDir 
 			// contract.
 			if vSeed.HelmConfig != nil {
 				if err := compareHelmConfigDrift(db, existingVersion, vSeed.HelmConfig, seed.Name, dryRun, report); err != nil {
+					return err
+				}
+				if err := resnapshotHelmValueFileIfDrifted(db, existingVersion, seed.Name, valuesDir, dryRun, report); err != nil {
 					return err
 				}
 			}
@@ -449,6 +453,67 @@ func compareHelmConfigDrift(db *gorm.DB, version *model.ContainerVersion, seed *
 			Applied:  false,
 		})
 	}
+	return nil
+}
+
+// resnapshotHelmValueFileIfDrifted re-snapshots the helm value_file for an
+// existing container_version when the on-disk source overlay (under
+// valuesDir/<systemName>.yaml — same convention as the new-version branch
+// and InitializeProducer) differs from the bytes already pinned by
+// helm_configs.value_file. This closes issue #360: on system reseed --apply
+// for an already-seeded version, operators expect a CM update to the overlay
+// to take effect on the next helm install. Without this, the row keeps
+// pointing at the original timestamped snapshot and helm silently installs
+// stale values.
+//
+// No-op when: source overlay missing, current value_file empty, or bytes
+// identical. The new-version INSERT branch is left alone — it already takes
+// the same snapshot at row creation time.
+func resnapshotHelmValueFileIfDrifted(db *gorm.DB, version *model.ContainerVersion, systemName, valuesDir string, dryRun bool, report *ReseedReport) error {
+	var helm model.HelmConfig
+	if err := db.Where("container_version_id = ?", version.ID).First(&helm).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		return fmt.Errorf("lookup helm_config for value_file resnapshot: %w", err)
+	}
+	if helm.ValueFile == "" {
+		return nil
+	}
+	srcPath := filepath.Join(valuesDir, fmt.Sprintf("%s.yaml", systemName))
+	srcBytes, err := os.ReadFile(srcPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read source overlay %s: %w", srcPath, err)
+	}
+	curBytes, err := os.ReadFile(helm.ValueFile)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read current snapshot %s: %w", helm.ValueFile, err)
+	}
+	if err == nil && bytes.Equal(curBytes, srcBytes) {
+		return nil
+	}
+	act := ReseedAction{
+		Layer:    "helm_configs",
+		System:   systemName,
+		Key:      version.Name,
+		OldValue: helm.ValueFile,
+		NewValue: srcPath,
+		Note:     "value_file overlay drift; re-snapshotting from CM source",
+	}
+	if dryRun {
+		report.Actions = append(report.Actions, act)
+		return nil
+	}
+	if err := containerrepo.NewRepository(db).UploadHelmValueFileFromPath(systemName, &helm, srcPath); err != nil {
+		return fmt.Errorf("upload re-snapshot for %s@%s: %w", systemName, version.Name, err)
+	}
+	act.NewValue = helm.ValueFile
+	act.Applied = true
+	report.Actions = append(report.Actions, act)
+	logrus.Infof("reseed %s: re-snapshotted helm value_file for version=%s old=%s new=%s", systemName, version.Name, act.OldValue, helm.ValueFile)
 	return nil
 }
 
@@ -854,6 +919,9 @@ func ReseedHelmConfigForVersion(ctx context.Context, db *gorm.DB, req ReseedHelm
 	helm, err := upsertHelmConfigForReseed(db, &version, seedVersion.HelmConfig, container.Name, req.DryRun, report)
 	if err != nil {
 		return report, fmt.Errorf("reseed helm_configs for %s@%s: %w", container.Name, version.Name, err)
+	}
+	if err := resnapshotHelmValueFileIfDrifted(db, &version, container.Name, filepath.Dir(req.DataPath), req.DryRun, report); err != nil {
+		return report, fmt.Errorf("re-snapshot helm value_file for %s@%s: %w", container.Name, version.Name, err)
 	}
 	if helm == nil {
 		// Dry-run path with no existing row: synthesize a placeholder so the

--- a/AegisLab/src/service/initialization/reseed.go
+++ b/AegisLab/src/service/initialization/reseed.go
@@ -500,7 +500,7 @@ func resnapshotHelmValueFileIfDrifted(db *gorm.DB, version *model.ContainerVersi
 		System:   systemName,
 		Key:      version.Name,
 		OldValue: helm.ValueFile,
-		NewValue: srcPath,
+		NewValue: "<new snapshot from " + srcPath + ">",
 		Note:     "value_file overlay drift; re-snapshotting from CM source",
 	}
 	if dryRun {

--- a/AegisLab/src/service/initialization/reseed_test.go
+++ b/AegisLab/src/service/initialization/reseed_test.go
@@ -10,6 +10,7 @@ import (
 	"aegis/consts"
 	"aegis/model"
 
+	"github.com/spf13/viper"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -1119,5 +1120,175 @@ func TestReseedHelmConfigForVersionMissingVersion(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatalf("expected error for missing version_id, got nil")
+	}
+}
+
+// --- issue #360 regression: re-snapshot helm value_file on overlay drift ---
+//
+// Setup helper: pre-seeds a container + version + helm_config that points at
+// a "frozen" snapshot file under <basePath>/helm-values/. The basePath is the
+// jfs.dataset_path Viper key used by HelmFileStore for re-snapshot writes.
+func seedHelmValueFileFixture(t *testing.T, db *gorm.DB, basePath, system, snapshotBytes string) string {
+	t.Helper()
+	helmValuesDir := filepath.Join(basePath, "helm-values")
+	if err := os.MkdirAll(helmValuesDir, 0o755); err != nil {
+		t.Fatalf("mkdir helm-values: %v", err)
+	}
+	snapshotPath := filepath.Join(helmValuesDir, system+"_values_initial.yaml")
+	if err := os.WriteFile(snapshotPath, []byte(snapshotBytes), 0o644); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+	mustExec(t, db, `INSERT INTO containers (id, name, type, status) VALUES (1, ?, 2, 1)`, system)
+	mustExec(t, db, `INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (10, '0.1.0', 1, 0, 1)`)
+	mustExec(t, db,
+		`INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name, value_file) VALUES (20, ?, '0.1.0', 10, 'https://x', 'r', ?)`,
+		system, snapshotPath)
+	return snapshotPath
+}
+
+func writeOverlayBesideSeed(t *testing.T, seedPath, system, body string) {
+	t.Helper()
+	overlayPath := filepath.Join(filepath.Dir(seedPath), system+".yaml")
+	if err := os.WriteFile(overlayPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+}
+
+func minimalSeedFor(system string) string {
+	return `
+containers:
+  - type: 2
+    name: ` + system + `
+    is_public: true
+    status: 1
+    versions:
+      - name: 0.1.0
+        helm_config:
+          version: 0.1.0
+          chart_name: ` + system + `
+          repo_name: r
+          repo_url: https://x
+`
+}
+
+func TestReseedResnapshotsHelmValueFileOnDrift(t *testing.T) {
+	db := newReseedTestDB(t)
+	basePath := t.TempDir()
+	viper.Set("jfs.dataset_path", basePath)
+	defer viper.Set("jfs.dataset_path", "")
+
+	system := "otel-demo"
+	oldSnapshot := seedHelmValueFileFixture(t, db, basePath, system, "imageTag: stale\n")
+
+	seed := writeSeedFile(t, minimalSeedFor(system))
+	writeOverlayBesideSeed(t, seed, system, "imageTag: fresh\n")
+
+	report, err := ReseedFromDataFile(context.Background(), db, nil, ReseedRequest{DataPath: seed})
+	if err != nil {
+		t.Fatalf("reseed: %v", err)
+	}
+
+	var got struct{ ValueFile string }
+	db.Raw(`SELECT value_file FROM helm_configs WHERE id = 20`).Scan(&got)
+	if got.ValueFile == oldSnapshot {
+		t.Fatalf("value_file not updated; still %s", got.ValueFile)
+	}
+	if got.ValueFile == "" {
+		t.Fatalf("value_file unexpectedly cleared")
+	}
+	newBytes, err := os.ReadFile(got.ValueFile)
+	if err != nil {
+		t.Fatalf("read new snapshot: %v", err)
+	}
+	if string(newBytes) != "imageTag: fresh\n" {
+		t.Fatalf("new snapshot bytes = %q, want %q", string(newBytes), "imageTag: fresh\n")
+	}
+
+	// Surfaced as an applied helm_configs action.
+	found := false
+	for _, a := range report.Actions {
+		if a.Layer == "helm_configs" && a.Applied && a.OldValue == oldSnapshot && a.Note == "value_file overlay drift; re-snapshotting from CM source" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected applied resnapshot action, got %+v", report.Actions)
+	}
+}
+
+func TestReseedResnapshotNoOpWhenBytesIdentical(t *testing.T) {
+	db := newReseedTestDB(t)
+	basePath := t.TempDir()
+	viper.Set("jfs.dataset_path", basePath)
+	defer viper.Set("jfs.dataset_path", "")
+
+	system := "otel-demo"
+	snapshot := seedHelmValueFileFixture(t, db, basePath, system, "imageTag: same\n")
+
+	seed := writeSeedFile(t, minimalSeedFor(system))
+	writeOverlayBesideSeed(t, seed, system, "imageTag: same\n")
+
+	report, err := ReseedFromDataFile(context.Background(), db, nil, ReseedRequest{DataPath: seed})
+	if err != nil {
+		t.Fatalf("reseed: %v", err)
+	}
+
+	var got struct{ ValueFile string }
+	db.Raw(`SELECT value_file FROM helm_configs WHERE id = 20`).Scan(&got)
+	if got.ValueFile != snapshot {
+		t.Fatalf("value_file mutated on no-op: %s != %s", got.ValueFile, snapshot)
+	}
+	for _, a := range report.Actions {
+		if a.Layer == "helm_configs" && a.OldValue == snapshot {
+			t.Fatalf("unexpected resnapshot action on identical bytes: %+v", a)
+		}
+	}
+}
+
+func TestReseedResnapshotNoOpWhenOverlayMissing(t *testing.T) {
+	db := newReseedTestDB(t)
+	basePath := t.TempDir()
+	viper.Set("jfs.dataset_path", basePath)
+	defer viper.Set("jfs.dataset_path", "")
+
+	system := "otel-demo"
+	snapshot := seedHelmValueFileFixture(t, db, basePath, system, "imageTag: keep\n")
+
+	// No <system>.yaml overlay written next to the seed.
+	seed := writeSeedFile(t, minimalSeedFor(system))
+
+	if _, err := ReseedFromDataFile(context.Background(), db, nil, ReseedRequest{DataPath: seed}); err != nil {
+		t.Fatalf("reseed: %v", err)
+	}
+	var got struct{ ValueFile string }
+	db.Raw(`SELECT value_file FROM helm_configs WHERE id = 20`).Scan(&got)
+	if got.ValueFile != snapshot {
+		t.Fatalf("value_file mutated when overlay absent: %s != %s", got.ValueFile, snapshot)
+	}
+}
+
+func TestReseedResnapshotNoOpWhenValueFileEmpty(t *testing.T) {
+	db := newReseedTestDB(t)
+	basePath := t.TempDir()
+	viper.Set("jfs.dataset_path", basePath)
+	defer viper.Set("jfs.dataset_path", "")
+
+	system := "otel-demo"
+	mustExec(t, db, `INSERT INTO containers (id, name, type, status) VALUES (1, ?, 2, 1)`, system)
+	mustExec(t, db, `INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (10, '0.1.0', 1, 0, 1)`)
+	mustExec(t, db,
+		`INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name, value_file) VALUES (20, ?, '0.1.0', 10, 'https://x', 'r', '')`,
+		system)
+
+	seed := writeSeedFile(t, minimalSeedFor(system))
+	writeOverlayBesideSeed(t, seed, system, "imageTag: fresh\n")
+
+	if _, err := ReseedFromDataFile(context.Background(), db, nil, ReseedRequest{DataPath: seed}); err != nil {
+		t.Fatalf("reseed: %v", err)
+	}
+	var got struct{ ValueFile string }
+	db.Raw(`SELECT value_file FROM helm_configs WHERE id = 20`).Scan(&got)
+	if got.ValueFile != "" {
+		t.Fatalf("value_file populated when initially empty: %s", got.ValueFile)
 	}
 }

--- a/AegisLab/src/service/initialization/reseed_test.go
+++ b/AegisLab/src/service/initialization/reseed_test.go
@@ -1123,6 +1123,24 @@ func TestReseedHelmConfigForVersionMissingVersion(t *testing.T) {
 	}
 }
 
+// setViperForTest sets a viper key for the duration of the test, restoring
+// the prior value (and IsSet state) on cleanup. Plain defer-set-to-"" leaks
+// state across tests when run in any order other than the one the author had
+// in mind.
+func setViperForTest(t *testing.T, key string, value any) {
+	t.Helper()
+	prior := viper.Get(key)
+	hadPrior := viper.IsSet(key)
+	viper.Set(key, value)
+	t.Cleanup(func() {
+		if hadPrior {
+			viper.Set(key, prior)
+		} else {
+			viper.Set(key, nil)
+		}
+	})
+}
+
 // --- issue #360 regression: re-snapshot helm value_file on overlay drift ---
 //
 // Setup helper: pre-seeds a container + version + helm_config that points at
@@ -1174,8 +1192,7 @@ containers:
 func TestReseedResnapshotsHelmValueFileOnDrift(t *testing.T) {
 	db := newReseedTestDB(t)
 	basePath := t.TempDir()
-	viper.Set("jfs.dataset_path", basePath)
-	defer viper.Set("jfs.dataset_path", "")
+	setViperForTest(t, "jfs.dataset_path", basePath)
 
 	system := "otel-demo"
 	oldSnapshot := seedHelmValueFileFixture(t, db, basePath, system, "imageTag: stale\n")
@@ -1219,8 +1236,7 @@ func TestReseedResnapshotsHelmValueFileOnDrift(t *testing.T) {
 func TestReseedResnapshotNoOpWhenBytesIdentical(t *testing.T) {
 	db := newReseedTestDB(t)
 	basePath := t.TempDir()
-	viper.Set("jfs.dataset_path", basePath)
-	defer viper.Set("jfs.dataset_path", "")
+	setViperForTest(t, "jfs.dataset_path", basePath)
 
 	system := "otel-demo"
 	snapshot := seedHelmValueFileFixture(t, db, basePath, system, "imageTag: same\n")
@@ -1248,8 +1264,7 @@ func TestReseedResnapshotNoOpWhenBytesIdentical(t *testing.T) {
 func TestReseedResnapshotNoOpWhenOverlayMissing(t *testing.T) {
 	db := newReseedTestDB(t)
 	basePath := t.TempDir()
-	viper.Set("jfs.dataset_path", basePath)
-	defer viper.Set("jfs.dataset_path", "")
+	setViperForTest(t, "jfs.dataset_path", basePath)
 
 	system := "otel-demo"
 	snapshot := seedHelmValueFileFixture(t, db, basePath, system, "imageTag: keep\n")
@@ -1270,8 +1285,7 @@ func TestReseedResnapshotNoOpWhenOverlayMissing(t *testing.T) {
 func TestReseedResnapshotNoOpWhenValueFileEmpty(t *testing.T) {
 	db := newReseedTestDB(t)
 	basePath := t.TempDir()
-	viper.Set("jfs.dataset_path", basePath)
-	defer viper.Set("jfs.dataset_path", "")
+	setViperForTest(t, "jfs.dataset_path", basePath)
 
 	system := "otel-demo"
 	mustExec(t, db, `INSERT INTO containers (id, name, type, status) VALUES (1, ?, 2, 1)`, system)


### PR DESCRIPTION
Closes #360.

## Summary

Implements **Option A** from the issue's option table: on `aegisctl system reseed --apply`, for an existing `(container_id, version_name)` pair, also re-snapshot `helm_configs.value_file` when the source overlay (`<valuesDir>/<system>.yaml`) bytes differ from the bytes pinned by the current snapshot path.

Without this, both `compareHelmConfigDrift` (batch reseed, `reseed.go:171`) and `upsertHelmConfigForReseed` (targeted single-version reseed, `reseed.go:854`) explicitly preserved the operator-set `value_file` and the next helm install silently used the stale timestamped snapshot — exactly what bit otel-demo today.

## Approach

New helper `resnapshotHelmValueFileIfDrifted` reuses the existing `UploadHelmValueFileFromPath` (which calls `HelmFileStore.SaveValueFile` to write a fresh `<system>_values_<ts>.yaml`) and updates the DB column. Wired into both reseed paths so batch and targeted-single behave the same.

No new file-write path, no flag, no migration. Historical snapshots remain on disk; only the column gets pointed at the new one.

## Test cases (all in `reseed_test.go`, sqlite-backed, no infra)

- `TestReseedResnapshotsHelmValueFileOnDrift` — drifted overlay → new path, new bytes, applied action surfaced.
- `TestReseedResnapshotNoOpWhenBytesIdentical` — identical bytes → DB untouched, no action.
- `TestReseedResnapshotNoOpWhenOverlayMissing` — overlay file absent → DB untouched.
- `TestReseedResnapshotNoOpWhenValueFileEmpty` — `value_file=''` → DB untouched (matches first-time-CM convention from `producer.go`).

`go test ./service/initialization/` is green; full backend builds with `-tags duckdb_arrow`.

## LOC delta

`reseed.go` +68, `reseed_test.go` +171.

## Test plan
- [ ] Reviewer skims helper logic + test fixtures.
- [ ] On a live cluster: edit `AegisLab/manifests/byte-cluster/initial-data/otel-demo.yaml`, `kubectl apply` the CM, `aegisctl system reseed --apply` → verify a `helm_configs / value_file overlay drift; re-snapshotting from CM source` action appears and the next helm install picks up the new bytes.