### PR TITLE
fix(helm): re-fetch chart when cached version differs from requested (#374)

### DIFF
--- a/AegisLab/src/infra/helm/gateway.go
+++ b/AegisLab/src/infra/helm/gateway.go
@@ -158,18 +158,23 @@ func (g *Gateway) installRelease(ctx context.Context, settings *cli.EnvSettings,
 		installAction.CreateNamespace = true
 		installAction.Version = version
 
-		chartPath, err := findCachedChart(settings, chartName)
+		chartPath, err := findCachedChart(settings, chartName, version)
 		if err != nil {
 			return err
 		}
 		if chartPath == "" {
-			logrus.Infof("Chart %s not found in cache, downloading...", chartName)
+			// Either no cached tgz exists, or the cached tgz is for a
+			// different version than requested. In both cases we let
+			// LocateChart re-resolve from the repo index so installAction.Version
+			// is honored — otherwise a stale `<chart>-<oldver>.tgz` shadows
+			// every subsequent version bump (issue #374).
+			logrus.Infof("Chart %s version %q not found in cache, downloading...", chartName, version)
 			chartPath, err = installAction.LocateChart(chartName, settings)
 			if err != nil {
 				return fmt.Errorf("failed to locate chart %s: %w", chartName, err)
 			}
 		} else {
-			logrus.Infof("Using cached chart for %s at %s", chartName, chartPath)
+			logrus.Infof("Using cached chart for %s version %q at %s", chartName, version, chartPath)
 		}
 
 		chart, err := loader.Load(chartPath)
@@ -259,7 +264,14 @@ func newRuntime(namespace string) (*cli.EnvSettings, *action.Configuration, erro
 	return settings, actionConfig, nil
 }
 
-func findCachedChart(settings *cli.EnvSettings, chartName string) (string, error) {
+// findCachedChart returns the path of a cached chart tgz (or local dir) that
+// matches both <chartName> and <version>. When <version> is non-empty, only an
+// exact <chartBaseName>-<version>.tgz match counts as a hit; an unversioned
+// glob would otherwise return e.g. trainticket-0.3.0.tgz when the caller asked
+// for 0.3.1, silently installing the stale chart (issue #374). When <version>
+// is empty (caller didn't pin a version), fall back to the legacy any-version
+// glob so installAction.LocateChart can resolve the latest from the repo.
+func findCachedChart(settings *cli.EnvSettings, chartName, version string) (string, error) {
 	if _, err := os.Stat(chartName); err == nil {
 		abs, err := filepath.Abs(chartName)
 		if err == nil {
@@ -269,21 +281,21 @@ func findCachedChart(settings *cli.EnvSettings, chartName string) (string, error
 	}
 
 	cacheDir := settings.RepositoryCache
-	var searchPatterns []string
+	chartBaseName := chartName
 	if strings.Contains(chartName, "/") {
 		parts := strings.Split(chartName, "/")
 		if len(parts) == 2 {
-			chartBaseName := parts[1]
-			searchPatterns = append(searchPatterns,
-				fmt.Sprintf("%s/*/%s-*.tgz", cacheDir, chartBaseName),
-				fmt.Sprintf("%s/%s-*.tgz", cacheDir, chartBaseName),
-			)
+			chartBaseName = parts[1]
 		}
-	} else {
-		searchPatterns = append(searchPatterns,
-			fmt.Sprintf("%s/*/%s-*.tgz", cacheDir, chartName),
-			fmt.Sprintf("%s/%s-*.tgz", cacheDir, chartName),
-		)
+	}
+
+	versionGlob := "*"
+	if version != "" {
+		versionGlob = version
+	}
+	searchPatterns := []string{
+		fmt.Sprintf("%s/*/%s-%s.tgz", cacheDir, chartBaseName, versionGlob),
+		fmt.Sprintf("%s/%s-%s.tgz", cacheDir, chartBaseName, versionGlob),
 	}
 
 	for _, pattern := range searchPatterns {

--- a/AegisLab/src/infra/helm/gateway_test.go
+++ b/AegisLab/src/infra/helm/gateway_test.go
@@ -1,0 +1,71 @@
+package helm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"helm.sh/helm/v3/pkg/cli"
+)
+
+// Reproduces issue #374: cached <chart>-<oldver>.tgz must NOT shadow a
+// caller-requested newer <chart>-<newver>.tgz.
+func TestFindCachedChart_VersionMismatchMisses(t *testing.T) {
+	tmp := t.TempDir()
+	staleTgz := filepath.Join(tmp, "trainticket-0.3.0.tgz")
+	if err := os.WriteFile(staleTgz, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	settings := cli.New()
+	settings.RepositoryCache = tmp
+
+	got, err := findCachedChart(settings, "operations-pai/trainticket", "0.3.1")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected cache miss for version 0.3.1 with only 0.3.0 cached; got %q", got)
+	}
+}
+
+func TestFindCachedChart_VersionMatchHits(t *testing.T) {
+	tmp := t.TempDir()
+	freshTgz := filepath.Join(tmp, "trainticket-0.3.1.tgz")
+	if err := os.WriteFile(freshTgz, []byte("fresh"), 0o644); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	settings := cli.New()
+	settings.RepositoryCache = tmp
+
+	got, err := findCachedChart(settings, "operations-pai/trainticket", "0.3.1")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != freshTgz {
+		t.Fatalf("expected cache hit at %q; got %q", freshTgz, got)
+	}
+}
+
+// When the caller doesn't pin a version (empty string), legacy any-version
+// behavior is preserved — the existing reseed flow that omits version (e.g.
+// during initial bootstrap) must still pick up whatever tgz is on disk.
+func TestFindCachedChart_EmptyVersionFallsBackToAnyMatch(t *testing.T) {
+	tmp := t.TempDir()
+	tgz := filepath.Join(tmp, "trainticket-0.3.0.tgz")
+	if err := os.WriteFile(tgz, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	settings := cli.New()
+	settings.RepositoryCache = tmp
+
+	got, err := findCachedChart(settings, "operations-pai/trainticket", "")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != tgz {
+		t.Fatalf("expected legacy any-version match at %q; got %q", tgz, got)
+	}
+}


### PR DESCRIPTION
## Symptom
After bumping `trainticket 0.3.0 → 0.3.1` in seed, the worker logged
`[INFO] [...] [0.3.1] Installing Helm chart from remote` but `helm history`
on the resulting release showed `CHART trainticket-0.3.0`. All freshly-installed
namespaces inherited the stale chart and reproduced the original bug.

## Root cause
`findCachedChart` in `AegisLab/src/infra/helm/gateway.go` searched the helm
repository cache with an unversioned glob (`<chartBaseName>-*.tgz`) and returned
the first match. Once `trainticket-0.3.0.tgz` was on disk, it satisfied every
subsequent `0.3.1` lookup — `loader.Load(chartPath)` then loaded the stale tgz
and `installAction.Run` happily installed it (`installAction.Version` is only
consulted when `LocateChart` is reached, which the cached path skipped).

## Fix
Approach A, sub-option 1 from the issue: pass the requested `version` down to
`findCachedChart` and pin the glob to `<chartBaseName>-<version>.tgz`. On miss,
fall through to `installAction.LocateChart` which honors `installAction.Version`
and re-fetches from the repo index. When the caller supplies an empty version
(legacy bootstrap path) the original any-version glob is preserved.

LOC delta: +83 / -15 (mostly the new test file).

## Tests
`AegisLab/src/infra/helm/gateway_test.go` — three table-style tests:
- version-mismatch must miss (the issue #374 scenario)
- version-match must hit
- empty-version must keep legacy any-match behavior

`cd src && go test ./infra/helm/... -v` → PASS (3/3).
`cd src && go build -tags duckdb_arrow -o /dev/null ./...` → clean.

Closes #374