### PR TITLE
feat(aegisctl): pedestal chart install --apply-overrides (#372)

### DIFF
--- a/AegisLab/src/cmd/aegisctl/cmd/pedestal_chart.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/pedestal_chart.go
@@ -174,12 +174,14 @@ func resolveProducerPod(namespace string) (string, error) {
 // --- chart install ---
 
 var (
-	pedestalChartInstallNamespace string
-	pedestalChartInstallTgz       string
-	pedestalChartInstallRepo      string
-	pedestalChartInstallChart     string
-	pedestalChartInstallVersion   string
-	pedestalChartInstallWait      bool
+	pedestalChartInstallNamespace          string
+	pedestalChartInstallTgz                string
+	pedestalChartInstallRepo               string
+	pedestalChartInstallChart              string
+	pedestalChartInstallVersion            string
+	pedestalChartInstallWait               bool
+	pedestalChartInstallApplyOverrides     bool
+	pedestalChartInstallFromPedestalVerArg string
 )
 
 var pedestalChartInstallCmd = &cobra.Command{
@@ -202,12 +204,22 @@ Chart source resolution (first match wins):
         local_path -> repo_url/chart_name -> error.
 
 The release name is set to the namespace (matches aegis's own
-installPedestal behavior so app labels line up).`,
+installPedestal behavior so app labels line up).
+
+By default the chart's value_file (raw YAML on the producer pod) is passed
+to helm as the only -f source, matching historical behaviour. Pass
+--apply-overrides to instead use the merged values map returned by
+/api/v2/systems/by-name/<code>/chart, which already overlays the
+helm_config_values DB rows on top of value_file (matching what the
+RestartPedestal pipeline does internally). Pin a specific pedestal
+container_version with --from-pedestal-version <ver>; otherwise the
+backend's latest active row wins.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runPedestalChartInstall(args[0], pedestalChartInstallNamespace,
 			pedestalChartInstallTgz, pedestalChartInstallRepo, pedestalChartInstallChart,
-			pedestalChartInstallVersion, pedestalChartInstallWait)
+			pedestalChartInstallVersion, pedestalChartInstallWait,
+			pedestalChartInstallApplyOverrides, pedestalChartInstallFromPedestalVerArg)
 	},
 }
 
@@ -216,16 +228,28 @@ installPedestal behavior so app labels line up).`,
 // URL, or chart name); `repo` is non-empty only when positional is a repo
 // chart name that needs --repo.
 type chartSource struct {
-	positional string
-	repo       string
-	version    string
-	valuesFile string
-	values     map[string]any
+	positional     string
+	repo           string
+	version        string
+	valuesFile     string
+	values         map[string]any
+	applyOverrides bool
+	pedestalTag    string
 }
 
-func runPedestalChartInstall(systemCode, namespace, tgz, repo, chartName, version string, wait bool) error {
+func runPedestalChartInstall(systemCode, namespace, tgz, repo, chartName, version string, wait bool, applyOverrides bool, fromPedestalVersion string) error {
 	if strings.TrimSpace(systemCode) == "" {
 		return usageErrorf("system short-code is required")
+	}
+
+	// --from-pedestal-version pins which container_versions.name the backend
+	// should resolve helm_config_values for. When set it takes precedence over
+	// --version for the `?version=` query string, but not over helm's own
+	// chart --version flag (those are independent semvers — chart version
+	// vs. container_version semver, see GetSystemChart docstring).
+	apiQueryVersion := strings.TrimSpace(fromPedestalVersion)
+	if apiQueryVersion == "" {
+		apiQueryVersion = version
 	}
 
 	if namespace == "" {
@@ -239,13 +263,22 @@ func runPedestalChartInstall(systemCode, namespace, tgz, repo, chartName, versio
 		namespace = derived
 	}
 
-	src, err := resolveChartSource(systemCode, tgz, repo, chartName, version)
+	src, err := resolveChartSource(systemCode, tgz, repo, chartName, version, apiQueryVersion)
 	if err != nil {
 		return err
 	}
+	src.applyOverrides = applyOverrides
 
 	if _, err := chartRunner.LookPath("helm"); err != nil {
 		return missingEnvErrorf("helm not found on PATH; install helm or place it on PATH")
+	}
+
+	if applyOverrides {
+		tag := src.pedestalTag
+		if tag == "" {
+			tag = apiQueryVersion
+		}
+		output.PrintInfo(fmt.Sprintf("merged %d helm_config_values overrides for %s@%s", len(src.values), systemCode, tag))
 	}
 
 	helmArgs := []string{"install", namespace, src.positional, "-n", namespace, "--create-namespace"}
@@ -292,12 +325,14 @@ func isURL(s string) bool {
 // resolveChartSource picks the helm positional argument (and optional --repo)
 // based on the precedence documented on pedestalChartInstallCmd.Long. It falls
 // back to GET /api/v2/systems/by-name/<code>/chart when the operator didn't
-// pass a source explicitly.
-func resolveChartSource(systemCode, tgz, repo, chartName, version string) (chartSource, error) {
+// pass a source explicitly. apiQueryVersion is the value passed as ?version=
+// (the container_version.name) and may differ from chartVersion (the helm
+// chart semver passed to `helm --version`) — see #372.
+func resolveChartSource(systemCode, tgz, repo, chartName, chartVersion, apiQueryVersion string) (chartSource, error) {
 	switch {
 	case tgz != "":
 		if isURL(tgz) {
-			return chartSource{positional: tgz, version: version}, nil
+			return chartSource{positional: tgz, version: chartVersion}, nil
 		}
 		if _, err := os.Stat(tgz); err != nil {
 			if os.IsNotExist(err) {
@@ -305,13 +340,13 @@ func resolveChartSource(systemCode, tgz, repo, chartName, version string) (chart
 			}
 			return chartSource{}, fmt.Errorf("stat --tgz: %w", err)
 		}
-		return chartSource{positional: tgz, version: version}, nil
+		return chartSource{positional: tgz, version: chartVersion}, nil
 
 	case repo != "" && chartName != "":
 		if strings.HasPrefix(repo, "oci://") {
-			return chartSource{positional: buildOCIRef(repo, chartName), version: version}, nil
+			return chartSource{positional: buildOCIRef(repo, chartName), version: chartVersion}, nil
 		}
-		return chartSource{positional: chartName, repo: repo, version: version}, nil
+		return chartSource{positional: chartName, repo: repo, version: chartVersion}, nil
 
 	case repo != "" || chartName != "":
 		return chartSource{}, usageErrorf("--repo and --chart must be provided together")
@@ -323,17 +358,18 @@ func resolveChartSource(systemCode, tgz, repo, chartName, version string) (chart
 	}
 	c := newClient()
 	var resp client.APIResponse[chartLookupResp]
-	// Pass --version through as a query string so the backend can return
-	// the helm_config_values for that specific container_version (issue
-	// #190). Empty version preserves the old "latest semver" behaviour.
+	// Pass apiQueryVersion through as a query string so the backend can
+	// return the helm_config_values for that specific container_version
+	// (issue #190 / #372). Empty value preserves the old "latest semver"
+	// behaviour.
 	chartPath := fmt.Sprintf("/api/v2/systems/by-name/%s/chart", systemCode)
-	if version != "" {
-		chartPath = fmt.Sprintf("%s?version=%s", chartPath, url.QueryEscape(version))
+	if apiQueryVersion != "" {
+		chartPath = fmt.Sprintf("%s?version=%s", chartPath, url.QueryEscape(apiQueryVersion))
 	}
 	if err := c.Get(chartPath, &resp); err != nil {
 		return chartSource{}, fmt.Errorf("lookup chart for system %q: %w (hint: pass --tgz or --repo/--chart explicitly)", systemCode, err)
 	}
-	backendVersion := version
+	backendVersion := chartVersion
 	if backendVersion == "" {
 		backendVersion = resp.Data.Version
 	}
@@ -342,34 +378,48 @@ func resolveChartSource(systemCode, tgz, repo, chartName, version string) (chart
 	if resp.Data.LocalPath != "" {
 		if _, err := os.Stat(resp.Data.LocalPath); err == nil {
 			return chartSource{
-				positional: resp.Data.LocalPath,
-				version:    backendVersion,
-				valuesFile: resp.Data.ValueFile,
-				values:     resp.Data.Values,
+				positional:  resp.Data.LocalPath,
+				version:     backendVersion,
+				valuesFile:  resp.Data.ValueFile,
+				values:      resp.Data.Values,
+				pedestalTag: resp.Data.PedestalTag,
 			}, nil
 		}
 	}
 	if resp.Data.RepoURL != "" && resp.Data.ChartName != "" {
 		if strings.HasPrefix(resp.Data.RepoURL, "oci://") {
 			return chartSource{
-				positional: buildOCIRef(resp.Data.RepoURL, resp.Data.ChartName),
-				version:    backendVersion,
-				valuesFile: resp.Data.ValueFile,
-				values:     resp.Data.Values,
+				positional:  buildOCIRef(resp.Data.RepoURL, resp.Data.ChartName),
+				version:     backendVersion,
+				valuesFile:  resp.Data.ValueFile,
+				values:      resp.Data.Values,
+				pedestalTag: resp.Data.PedestalTag,
 			}, nil
 		}
 		return chartSource{
-			positional: resp.Data.ChartName,
-			repo:       resp.Data.RepoURL,
-			version:    backendVersion,
-			valuesFile: resp.Data.ValueFile,
-			values:     resp.Data.Values,
+			positional:  resp.Data.ChartName,
+			repo:        resp.Data.RepoURL,
+			version:     backendVersion,
+			valuesFile:  resp.Data.ValueFile,
+			values:      resp.Data.Values,
+			pedestalTag: resp.Data.PedestalTag,
 		}, nil
 	}
 	return chartSource{}, notFoundErrorf("system %q has no installable chart source (no local_path, no repo_url); pass --tgz or --repo/--chart", systemCode)
 }
 
 func materializeChartValuesFile(src chartSource) (string, func(), error) {
+	// applyOverrides flips the precedence: prefer the merged values map
+	// (file YAML overlaid with helm_config_values DB rows by the backend)
+	// over the raw value_file path. Without this flag, the raw file wins
+	// even when DB overrides drift away from it — see #372.
+	if src.applyOverrides && len(src.values) > 0 {
+		data, err := yaml.Marshal(src.values)
+		if err != nil {
+			return "", func() {}, fmt.Errorf("marshal chart values: %w", err)
+		}
+		return writeTempChartValuesFile(data)
+	}
 	if src.valuesFile != "" {
 		if _, err := os.Stat(src.valuesFile); err == nil {
 			return src.valuesFile, func() {}, nil
@@ -571,6 +621,8 @@ func init() {
 	pedestalChartInstallCmd.Flags().StringVar(&pedestalChartInstallChart, "chart", "", "Chart name in the repo given by --repo")
 	pedestalChartInstallCmd.Flags().StringVar(&pedestalChartInstallVersion, "version", "", "Chart version (passed to helm --version)")
 	pedestalChartInstallCmd.Flags().BoolVar(&pedestalChartInstallWait, "wait", false, "Pass --wait to helm install")
+	pedestalChartInstallCmd.Flags().BoolVar(&pedestalChartInstallApplyOverrides, "apply-overrides", false, "Merge helm_config_values rows for the matched pedestal version into the values file before helm install (matches RestartPedestal behaviour). Default: false (current behaviour preserved).")
+	pedestalChartInstallCmd.Flags().StringVar(&pedestalChartInstallFromPedestalVerArg, "from-pedestal-version", "", "Pin which container_versions.name the backend should resolve helm_config_values for (default: latest status=1 row for this system).")
 
 	pedestalChartCmd.AddCommand(pedestalChartPushCmd)
 	pedestalChartCmd.AddCommand(pedestalChartInstallCmd)

--- a/AegisLab/src/cmd/aegisctl/cmd/pedestal_chart_test.go
+++ b/AegisLab/src/cmd/aegisctl/cmd/pedestal_chart_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -168,21 +169,21 @@ func TestNsPatternToNamespace(t *testing.T) {
 // via TestNsPatternToNamespace.
 func TestPedestalChartInstallValidation(t *testing.T) {
 	t.Run("missing_code", func(t *testing.T) {
-		err := runPedestalChartInstall("", "ts0", "/tmp/x.tgz", "", "", "", false)
+		err := runPedestalChartInstall("", "ts0", "/tmp/x.tgz", "", "", "", false, false, "")
 		if err == nil || !strings.Contains(err.Error(), "short-code") {
 			t.Fatalf("want short-code error, got %v", err)
 		}
 	})
 
 	t.Run("repo_without_chart_rejected", func(t *testing.T) {
-		err := runPedestalChartInstall("ts", "ts0", "", "https://example.com/charts", "", "", false)
+		err := runPedestalChartInstall("ts", "ts0", "", "https://example.com/charts", "", "", false, false, "")
 		if err == nil || !strings.Contains(err.Error(), "--repo and --chart must be provided together") {
 			t.Fatalf("want repo/chart pairing error, got %v", err)
 		}
 	})
 
 	t.Run("tgz_not_found", func(t *testing.T) {
-		err := runPedestalChartInstall("ts", "ts0", "/does/not/exist.tgz", "", "", "", false)
+		err := runPedestalChartInstall("ts", "ts0", "/does/not/exist.tgz", "", "", "", false, false, "")
 		if err == nil || !strings.Contains(err.Error(), "not found") {
 			t.Fatalf("want not-found error, got %v", err)
 		}
@@ -195,7 +196,7 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 		if err := os.WriteFile(tgz, []byte("pkg"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		err := runPedestalChartInstall("ts", "ts0", tgz, "", "", "", false)
+		err := runPedestalChartInstall("ts", "ts0", tgz, "", "", "", false, false, "")
 		if err == nil || !strings.Contains(err.Error(), "helm not found") {
 			t.Fatalf("want helm-missing error, got %v", err)
 		}
@@ -211,7 +212,7 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 		}
 		withFakeRunner(t, f)
 		url := "https://example.com/charts/foo-0.1.0.tgz"
-		if err := runPedestalChartInstall("ts", "ts0", url, "", "", "", false); err != nil {
+		if err := runPedestalChartInstall("ts", "ts0", url, "", "", "", false, false, ""); err != nil {
 			t.Fatalf("url install failed: %v", err)
 		}
 		if len(got) == 0 || got[0] != "helm" || !containsArg(got, url) {
@@ -228,7 +229,7 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 			},
 		}
 		withFakeRunner(t, f)
-		if err := runPedestalChartInstall("ts", "ts0", "", "https://charts.example.com", "foo", "1.0.0", false); err != nil {
+		if err := runPedestalChartInstall("ts", "ts0", "", "https://charts.example.com", "foo", "1.0.0", false, false, ""); err != nil {
 			t.Fatalf("repo install failed: %v", err)
 		}
 		if !containsArg(got, "--repo") || !containsArg(got, "https://charts.example.com") || !containsArg(got, "foo") {
@@ -247,7 +248,7 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 		if err := os.WriteFile(tgz, []byte("pkg"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if err := runPedestalChartInstall("ts", "ts0", tgz, "", "", "1.2.3", true); err != nil {
+		if err := runPedestalChartInstall("ts", "ts0", tgz, "", "", "1.2.3", true, false, ""); err != nil {
 			t.Fatalf("install failed: %v", err)
 		}
 		if len(f.calls) != 1 {
@@ -300,7 +301,7 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 		}
 		withFakeRunner(t, f)
 
-		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false); err != nil {
+		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, false, ""); err != nil {
 			t.Fatalf("backend chart install failed: %v", err)
 		}
 		var helmCalls [][]string
@@ -318,6 +319,161 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 		}
 		if !strings.Contains(gotValues, "allowInsecureImages: true") {
 			t.Fatalf("expected marshaled backend values, got %q", gotValues)
+		}
+	})
+}
+
+// TestPedestalChartInstallApplyOverrides covers the #372 flag wiring: with
+// --apply-overrides the merged values map (value_file + helm_config_values
+// rows, already overlaid by the backend) wins over the raw value_file path,
+// even when the file is locally accessible and would otherwise be passed to
+// helm as-is.
+func TestPedestalChartInstallApplyOverrides(t *testing.T) {
+	// Stale local value_file: the chart default that the byte-cluster ts
+	// case in #372 hit. Backend's `values` carries the corrected mirror.
+	staleFile := filepath.Join(t.TempDir(), "ts_values.yaml")
+	if err := os.WriteFile(staleFile, []byte("otelCollector:\n  image:\n    repository: otel/opentelemetry-collector-contrib\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mergedRepo := "pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib"
+
+	mockServer := func(version string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v2/systems/by-name/ts/chart" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			body := fmt.Sprintf(`{"code":200,"message":"ok","data":{"system_name":"ts","chart_name":"trainticket","version":"0.1.0","repo_url":"https://operationspai.github.io/train-ticket","repo_name":"train-ticket","value_file":%q,"values":{"otelCollector":{"image":{"repository":%q}}},"pedestal_tag":%q}}`,
+				staleFile, mergedRepo, version)
+			_, _ = w.Write([]byte(body))
+		}))
+	}
+
+	captureValues := func(t *testing.T, capture *string) *fakeChartExec {
+		t.Helper()
+		return &fakeChartExec{
+			fallback: func(name string, args []string) ([]byte, error) {
+				for i := 0; i < len(args)-1; i++ {
+					if args[i] == "-f" {
+						data, err := os.ReadFile(args[i+1])
+						if err != nil {
+							t.Fatalf("read values file: %v", err)
+						}
+						*capture = string(data)
+					}
+				}
+				return []byte("ok"), nil
+			},
+		}
+	}
+
+	t.Run("default_preserves_stale_file_path", func(t *testing.T) {
+		oldServer, oldToken := flagServer, flagToken
+		t.Cleanup(func() { flagServer, flagToken = oldServer, oldToken })
+		ts := mockServer("1.0.7")
+		defer ts.Close()
+		flagServer = ts.URL
+		flagToken = "test-token"
+
+		var got string
+		f := captureValues(t, &got)
+		withFakeRunner(t, f)
+
+		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, false, ""); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+		if !strings.Contains(got, "otel/opentelemetry-collector-contrib") {
+			t.Fatalf("default path should keep the raw value_file (stale image), got %q", got)
+		}
+		if strings.Contains(got, mergedRepo) {
+			t.Fatalf("default path must not include merged override, got %q", got)
+		}
+	})
+
+	t.Run("apply_overrides_uses_merged_values", func(t *testing.T) {
+		oldServer, oldToken := flagServer, flagToken
+		t.Cleanup(func() { flagServer, flagToken = oldServer, oldToken })
+		ts := mockServer("1.0.7")
+		defer ts.Close()
+		flagServer = ts.URL
+		flagToken = "test-token"
+
+		var got string
+		f := captureValues(t, &got)
+		withFakeRunner(t, f)
+
+		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, true, ""); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+		if !strings.Contains(got, mergedRepo) {
+			t.Fatalf("apply-overrides should use merged values containing %q, got %q", mergedRepo, got)
+		}
+	})
+
+	t.Run("from_pedestal_version_passes_through_query", func(t *testing.T) {
+		oldServer, oldToken := flagServer, flagToken
+		t.Cleanup(func() { flagServer, flagToken = oldServer, oldToken })
+
+		var gotQuery string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v2/systems/by-name/ts/chart" {
+				http.NotFound(w, r)
+				return
+			}
+			gotQuery = r.URL.Query().Get("version")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":200,"message":"ok","data":{"system_name":"ts","chart_name":"trainticket","version":"0.1.0","repo_url":"https://operationspai.github.io/train-ticket","repo_name":"train-ticket","values":{"x":1},"pedestal_tag":"1.0.7"}}`))
+		}))
+		defer ts.Close()
+		flagServer = ts.URL
+		flagToken = "test-token"
+
+		f := &fakeChartExec{fallback: func(name string, args []string) ([]byte, error) { return []byte("ok"), nil }}
+		withFakeRunner(t, f)
+
+		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, true, "1.0.7"); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+		if gotQuery != "1.0.7" {
+			t.Fatalf("backend should receive ?version=1.0.7, got %q", gotQuery)
+		}
+	})
+
+	t.Run("apply_overrides_without_backend_values_is_noop", func(t *testing.T) {
+		// When the backend returns no values and no value_file (e.g. a
+		// pedestal that hasn't seeded helm_config_values yet), enabling
+		// --apply-overrides must not error and must not pass -f.
+		oldServer, oldToken := flagServer, flagToken
+		t.Cleanup(func() { flagServer, flagToken = oldServer, oldToken })
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v2/systems/by-name/ts/chart" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"code":200,"message":"ok","data":{"system_name":"ts","chart_name":"trainticket","version":"0.1.0","repo_url":"https://operationspai.github.io/train-ticket","repo_name":"train-ticket"}}`))
+		}))
+		defer ts.Close()
+		flagServer = ts.URL
+		flagToken = "test-token"
+
+		f := &fakeChartExec{fallback: func(name string, args []string) ([]byte, error) { return []byte("ok"), nil }}
+		withFakeRunner(t, f)
+
+		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, true, ""); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+		var sawValuesFlag bool
+		for _, c := range f.calls {
+			for _, a := range c {
+				if a == "-f" {
+					sawValuesFlag = true
+				}
+			}
+		}
+		if sawValuesFlag {
+			t.Fatalf("apply-overrides with no backend values must not pass -f")
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Add two flags to `aegisctl pedestal chart install` so it can match
`RestartPedestal`'s helm-install behaviour:

- `--apply-overrides` (bool, default false): use the merged values map
  from the chart endpoint (which overlays `helm_config_values` DB rows
  onto `value_file` server-side) instead of the raw `value_file` path.
- `--from-pedestal-version <ver>` (string): pin which
  `container_versions.name` the backend should resolve overrides for.
  Routes to the existing `?version=` query. Default: latest `status=1`
  row.

Default behaviour (no flag) is byte-for-byte identical to today.

## Approach

**B (CLI-only)**, because the backend already does the work:

- `GET /api/v2/systems/by-name/<code>/chart?version=<ver>` already
  accepts `?version=` (#190) and returns both `value_file` (raw YAML
  path) **and** `values` (merged map: file YAML + `helm_config_values`
  defaults overlaid via `dto.HelmConfigItem.GetValuesMap()`).
- The CLI's `materializeChartValuesFile` was preferring the raw
  `value_file` path over the merged map — that's the bug. With
  `--apply-overrides` set, the merged map wins.
- No backend changes, no new endpoints, no new SQL.

Approach A would have meant adding a query param to the same endpoint to
either include or strip overrides, but the endpoint already returns both
shapes — the CLI just had the precedence wrong for the override case.

## Concrete failure this fixes

byte-cluster ts seed: chart default
`otelCollector.image.repository=otel/opentelemetry-collector-contrib`
(unreachable from byte-cluster). `helm_config_values` overrides it to
`pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib`.
Today: `aegisctl pedestal chart install ts --namespace ts0` deploys with
the docker.io default → `ImagePullBackOff`. With this PR:
`aegisctl pedestal chart install ts --namespace ts0 --apply-overrides`
deploys with the volces mirror → ready.

## Test plan

- [x] `go test ./cmd/aegisctl/cmd/... -run "Pedestal|NsPattern"` passes
- [x] `go test ./cmd/aegisctl/...` passes (4.2s)
- [x] `aegisctl pedestal chart install --help` shows both new flags
- New tests cover:
  - default path keeps raw `value_file` (back-compat)
  - `--apply-overrides` swaps in the merged values map
  - `--from-pedestal-version` routes to backend `?version=` query
  - `--apply-overrides` with no backend values is a no-op (no `-f`)
- Verbose output prints
  `merged N helm_config_values overrides for <sys>@<ver>` before the
  `helm install` line when the flag is set.

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

schema-changes-acknowledged: true

The aegisctl schema diff is intentional: this PR adds `--apply-overrides` and `--from-pedestal-version` to `pedestal chart install`. Both flags are optional with backward-compatible defaults; existing scripts that don't pass them get byte-for-byte identical behaviour.
