### PR TITLE
chore(byte-cluster/seed): bump per-ns collector chart versions to drop blocking key

### DIFF
--- a/AegisLab/manifests/byte-cluster/initial-data/data.yaml
+++ b/AegisLab/manifests/byte-cluster/initial-data/data.yaml
@@ -225,7 +225,11 @@ containers:
         github_link: OperationsPAI/train-ticket
         status: 1
         helm_config:
-          version: 0.3.0
+          # Bumped 0.3.0 → 0.3.1 (OperationsPAI/train-ticket#25): the per-ns
+          # collector sidecar's CM had `sending_queue.blocking: true` which
+          # collector v0.142.0 rejects (CrashLoopBackOff: invalid keys: blocking).
+          # Same pedestal_tag 1.0.7 — chart-only fix.
+          version: 0.3.1
           chart_name: trainticket
           repo_name: train-ticket
           repo_url: https://operationspai.github.io/train-ticket
@@ -382,7 +386,10 @@ containers:
         github_link: open-telemetry/opentelemetry-demo
         status: 1
         helm_config:
-          version: 0.1.9
+          # Bumped 0.1.9 → 0.1.10 (OperationsPAI/benchmark-charts#12): drops
+          # `sending_queue.blocking: true` from the per-ns collector CM that
+          # collector v0.142.0 rejects (CrashLoopBackOff). Chart-only fix.
+          version: 0.1.10
           chart_name: otel-demo-aegis
           repo_name: opspai
           repo_url: oci://pair-cn-shanghai.cr.volces.com/opspai
@@ -566,7 +573,10 @@ containers:
         github_link: LGU-SE-Internal/DeathStarBench
         status: 1
         helm_config:
-          version: 0.2.0
+          # Bumped 0.2.0 → 0.2.1 (LGU-SE-Internal/DeathStarBench#60): drops
+          # `sending_queue.blocking: true` from the per-ns collector CM that
+          # collector v0.142.0 rejects (CrashLoopBackOff). Chart-only fix.
+          version: 0.2.1
           chart_name: hotel-reservation
           repo_name: lgu-dsb
           repo_url: https://lgu-se-internal.github.io/DeathStarBench


### PR DESCRIPTION
Bumps per-ns OTel collector chart versions to fix collector v0.142.0 `CrashLoopBackOff: invalid keys: blocking`:

- ts trainticket 0.3.0 → 0.3.1 (#25 in train-ticket)
- hs hotel-reservation 0.2.0 → 0.2.1 (#60 in DSB)
- otel-demo otel-demo-aegis 0.1.9 → 0.1.10 (#12 in benchmark-charts)

Pedestal versions unchanged. Live cluster already received the same pin via SQL; this PR makes it durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)