### PR TITLE
feat(llm-eval/v2): rework prompts + open SQL sandbox + service/kind F1 split (0.4.24)

### DIFF
--- a/rcabench-platform/pyproject.toml
+++ b/rcabench-platform/pyproject.toml
@@ -116,6 +116,7 @@ dev = [ #
 [tool.pytest.ini_options]
 testpaths = [
     "src/rcabench_platform/v3/internal/reasoning/ir_tests",
+    "src/rcabench_platform/v3/sdk/evaluation/v2_tests",
 ]
 
 [build-system]

--- a/rcabench-platform/pyproject.toml
+++ b/rcabench-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rcabench-platform"
-version = "0.4.23"
+version = "0.4.24"
 description = "An experiment framework for Root Cause Analysis"
 readme = "README.md"
 authors = [ #

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/__init__.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/__init__.py
@@ -1,0 +1,48 @@
+"""Top-down RCA evaluation v2.
+
+Public API:
+    AgentRCAOutput / RootCauseClaim / Evidence / PropagationClaim — agent contract
+    FaultKind, map_chaos_type — controlled fault-kind vocabulary
+    extract_gt_faults — pull list[GTFault] from injection.json
+    evaluate_v2 — async top-level scorer returning EvaluationResultV2
+"""
+
+from .chain_judge import ChainJudgeResult, chain_coherence
+from .evaluator import EvaluationResultV2, evaluate_v2
+from .fault_kind import FaultKind, map_chaos_type
+from .ground_truth import GTFault, extract_gt_faults
+from .matcher import FaultMatchResult, GraphMetrics, MatchStatus, compute_graph_metrics, compute_outcome
+from .schema import (
+    AgentRCAOutput,
+    Direction,
+    Evidence,
+    EvidenceKind,
+    PropagationClaim,
+    RootCauseClaim,
+)
+from .sql_verify import EvidenceStatus, EvidenceVerifyResult, verify_evidence
+
+__all__ = [
+    "AgentRCAOutput",
+    "Direction",
+    "Evidence",
+    "EvidenceKind",
+    "PropagationClaim",
+    "RootCauseClaim",
+    "FaultKind",
+    "map_chaos_type",
+    "GTFault",
+    "extract_gt_faults",
+    "MatchStatus",
+    "FaultMatchResult",
+    "GraphMetrics",
+    "compute_outcome",
+    "compute_graph_metrics",
+    "EvidenceVerifyResult",
+    "EvidenceStatus",
+    "verify_evidence",
+    "ChainJudgeResult",
+    "chain_coherence",
+    "EvaluationResultV2",
+    "evaluate_v2",
+]

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/chain_judge.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/chain_judge.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field
 
 from ..causal_graph import CausalGraph
 from .schema import AgentRCAOutput
-from .sql_verify import EvidenceStatus, EvidenceVerifyResult
+from .sql_verify import EvidenceVerifyResult
 
 
 class ChainJudgeResult(BaseModel):
@@ -45,7 +45,7 @@ Score on a single 0.0–1.0 scale:
 You must NOT use any prior knowledge of which case this is. Judge only what is
 shown.
 
-Respond with strict JSON: {"score": <float 0..1>, "reasoning": "<≤80 words>"}.
+Respond with strict JSON: {{"score": <float 0..1>, "reasoning": "<=80 words>"}}.
 
 == Agent output ==
 {agent_output}
@@ -100,10 +100,10 @@ async def chain_coherence(
     model: str = "gpt-4o-mini",
 ) -> ChainJudgeResult:
     if llm_client is None:
-        ok = sum(1 for _, vr in evidence_results if vr.status == EvidenceStatus.OK)
-        total = len(evidence_results)
-        fallback = ok / total if total else 0.0
-        return ChainJudgeResult(score=fallback, reasoning="(no llm_client; fallback = sql_executable_rate)")
+        raise ValueError(
+            "chain_coherence requires an LLM client; configure judge_model in "
+            "the eval config so a non-None client is provided."
+        )
 
     prompt = _JUDGE_PROMPT.format(
         agent_output=agent.model_dump_json(by_alias=True, indent=2),

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/chain_judge.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/chain_judge.py
@@ -1,0 +1,133 @@
+"""LLM-as-judge for causal-chain coherence.
+
+Inputs the agent's structured output, the executed SQL preview, and the GT
+causal_graph; asks the LLM whether the agent's claims are mutually coherent
+AND consistent with the GT graph. Returns a 0–1 coherence score plus a short
+explanation. The score is informational; the deterministic outcome metrics
+remain primary.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from openai import AsyncOpenAI
+from pydantic import BaseModel, Field
+
+from ..causal_graph import CausalGraph
+from .schema import AgentRCAOutput
+from .sql_verify import EvidenceStatus, EvidenceVerifyResult
+
+
+class ChainJudgeResult(BaseModel):
+    score: float = Field(0.0, ge=0.0, le=1.0)
+    reasoning: str = ""
+    raw_response: str | None = None
+
+
+_JUDGE_PROMPT = """You are scoring whether an RCA agent's reasoning chain is coherent
+and consistent with the ground-truth causal graph.
+
+You will be given:
+  • the agent's structured output (root_causes + propagation edges, each with
+    an evidence SQL and a natural-language claim);
+  • a preview (first rows) of what each SQL actually returned when re-executed;
+  • the ground-truth causal_graph at service granularity.
+
+Score on a single 0.0–1.0 scale:
+  1.0 — every claim is internally consistent, the evidence rows demonstrably
+        support it, AND the propagation chain is reachable in the GT graph.
+  0.0 — the chain is incoherent, or contradicts the GT graph, or the SQL
+        results disprove the claims.
+  Intermediate values are allowed; calibrate so 0.5 means "half the chain is
+  supported."
+
+You must NOT use any prior knowledge of which case this is. Judge only what is
+shown.
+
+Respond with strict JSON: {"score": <float 0..1>, "reasoning": "<≤80 words>"}.
+
+== Agent output ==
+{agent_output}
+
+== Evidence executions (status + sample rows) ==
+{evidence_block}
+
+== Ground truth causal graph (service-level) ==
+{gt_block}
+"""
+
+
+def _format_evidence_block(
+    agent: AgentRCAOutput, results: list[tuple[str, EvidenceVerifyResult]]
+) -> str:
+    """Pair each evidence with its verifier result; truncate sample rows."""
+    if not results:
+        return "(no evidence)"
+    lines: list[str] = []
+    for label, vr in results:
+        head = f"[{label}] status={vr.status.value} rows={vr.row_count}"
+        if vr.error:
+            lines.append(f"{head} error={vr.error[:200]}")
+            continue
+        lines.append(head)
+        for row in vr.sample_rows[:3]:
+            shrunk = {k: (str(v)[:80] if v is not None else None) for k, v in row.items()}
+            lines.append(f"    {json.dumps(shrunk, ensure_ascii=False, default=str)}")
+    return "\n".join(lines)
+
+
+def _format_gt_block(gt_graph: CausalGraph | None) -> str:
+    if gt_graph is None:
+        return "(no ground-truth graph available)"
+    nodes = sorted(gt_graph.get_service_nodes())
+    edges = sorted(gt_graph.get_service_edges())
+    roots = sorted(gt_graph.get_root_cause_services())
+    alarms = sorted(gt_graph.get_alarm_services())
+    return (
+        f"services: {nodes}\n"
+        f"edges: {edges}\n"
+        f"root_cause_services: {roots}\n"
+        f"alarm_services: {alarms}"
+    )
+
+
+async def chain_coherence(
+    agent: AgentRCAOutput,
+    evidence_results: list[tuple[str, EvidenceVerifyResult]],
+    gt_graph: CausalGraph | None,
+    llm_client: AsyncOpenAI | None,
+    model: str = "gpt-4o-mini",
+) -> ChainJudgeResult:
+    if llm_client is None:
+        ok = sum(1 for _, vr in evidence_results if vr.status == EvidenceStatus.OK)
+        total = len(evidence_results)
+        fallback = ok / total if total else 0.0
+        return ChainJudgeResult(score=fallback, reasoning="(no llm_client; fallback = sql_executable_rate)")
+
+    prompt = _JUDGE_PROMPT.format(
+        agent_output=agent.model_dump_json(by_alias=True, indent=2),
+        evidence_block=_format_evidence_block(agent, evidence_results),
+        gt_block=_format_gt_block(gt_graph),
+    )
+
+    try:
+        response = await llm_client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+            max_tokens=400,
+            response_format={"type": "json_object"},
+        )
+    except Exception as exc:
+        return ChainJudgeResult(score=0.0, reasoning=f"(judge error: {exc!s:.200})")
+
+    content = response.choices[0].message.content or ""
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return ChainJudgeResult(score=0.0, reasoning="(judge returned non-JSON)", raw_response=content)
+    score = float(parsed.get("score") or 0.0)
+    score = max(0.0, min(1.0, score))
+    reasoning = str(parsed.get("reasoning") or "")
+    return ChainJudgeResult(score=score, reasoning=reasoning, raw_response=content)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/chain_judge.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/chain_judge.py
@@ -6,6 +6,7 @@ AND consistent with the GT graph. Returns a 0–1 coherence score plus a short
 explanation. The score is informational; the deterministic outcome metrics
 remain primary.
 """
+
 from __future__ import annotations
 
 import json
@@ -58,9 +59,7 @@ Respond with strict JSON: {{"score": <float 0..1>, "reasoning": "<=80 words>"}}.
 """
 
 
-def _format_evidence_block(
-    agent: AgentRCAOutput, results: list[tuple[str, EvidenceVerifyResult]]
-) -> str:
+def _format_evidence_block(agent: AgentRCAOutput, results: list[tuple[str, EvidenceVerifyResult]]) -> str:
     """Pair each evidence with its verifier result; truncate sample rows."""
     if not results:
         return "(no evidence)"
@@ -84,12 +83,7 @@ def _format_gt_block(gt_graph: CausalGraph | None) -> str:
     edges = sorted(gt_graph.get_service_edges())
     roots = sorted(gt_graph.get_root_cause_services())
     alarms = sorted(gt_graph.get_alarm_services())
-    return (
-        f"services: {nodes}\n"
-        f"edges: {edges}\n"
-        f"root_cause_services: {roots}\n"
-        f"alarm_services: {alarms}"
-    )
+    return f"services: {nodes}\nedges: {edges}\nroot_cause_services: {roots}\nalarm_services: {alarms}"
 
 
 async def chain_coherence(

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/evaluator.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/evaluator.py
@@ -8,6 +8,7 @@ Pipeline per case:
     5. LLM-as-judge over chain        → chain_coherence
     6. Compose 4 numbers + headline.
 """
+
 from __future__ import annotations
 
 import json
@@ -56,9 +57,7 @@ class EvaluationResultV2(BaseModel):
     node_f1: float = 0.0
     edge_f1: float = 0.0
 
-    headline: float = Field(
-        ..., description="root_cause_f1 × sql_executable_rate × chain_coherence"
-    )
+    headline: float = Field(..., description="root_cause_f1 × sql_executable_rate × chain_coherence")
     case_correct: bool = False
 
     service_precision: float = 0.0

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/evaluator.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/evaluator.py
@@ -1,0 +1,222 @@
+"""Top-level v2 evaluator.
+
+Pipeline per case:
+    1. Parse agent output JSON      → AgentRCAOutput
+    2. Extract GT faults             → list[GTFault] (+ time window)
+    3. Type-aware match              → root_cause_f1, overclaim_rate, per_fault
+    4. Verify each evidence SQL      → sql_executable_rate, per_evidence
+    5. LLM-as-judge over chain        → chain_coherence
+    6. Compose 4 numbers + headline.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from openai import AsyncOpenAI
+from pydantic import BaseModel, Field, ValidationError
+
+from ..causal_graph import CausalGraph
+from .chain_judge import ChainJudgeResult, chain_coherence
+from .ground_truth import GTContext, extract_gt_faults
+from .matcher import FaultMatchResult, GraphMetrics, OutcomeResult, compute_graph_metrics, compute_outcome
+from .schema import AgentRCAOutput, RootCauseClaim
+from .sql_verify import EvidenceStatus, EvidenceVerifyResult, verify_evidence
+
+
+class PerEvidenceRecord(BaseModel):
+    label: str
+    kind: str
+    sql: str
+    claim: str
+    status: EvidenceStatus
+    error: str | None = None
+    row_count: int = 0
+
+
+class EvaluationResultV2(BaseModel):
+    """Headline scores + every diagnostic needed to debug them.
+
+    Headline numbers (per case):
+      - root_cause_f1:     type-aware match against engine_config faults
+      - overclaim_rate:    agent root_causes that did not align to any GT fault
+      - sql_executable_rate: evidence SQL that ran, returned rows, and aligned
+      - chain_coherence:   LLM judge over (claims + SQL preview + GT graph)
+      - node_f1 / edge_f1: agent's claimed graph vs GT causal_graph (service-level)
+
+    `headline = root_cause_f1 × sql_executable_rate × chain_coherence`
+    """
+
+    root_cause_f1: float
+    overclaim_rate: float
+    sql_executable_rate: float
+    chain_coherence: float
+
+    node_f1: float = 0.0
+    edge_f1: float = 0.0
+
+    headline: float = Field(
+        ..., description="root_cause_f1 × sql_executable_rate × chain_coherence"
+    )
+    case_correct: bool = False
+
+    root_cause_precision: float = 0.0
+    root_cause_recall: float = 0.0
+    node_precision: float = 0.0
+    node_recall: float = 0.0
+    edge_precision: float = 0.0
+    edge_recall: float = 0.0
+
+    per_fault: list[FaultMatchResult] = Field(default_factory=list)
+    overclaim_indices: list[int] = Field(default_factory=list)
+    per_evidence: list[PerEvidenceRecord] = Field(default_factory=list)
+    graph_metrics: GraphMetrics | None = None
+
+    chain_judge: ChainJudgeResult | None = None
+
+    parse_error: str | None = None
+    notes: list[str] = Field(default_factory=list)
+
+
+def _parse_agent(raw: str | dict[str, Any] | None) -> tuple[AgentRCAOutput | None, str | None]:
+    if raw is None:
+        return None, "agent output is empty"
+    try:
+        data = json.loads(raw) if isinstance(raw, str) else raw
+    except json.JSONDecodeError as exc:
+        return None, f"JSON decode error: {exc}"
+    try:
+        return AgentRCAOutput.model_validate(data), None
+    except ValidationError as exc:
+        return None, f"schema validation error: {exc}"
+
+
+def _allowed_services_for(rc: RootCauseClaim) -> set[str]:
+    s: set[str] = {rc.service}
+    if rc.direction:
+        s.update({rc.direction.src, rc.direction.dst})
+    return {x for x in s if x}
+
+
+def _zero_result(parse_error: str, notes: list[str] | None = None) -> EvaluationResultV2:
+    return EvaluationResultV2(
+        root_cause_f1=0.0,
+        overclaim_rate=0.0,
+        sql_executable_rate=0.0,
+        chain_coherence=0.0,
+        headline=0.0,
+        case_correct=False,
+        parse_error=parse_error,
+        notes=notes or [],
+    )
+
+
+async def evaluate_v2(
+    agent_output_raw: str | dict[str, Any] | None,
+    injection: dict[str, Any],
+    parquet_dir: str | Path,
+    gt_graph: CausalGraph | None = None,
+    llm_client: AsyncOpenAI | None = None,
+    judge_model: str = "gpt-4o-mini",
+    case_name: str | None = None,
+) -> EvaluationResultV2:
+    parquet_dir = Path(parquet_dir)
+
+    agent, parse_error = _parse_agent(agent_output_raw)
+    if agent is None:
+        return _zero_result(parse_error or "agent output unparseable")
+
+    gt_ctx: GTContext = extract_gt_faults(injection, case_name=case_name)
+    if not gt_ctx.faults:
+        return _zero_result("no GT faults extractable from injection.json")
+
+    outcome: OutcomeResult = compute_outcome(agent, gt_ctx.faults)
+    graph: GraphMetrics = compute_graph_metrics(agent, gt_graph)
+
+    per_evidence: list[PerEvidenceRecord] = []
+    sql_evidence_results: list[tuple[str, EvidenceVerifyResult]] = []
+
+    for ri, rc in enumerate(agent.root_causes):
+        allowed = _allowed_services_for(rc)
+        for ei, ev in enumerate(rc.evidence):
+            label = f"rc[{ri}].ev[{ei}]"
+            vr = verify_evidence(
+                evidence=ev,
+                parquet_dir=parquet_dir,
+                start_time_ns=gt_ctx.start_time_ns,
+                end_time_ns=gt_ctx.end_time_ns,
+                allowed_services=allowed,
+            )
+            per_evidence.append(
+                PerEvidenceRecord(
+                    label=label,
+                    kind=ev.kind.value,
+                    sql=ev.sql,
+                    claim=ev.claim,
+                    status=vr.status,
+                    error=vr.error,
+                    row_count=vr.row_count,
+                )
+            )
+            sql_evidence_results.append((label, vr))
+
+    for pi, prop in enumerate(agent.propagation):
+        allowed = {prop.from_, prop.to}
+        for ei, ev in enumerate(prop.evidence):
+            label = f"prop[{pi}].ev[{ei}]"
+            vr = verify_evidence(
+                evidence=ev,
+                parquet_dir=parquet_dir,
+                start_time_ns=gt_ctx.start_time_ns,
+                end_time_ns=gt_ctx.end_time_ns,
+                allowed_services=allowed,
+            )
+            per_evidence.append(
+                PerEvidenceRecord(
+                    label=label,
+                    kind=ev.kind.value,
+                    sql=ev.sql,
+                    claim=ev.claim,
+                    status=vr.status,
+                    error=vr.error,
+                    row_count=vr.row_count,
+                )
+            )
+            sql_evidence_results.append((label, vr))
+
+    n_ev = len(per_evidence)
+    n_ok = sum(1 for r in per_evidence if r.status == EvidenceStatus.OK)
+    sql_executable_rate = n_ok / n_ev if n_ev else 0.0
+
+    judge_result = await chain_coherence(
+        agent=agent,
+        evidence_results=sql_evidence_results,
+        gt_graph=gt_graph,
+        llm_client=llm_client,
+        model=judge_model,
+    )
+
+    headline = outcome.root_cause_f1 * sql_executable_rate * judge_result.score
+
+    return EvaluationResultV2(
+        root_cause_f1=outcome.root_cause_f1,
+        overclaim_rate=outcome.overclaim_rate,
+        sql_executable_rate=sql_executable_rate,
+        chain_coherence=judge_result.score,
+        node_f1=graph.node_f1,
+        edge_f1=graph.edge_f1,
+        headline=headline,
+        case_correct=outcome.case_correct,
+        root_cause_precision=outcome.root_cause_precision,
+        root_cause_recall=outcome.root_cause_recall,
+        node_precision=graph.node_precision,
+        node_recall=graph.node_recall,
+        edge_precision=graph.edge_precision,
+        edge_recall=graph.edge_recall,
+        per_fault=outcome.per_fault,
+        overclaim_indices=outcome.overclaim_indices,
+        per_evidence=per_evidence,
+        graph_metrics=graph,
+        chain_judge=judge_result,
+    )

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/evaluator.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/evaluator.py
@@ -21,7 +21,7 @@ from ..causal_graph import CausalGraph
 from .chain_judge import ChainJudgeResult, chain_coherence
 from .ground_truth import GTContext, extract_gt_faults
 from .matcher import FaultMatchResult, GraphMetrics, OutcomeResult, compute_graph_metrics, compute_outcome
-from .schema import AgentRCAOutput, RootCauseClaim
+from .schema import AgentRCAOutput
 from .sql_verify import EvidenceStatus, EvidenceVerifyResult, verify_evidence
 
 
@@ -61,6 +61,10 @@ class EvaluationResultV2(BaseModel):
     )
     case_correct: bool = False
 
+    service_precision: float = 0.0
+    service_recall: float = 0.0
+    service_f1: float = 0.0
+
     root_cause_precision: float = 0.0
     root_cause_recall: float = 0.0
     node_precision: float = 0.0
@@ -90,13 +94,6 @@ def _parse_agent(raw: str | dict[str, Any] | None) -> tuple[AgentRCAOutput | Non
         return AgentRCAOutput.model_validate(data), None
     except ValidationError as exc:
         return None, f"schema validation error: {exc}"
-
-
-def _allowed_services_for(rc: RootCauseClaim) -> set[str]:
-    s: set[str] = {rc.service}
-    if rc.direction:
-        s.update({rc.direction.src, rc.direction.dst})
-    return {x for x in s if x}
 
 
 def _zero_result(parse_error: str, notes: list[str] | None = None) -> EvaluationResultV2:
@@ -138,16 +135,9 @@ async def evaluate_v2(
     sql_evidence_results: list[tuple[str, EvidenceVerifyResult]] = []
 
     for ri, rc in enumerate(agent.root_causes):
-        allowed = _allowed_services_for(rc)
         for ei, ev in enumerate(rc.evidence):
             label = f"rc[{ri}].ev[{ei}]"
-            vr = verify_evidence(
-                evidence=ev,
-                parquet_dir=parquet_dir,
-                start_time_ns=gt_ctx.start_time_ns,
-                end_time_ns=gt_ctx.end_time_ns,
-                allowed_services=allowed,
-            )
+            vr = verify_evidence(evidence=ev, parquet_dir=parquet_dir)
             per_evidence.append(
                 PerEvidenceRecord(
                     label=label,
@@ -162,16 +152,9 @@ async def evaluate_v2(
             sql_evidence_results.append((label, vr))
 
     for pi, prop in enumerate(agent.propagation):
-        allowed = {prop.from_, prop.to}
         for ei, ev in enumerate(prop.evidence):
             label = f"prop[{pi}].ev[{ei}]"
-            vr = verify_evidence(
-                evidence=ev,
-                parquet_dir=parquet_dir,
-                start_time_ns=gt_ctx.start_time_ns,
-                end_time_ns=gt_ctx.end_time_ns,
-                allowed_services=allowed,
-            )
+            vr = verify_evidence(evidence=ev, parquet_dir=parquet_dir)
             per_evidence.append(
                 PerEvidenceRecord(
                     label=label,
@@ -208,6 +191,9 @@ async def evaluate_v2(
         edge_f1=graph.edge_f1,
         headline=headline,
         case_correct=outcome.case_correct,
+        service_precision=outcome.service_precision,
+        service_recall=outcome.service_recall,
+        service_f1=outcome.service_f1,
         root_cause_precision=outcome.root_cause_precision,
         root_cause_recall=outcome.root_cause_recall,
         node_precision=graph.node_precision,

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/fault_kind.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/fault_kind.py
@@ -1,0 +1,79 @@
+"""Controlled fault-kind vocabulary + chaos_type mapping."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class FaultKind(str, Enum):
+    POD_FAILURE = "pod_failure"
+    CPU_STRESS = "cpu_stress"
+    MEM_STRESS = "mem_stress"
+    NETWORK_DELAY = "network_delay"
+    NETWORK_LOSS = "network_loss"
+    NETWORK_PARTITION = "network_partition"
+    NETWORK_CORRUPT = "network_corrupt"
+    NETWORK_DUPLICATE = "network_duplicate"
+    JVM_EXCEPTION = "jvm_exception"
+    JVM_MUTATOR = "jvm_mutator"
+    HTTP_ABORT = "http_abort"
+    HTTP_REPLACE = "http_replace"
+    DNS = "dns"
+    TIME_SKEW = "time_skew"
+    UNKNOWN = "unknown"
+
+
+_CHAOS_TYPE_MAP: dict[str, FaultKind] = {
+    "PodFailure": FaultKind.POD_FAILURE,
+    "PodKill": FaultKind.POD_FAILURE,
+    "ContainerKill": FaultKind.POD_FAILURE,
+    "CPUStress": FaultKind.CPU_STRESS,
+    "JVMCPUStress": FaultKind.CPU_STRESS,
+    "MemoryStress": FaultKind.MEM_STRESS,
+    "JVMMemoryStress": FaultKind.MEM_STRESS,
+    "NetworkDelay": FaultKind.NETWORK_DELAY,
+    "NetworkLoss": FaultKind.NETWORK_LOSS,
+    "NetworkPartition": FaultKind.NETWORK_PARTITION,
+    "NetworkCorrupt": FaultKind.NETWORK_CORRUPT,
+    "NetworkDuplicate": FaultKind.NETWORK_DUPLICATE,
+    "JVMException": FaultKind.JVM_EXCEPTION,
+    "JVMReturnValue": FaultKind.JVM_MUTATOR,
+    "JVMRuntimeMutator": FaultKind.JVM_MUTATOR,
+    "HTTPRequestAbort": FaultKind.HTTP_ABORT,
+    "HTTPResponseAbort": FaultKind.HTTP_ABORT,
+    "HTTPRequestReplaceMethod": FaultKind.HTTP_REPLACE,
+    "HTTPResponseReplaceCode": FaultKind.HTTP_REPLACE,
+    "HTTPResponseReplaceBody": FaultKind.HTTP_REPLACE,
+    "HTTPRequestReplacePath": FaultKind.HTTP_REPLACE,
+    "DNSChaos": FaultKind.DNS,
+    "DNSError": FaultKind.DNS,
+    "DNSRandom": FaultKind.DNS,
+    "TimeChaos": FaultKind.TIME_SKEW,
+    "TimeSkew": FaultKind.TIME_SKEW,
+}
+
+
+NETWORK_KINDS: frozenset[FaultKind] = frozenset(
+    {
+        FaultKind.NETWORK_DELAY,
+        FaultKind.NETWORK_LOSS,
+        FaultKind.NETWORK_PARTITION,
+        FaultKind.NETWORK_CORRUPT,
+        FaultKind.NETWORK_DUPLICATE,
+    }
+)
+
+CODE_LEVEL_KINDS: frozenset[FaultKind] = frozenset(
+    {
+        FaultKind.JVM_EXCEPTION,
+        FaultKind.JVM_MUTATOR,
+        FaultKind.HTTP_ABORT,
+        FaultKind.HTTP_REPLACE,
+    }
+)
+
+
+def map_chaos_type(chaos_type: str | None) -> FaultKind:
+    """Map a chaos_type string from engine_config to the controlled FaultKind."""
+    if not chaos_type:
+        return FaultKind.UNKNOWN
+    return _CHAOS_TYPE_MAP.get(chaos_type, FaultKind.UNKNOWN)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/fault_kind.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/fault_kind.py
@@ -1,4 +1,5 @@
 """Controlled fault-kind vocabulary + chaos_type mapping."""
+
 from __future__ import annotations
 
 from enum import Enum

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/ground_truth.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/ground_truth.py
@@ -1,0 +1,169 @@
+"""Extract ground-truth fault list from injection.json.
+
+Two on-disk formats are supported:
+  1. New (aegisctl detector_success): `engine_config` is a JSON list of dicts
+     with `app`, `chaos_type`, `target_service`, `direction`, `class`, `method`.
+  2. Old (FSE/openrca2): `engine_config` is an opaque JSON-encoded string,
+     `fault_type` is numeric. We fall back to data.jsonl side-channel for the
+     canonical chaos_type label, and read `ground_truth.service[0]` for the app.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .fault_kind import NETWORK_KINDS, FaultKind, map_chaos_type
+
+
+class GTFault(BaseModel):
+    """One ground-truth fault entry (one item from engine_config)."""
+
+    service: str
+    fault_kind: FaultKind
+    direction_src: str | None = None
+    direction_dst: str | None = None
+    method: str | None = Field(
+        default=None,
+        description="Canonical class.method (jvm/http only).",
+    )
+
+    raw_chaos_type: str | None = None
+
+
+class GTContext(BaseModel):
+    """All ground-truth signal a single case carries."""
+
+    faults: list[GTFault]
+    start_time_ns: int | None = None
+    end_time_ns: int | None = None
+
+
+_OLD_INDEX_PATH = Path("/home/ddq/AoyangSpace/dataset/rca/data.jsonl")
+_OLD_INDEX_CACHE: dict[str, dict[str, Any]] | None = None
+
+
+def _load_old_index() -> dict[str, dict[str, Any]]:
+    global _OLD_INDEX_CACHE
+    if _OLD_INDEX_CACHE is None:
+        idx: dict[str, dict[str, Any]] = {}
+        if _OLD_INDEX_PATH.exists():
+            with _OLD_INDEX_PATH.open() as f:
+                for line in f:
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    key = row.get("source") or row.get("datapack_name")
+                    if key:
+                        idx[key] = row
+        _OLD_INDEX_CACHE = idx
+    return _OLD_INDEX_CACHE
+
+
+def _parse_iso_to_ns(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        v = int(value)
+        return v * 1_000_000_000 if v < 1_000_000_000_000_000 else v
+    if not isinstance(value, str):
+        return None
+    s = value.strip()
+    if not s:
+        return None
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1_000_000_000)
+
+
+def _build_method(class_name: str | None, method_name: str | None) -> str | None:
+    if not method_name:
+        return None
+    return f"{class_name}.{method_name}" if class_name else method_name
+
+
+def _new_format_faults(engine_config: list[dict[str, Any]]) -> list[GTFault]:
+    faults: list[GTFault] = []
+    for leaf in engine_config:
+        if not isinstance(leaf, dict):
+            continue
+        app = leaf.get("app")
+        if not app:
+            continue
+        chaos_type = leaf.get("chaos_type") or ""
+        kind = map_chaos_type(chaos_type)
+        src = dst = None
+        if kind in NETWORK_KINDS:
+            src = app
+            dst = leaf.get("target_service")
+        method = None
+        if kind in {FaultKind.JVM_EXCEPTION, FaultKind.JVM_MUTATOR, FaultKind.HTTP_ABORT, FaultKind.HTTP_REPLACE}:
+            method = _build_method(leaf.get("class"), leaf.get("method"))
+        faults.append(
+            GTFault(
+                service=str(app),
+                fault_kind=kind,
+                direction_src=src,
+                direction_dst=dst,
+                method=method,
+                raw_chaos_type=chaos_type,
+            )
+        )
+    return faults
+
+
+def _old_format_faults(injection: dict[str, Any], case_name: str | None) -> list[GTFault]:
+    canonical_chaos: str | None = None
+    if case_name:
+        old = _load_old_index().get(case_name) or {}
+        ft = old.get("fault_type")
+        if isinstance(ft, str) and ft:
+            canonical_chaos = ft
+
+    gt = injection.get("ground_truth") or {}
+    if isinstance(gt, list):
+        gt = gt[0] if gt and isinstance(gt[0], dict) else {}
+    if not isinstance(gt, dict):
+        return []
+    services = gt.get("service") or []
+    if not services:
+        return []
+    service = str(services[0])
+
+    function = gt.get("function") or []
+    method = str(function[0]) if function and function[0] else None
+
+    return [
+        GTFault(
+            service=service,
+            fault_kind=map_chaos_type(canonical_chaos),
+            direction_src=None,
+            direction_dst=None,
+            method=method,
+            raw_chaos_type=canonical_chaos,
+        )
+    ]
+
+
+def extract_gt_faults(injection: dict[str, Any], case_name: str | None = None) -> GTContext:
+    engine = injection.get("engine_config")
+    if isinstance(engine, list) and engine and isinstance(engine[0], dict):
+        faults = _new_format_faults(engine)
+    else:
+        faults = _old_format_faults(injection, case_name)
+
+    return GTContext(
+        faults=faults,
+        start_time_ns=_parse_iso_to_ns(injection.get("start_time")),
+        end_time_ns=_parse_iso_to_ns(injection.get("end_time")),
+    )

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/ground_truth.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/ground_truth.py
@@ -7,6 +7,7 @@ Two on-disk formats are supported:
      `fault_type` is numeric. We fall back to data.jsonl side-channel for the
      canonical chaos_type label, and read `ground_truth.service[0]` for the app.
 """
+
 from __future__ import annotations
 
 import json

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/matcher.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/matcher.py
@@ -57,9 +57,25 @@ class GraphMetrics(BaseModel):
 
 
 class OutcomeResult(BaseModel):
+    """Two-tier outcome scoring derived from the same per_fault assignment.
+
+    `service_*` counts a fault matched if the agent picked the right service
+    (regardless of fault kind / direction). `root_cause_*` (kind-level) is
+    stricter: requires kind match and, for network_*, direction match too —
+    i.e. the per_fault status == HIT.
+
+    Both pairs share denominators: precision over n_agent_root_causes,
+    recall over n_gt_faults.
+    """
+
+    service_precision: float
+    service_recall: float
+    service_f1: float
+
     root_cause_precision: float
     root_cause_recall: float
     root_cause_f1: float
+
     overclaim_rate: float
     per_fault: list[FaultMatchResult] = Field(default_factory=list)
     overclaim_indices: list[int] = Field(default_factory=list)
@@ -67,12 +83,14 @@ class OutcomeResult(BaseModel):
 
 
 def _norm(name: str | None) -> str:
+    """Uniform service-name normalization used by both the matcher and the
+    SQL verifier. Lower-case, strip dashes and underscores. No system-specific
+    prefix stripping — agents may use various writings, but they must avoid
+    inventing names not present in the data.
+    """
     if not name:
         return ""
-    s = name.strip().lower()
-    if s.startswith("ts-"):
-        s = s[3:]
-    return s.replace("-", "").replace("_", "")
+    return name.strip().lower().replace("-", "").replace("_", "")
 
 
 def _service_eq(a: str | None, b: str | None) -> bool:
@@ -164,17 +182,30 @@ def compute_outcome(agent: AgentRCAOutput, gt_faults: list[GTFault]) -> OutcomeR
 
     overclaim_indices = [i for i in range(n_agent) if i not in assigned_agent]
 
-    n_hit = sum(1 for r in per_fault if r.status == MatchStatus.HIT)
-    precision = n_hit / n_agent if n_agent else (1.0 if n_gt == 0 else 0.0)
-    recall = n_hit / n_gt if n_gt else (1.0 if n_agent == 0 else 0.0)
-    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    # service-level: any matched assignment counts (status != MISS)
+    n_service_hit = sum(1 for r in per_fault if r.status != MatchStatus.MISS)
+    # kind-level (the strict reading): status must be HIT
+    n_kind_hit = sum(1 for r in per_fault if r.status == MatchStatus.HIT)
+
+    def _prf(hits: int) -> tuple[float, float, float]:
+        p = hits / n_agent if n_agent else (1.0 if n_gt == 0 else 0.0)
+        r = hits / n_gt if n_gt else (1.0 if n_agent == 0 else 0.0)
+        f = (2 * p * r / (p + r)) if (p + r) else 0.0
+        return p, r, f
+
+    sp, sr, sf = _prf(n_service_hit)
+    kp, kr, kf = _prf(n_kind_hit)
+
     overclaim_rate = len(overclaim_indices) / n_agent if n_agent else 0.0
-    case_correct = (n_hit == n_gt) and (len(overclaim_indices) == 0) and n_gt > 0
+    case_correct = (n_kind_hit == n_gt) and (len(overclaim_indices) == 0) and n_gt > 0
 
     return OutcomeResult(
-        root_cause_precision=precision,
-        root_cause_recall=recall,
-        root_cause_f1=f1,
+        service_precision=sp,
+        service_recall=sr,
+        service_f1=sf,
+        root_cause_precision=kp,
+        root_cause_recall=kr,
+        root_cause_f1=kf,
         overclaim_rate=overclaim_rate,
         per_fault=per_fault,
         overclaim_indices=overclaim_indices,

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/matcher.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/matcher.py
@@ -1,5 +1,6 @@
 """Type-aware matcher: pair each agent root_cause to a GT fault, plus
 service-level node / edge F1 against the ground-truth causal graph."""
+
 from __future__ import annotations
 
 from enum import Enum

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/matcher.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/matcher.py
@@ -1,0 +1,255 @@
+"""Type-aware matcher: pair each agent root_cause to a GT fault, plus
+service-level node / edge F1 against the ground-truth causal graph."""
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from ..causal_graph import CausalGraph
+from .fault_kind import NETWORK_KINDS, FaultKind
+from .ground_truth import GTFault
+from .schema import AgentRCAOutput, RootCauseClaim
+
+
+class MatchStatus(str, Enum):
+    HIT = "HIT"
+    WRONG_DIRECTION = "WRONG_DIRECTION"
+    WRONG_KIND = "WRONG_KIND"
+    MISS = "MISS"
+
+
+class FaultMatchResult(BaseModel):
+    """Per-GT-fault diagnostic."""
+
+    gt_service: str
+    gt_fault_kind: FaultKind
+    matched_root_cause_index: int | None = None
+    status: MatchStatus
+    method_match: bool | None = None
+
+
+class GraphMetrics(BaseModel):
+    """Service-level graph comparison vs ground-truth causal_graph.json.
+
+    The agent's service set is the union of every service mentioned across
+    root_causes, propagation endpoints, and Network direction pairs. Its edge
+    set is the propagation list collapsed to (src, dst) tuples (self-loops
+    dropped).
+    """
+
+    node_precision: float = 0.0
+    node_recall: float = 0.0
+    node_f1: float = 0.0
+    edge_precision: float = 0.0
+    edge_recall: float = 0.0
+    edge_f1: float = 0.0
+
+    matched_services: list[str] = Field(default_factory=list)
+    missed_services: list[str] = Field(default_factory=list)
+    hallucinated_services: list[str] = Field(default_factory=list)
+
+    matched_edges: list[tuple[str, str]] = Field(default_factory=list)
+    missed_edges: list[tuple[str, str]] = Field(default_factory=list)
+    hallucinated_edges: list[tuple[str, str]] = Field(default_factory=list)
+
+    applicable: bool = True
+
+
+class OutcomeResult(BaseModel):
+    root_cause_precision: float
+    root_cause_recall: float
+    root_cause_f1: float
+    overclaim_rate: float
+    per_fault: list[FaultMatchResult] = Field(default_factory=list)
+    overclaim_indices: list[int] = Field(default_factory=list)
+    case_correct: bool = False
+
+
+def _norm(name: str | None) -> str:
+    if not name:
+        return ""
+    s = name.strip().lower()
+    if s.startswith("ts-"):
+        s = s[3:]
+    return s.replace("-", "").replace("_", "")
+
+
+def _service_eq(a: str | None, b: str | None) -> bool:
+    return _norm(a) == _norm(b) and bool(_norm(a))
+
+
+def _evaluate_pair(rc: RootCauseClaim, gt: GTFault) -> tuple[MatchStatus, bool | None]:
+    """Score one (agent_rc, gt_fault) pair without committing — caller picks best."""
+    if not _service_eq(rc.service, gt.service):
+        return MatchStatus.MISS, None
+
+    if rc.fault_kind != gt.fault_kind:
+        return MatchStatus.WRONG_KIND, None
+
+    if gt.fault_kind in NETWORK_KINDS:
+        d = rc.direction
+        if d is None:
+            return MatchStatus.WRONG_DIRECTION, None
+        src_ok = _service_eq(d.src, gt.direction_src)
+        dst_ok = _service_eq(d.dst, gt.direction_dst)
+        if not (src_ok and dst_ok):
+            return MatchStatus.WRONG_DIRECTION, None
+
+    method_match: bool | None = None
+    if gt.method:
+        method_match = (rc.method or "").strip() == gt.method.strip()
+
+    return MatchStatus.HIT, method_match
+
+
+_RANK = {
+    MatchStatus.HIT: 0,
+    MatchStatus.WRONG_DIRECTION: 1,
+    MatchStatus.WRONG_KIND: 2,
+    MatchStatus.MISS: 3,
+}
+
+
+def compute_outcome(agent: AgentRCAOutput, gt_faults: list[GTFault]) -> OutcomeResult:
+    """Greedy assignment: each agent_rc and each gt_fault used at most once.
+
+    Strategy: enumerate all (rc, gt) pairs, sort by tightness (HIT first), then
+    consume top-down skipping pairs whose endpoints are already taken. Remaining
+    GT faults become MISS; remaining agent rcs become overclaim.
+    """
+    n_agent = len(agent.root_causes)
+    n_gt = len(gt_faults)
+
+    triples: list[tuple[int, int, MatchStatus, bool | None]] = []
+    for i, rc in enumerate(agent.root_causes):
+        for j, gt in enumerate(gt_faults):
+            status, method_match = _evaluate_pair(rc, gt)
+            triples.append((i, j, status, method_match))
+    triples.sort(key=lambda t: _RANK[t[2]])
+
+    assigned_agent: dict[int, tuple[int, MatchStatus, bool | None]] = {}
+    assigned_gt: dict[int, tuple[int, MatchStatus, bool | None]] = {}
+    for i, j, status, method_match in triples:
+        if status == MatchStatus.MISS:
+            break
+        if i in assigned_agent or j in assigned_gt:
+            continue
+        assigned_agent[i] = (j, status, method_match)
+        assigned_gt[j] = (i, status, method_match)
+
+    per_fault: list[FaultMatchResult] = []
+    for j, gt in enumerate(gt_faults):
+        if j in assigned_gt:
+            i, status, method_match = assigned_gt[j]
+            per_fault.append(
+                FaultMatchResult(
+                    gt_service=gt.service,
+                    gt_fault_kind=gt.fault_kind,
+                    matched_root_cause_index=i,
+                    status=status,
+                    method_match=method_match,
+                )
+            )
+        else:
+            per_fault.append(
+                FaultMatchResult(
+                    gt_service=gt.service,
+                    gt_fault_kind=gt.fault_kind,
+                    matched_root_cause_index=None,
+                    status=MatchStatus.MISS,
+                    method_match=None,
+                )
+            )
+
+    overclaim_indices = [i for i in range(n_agent) if i not in assigned_agent]
+
+    n_hit = sum(1 for r in per_fault if r.status == MatchStatus.HIT)
+    precision = n_hit / n_agent if n_agent else (1.0 if n_gt == 0 else 0.0)
+    recall = n_hit / n_gt if n_gt else (1.0 if n_agent == 0 else 0.0)
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    overclaim_rate = len(overclaim_indices) / n_agent if n_agent else 0.0
+    case_correct = (n_hit == n_gt) and (len(overclaim_indices) == 0) and n_gt > 0
+
+    return OutcomeResult(
+        root_cause_precision=precision,
+        root_cause_recall=recall,
+        root_cause_f1=f1,
+        overclaim_rate=overclaim_rate,
+        per_fault=per_fault,
+        overclaim_indices=overclaim_indices,
+        case_correct=case_correct,
+    )
+
+
+def _agent_service_set(agent: AgentRCAOutput) -> set[str]:
+    out: set[str] = set()
+    for rc in agent.root_causes:
+        out.add(_norm(rc.service))
+        if rc.direction:
+            out.add(_norm(rc.direction.src))
+            out.add(_norm(rc.direction.dst))
+    for prop in agent.propagation:
+        out.add(_norm(prop.from_))
+        out.add(_norm(prop.to))
+    out.discard("")
+    return out
+
+
+def _agent_edge_set(agent: AgentRCAOutput) -> set[tuple[str, str]]:
+    out: set[tuple[str, str]] = set()
+    for prop in agent.propagation:
+        s, t = _norm(prop.from_), _norm(prop.to)
+        if s and t and s != t:
+            out.add((s, t))
+    return out
+
+
+def _prf(agent: set, gt: set) -> tuple[float, float, float]:
+    if not agent and not gt:
+        return 1.0, 1.0, 1.0
+    matched = agent & gt
+    p = len(matched) / len(agent) if agent else 0.0
+    r = len(matched) / len(gt) if gt else 0.0
+    f1 = (2 * p * r / (p + r)) if (p + r) else 0.0
+    return p, r, f1
+
+
+def compute_graph_metrics(agent: AgentRCAOutput, gt_graph: CausalGraph | None) -> GraphMetrics:
+    """Service-level node/edge F1 of the agent's claimed graph against the GT.
+
+    Names are normalized with the same rule as the type-aware matcher (lowercased,
+    `ts-` stripped, hyphens/underscores removed) so trivial naming variance does
+    not show up as missed/hallucinated.
+    """
+    if gt_graph is None:
+        return GraphMetrics(applicable=False)
+
+    agent_nodes = _agent_service_set(agent)
+    agent_edges = _agent_edge_set(agent)
+
+    gt_nodes_raw = gt_graph.get_service_nodes()
+    gt_edges_raw = gt_graph.get_service_edges()
+    gt_nodes = {_norm(s) for s in gt_nodes_raw}
+    gt_nodes.discard("")
+    gt_edges = {(_norm(s), _norm(t)) for s, t in gt_edges_raw}
+    gt_edges = {(s, t) for s, t in gt_edges if s and t and s != t}
+
+    node_p, node_r, node_f1 = _prf(agent_nodes, gt_nodes)
+    edge_p, edge_r, edge_f1 = _prf(agent_edges, gt_edges)
+
+    return GraphMetrics(
+        node_precision=node_p,
+        node_recall=node_r,
+        node_f1=node_f1,
+        edge_precision=edge_p,
+        edge_recall=edge_r,
+        edge_f1=edge_f1,
+        matched_services=sorted(agent_nodes & gt_nodes),
+        missed_services=sorted(gt_nodes - agent_nodes),
+        hallucinated_services=sorted(agent_nodes - gt_nodes),
+        matched_edges=sorted(agent_edges & gt_edges),
+        missed_edges=sorted(gt_edges - agent_edges),
+        hallucinated_edges=sorted(agent_edges - gt_edges),
+        applicable=True,
+    )

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/schema.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/schema.py
@@ -6,6 +6,7 @@ ground-truth fault list extracted from injection.json.
 
 Each root_cause MUST carry at least one DuckDB-executable SQL evidence row.
 """
+
 from __future__ import annotations
 
 from enum import Enum

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/schema.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/schema.py
@@ -1,0 +1,95 @@
+"""Agent RCA output contract (v2).
+
+The agent does not know in advance whether the case is hybrid or single-fault.
+It emits a flat list of root_causes; the matcher pairs each one against the
+ground-truth fault list extracted from injection.json.
+
+Each root_cause MUST carry at least one DuckDB-executable SQL evidence row.
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .fault_kind import FaultKind
+
+
+class EvidenceKind(str, Enum):
+    METRIC = "metric"
+    TRACE = "trace"
+    LOG = "log"
+
+
+class Direction(BaseModel):
+    """For Network* faults: the netem rule is installed on `src` and shapes
+    traffic toward `dst`. For other fault kinds this field is null.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    src: str = Field(..., description="The service the netem rule sits on (== engine_config.app)")
+    dst: str = Field(..., description="The remote peer (== engine_config.target_service)")
+
+
+class Evidence(BaseModel):
+    """One DuckDB SQL + a natural-language claim it is supposed to prove.
+
+    The SQL is executed read-only against the case's parquets. The claim is
+    used by the LLM-as-judge to decide whether the row set returned actually
+    supports the assertion.
+    """
+
+    model_config = ConfigDict(frozen=False)
+
+    kind: EvidenceKind
+    sql: str = Field(..., description="DuckDB SQL; only read_parquet on the case dir is allowed.")
+    claim: str = Field(..., description="What the SQL result is supposed to demonstrate.")
+
+
+class RootCauseClaim(BaseModel):
+    """One root cause the agent is asserting for this case."""
+
+    service: str
+    fault_kind: FaultKind
+    direction: Direction | None = None
+    method: str | None = Field(
+        default=None,
+        description="class.method for jvm_*/http_* faults; ignored otherwise.",
+    )
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    evidence: list[Evidence] = Field(default_factory=list)
+
+    @field_validator("evidence")
+    @classmethod
+    def _at_least_one_evidence(cls, v: list[Evidence]) -> list[Evidence]:
+        if not v:
+            raise ValueError("each root_cause must carry at least one evidence")
+        return v
+
+
+class PropagationClaim(BaseModel):
+    """An asserted causal edge from `from_` (upstream) to `to` (downstream)."""
+
+    from_: str = Field(..., alias="from")
+    to: str
+    evidence: list[Evidence] = Field(default_factory=list)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class AgentRCAOutput(BaseModel):
+    """The structured JSON the agent must produce.
+
+    Shape is uniform across hybrid and single-fault cases; the agent simply
+    fills `root_causes` with as many entries as it believes there are.
+    """
+
+    root_causes: list[RootCauseClaim] = Field(default_factory=list)
+    propagation: list[PropagationClaim] = Field(default_factory=list)
+
+    @classmethod
+    def parse_str(cls, raw: str) -> AgentRCAOutput:
+        import json
+
+        return cls.model_validate(json.loads(raw))

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/sql_verify.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/sql_verify.py
@@ -15,6 +15,7 @@ Coherence checks (does the SQL actually back the claim, are the rows in the
 incident window, etc.) are the chain-coherence judge's job, not the
 verifier's — the verifier only certifies that the SQL is *runnable*.
 """
+
 from __future__ import annotations
 
 import os
@@ -49,7 +50,7 @@ def _mount_views(con: Any, parquet_dir: Path) -> None:
     for path in parquet_dir.glob("*.parquet"):
         view_name = path.stem.replace('"', '""')
         path_lit = str(path).replace("'", "''")
-        con.execute(f'CREATE VIEW "{view_name}" AS SELECT * FROM read_parquet(\'{path_lit}\')')
+        con.execute(f"CREATE VIEW \"{view_name}\" AS SELECT * FROM read_parquet('{path_lit}')")
 
 
 def verify_evidence(

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/sql_verify.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/sql_verify.py
@@ -1,0 +1,218 @@
+"""DuckDB on parquet — verify each evidence SQL is executable, non-empty,
+inside the injection time window, and returns rows for services the claim
+implicates.
+
+The verifier reads only the parquets in `<case_dir>/<file>.parquet`. Disable
+attach/external IO by running each query on a fresh in-memory connection with
+an `enable_external_access=false` setting where supported.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from .schema import Evidence, EvidenceKind
+
+
+class EvidenceStatus(str, Enum):
+    OK = "OK"
+    EMPTY = "EMPTY"
+    OUT_OF_WINDOW = "OUT_OF_WINDOW"
+    SERVICE_MISMATCH = "SERVICE_MISMATCH"
+    SQL_ERROR = "SQL_ERROR"
+    UNSAFE_SQL = "UNSAFE_SQL"
+
+
+class EvidenceVerifyResult(BaseModel):
+    status: EvidenceStatus
+    row_count: int = 0
+    error: str | None = None
+    sample_rows: list[dict[str, Any]] = Field(default_factory=list)
+    columns: list[str] = Field(default_factory=list)
+
+
+_FORBIDDEN_RE = re.compile(
+    r"\b(ATTACH|INSTALL|LOAD|COPY|EXPORT|PRAGMA|SET|CREATE|DROP|DELETE|UPDATE|INSERT|ALTER)\b",
+    re.IGNORECASE,
+)
+_READ_PARQUET_RE = re.compile(r"read_parquet\s*\(\s*'([^']+)'", re.IGNORECASE)
+_TIME_COLUMN_HINTS = ("time", "timestamp", "ts")
+_SERVICE_COLUMN_HINTS = ("service_name", "service", "attr.k8s.service.name")
+
+
+def _is_safe_sql(sql: str) -> tuple[bool, str | None]:
+    if not sql or not sql.strip():
+        return False, "empty SQL"
+    if _FORBIDDEN_RE.search(sql):
+        return False, "SQL contains a forbidden keyword (DDL/DML/ATTACH/etc.)"
+    if ";" in sql.rstrip().rstrip(";"):
+        return False, "multiple statements are not allowed"
+    return True, None
+
+
+def _resolve_paths(sql: str, parquet_dir: Path) -> tuple[str, list[Path]]:
+    """Rewrite read_parquet('foo.parquet') -> read_parquet('<dir>/foo.parquet').
+
+    Bare names (no '/') are interpreted relative to the case dir; absolute or
+    relative paths that escape the dir are rejected by checking the resolved
+    path is a child of `parquet_dir`.
+    """
+    referenced: list[Path] = []
+    parquet_dir = parquet_dir.resolve()
+
+    def replace(match: re.Match[str]) -> str:
+        ref = match.group(1)
+        candidate = (parquet_dir / ref) if ("/" not in ref) else Path(ref)
+        candidate = candidate.resolve()
+        try:
+            candidate.relative_to(parquet_dir)
+        except ValueError as exc:
+            raise ValueError(f"path {ref!r} escapes case dir") from exc
+        if not candidate.exists():
+            raise FileNotFoundError(f"parquet not found: {candidate}")
+        referenced.append(candidate)
+        return f"read_parquet('{candidate}'"
+
+    rewritten = _READ_PARQUET_RE.sub(replace, sql)
+    return rewritten, referenced
+
+
+def _to_ns(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        v = int(value)
+        return v * 1_000_000_000 if v < 1_000_000_000_000_000 else v
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return int(value.timestamp() * 1_000_000_000)
+    return None
+
+
+def _normalize_service(value: Any) -> str:
+    if value is None:
+        return ""
+    s = str(value).strip().lower()
+    if s.startswith("ts-"):
+        s = s[3:]
+    return s.replace("-", "").replace("_", "")
+
+
+def _within_window(rows: list[dict[str, Any]], start_ns: int | None, end_ns: int | None) -> bool:
+    if start_ns is None or end_ns is None:
+        return True
+    pad_ns = 60 * 1_000_000_000
+    lo = start_ns - pad_ns
+    hi = end_ns + pad_ns
+    found_any = False
+    for row in rows:
+        for col in _TIME_COLUMN_HINTS:
+            ts = row.get(col)
+            ns = _to_ns(ts)
+            if ns is None:
+                continue
+            found_any = True
+            if lo <= ns <= hi:
+                return True
+        if not any(c in row for c in _TIME_COLUMN_HINTS):
+            return True
+    return not found_any
+
+
+def _service_aligned(rows: list[dict[str, Any]], allowed: set[str]) -> bool:
+    if not allowed:
+        return True
+    norm_allowed = {_normalize_service(s) for s in allowed if s}
+    norm_allowed.discard("")
+    if not norm_allowed:
+        return True
+    saw_service_col = False
+    for row in rows:
+        for col in _SERVICE_COLUMN_HINTS:
+            if col not in row:
+                continue
+            saw_service_col = True
+            if _normalize_service(row[col]) in norm_allowed:
+                return True
+    return not saw_service_col
+
+
+def verify_evidence(
+    evidence: Evidence,
+    parquet_dir: Path,
+    start_time_ns: int | None = None,
+    end_time_ns: int | None = None,
+    allowed_services: set[str] | None = None,
+    timeout_seconds: float = 5.0,
+    sample_limit: int = 50,
+) -> EvidenceVerifyResult:
+    safe, why = _is_safe_sql(evidence.sql)
+    if not safe:
+        return EvidenceVerifyResult(status=EvidenceStatus.UNSAFE_SQL, error=why)
+
+    try:
+        rewritten, refs = _resolve_paths(evidence.sql, parquet_dir)
+    except (ValueError, FileNotFoundError) as exc:
+        return EvidenceVerifyResult(status=EvidenceStatus.UNSAFE_SQL, error=str(exc))
+    if not refs:
+        return EvidenceVerifyResult(
+            status=EvidenceStatus.UNSAFE_SQL,
+            error="SQL must reference at least one read_parquet(...) on the case dir",
+        )
+
+    try:
+        import duckdb
+    except ImportError as exc:
+        return EvidenceVerifyResult(status=EvidenceStatus.SQL_ERROR, error=f"duckdb unavailable: {exc}")
+
+    con = duckdb.connect(database=":memory:")
+    try:
+        try:
+            con.execute(f"SET statement_timeout = '{int(timeout_seconds * 1000)}ms'")
+        except Exception:
+            pass
+        try:
+            cursor = con.execute(rewritten)
+            columns = [d[0] for d in (cursor.description or [])]
+            raw_rows = cursor.fetchmany(sample_limit)
+        except Exception as exc:
+            return EvidenceVerifyResult(status=EvidenceStatus.SQL_ERROR, error=str(exc))
+    finally:
+        con.close()
+
+    sample_rows = [dict(zip(columns, row)) for row in raw_rows]
+
+    if not sample_rows:
+        return EvidenceVerifyResult(status=EvidenceStatus.EMPTY, row_count=0, columns=columns)
+
+    if not _within_window(sample_rows, start_time_ns, end_time_ns):
+        return EvidenceVerifyResult(
+            status=EvidenceStatus.OUT_OF_WINDOW,
+            row_count=len(sample_rows),
+            sample_rows=sample_rows[:5],
+            columns=columns,
+        )
+
+    if not _service_aligned(sample_rows, allowed_services or set()):
+        return EvidenceVerifyResult(
+            status=EvidenceStatus.SERVICE_MISMATCH,
+            row_count=len(sample_rows),
+            sample_rows=sample_rows[:5],
+            columns=columns,
+        )
+
+    return EvidenceVerifyResult(
+        status=EvidenceStatus.OK,
+        row_count=len(sample_rows),
+        sample_rows=sample_rows[:5],
+        columns=columns,
+    )
+
+
+_ = EvidenceKind  # re-export indirectly so callers can import from this module

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/sql_verify.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/sql_verify.py
@@ -1,15 +1,23 @@
-"""DuckDB on parquet — verify each evidence SQL is executable, non-empty,
-inside the injection time window, and returns rows for services the claim
-implicates.
+"""DuckDB on parquet — verify each evidence SQL is executable on the case dir.
 
-The verifier reads only the parquets in `<case_dir>/<file>.parquet`. Disable
-attach/external IO by running each query on a fresh in-memory connection with
-an `enable_external_access=false` setting where supported.
+Every ``*.parquet`` file in the case dir is mounted as a same-named view (the
+file ``abnormal_traces.parquet`` becomes view ``abnormal_traces``) so the agent
+can use either bare names (``FROM abnormal_traces``) or explicit
+``read_parquet(...)`` calls. The SQL itself is run as-is on a fresh in-memory
+DuckDB connection — there is no keyword whitelist, no path-prefix sandbox, no
+time-window or service-name post-filter. The only outcomes are:
+
+    OK         — the query executed and returned at least one row
+    EMPTY      — the query executed and returned zero rows
+    SQL_ERROR  — DuckDB raised on parse/exec
+
+Coherence checks (does the SQL actually back the claim, are the rows in the
+incident window, etc.) are the chain-coherence judge's job, not the
+verifier's — the verifier only certifies that the SQL is *runnable*.
 """
 from __future__ import annotations
 
-import re
-from datetime import datetime, timezone
+import os
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -22,10 +30,7 @@ from .schema import Evidence, EvidenceKind
 class EvidenceStatus(str, Enum):
     OK = "OK"
     EMPTY = "EMPTY"
-    OUT_OF_WINDOW = "OUT_OF_WINDOW"
-    SERVICE_MISMATCH = "SERVICE_MISMATCH"
     SQL_ERROR = "SQL_ERROR"
-    UNSAFE_SQL = "UNSAFE_SQL"
 
 
 class EvidenceVerifyResult(BaseModel):
@@ -36,135 +41,26 @@ class EvidenceVerifyResult(BaseModel):
     columns: list[str] = Field(default_factory=list)
 
 
-_FORBIDDEN_RE = re.compile(
-    r"\b(ATTACH|INSTALL|LOAD|COPY|EXPORT|PRAGMA|SET|CREATE|DROP|DELETE|UPDATE|INSERT|ALTER)\b",
-    re.IGNORECASE,
-)
-_READ_PARQUET_RE = re.compile(r"read_parquet\s*\(\s*'([^']+)'", re.IGNORECASE)
-_TIME_COLUMN_HINTS = ("time", "timestamp", "ts")
-_SERVICE_COLUMN_HINTS = ("service_name", "service", "attr.k8s.service.name")
+def _mount_views(con: Any, parquet_dir: Path) -> None:
+    """Create one view per *.parquet in the case dir, named after the file stem.
 
-
-def _is_safe_sql(sql: str) -> tuple[bool, str | None]:
-    if not sql or not sql.strip():
-        return False, "empty SQL"
-    if _FORBIDDEN_RE.search(sql):
-        return False, "SQL contains a forbidden keyword (DDL/DML/ATTACH/etc.)"
-    if ";" in sql.rstrip().rstrip(";"):
-        return False, "multiple statements are not allowed"
-    return True, None
-
-
-def _resolve_paths(sql: str, parquet_dir: Path) -> tuple[str, list[Path]]:
-    """Rewrite read_parquet('foo.parquet') -> read_parquet('<dir>/foo.parquet').
-
-    Bare names (no '/') are interpreted relative to the case dir; absolute or
-    relative paths that escape the dir are rejected by checking the resolved
-    path is a child of `parquet_dir`.
+    Identifiers are quoted so unusual file names don't break the CREATE.
     """
-    referenced: list[Path] = []
-    parquet_dir = parquet_dir.resolve()
-
-    def replace(match: re.Match[str]) -> str:
-        ref = match.group(1)
-        candidate = (parquet_dir / ref) if ("/" not in ref) else Path(ref)
-        candidate = candidate.resolve()
-        try:
-            candidate.relative_to(parquet_dir)
-        except ValueError as exc:
-            raise ValueError(f"path {ref!r} escapes case dir") from exc
-        if not candidate.exists():
-            raise FileNotFoundError(f"parquet not found: {candidate}")
-        referenced.append(candidate)
-        return f"read_parquet('{candidate}'"
-
-    rewritten = _READ_PARQUET_RE.sub(replace, sql)
-    return rewritten, referenced
-
-
-def _to_ns(value: Any) -> int | None:
-    if value is None:
-        return None
-    if isinstance(value, (int, float)):
-        v = int(value)
-        return v * 1_000_000_000 if v < 1_000_000_000_000_000 else v
-    if isinstance(value, datetime):
-        if value.tzinfo is None:
-            value = value.replace(tzinfo=timezone.utc)
-        return int(value.timestamp() * 1_000_000_000)
-    return None
-
-
-def _normalize_service(value: Any) -> str:
-    if value is None:
-        return ""
-    s = str(value).strip().lower()
-    if s.startswith("ts-"):
-        s = s[3:]
-    return s.replace("-", "").replace("_", "")
-
-
-def _within_window(rows: list[dict[str, Any]], start_ns: int | None, end_ns: int | None) -> bool:
-    if start_ns is None or end_ns is None:
-        return True
-    pad_ns = 60 * 1_000_000_000
-    lo = start_ns - pad_ns
-    hi = end_ns + pad_ns
-    found_any = False
-    for row in rows:
-        for col in _TIME_COLUMN_HINTS:
-            ts = row.get(col)
-            ns = _to_ns(ts)
-            if ns is None:
-                continue
-            found_any = True
-            if lo <= ns <= hi:
-                return True
-        if not any(c in row for c in _TIME_COLUMN_HINTS):
-            return True
-    return not found_any
-
-
-def _service_aligned(rows: list[dict[str, Any]], allowed: set[str]) -> bool:
-    if not allowed:
-        return True
-    norm_allowed = {_normalize_service(s) for s in allowed if s}
-    norm_allowed.discard("")
-    if not norm_allowed:
-        return True
-    saw_service_col = False
-    for row in rows:
-        for col in _SERVICE_COLUMN_HINTS:
-            if col not in row:
-                continue
-            saw_service_col = True
-            if _normalize_service(row[col]) in norm_allowed:
-                return True
-    return not saw_service_col
+    for path in parquet_dir.glob("*.parquet"):
+        view_name = path.stem.replace('"', '""')
+        path_lit = str(path).replace("'", "''")
+        con.execute(f'CREATE VIEW "{view_name}" AS SELECT * FROM read_parquet(\'{path_lit}\')')
 
 
 def verify_evidence(
     evidence: Evidence,
     parquet_dir: Path,
-    start_time_ns: int | None = None,
-    end_time_ns: int | None = None,
-    allowed_services: set[str] | None = None,
     timeout_seconds: float = 5.0,
     sample_limit: int = 50,
+    **_: Any,  # accept and ignore legacy kwargs (start_time_ns, allowed_services, ...)
 ) -> EvidenceVerifyResult:
-    safe, why = _is_safe_sql(evidence.sql)
-    if not safe:
-        return EvidenceVerifyResult(status=EvidenceStatus.UNSAFE_SQL, error=why)
-
-    try:
-        rewritten, refs = _resolve_paths(evidence.sql, parquet_dir)
-    except (ValueError, FileNotFoundError) as exc:
-        return EvidenceVerifyResult(status=EvidenceStatus.UNSAFE_SQL, error=str(exc))
-    if not refs:
-        return EvidenceVerifyResult(
-            status=EvidenceStatus.UNSAFE_SQL,
-            error="SQL must reference at least one read_parquet(...) on the case dir",
-        )
+    if not evidence.sql or not evidence.sql.strip():
+        return EvidenceVerifyResult(status=EvidenceStatus.SQL_ERROR, error="empty SQL")
 
     try:
         import duckdb
@@ -172,40 +68,41 @@ def verify_evidence(
         return EvidenceVerifyResult(status=EvidenceStatus.SQL_ERROR, error=f"duckdb unavailable: {exc}")
 
     con = duckdb.connect(database=":memory:")
+    cwd = os.getcwd()
     try:
         try:
             con.execute(f"SET statement_timeout = '{int(timeout_seconds * 1000)}ms'")
         except Exception:
             pass
+
         try:
-            cursor = con.execute(rewritten)
+            _mount_views(con, parquet_dir)
+        except Exception as exc:
+            return EvidenceVerifyResult(status=EvidenceStatus.SQL_ERROR, error=f"view mount failed: {exc}")
+
+        # Resolve relative read_parquet('foo.parquet') paths against the case dir.
+        try:
+            os.chdir(parquet_dir)
+        except Exception:
+            pass
+
+        try:
+            cursor = con.execute(evidence.sql)
             columns = [d[0] for d in (cursor.description or [])]
             raw_rows = cursor.fetchmany(sample_limit)
         except Exception as exc:
             return EvidenceVerifyResult(status=EvidenceStatus.SQL_ERROR, error=str(exc))
     finally:
+        try:
+            os.chdir(cwd)
+        except Exception:
+            pass
         con.close()
 
     sample_rows = [dict(zip(columns, row)) for row in raw_rows]
 
     if not sample_rows:
         return EvidenceVerifyResult(status=EvidenceStatus.EMPTY, row_count=0, columns=columns)
-
-    if not _within_window(sample_rows, start_time_ns, end_time_ns):
-        return EvidenceVerifyResult(
-            status=EvidenceStatus.OUT_OF_WINDOW,
-            row_count=len(sample_rows),
-            sample_rows=sample_rows[:5],
-            columns=columns,
-        )
-
-    if not _service_aligned(sample_rows, allowed_services or set()):
-        return EvidenceVerifyResult(
-            status=EvidenceStatus.SERVICE_MISMATCH,
-            row_count=len(sample_rows),
-            sample_rows=sample_rows[:5],
-            columns=columns,
-        )
 
     return EvidenceVerifyResult(
         status=EvidenceStatus.OK,

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
@@ -202,14 +202,49 @@ def test_match_overclaim_drops_case_correct() -> None:
     assert out.overclaim_rate == 0.5
 
 
-def test_match_normalizes_ts_prefix_and_hyphens() -> None:
-    """Service name normalization: ts- prefix and hyphens are stripped."""
+def test_match_normalization_is_uniform_across_systems() -> None:
+    """Service name normalization is the same across ts/hs/otel-demo: lowercase
+    + drop dashes and underscores. No system-specific prefix stripping.
+
+    The agent must use names that exist in the data (modulo case + dash/underscore
+    style). It does NOT get matching for free by dropping a `ts-` prefix that
+    the GT actually carries.
+    """
+    # Same name, different dash/underscore styling → still HIT.
     gt = [GTFault(service="ts-route-plan-service", fault_kind=FaultKind.POD_FAILURE)]
     agent = _agent([{
-        "service": "RoutePlanService", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV],
+        "service": "ts_route_plan_service", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV],
+    }])
+    assert compute_outcome(agent, gt).per_fault[0].status is MatchStatus.HIT
+
+    # Mixed case → still HIT.
+    agent_caps = _agent([{
+        "service": "TS-Route-Plan-Service", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV],
+    }])
+    assert compute_outcome(agent_caps, gt).per_fault[0].status is MatchStatus.HIT
+
+    # Dropping the ts- prefix is now a MISS (the agent must use a name
+    # that actually appears in the case data).
+    agent_stripped = _agent([{
+        "service": "route-plan-service", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV],
+    }])
+    assert compute_outcome(agent_stripped, gt).per_fault[0].status is MatchStatus.MISS
+
+
+def test_match_service_only_f1_separates_from_kind_f1() -> None:
+    """service_f1 counts a fault as matched whenever the agent picked the right
+    service, even if it got the kind wrong. root_cause_f1 (kind-level) only
+    counts HIT. Both share denominators, so on a 1-fault case where the agent
+    nailed the service but missed the kind, service_f1=1.0 and root_cause_f1=0.0.
+    """
+    gt = [GTFault(service="payment", fault_kind=FaultKind.CPU_STRESS)]
+    agent = _agent([{
+        "service": "payment", "fault_kind": "mem_stress", "evidence": [_DUMMY_EV],
     }])
     out = compute_outcome(agent, gt)
-    assert out.per_fault[0].status is MatchStatus.HIT
+    assert out.service_f1 == 1.0
+    assert out.root_cause_f1 == 0.0
+    assert out.per_fault[0].status is MatchStatus.WRONG_KIND
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -291,58 +326,65 @@ def _make_case(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_sql_verify_ok(tmp_path: Path) -> None:
+def test_sql_verify_ok_via_view_name(tmp_path: Path) -> None:
+    """Each *.parquet in the case dir is mounted as a same-named view, so the
+    agent can use bare table names without an explicit read_parquet(...)."""
+    case = _make_case(tmp_path)
+    ev = Evidence(
+        kind=EvidenceKind.METRIC,
+        sql="SELECT * FROM abnormal_metrics WHERE service_name='shipping'",
+        claim="shipping latency rises",
+    )
+    r = verify_evidence(ev, parquet_dir=case)
+    assert r.status is EvidenceStatus.OK
+    assert r.row_count == 5
+
+
+def test_sql_verify_ok_via_read_parquet(tmp_path: Path) -> None:
+    """Relative read_parquet('foo.parquet') paths resolve against the case dir
+    because the verifier chdirs into it before executing."""
     case = _make_case(tmp_path)
     ev = Evidence(
         kind=EvidenceKind.METRIC,
         sql="SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='shipping'",
         claim="shipping latency rises",
     )
-    r = verify_evidence(ev, parquet_dir=case, allowed_services={"shipping"})
+    r = verify_evidence(ev, parquet_dir=case)
     assert r.status is EvidenceStatus.OK
     assert r.row_count == 5
 
 
-def test_sql_verify_unsafe_keyword(tmp_path: Path) -> None:
-    case = _make_case(tmp_path)
-    ev = Evidence(kind=EvidenceKind.METRIC, sql="DROP TABLE foo", claim="x")
-    assert verify_evidence(ev, parquet_dir=case).status is EvidenceStatus.UNSAFE_SQL
-
-
-def test_sql_verify_path_escape(tmp_path: Path) -> None:
-    case = _make_case(tmp_path)
-    ev = Evidence(
-        kind=EvidenceKind.METRIC,
-        sql="SELECT 1 FROM read_parquet('/etc/passwd')",
-        claim="x",
-    )
-    assert verify_evidence(ev, parquet_dir=case).status is EvidenceStatus.UNSAFE_SQL
-
-
 def test_sql_verify_empty(tmp_path: Path) -> None:
+    """Query executes but matches no rows → EMPTY (still distinguishable from
+    SQL_ERROR, so the agent sees that the SQL parses but its filter is wrong)."""
     case = _make_case(tmp_path)
     ev = Evidence(
         kind=EvidenceKind.METRIC,
-        sql="SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='nonexistent'",
+        sql="SELECT * FROM abnormal_metrics WHERE service_name='nonexistent'",
         claim="x",
     )
     assert verify_evidence(ev, parquet_dir=case).status is EvidenceStatus.EMPTY
 
 
-def test_sql_verify_service_mismatch(tmp_path: Path) -> None:
+def test_sql_verify_sql_error_on_bad_syntax(tmp_path: Path) -> None:
+    """Anything DuckDB can't run surfaces as SQL_ERROR — no curated allowlist."""
     case = _make_case(tmp_path)
-    ev = Evidence(
-        kind=EvidenceKind.METRIC,
-        sql="SELECT * FROM read_parquet('abnormal_metrics.parquet')",
-        claim="x",
-    )
-    r = verify_evidence(ev, parquet_dir=case, allowed_services={"unrelated_service"})
-    assert r.status is EvidenceStatus.SERVICE_MISMATCH
+    ev = Evidence(kind=EvidenceKind.METRIC, sql="SELECT FROM WHERE", claim="x")
+    assert verify_evidence(ev, parquet_dir=case).status is EvidenceStatus.SQL_ERROR
+
+
+def test_sql_verify_sql_error_on_missing_table(tmp_path: Path) -> None:
+    """Reference to a parquet that isn't in the case dir → DuckDB raises a
+    catalog error, surfaced as SQL_ERROR."""
+    case = _make_case(tmp_path)
+    ev = Evidence(kind=EvidenceKind.METRIC, sql="SELECT * FROM nonexistent_table", claim="x")
+    assert verify_evidence(ev, parquet_dir=case).status is EvidenceStatus.SQL_ERROR
 
 
 # ──────────────────────────────────────────────────────────────────────
-# End-to-end evaluator (no LLM client → chain_coherence falls back to
-# sql_executable_rate, so the headline = rc_f1 × sql × sql).
+# End-to-end evaluator. chain_coherence requires an LLM client; tests
+# inject a tiny stub that always returns score=1.0 so the deterministic
+# axes (rc_f1, sql_executable_rate) stay decoupled from the judge.
 # ──────────────────────────────────────────────────────────────────────
 
 def _injection() -> dict[str, Any]:
@@ -356,8 +398,47 @@ def _injection() -> dict[str, Any]:
     }
 
 
+class _StubChoiceMessage:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _StubChoice:
+    def __init__(self, content: str) -> None:
+        self.message = _StubChoiceMessage(content)
+
+
+class _StubResponse:
+    def __init__(self, content: str) -> None:
+        self.choices = [_StubChoice(content)]
+
+
+class _StubCompletions:
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    async def create(self, **_kwargs: Any) -> _StubResponse:
+        return _StubResponse(self._content)
+
+
+class _StubChat:
+    def __init__(self, content: str) -> None:
+        self.completions = _StubCompletions(content)
+
+
+class _StubLLMClient:
+    """Minimal AsyncOpenAI-compatible stub for the chain judge.
+
+    Returns a fixed JSON payload so deterministic axes can be tested without
+    flaky LLM behavior. Pass `score=1.0` for the perfect-case test, etc.
+    """
+
+    def __init__(self, score: float = 1.0, reasoning: str = "stub") -> None:
+        self.chat = _StubChat(json.dumps({"score": score, "reasoning": reasoning}))
+
+
 def test_evaluate_v2_perfect(tmp_path: Path) -> None:
-    """Perfect agent: rc_f1=1, sql=1, chain=1 (fallback), headline=1."""
+    """Perfect agent: rc_f1=1, sql=1, chain=1 (stub), headline=1."""
     case = _make_case(tmp_path)
     agent = json.dumps({
         "root_causes": [{
@@ -371,8 +452,11 @@ def test_evaluate_v2_perfect(tmp_path: Path) -> None:
         }],
         "propagation": [],
     })
-    res = asyncio.run(evaluate_v2(agent, _injection(), case, gt_graph=None, llm_client=None))
+    res = asyncio.run(evaluate_v2(
+        agent, _injection(), case, gt_graph=None, llm_client=_StubLLMClient(score=1.0),
+    ))
     assert res.root_cause_f1 == 1.0
+    assert res.service_f1 == 1.0
     assert res.overclaim_rate == 0.0
     assert res.sql_executable_rate == 1.0
     assert res.chain_coherence == 1.0
@@ -381,7 +465,9 @@ def test_evaluate_v2_perfect(tmp_path: Path) -> None:
 
 
 def test_evaluate_v2_wrong_direction(tmp_path: Path) -> None:
-    """Service+kind right but direction flipped → rc_f1=0, headline=0."""
+    """Service+kind right but direction flipped → rc_f1=0, headline=0.
+    service_f1 stays at 1.0 because the service was correctly identified.
+    """
     case = _make_case(tmp_path)
     agent = json.dumps({
         "root_causes": [{
@@ -395,18 +481,48 @@ def test_evaluate_v2_wrong_direction(tmp_path: Path) -> None:
         }],
         "propagation": [],
     })
-    res = asyncio.run(evaluate_v2(agent, _injection(), case, gt_graph=None, llm_client=None))
+    res = asyncio.run(evaluate_v2(
+        agent, _injection(), case, gt_graph=None, llm_client=_StubLLMClient(score=0.5),
+    ))
     assert res.root_cause_f1 == 0.0
+    assert res.service_f1 == 1.0
     assert res.headline == 0.0
     assert res.case_correct is False
     assert res.per_fault[0].status is MatchStatus.WRONG_DIRECTION
 
 
 def test_evaluate_v2_unparseable_response(tmp_path: Path) -> None:
+    """Parse-error path doesn't reach the chain judge, so llm_client is unused."""
     case = _make_case(tmp_path)
-    res = asyncio.run(evaluate_v2("NOT JSON", _injection(), case, gt_graph=None, llm_client=None))
+    res = asyncio.run(evaluate_v2(
+        "NOT JSON", _injection(), case, gt_graph=None, llm_client=_StubLLMClient(),
+    ))
     assert res.headline == 0.0
     assert res.parse_error is not None and "JSON" in res.parse_error
+
+
+def test_evaluate_v2_requires_llm_client(tmp_path: Path) -> None:
+    """chain_coherence has no fallback now: passing llm_client=None on a
+    parseable agent output raises so misconfiguration fails loudly instead of
+    silently double-counting sql_executable_rate as the chain score.
+    """
+    import pytest
+
+    case = _make_case(tmp_path)
+    agent = json.dumps({
+        "root_causes": [{
+            "service": "shipping", "fault_kind": "network_delay",
+            "direction": {"src": "shipping", "dst": "quote"},
+            "evidence": [{
+                "kind": "metric",
+                "sql": "SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='shipping'",
+                "claim": "x",
+            }],
+        }],
+        "propagation": [],
+    })
+    with pytest.raises(ValueError, match="chain_coherence requires an LLM client"):
+        asyncio.run(evaluate_v2(agent, _injection(), case, gt_graph=None, llm_client=None))
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -431,18 +547,21 @@ def test_calculate_metrics_aggregation() -> None:
 
     samples = [
         _StubSample({"eval_v2": {
+            "service_f1": 1.0,
             "root_cause_f1": 1.0, "overclaim_rate": 0.0,
             "sql_executable_rate": 1.0, "chain_coherence": 1.0,
             "node_f1": 1.0, "edge_f1": 1.0, "headline": 1.0,
             "case_correct": True, "per_evidence": [{}],
         }}),
         _StubSample({"eval_v2": {
+            "service_f1": 0.7,
             "root_cause_f1": 0.5, "overclaim_rate": 0.5,
             "sql_executable_rate": 0.8, "chain_coherence": 0.6,
             "node_f1": 0.4, "edge_f1": 0.2, "headline": 0.24,
             "case_correct": False, "per_evidence": [{}],
         }}),
         _StubSample({"eval_v2": {
+            "service_f1": 0.0,
             "root_cause_f1": 0.0, "overclaim_rate": 1.0,
             "sql_executable_rate": 0.0, "chain_coherence": 0.0,
             "node_f1": 0.0, "edge_f1": 0.0, "headline": 0.0,
@@ -462,6 +581,7 @@ def test_calculate_metrics_aggregation() -> None:
     assert metrics["case_correct_rate"] == round(1 / 3, 4)
     assert metrics["parse_errors"] == 1
     assert metrics["zero_evidence_outputs"] == 1
+    assert metrics["avg_service_f1"] == round((1.0 + 0.7 + 0.0) / 3, 4)
     assert metrics["avg_root_cause_f1"] == round((1.0 + 0.5 + 0.0) / 3, 4)
     assert metrics["avg_sql_executable_rate"] == round((1.0 + 0.8 + 0.0) / 3, 4)
     assert metrics["avg_chain_coherence"] == round((1.0 + 0.6 + 0.0) / 3, 4)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
@@ -5,6 +5,7 @@ and the resulting score so the contract reads top-to-bottom. The final test
 shows how a batch of mixed-quality outputs aggregates via the processer's
 `calculate_metrics`.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -35,6 +36,7 @@ from rcabench_platform.v3.sdk.evaluation.v2 import (
 # Fault-kind controlled vocabulary
 # ──────────────────────────────────────────────────────────────────────
 
+
 def test_map_chaos_type_known() -> None:
     assert map_chaos_type("NetworkDelay") is FaultKind.NETWORK_DELAY
     assert map_chaos_type("PodFailure") is FaultKind.POD_FAILURE
@@ -52,11 +54,11 @@ def test_map_chaos_type_unknown() -> None:
 # GT fault extraction (new + old format)
 # ──────────────────────────────────────────────────────────────────────
 
+
 def test_extract_gt_new_format_hybrid() -> None:
     inj = {
         "engine_config": [
-            {"app": "shipping", "chaos_type": "NetworkDelay",
-             "target_service": "quote", "direction": "to"},
+            {"app": "shipping", "chaos_type": "NetworkDelay", "target_service": "quote", "direction": "to"},
             {"app": "payment", "chaos_type": "CPUStress"},
         ],
         "start_time": "2026-05-02T08:00:00Z",
@@ -79,10 +81,14 @@ def test_extract_gt_new_format_hybrid() -> None:
 
 def test_extract_gt_jvm_method() -> None:
     inj = {
-        "engine_config": [{
-            "app": "ts-basic-service", "chaos_type": "JVMRuntimeMutator",
-            "class": "com.foo.BasicController", "method": "queryForX",
-        }]
+        "engine_config": [
+            {
+                "app": "ts-basic-service",
+                "chaos_type": "JVMRuntimeMutator",
+                "class": "com.foo.BasicController",
+                "method": "queryForX",
+            }
+        ]
     }
     ctx = extract_gt_faults(inj)
     assert ctx.faults[0].method == "com.foo.BasicController.queryForX"
@@ -112,7 +118,9 @@ def test_extract_gt_old_format_falls_back() -> None:
 # ──────────────────────────────────────────────────────────────────────
 
 _DUMMY_EV: dict[str, str] = {
-    "kind": "metric", "sql": "SELECT 1 FROM read_parquet('m.parquet')", "claim": "x",
+    "kind": "metric",
+    "sql": "SELECT 1 FROM read_parquet('m.parquet')",
+    "claim": "x",
 }
 
 
@@ -123,9 +131,15 @@ def _agent(rcs: list[dict[str, Any]], propagation: list[dict[str, Any]] | None =
 def test_match_perfect_single_fault() -> None:
     """Agent: 1 root_cause, kind+service correct → HIT, F1=1, case_correct=True."""
     gt = [GTFault(service="ts-basic-service", fault_kind=FaultKind.JVM_MUTATOR)]
-    agent = _agent([{
-        "service": "ts-basic-service", "fault_kind": "jvm_mutator", "evidence": [_DUMMY_EV],
-    }])
+    agent = _agent(
+        [
+            {
+                "service": "ts-basic-service",
+                "fault_kind": "jvm_mutator",
+                "evidence": [_DUMMY_EV],
+            }
+        ]
+    )
     out = compute_outcome(agent, gt)
     assert out.root_cause_f1 == 1.0
     assert out.case_correct is True
@@ -134,23 +148,37 @@ def test_match_perfect_single_fault() -> None:
 
 def test_match_network_no_direction_is_wrong_direction() -> None:
     """Agent gets service+kind on Network* but skips direction → WRONG_DIRECTION."""
-    gt = [GTFault(service="shipping", fault_kind=FaultKind.NETWORK_DELAY,
-                  direction_src="shipping", direction_dst="quote")]
-    agent = _agent([{
-        "service": "shipping", "fault_kind": "network_delay", "evidence": [_DUMMY_EV],
-    }])
+    gt = [
+        GTFault(service="shipping", fault_kind=FaultKind.NETWORK_DELAY, direction_src="shipping", direction_dst="quote")
+    ]
+    agent = _agent(
+        [
+            {
+                "service": "shipping",
+                "fault_kind": "network_delay",
+                "evidence": [_DUMMY_EV],
+            }
+        ]
+    )
     out = compute_outcome(agent, gt)
     assert out.per_fault[0].status is MatchStatus.WRONG_DIRECTION
     assert out.root_cause_f1 == 0.0
 
 
 def test_match_network_correct_direction() -> None:
-    gt = [GTFault(service="shipping", fault_kind=FaultKind.NETWORK_DELAY,
-                  direction_src="shipping", direction_dst="quote")]
-    agent = _agent([{
-        "service": "shipping", "fault_kind": "network_delay",
-        "direction": {"src": "shipping", "dst": "quote"}, "evidence": [_DUMMY_EV],
-    }])
+    gt = [
+        GTFault(service="shipping", fault_kind=FaultKind.NETWORK_DELAY, direction_src="shipping", direction_dst="quote")
+    ]
+    agent = _agent(
+        [
+            {
+                "service": "shipping",
+                "fault_kind": "network_delay",
+                "direction": {"src": "shipping", "dst": "quote"},
+                "evidence": [_DUMMY_EV],
+            }
+        ]
+    )
     out = compute_outcome(agent, gt)
     assert out.per_fault[0].status is MatchStatus.HIT
     assert out.root_cause_f1 == 1.0
@@ -158,9 +186,15 @@ def test_match_network_correct_direction() -> None:
 
 def test_match_wrong_kind() -> None:
     gt = [GTFault(service="payment", fault_kind=FaultKind.CPU_STRESS)]
-    agent = _agent([{
-        "service": "payment", "fault_kind": "mem_stress", "evidence": [_DUMMY_EV],
-    }])
+    agent = _agent(
+        [
+            {
+                "service": "payment",
+                "fault_kind": "mem_stress",
+                "evidence": [_DUMMY_EV],
+            }
+        ]
+    )
     out = compute_outcome(agent, gt)
     assert out.per_fault[0].status is MatchStatus.WRONG_KIND
     assert out.root_cause_f1 == 0.0
@@ -169,15 +203,22 @@ def test_match_wrong_kind() -> None:
 def test_match_partial_hybrid() -> None:
     """Hybrid GT (2 faults). Agent gets one right + an unrelated overclaim → F1=0.5."""
     gt = [
-        GTFault(service="shipping", fault_kind=FaultKind.NETWORK_DELAY,
-                direction_src="shipping", direction_dst="quote"),
+        GTFault(
+            service="shipping", fault_kind=FaultKind.NETWORK_DELAY, direction_src="shipping", direction_dst="quote"
+        ),
         GTFault(service="payment", fault_kind=FaultKind.CPU_STRESS),
     ]
-    agent = _agent([
-        {"service": "shipping", "fault_kind": "network_delay",
-         "direction": {"src": "shipping", "dst": "quote"}, "evidence": [_DUMMY_EV]},
-        {"service": "noise", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV]},
-    ])
+    agent = _agent(
+        [
+            {
+                "service": "shipping",
+                "fault_kind": "network_delay",
+                "direction": {"src": "shipping", "dst": "quote"},
+                "evidence": [_DUMMY_EV],
+            },
+            {"service": "noise", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV]},
+        ]
+    )
     out = compute_outcome(agent, gt)
     assert out.root_cause_precision == 0.5
     assert out.root_cause_recall == 0.5
@@ -191,10 +232,12 @@ def test_match_partial_hybrid() -> None:
 def test_match_overclaim_drops_case_correct() -> None:
     """Agent finds the GT fault but adds an unrelated extra → case_correct=False."""
     gt = [GTFault(service="payment", fault_kind=FaultKind.CPU_STRESS)]
-    agent = _agent([
-        {"service": "payment", "fault_kind": "cpu_stress", "evidence": [_DUMMY_EV]},
-        {"service": "noise", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV]},
-    ])
+    agent = _agent(
+        [
+            {"service": "payment", "fault_kind": "cpu_stress", "evidence": [_DUMMY_EV]},
+            {"service": "noise", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV]},
+        ]
+    )
     out = compute_outcome(agent, gt)
     assert out.root_cause_recall == 1.0
     assert out.root_cause_precision == 0.5
@@ -212,22 +255,40 @@ def test_match_normalization_is_uniform_across_systems() -> None:
     """
     # Same name, different dash/underscore styling → still HIT.
     gt = [GTFault(service="ts-route-plan-service", fault_kind=FaultKind.POD_FAILURE)]
-    agent = _agent([{
-        "service": "ts_route_plan_service", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV],
-    }])
+    agent = _agent(
+        [
+            {
+                "service": "ts_route_plan_service",
+                "fault_kind": "pod_failure",
+                "evidence": [_DUMMY_EV],
+            }
+        ]
+    )
     assert compute_outcome(agent, gt).per_fault[0].status is MatchStatus.HIT
 
     # Mixed case → still HIT.
-    agent_caps = _agent([{
-        "service": "TS-Route-Plan-Service", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV],
-    }])
+    agent_caps = _agent(
+        [
+            {
+                "service": "TS-Route-Plan-Service",
+                "fault_kind": "pod_failure",
+                "evidence": [_DUMMY_EV],
+            }
+        ]
+    )
     assert compute_outcome(agent_caps, gt).per_fault[0].status is MatchStatus.HIT
 
     # Dropping the ts- prefix is now a MISS (the agent must use a name
     # that actually appears in the case data).
-    agent_stripped = _agent([{
-        "service": "route-plan-service", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV],
-    }])
+    agent_stripped = _agent(
+        [
+            {
+                "service": "route-plan-service",
+                "fault_kind": "pod_failure",
+                "evidence": [_DUMMY_EV],
+            }
+        ]
+    )
     assert compute_outcome(agent_stripped, gt).per_fault[0].status is MatchStatus.MISS
 
 
@@ -238,9 +299,15 @@ def test_match_service_only_f1_separates_from_kind_f1() -> None:
     nailed the service but missed the kind, service_f1=1.0 and root_cause_f1=0.0.
     """
     gt = [GTFault(service="payment", fault_kind=FaultKind.CPU_STRESS)]
-    agent = _agent([{
-        "service": "payment", "fault_kind": "mem_stress", "evidence": [_DUMMY_EV],
-    }])
+    agent = _agent(
+        [
+            {
+                "service": "payment",
+                "fault_kind": "mem_stress",
+                "evidence": [_DUMMY_EV],
+            }
+        ]
+    )
     out = compute_outcome(agent, gt)
     assert out.service_f1 == 1.0
     assert out.root_cause_f1 == 0.0
@@ -251,12 +318,15 @@ def test_match_service_only_f1_separates_from_kind_f1() -> None:
 # Graph metrics (agent's claimed graph vs GT causal_graph)
 # ──────────────────────────────────────────────────────────────────────
 
+
 def _gt_graph(nodes: list[str], edges: list[tuple[str, str]]) -> CausalGraph:
-    return CausalGraph.from_dict({
-        "nodes": [{"component": n} for n in nodes],
-        "edges": [{"source": s, "target": t} for s, t in edges],
-        "component_to_service": {n: n for n in nodes},
-    })
+    return CausalGraph.from_dict(
+        {
+            "nodes": [{"component": n} for n in nodes],
+            "edges": [{"source": s, "target": t} for s, t in edges],
+            "component_to_service": {n: n for n in nodes},
+        }
+    )
 
 
 def test_graph_metrics_perfect() -> None:
@@ -302,6 +372,7 @@ def test_graph_metrics_no_gt_marks_inapplicable() -> None:
 # DuckDB SQL evidence verification
 # ──────────────────────────────────────────────────────────────────────
 
+
 def _make_case(tmp_path: Path) -> Path:
     """Synthesize a tiny case dir with one trace + one metrics parquet."""
     times = pl.datetime_range(
@@ -310,19 +381,23 @@ def _make_case(tmp_path: Path) -> Path:
         "1m",
         eager=True,
     )
-    pl.DataFrame({
-        "time": times,
-        "metric": ["latency_p99"] * len(times),
-        "value": [10.0, 20.0, 30.0, 40.0, 50.0],
-        "service_name": ["shipping"] * len(times),
-    }).write_parquet(tmp_path / "abnormal_metrics.parquet")
-    pl.DataFrame({
-        "time": times,
-        "trace_id": ["t"] * len(times),
-        "span_id": [str(i) for i in range(len(times))],
-        "service_name": ["shipping"] * len(times),
-        "duration": [1000, 2000, 3000, 4000, 5000],
-    }).write_parquet(tmp_path / "abnormal_traces.parquet")
+    pl.DataFrame(
+        {
+            "time": times,
+            "metric": ["latency_p99"] * len(times),
+            "value": [10.0, 20.0, 30.0, 40.0, 50.0],
+            "service_name": ["shipping"] * len(times),
+        }
+    ).write_parquet(tmp_path / "abnormal_metrics.parquet")
+    pl.DataFrame(
+        {
+            "time": times,
+            "trace_id": ["t"] * len(times),
+            "span_id": [str(i) for i in range(len(times))],
+            "service_name": ["shipping"] * len(times),
+            "duration": [1000, 2000, 3000, 4000, 5000],
+        }
+    ).write_parquet(tmp_path / "abnormal_traces.parquet")
     return tmp_path
 
 
@@ -387,12 +462,17 @@ def test_sql_verify_sql_error_on_missing_table(tmp_path: Path) -> None:
 # axes (rc_f1, sql_executable_rate) stay decoupled from the judge.
 # ──────────────────────────────────────────────────────────────────────
 
+
 def _injection() -> dict[str, Any]:
     return {
-        "engine_config": [{
-            "app": "shipping", "chaos_type": "NetworkDelay",
-            "target_service": "quote", "direction": "to",
-        }],
+        "engine_config": [
+            {
+                "app": "shipping",
+                "chaos_type": "NetworkDelay",
+                "target_service": "quote",
+                "direction": "to",
+            }
+        ],
         "start_time": "2026-05-02T08:00:00Z",
         "end_time": "2026-05-02T08:05:00Z",
     }
@@ -440,21 +520,36 @@ class _StubLLMClient:
 def test_evaluate_v2_perfect(tmp_path: Path) -> None:
     """Perfect agent: rc_f1=1, sql=1, chain=1 (stub), headline=1."""
     case = _make_case(tmp_path)
-    agent = json.dumps({
-        "root_causes": [{
-            "service": "shipping", "fault_kind": "network_delay",
-            "direction": {"src": "shipping", "dst": "quote"},
-            "evidence": [{
-                "kind": "metric",
-                "sql": "SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='shipping'",
-                "claim": "shipping latency rises",
-            }],
-        }],
-        "propagation": [],
-    })
-    res = asyncio.run(evaluate_v2(
-        agent, _injection(), case, gt_graph=None, llm_client=_StubLLMClient(score=1.0),
-    ))
+    agent = json.dumps(
+        {
+            "root_causes": [
+                {
+                    "service": "shipping",
+                    "fault_kind": "network_delay",
+                    "direction": {"src": "shipping", "dst": "quote"},
+                    "evidence": [
+                        {
+                            "kind": "metric",
+                            "sql": (
+                                "SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='shipping'"
+                            ),
+                            "claim": "shipping latency rises",
+                        }
+                    ],
+                }
+            ],
+            "propagation": [],
+        }
+    )
+    res = asyncio.run(
+        evaluate_v2(
+            agent,
+            _injection(),
+            case,
+            gt_graph=None,
+            llm_client=_StubLLMClient(score=1.0),  # type: ignore[arg-type]
+        )
+    )
     assert res.root_cause_f1 == 1.0
     assert res.service_f1 == 1.0
     assert res.overclaim_rate == 0.0
@@ -469,21 +564,36 @@ def test_evaluate_v2_wrong_direction(tmp_path: Path) -> None:
     service_f1 stays at 1.0 because the service was correctly identified.
     """
     case = _make_case(tmp_path)
-    agent = json.dumps({
-        "root_causes": [{
-            "service": "shipping", "fault_kind": "network_delay",
-            "direction": {"src": "quote", "dst": "shipping"},  # flipped
-            "evidence": [{
-                "kind": "metric",
-                "sql": "SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='shipping'",
-                "claim": "x",
-            }],
-        }],
-        "propagation": [],
-    })
-    res = asyncio.run(evaluate_v2(
-        agent, _injection(), case, gt_graph=None, llm_client=_StubLLMClient(score=0.5),
-    ))
+    agent = json.dumps(
+        {
+            "root_causes": [
+                {
+                    "service": "shipping",
+                    "fault_kind": "network_delay",
+                    "direction": {"src": "quote", "dst": "shipping"},  # flipped
+                    "evidence": [
+                        {
+                            "kind": "metric",
+                            "sql": (
+                                "SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='shipping'"
+                            ),
+                            "claim": "x",
+                        }
+                    ],
+                }
+            ],
+            "propagation": [],
+        }
+    )
+    res = asyncio.run(
+        evaluate_v2(
+            agent,
+            _injection(),
+            case,
+            gt_graph=None,
+            llm_client=_StubLLMClient(score=0.5),  # type: ignore[arg-type]
+        )
+    )
     assert res.root_cause_f1 == 0.0
     assert res.service_f1 == 1.0
     assert res.headline == 0.0
@@ -494,9 +604,15 @@ def test_evaluate_v2_wrong_direction(tmp_path: Path) -> None:
 def test_evaluate_v2_unparseable_response(tmp_path: Path) -> None:
     """Parse-error path doesn't reach the chain judge, so llm_client is unused."""
     case = _make_case(tmp_path)
-    res = asyncio.run(evaluate_v2(
-        "NOT JSON", _injection(), case, gt_graph=None, llm_client=_StubLLMClient(),
-    ))
+    res = asyncio.run(
+        evaluate_v2(
+            "NOT JSON",
+            _injection(),
+            case,
+            gt_graph=None,
+            llm_client=_StubLLMClient(),  # type: ignore[arg-type]
+        )
+    )
     assert res.headline == 0.0
     assert res.parse_error is not None and "JSON" in res.parse_error
 
@@ -509,18 +625,27 @@ def test_evaluate_v2_requires_llm_client(tmp_path: Path) -> None:
     import pytest
 
     case = _make_case(tmp_path)
-    agent = json.dumps({
-        "root_causes": [{
-            "service": "shipping", "fault_kind": "network_delay",
-            "direction": {"src": "shipping", "dst": "quote"},
-            "evidence": [{
-                "kind": "metric",
-                "sql": "SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='shipping'",
-                "claim": "x",
-            }],
-        }],
-        "propagation": [],
-    })
+    agent = json.dumps(
+        {
+            "root_causes": [
+                {
+                    "service": "shipping",
+                    "fault_kind": "network_delay",
+                    "direction": {"src": "shipping", "dst": "quote"},
+                    "evidence": [
+                        {
+                            "kind": "metric",
+                            "sql": (
+                                "SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='shipping'"
+                            ),
+                            "claim": "x",
+                        }
+                    ],
+                }
+            ],
+            "propagation": [],
+        }
+    )
     with pytest.raises(ValueError, match="chain_coherence requires an LLM client"):
         asyncio.run(evaluate_v2(agent, _injection(), case, gt_graph=None, llm_client=None))
 
@@ -528,6 +653,7 @@ def test_evaluate_v2_requires_llm_client(tmp_path: Path) -> None:
 # ──────────────────────────────────────────────────────────────────────
 # Batch aggregation via RCABenchProcesser.calculate_metrics
 # ──────────────────────────────────────────────────────────────────────
+
 
 def test_calculate_metrics_aggregation() -> None:
     """4 stub samples → aggregate is the mean over the 3 successfully scored.
@@ -546,28 +672,55 @@ def test_calculate_metrics_aggregation() -> None:
             self.meta: dict[str, Any] = meta
 
     samples = [
-        _StubSample({"eval_v2": {
-            "service_f1": 1.0,
-            "root_cause_f1": 1.0, "overclaim_rate": 0.0,
-            "sql_executable_rate": 1.0, "chain_coherence": 1.0,
-            "node_f1": 1.0, "edge_f1": 1.0, "headline": 1.0,
-            "case_correct": True, "per_evidence": [{}],
-        }}),
-        _StubSample({"eval_v2": {
-            "service_f1": 0.7,
-            "root_cause_f1": 0.5, "overclaim_rate": 0.5,
-            "sql_executable_rate": 0.8, "chain_coherence": 0.6,
-            "node_f1": 0.4, "edge_f1": 0.2, "headline": 0.24,
-            "case_correct": False, "per_evidence": [{}],
-        }}),
-        _StubSample({"eval_v2": {
-            "service_f1": 0.0,
-            "root_cause_f1": 0.0, "overclaim_rate": 1.0,
-            "sql_executable_rate": 0.0, "chain_coherence": 0.0,
-            "node_f1": 0.0, "edge_f1": 0.0, "headline": 0.0,
-            "case_correct": False, "parse_error": "bad json",
-            "per_evidence": [],
-        }}),
+        _StubSample(
+            {
+                "eval_v2": {
+                    "service_f1": 1.0,
+                    "root_cause_f1": 1.0,
+                    "overclaim_rate": 0.0,
+                    "sql_executable_rate": 1.0,
+                    "chain_coherence": 1.0,
+                    "node_f1": 1.0,
+                    "edge_f1": 1.0,
+                    "headline": 1.0,
+                    "case_correct": True,
+                    "per_evidence": [{}],
+                }
+            }
+        ),
+        _StubSample(
+            {
+                "eval_v2": {
+                    "service_f1": 0.7,
+                    "root_cause_f1": 0.5,
+                    "overclaim_rate": 0.5,
+                    "sql_executable_rate": 0.8,
+                    "chain_coherence": 0.6,
+                    "node_f1": 0.4,
+                    "edge_f1": 0.2,
+                    "headline": 0.24,
+                    "case_correct": False,
+                    "per_evidence": [{}],
+                }
+            }
+        ),
+        _StubSample(
+            {
+                "eval_v2": {
+                    "service_f1": 0.0,
+                    "root_cause_f1": 0.0,
+                    "overclaim_rate": 1.0,
+                    "sql_executable_rate": 0.0,
+                    "chain_coherence": 0.0,
+                    "node_f1": 0.0,
+                    "edge_f1": 0.0,
+                    "headline": 0.0,
+                    "case_correct": False,
+                    "parse_error": "bad json",
+                    "per_evidence": [],
+                }
+            }
+        ),
         _StubSample({"eval_v2": {"error": "missing case dir"}}),
     ]
 

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
@@ -1,0 +1,470 @@
+"""Unit tests for evaluation v2 — by example.
+
+Each test case below shows an agent output, the GT it was compared against,
+and the resulting score so the contract reads top-to-bottom. The final test
+shows how a batch of mixed-quality outputs aggregates via the processer's
+`calculate_metrics`.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+
+from rcabench_platform.v3.sdk.evaluation.causal_graph import CausalGraph
+from rcabench_platform.v3.sdk.evaluation.v2 import (
+    AgentRCAOutput,
+    Evidence,
+    EvidenceKind,
+    EvidenceStatus,
+    FaultKind,
+    GTFault,
+    MatchStatus,
+    compute_graph_metrics,
+    compute_outcome,
+    evaluate_v2,
+    extract_gt_faults,
+    map_chaos_type,
+    verify_evidence,
+)
+
+# ──────────────────────────────────────────────────────────────────────
+# Fault-kind controlled vocabulary
+# ──────────────────────────────────────────────────────────────────────
+
+def test_map_chaos_type_known() -> None:
+    assert map_chaos_type("NetworkDelay") is FaultKind.NETWORK_DELAY
+    assert map_chaos_type("PodFailure") is FaultKind.POD_FAILURE
+    assert map_chaos_type("JVMRuntimeMutator") is FaultKind.JVM_MUTATOR
+    assert map_chaos_type("HTTPResponseReplaceCode") is FaultKind.HTTP_REPLACE
+    assert map_chaos_type("DNSChaos") is FaultKind.DNS
+
+
+def test_map_chaos_type_unknown() -> None:
+    assert map_chaos_type(None) is FaultKind.UNKNOWN
+    assert map_chaos_type("UnseenChaos") is FaultKind.UNKNOWN
+
+
+# ──────────────────────────────────────────────────────────────────────
+# GT fault extraction (new + old format)
+# ──────────────────────────────────────────────────────────────────────
+
+def test_extract_gt_new_format_hybrid() -> None:
+    inj = {
+        "engine_config": [
+            {"app": "shipping", "chaos_type": "NetworkDelay",
+             "target_service": "quote", "direction": "to"},
+            {"app": "payment", "chaos_type": "CPUStress"},
+        ],
+        "start_time": "2026-05-02T08:00:00Z",
+        "end_time": "2026-05-02T08:05:00Z",
+    }
+    ctx = extract_gt_faults(inj)
+    assert len(ctx.faults) == 2
+
+    f0 = ctx.faults[0]
+    assert f0.service == "shipping"
+    assert f0.fault_kind is FaultKind.NETWORK_DELAY
+    assert f0.direction_src == "shipping" and f0.direction_dst == "quote"
+
+    f1 = ctx.faults[1]
+    assert f1.service == "payment" and f1.fault_kind is FaultKind.CPU_STRESS
+
+    assert ctx.start_time_ns and ctx.end_time_ns
+    assert ctx.end_time_ns - ctx.start_time_ns == 5 * 60 * 1_000_000_000
+
+
+def test_extract_gt_jvm_method() -> None:
+    inj = {
+        "engine_config": [{
+            "app": "ts-basic-service", "chaos_type": "JVMRuntimeMutator",
+            "class": "com.foo.BasicController", "method": "queryForX",
+        }]
+    }
+    ctx = extract_gt_faults(inj)
+    assert ctx.faults[0].method == "com.foo.BasicController.queryForX"
+
+
+def test_extract_gt_old_format_falls_back() -> None:
+    """Old-format injection.json has engine_config as an opaque JSON-encoded
+    string and a numeric fault_type; only `ground_truth` is reliable."""
+    inj = {
+        "engine_config": '{"some":"opaque","tree":1}',
+        "fault_type": 27,
+        "ground_truth": {
+            "service": ["ts-cancel-service"],
+            "function": ["fdse.cancel.CancelImpl.cancelFromOrder"],
+        },
+    }
+    ctx = extract_gt_faults(inj, case_name="<no-side-channel>")
+    assert len(ctx.faults) == 1
+    f = ctx.faults[0]
+    assert f.service == "ts-cancel-service"
+    assert f.method == "fdse.cancel.CancelImpl.cancelFromOrder"
+    assert f.fault_kind is FaultKind.UNKNOWN  # numeric fault_type, no data.jsonl
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Type-aware matcher — by example
+# ──────────────────────────────────────────────────────────────────────
+
+_DUMMY_EV: dict[str, str] = {
+    "kind": "metric", "sql": "SELECT 1 FROM read_parquet('m.parquet')", "claim": "x",
+}
+
+
+def _agent(rcs: list[dict[str, Any]], propagation: list[dict[str, Any]] | None = None) -> AgentRCAOutput:
+    return AgentRCAOutput.model_validate({"root_causes": rcs, "propagation": propagation or []})
+
+
+def test_match_perfect_single_fault() -> None:
+    """Agent: 1 root_cause, kind+service correct → HIT, F1=1, case_correct=True."""
+    gt = [GTFault(service="ts-basic-service", fault_kind=FaultKind.JVM_MUTATOR)]
+    agent = _agent([{
+        "service": "ts-basic-service", "fault_kind": "jvm_mutator", "evidence": [_DUMMY_EV],
+    }])
+    out = compute_outcome(agent, gt)
+    assert out.root_cause_f1 == 1.0
+    assert out.case_correct is True
+    assert out.per_fault[0].status is MatchStatus.HIT
+
+
+def test_match_network_no_direction_is_wrong_direction() -> None:
+    """Agent gets service+kind on Network* but skips direction → WRONG_DIRECTION."""
+    gt = [GTFault(service="shipping", fault_kind=FaultKind.NETWORK_DELAY,
+                  direction_src="shipping", direction_dst="quote")]
+    agent = _agent([{
+        "service": "shipping", "fault_kind": "network_delay", "evidence": [_DUMMY_EV],
+    }])
+    out = compute_outcome(agent, gt)
+    assert out.per_fault[0].status is MatchStatus.WRONG_DIRECTION
+    assert out.root_cause_f1 == 0.0
+
+
+def test_match_network_correct_direction() -> None:
+    gt = [GTFault(service="shipping", fault_kind=FaultKind.NETWORK_DELAY,
+                  direction_src="shipping", direction_dst="quote")]
+    agent = _agent([{
+        "service": "shipping", "fault_kind": "network_delay",
+        "direction": {"src": "shipping", "dst": "quote"}, "evidence": [_DUMMY_EV],
+    }])
+    out = compute_outcome(agent, gt)
+    assert out.per_fault[0].status is MatchStatus.HIT
+    assert out.root_cause_f1 == 1.0
+
+
+def test_match_wrong_kind() -> None:
+    gt = [GTFault(service="payment", fault_kind=FaultKind.CPU_STRESS)]
+    agent = _agent([{
+        "service": "payment", "fault_kind": "mem_stress", "evidence": [_DUMMY_EV],
+    }])
+    out = compute_outcome(agent, gt)
+    assert out.per_fault[0].status is MatchStatus.WRONG_KIND
+    assert out.root_cause_f1 == 0.0
+
+
+def test_match_partial_hybrid() -> None:
+    """Hybrid GT (2 faults). Agent gets one right + an unrelated overclaim → F1=0.5."""
+    gt = [
+        GTFault(service="shipping", fault_kind=FaultKind.NETWORK_DELAY,
+                direction_src="shipping", direction_dst="quote"),
+        GTFault(service="payment", fault_kind=FaultKind.CPU_STRESS),
+    ]
+    agent = _agent([
+        {"service": "shipping", "fault_kind": "network_delay",
+         "direction": {"src": "shipping", "dst": "quote"}, "evidence": [_DUMMY_EV]},
+        {"service": "noise", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV]},
+    ])
+    out = compute_outcome(agent, gt)
+    assert out.root_cause_precision == 0.5
+    assert out.root_cause_recall == 0.5
+    assert out.root_cause_f1 == 0.5
+    assert out.overclaim_rate == 0.5
+    assert out.case_correct is False
+    statuses = sorted(r.status.value for r in out.per_fault)
+    assert statuses == ["HIT", "MISS"]
+
+
+def test_match_overclaim_drops_case_correct() -> None:
+    """Agent finds the GT fault but adds an unrelated extra → case_correct=False."""
+    gt = [GTFault(service="payment", fault_kind=FaultKind.CPU_STRESS)]
+    agent = _agent([
+        {"service": "payment", "fault_kind": "cpu_stress", "evidence": [_DUMMY_EV]},
+        {"service": "noise", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV]},
+    ])
+    out = compute_outcome(agent, gt)
+    assert out.root_cause_recall == 1.0
+    assert out.root_cause_precision == 0.5
+    assert out.case_correct is False
+    assert out.overclaim_rate == 0.5
+
+
+def test_match_normalizes_ts_prefix_and_hyphens() -> None:
+    """Service name normalization: ts- prefix and hyphens are stripped."""
+    gt = [GTFault(service="ts-route-plan-service", fault_kind=FaultKind.POD_FAILURE)]
+    agent = _agent([{
+        "service": "RoutePlanService", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV],
+    }])
+    out = compute_outcome(agent, gt)
+    assert out.per_fault[0].status is MatchStatus.HIT
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Graph metrics (agent's claimed graph vs GT causal_graph)
+# ──────────────────────────────────────────────────────────────────────
+
+def _gt_graph(nodes: list[str], edges: list[tuple[str, str]]) -> CausalGraph:
+    return CausalGraph.from_dict({
+        "nodes": [{"component": n} for n in nodes],
+        "edges": [{"source": s, "target": t} for s, t in edges],
+        "component_to_service": {n: n for n in nodes},
+    })
+
+
+def test_graph_metrics_perfect() -> None:
+    gt = _gt_graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+    agent = _agent(
+        [{"service": "a", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV]}],
+        propagation=[
+            {"from": "a", "to": "b", "evidence": [_DUMMY_EV]},
+            {"from": "b", "to": "c", "evidence": [_DUMMY_EV]},
+        ],
+    )
+    gm = compute_graph_metrics(agent, gt)
+    assert gm.node_f1 == 1.0
+    assert gm.edge_f1 == 1.0
+
+
+def test_graph_metrics_partial_recall_and_hallucination() -> None:
+    """Agent claims one correct edge + one hallucinated edge; misses 2 GT edges."""
+    gt = _gt_graph(["a", "b", "c", "d"], [("a", "b"), ("b", "c"), ("c", "d")])
+    agent = _agent(
+        [{"service": "a", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV]}],
+        propagation=[
+            {"from": "a", "to": "b", "evidence": [_DUMMY_EV]},  # in GT
+            {"from": "a", "to": "c", "evidence": [_DUMMY_EV]},  # hallucinated
+        ],
+    )
+    gm = compute_graph_metrics(agent, gt)
+    assert gm.node_precision == 1.0  # {a,b,c} ⊆ {a,b,c,d}
+    assert abs(gm.node_recall - 0.75) < 1e-9
+    assert gm.edge_precision == 0.5
+    assert abs(gm.edge_recall - 1 / 3) < 1e-9
+    assert gm.hallucinated_edges == [("a", "c")]
+
+
+def test_graph_metrics_no_gt_marks_inapplicable() -> None:
+    agent = _agent([{"service": "a", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV]}])
+    gm = compute_graph_metrics(agent, None)
+    assert gm.applicable is False
+    assert gm.node_f1 == 0.0
+
+
+# ──────────────────────────────────────────────────────────────────────
+# DuckDB SQL evidence verification
+# ──────────────────────────────────────────────────────────────────────
+
+def _make_case(tmp_path: Path) -> Path:
+    """Synthesize a tiny case dir with one trace + one metrics parquet."""
+    times = pl.datetime_range(
+        pl.datetime(2026, 5, 2, 8, 0, 0),
+        pl.datetime(2026, 5, 2, 8, 4, 0),
+        "1m",
+        eager=True,
+    )
+    pl.DataFrame({
+        "time": times,
+        "metric": ["latency_p99"] * len(times),
+        "value": [10.0, 20.0, 30.0, 40.0, 50.0],
+        "service_name": ["shipping"] * len(times),
+    }).write_parquet(tmp_path / "abnormal_metrics.parquet")
+    pl.DataFrame({
+        "time": times,
+        "trace_id": ["t"] * len(times),
+        "span_id": [str(i) for i in range(len(times))],
+        "service_name": ["shipping"] * len(times),
+        "duration": [1000, 2000, 3000, 4000, 5000],
+    }).write_parquet(tmp_path / "abnormal_traces.parquet")
+    return tmp_path
+
+
+def test_sql_verify_ok(tmp_path: Path) -> None:
+    case = _make_case(tmp_path)
+    ev = Evidence(
+        kind=EvidenceKind.METRIC,
+        sql="SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='shipping'",
+        claim="shipping latency rises",
+    )
+    r = verify_evidence(ev, parquet_dir=case, allowed_services={"shipping"})
+    assert r.status is EvidenceStatus.OK
+    assert r.row_count == 5
+
+
+def test_sql_verify_unsafe_keyword(tmp_path: Path) -> None:
+    case = _make_case(tmp_path)
+    ev = Evidence(kind=EvidenceKind.METRIC, sql="DROP TABLE foo", claim="x")
+    assert verify_evidence(ev, parquet_dir=case).status is EvidenceStatus.UNSAFE_SQL
+
+
+def test_sql_verify_path_escape(tmp_path: Path) -> None:
+    case = _make_case(tmp_path)
+    ev = Evidence(
+        kind=EvidenceKind.METRIC,
+        sql="SELECT 1 FROM read_parquet('/etc/passwd')",
+        claim="x",
+    )
+    assert verify_evidence(ev, parquet_dir=case).status is EvidenceStatus.UNSAFE_SQL
+
+
+def test_sql_verify_empty(tmp_path: Path) -> None:
+    case = _make_case(tmp_path)
+    ev = Evidence(
+        kind=EvidenceKind.METRIC,
+        sql="SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='nonexistent'",
+        claim="x",
+    )
+    assert verify_evidence(ev, parquet_dir=case).status is EvidenceStatus.EMPTY
+
+
+def test_sql_verify_service_mismatch(tmp_path: Path) -> None:
+    case = _make_case(tmp_path)
+    ev = Evidence(
+        kind=EvidenceKind.METRIC,
+        sql="SELECT * FROM read_parquet('abnormal_metrics.parquet')",
+        claim="x",
+    )
+    r = verify_evidence(ev, parquet_dir=case, allowed_services={"unrelated_service"})
+    assert r.status is EvidenceStatus.SERVICE_MISMATCH
+
+
+# ──────────────────────────────────────────────────────────────────────
+# End-to-end evaluator (no LLM client → chain_coherence falls back to
+# sql_executable_rate, so the headline = rc_f1 × sql × sql).
+# ──────────────────────────────────────────────────────────────────────
+
+def _injection() -> dict[str, Any]:
+    return {
+        "engine_config": [{
+            "app": "shipping", "chaos_type": "NetworkDelay",
+            "target_service": "quote", "direction": "to",
+        }],
+        "start_time": "2026-05-02T08:00:00Z",
+        "end_time": "2026-05-02T08:05:00Z",
+    }
+
+
+def test_evaluate_v2_perfect(tmp_path: Path) -> None:
+    """Perfect agent: rc_f1=1, sql=1, chain=1 (fallback), headline=1."""
+    case = _make_case(tmp_path)
+    agent = json.dumps({
+        "root_causes": [{
+            "service": "shipping", "fault_kind": "network_delay",
+            "direction": {"src": "shipping", "dst": "quote"},
+            "evidence": [{
+                "kind": "metric",
+                "sql": "SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='shipping'",
+                "claim": "shipping latency rises",
+            }],
+        }],
+        "propagation": [],
+    })
+    res = asyncio.run(evaluate_v2(agent, _injection(), case, gt_graph=None, llm_client=None))
+    assert res.root_cause_f1 == 1.0
+    assert res.overclaim_rate == 0.0
+    assert res.sql_executable_rate == 1.0
+    assert res.chain_coherence == 1.0
+    assert res.headline == 1.0
+    assert res.case_correct is True
+
+
+def test_evaluate_v2_wrong_direction(tmp_path: Path) -> None:
+    """Service+kind right but direction flipped → rc_f1=0, headline=0."""
+    case = _make_case(tmp_path)
+    agent = json.dumps({
+        "root_causes": [{
+            "service": "shipping", "fault_kind": "network_delay",
+            "direction": {"src": "quote", "dst": "shipping"},  # flipped
+            "evidence": [{
+                "kind": "metric",
+                "sql": "SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='shipping'",
+                "claim": "x",
+            }],
+        }],
+        "propagation": [],
+    })
+    res = asyncio.run(evaluate_v2(agent, _injection(), case, gt_graph=None, llm_client=None))
+    assert res.root_cause_f1 == 0.0
+    assert res.headline == 0.0
+    assert res.case_correct is False
+    assert res.per_fault[0].status is MatchStatus.WRONG_DIRECTION
+
+
+def test_evaluate_v2_unparseable_response(tmp_path: Path) -> None:
+    case = _make_case(tmp_path)
+    res = asyncio.run(evaluate_v2("NOT JSON", _injection(), case, gt_graph=None, llm_client=None))
+    assert res.headline == 0.0
+    assert res.parse_error is not None and "JSON" in res.parse_error
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Batch aggregation via RCABenchProcesser.calculate_metrics
+# ──────────────────────────────────────────────────────────────────────
+
+def test_calculate_metrics_aggregation() -> None:
+    """4 stub samples → aggregate is the mean over the 3 successfully scored.
+
+    Sample mix:
+      [0] perfect    rc_f1=1.0  sql=1.0  chain=1.0  headline=1.0  correct=True
+      [1] partial    rc_f1=0.5  sql=0.8  chain=0.6  headline=0.24
+      [2] parse-err  zeros + parse_error=True
+      [3] eval-err   sample.meta['eval_v2'] = {'error': '...'}  → excluded
+    Expected averages over the 3 scored samples (excluding [3]).
+    """
+    from rcabench_platform.v3.sdk.llm_eval.eval.processer.rcabench import RCABenchProcesser
+
+    class _StubSample:
+        def __init__(self, meta: dict[str, Any]) -> None:
+            self.meta: dict[str, Any] = meta
+
+    samples = [
+        _StubSample({"eval_v2": {
+            "root_cause_f1": 1.0, "overclaim_rate": 0.0,
+            "sql_executable_rate": 1.0, "chain_coherence": 1.0,
+            "node_f1": 1.0, "edge_f1": 1.0, "headline": 1.0,
+            "case_correct": True, "per_evidence": [{}],
+        }}),
+        _StubSample({"eval_v2": {
+            "root_cause_f1": 0.5, "overclaim_rate": 0.5,
+            "sql_executable_rate": 0.8, "chain_coherence": 0.6,
+            "node_f1": 0.4, "edge_f1": 0.2, "headline": 0.24,
+            "case_correct": False, "per_evidence": [{}],
+        }}),
+        _StubSample({"eval_v2": {
+            "root_cause_f1": 0.0, "overclaim_rate": 1.0,
+            "sql_executable_rate": 0.0, "chain_coherence": 0.0,
+            "node_f1": 0.0, "edge_f1": 0.0, "headline": 0.0,
+            "case_correct": False, "parse_error": "bad json",
+            "per_evidence": [],
+        }}),
+        _StubSample({"eval_v2": {"error": "missing case dir"}}),
+    ]
+
+    proc = RCABenchProcesser.__new__(RCABenchProcesser)
+    proc.name = "RCABench"
+    metrics = proc.calculate_metrics(samples)  # type: ignore[arg-type]
+
+    assert metrics["total_samples"] == 4
+    assert metrics["scored_samples"] == 3
+    assert metrics["case_correct"] == 1
+    assert metrics["case_correct_rate"] == round(1 / 3, 4)
+    assert metrics["parse_errors"] == 1
+    assert metrics["zero_evidence_outputs"] == 1
+    assert metrics["avg_root_cause_f1"] == round((1.0 + 0.5 + 0.0) / 3, 4)
+    assert metrics["avg_sql_executable_rate"] == round((1.0 + 0.8 + 0.0) / 3, 4)
+    assert metrics["avg_chain_coherence"] == round((1.0 + 0.6 + 0.0) / 3, 4)
+    assert metrics["avg_node_f1"] == round((1.0 + 0.4 + 0.0) / 3, 4)
+    assert metrics["avg_edge_f1"] == round((1.0 + 0.2 + 0.0) / 3, 4)
+    assert metrics["avg_headline"] == round((1.0 + 0.24 + 0.0) / 3, 4)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/rcabench.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/rcabench.py
@@ -194,6 +194,7 @@ class RCABenchProcesser(BaseMatchProcesser):
                 "benchmark": self.name,
                 "total_samples": 0,
                 "case_correct_rate": 0.0,
+                "avg_service_f1": 0.0,
                 "avg_root_cause_f1": 0.0,
                 "avg_sql_executable_rate": 0.0,
                 "avg_chain_coherence": 0.0,
@@ -202,6 +203,7 @@ class RCABenchProcesser(BaseMatchProcesser):
             }
 
         n = len(samples)
+        service_f1 = 0.0
         rc_f1 = 0.0
         overclaim = 0.0
         sql_ok = 0.0
@@ -221,6 +223,7 @@ class RCABenchProcesser(BaseMatchProcesser):
             if not isinstance(ev, dict) or "error" in ev:
                 continue
             with_eval += 1
+            service_f1 += float(ev.get("service_f1") or 0.0)
             rc_f1 += float(ev.get("root_cause_f1") or 0.0)
             overclaim += float(ev.get("overclaim_rate") or 0.0)
             sql_ok += float(ev.get("sql_executable_rate") or 0.0)
@@ -242,6 +245,7 @@ class RCABenchProcesser(BaseMatchProcesser):
             "scored_samples": with_eval,
             "case_correct": correct,
             "case_correct_rate": round(correct / denom, 4),
+            "avg_service_f1": round(service_f1 / denom, 4),
             "avg_root_cause_f1": round(rc_f1 / denom, 4),
             "avg_overclaim_rate": round(overclaim / denom, 4),
             "avg_sql_executable_rate": round(sql_ok / denom, 4),

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/rcabench.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/rcabench.py
@@ -4,6 +4,7 @@ The agent emits an `AgentRCAOutput` JSON. Judging is fully mechanical for the
 deterministic axes (root_cause F1, overclaim, sql_executable) and uses an
 LLM-as-judge only for chain coherence.
 """
+
 import json
 import uuid
 from collections.abc import Callable

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/rcabench.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/rcabench.py
@@ -1,12 +1,17 @@
+"""RCABench evaluator (v2 schema).
+
+The agent emits an `AgentRCAOutput` JSON. Judging is fully mechanical for the
+deterministic axes (root_cause F1, overclaim, sql_executable) and uses an
+LLM-as-judge only for chain coherence.
+"""
 import json
-import math
 import uuid
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 from ....evaluation.causal_graph import CausalGraph
-from ....evaluation.rca_metrics import evaluate_graphs
+from ....evaluation.v2 import EvaluationResultV2, evaluate_v2
 from ...config import EvalConfig
 from ..data import EvaluationSample
 from .base_match_processor import BaseMatchProcesser
@@ -14,11 +19,19 @@ from .prompts import AUGMENTATION_PROMPTS
 
 
 class RCABenchProcesser(BaseMatchProcesser):
-    """Processer for RCABench evaluation.
+    """Processer for RCABench v2 evaluation.
 
-    RCABench (Root Cause Analysis Benchmark) is designed to evaluate
-    agent capabilities in systematic problem analysis and root cause identification
-    using keyword matching and structural analysis.
+    Agent contract: structured JSON (`AgentRCAOutput`). The judge:
+      1. Type-aware matches each agent root_cause to a GT fault from
+         injection.json's engine_config.
+      2. Re-runs every evidence SQL via DuckDB on the case parquets.
+      3. Asks an LLM to score the chain's coherence given the merged claims +
+         executed SQL preview + GT causal_graph.
+
+    Output (per sample, stored on `sample.meta['eval_v2']`):
+        - root_cause_f1, overclaim_rate, sql_executable_rate, chain_coherence
+        - headline = product of the four
+        - per_fault, per_evidence, chain_judge — diagnostic detail
     """
 
     name: str = "RCABench"
@@ -32,24 +45,10 @@ class RCABenchProcesser(BaseMatchProcesser):
         self.source_path_fn = source_path_fn
 
     def preprocess_one(self, sample: EvaluationSample) -> EvaluationSample:
-        """Preprocess a sample by dynamically generating symlink and question.
-
-        This method:
-        1. Creates a symlink from the original data directory to a random path
-        2. Reads alarm_nodes from causal_graph.json to extract SLO-violated endpoints
-        3. Formats the question using the RCABench template
-        4. Updates the sample's meta with the dynamic path
-
-        Args:
-            sample: The evaluation sample to preprocess.
-
-        Returns:
-            The preprocessed sample with augmented_question and updated meta.
-        """
+        """Materialize a per-sample symlinked data dir + render the V2 prompt."""
         assert sample.meta is not None
         meta = dict(sample.meta)
 
-        # Resolve source data directory: fn takes priority, then meta fields
         if self.source_path_fn is not None:
             source_data_dir = str(self.source_path_fn(sample.source))
         else:
@@ -58,655 +57,198 @@ class RCABenchProcesser(BaseMatchProcesser):
             raise ValueError(f"Sample {sample.id} has no source_data_dir or path in meta")
 
         source_path = Path(source_data_dir).expanduser()
-
         if not source_path.exists() or not source_path.is_dir():
-            raise ValueError(f"Source data directory does not exist or is not a directory: {source_path}")
+            raise ValueError(f"Source data dir missing: {source_path}")
 
-        # Create eval-data directory with exp_id subdirectory
         eval_data_dir = Path("eval-data") / sample.exp_id
         eval_data_dir.mkdir(parents=True, exist_ok=True)
-
-        # Generate random name for symlink to prevent model hack
-        random_name = f"data_{uuid.uuid4().hex[:8]}"
-        symlink_path = eval_data_dir / random_name
-
-        # Remove existing symlink if present
+        symlink_path = eval_data_dir / f"data_{uuid.uuid4().hex[:8]}"
         if symlink_path.exists() or symlink_path.is_symlink():
             symlink_path.unlink()
-
-        # Create symlink to original data directory
         symlink_path.symlink_to(source_path.absolute(), target_is_directory=True)
 
-        # Extract alarm endpoints from causal_graph.json
         alarm_endpoints = self._extract_alarm_endpoints(source_path)
         meta["alarm_endpoints"] = alarm_endpoints
-
-        # Format reports for the question
-        formatted_reports = "\n".join(f"- {endpoint}" for endpoint in alarm_endpoints)
-
-        # Use template to generate question
-        template_key = "RCABench" if "RCABench" in AUGMENTATION_PROMPTS else "default"
-
-        if template_key == "RCABench":
-            # RCABench template uses {reports} and {directory_path}
-            augmented_question = AUGMENTATION_PROMPTS[template_key].format(
-                reports=formatted_reports,
-                directory_path=str(symlink_path.absolute()),
-            )
-        else:
-            # Fallback to default template
-            augmented_question = AUGMENTATION_PROMPTS[template_key].format(
-                question=sample.raw_question, directory_path=str(symlink_path.absolute())
-            )
-
-        # Update meta with dynamic path (for judge_one to use)
         meta["path"] = str(symlink_path.absolute())
 
-        sample.update(
-            augmented_question=augmented_question,
-            meta=meta,
+        formatted_reports = "\n".join(f"- {ep}" for ep in alarm_endpoints)
+        template = AUGMENTATION_PROMPTS.get("RCABench", AUGMENTATION_PROMPTS["default"])
+        augmented_question = template.format(
+            reports=formatted_reports,
+            directory_path=str(symlink_path.absolute()),
         )
+
+        sample.update(augmented_question=augmented_question, meta=meta)
         return sample
 
     @staticmethod
     def _extract_endpoint_from_component(component: str) -> str | None:
-        """Extract an endpoint identifier from a causal graph component.
-
-        Handles both HTTP and RPC-style spans. Examples:
-        - "span|loadgenerator::HTTP POST http://ts-ui-dashboard:8080/api/v1/..."
-        - "span|ts-ui-dashboard::POST /api/v1/..."
-        - "span|search::search.Search/Nearby"  (gRPC method)
-        - "span|HTTP POST http://ts-ui-dashboard:8080/..."  (no :: separator)
-
-        Non-span components (``service|``, ``pod|``, ``container|`` …) return
-        ``None`` because they do not name endpoints.
-
-        Args:
-            component: Component identifier string.
-
-        Returns:
-            Endpoint string (everything after ``::`` or ``|``), or ``None`` if
-            the component is not a span or has no body.
-        """
         if not component.startswith("span|"):
             return None
-
-        if "::" in component:
-            endpoint = component.split("::", 1)[1].strip()
-        else:
-            # Fallback: "span|ENDPOINT" with no service prefix
-            endpoint = component.split("|", 1)[1].strip()
-
+        endpoint = component.split("::", 1)[1].strip() if "::" in component else component.split("|", 1)[1].strip()
         return endpoint or None
 
     @staticmethod
     def _extract_alarm_endpoints(source_path: Path) -> list[str]:
-        """Extract alarm endpoint descriptions from causal_graph.json.
-
-        Reads the alarm_nodes from causal_graph.json and extracts user-facing
-        HTTP endpoints that are experiencing SLO violations.
-
-        Falls back to scanning all nodes for loadgenerator spans if alarm_nodes
-        is empty, and returns a generic message if no endpoints are found.
-
-        Args:
-            source_path: Path to the data directory containing causal_graph.json.
-
-        Returns:
-            List of endpoint description strings.
-        """
-        causal_graph_file = source_path / "causal_graph.json"
-        if not causal_graph_file.exists():
+        cg_path = source_path / "causal_graph.json"
+        if not cg_path.exists():
             raise ValueError(f"causal_graph.json not found in {source_path}")
-
-        with open(causal_graph_file) as f:
-            cg_data = json.load(f)
-
-        graph = CausalGraph.from_dict(cg_data)
-
-        # Primary: use alarm_nodes
-        endpoints: list[str] = []
-        seen: set[str] = set()
-
+        graph = CausalGraph.from_dict(json.loads(cg_path.read_text()))
         candidates = (
             graph.alarm_nodes
             if graph.alarm_nodes
             else [n for n in graph.nodes if n.component.startswith("span|loadgenerator::")]
         )
-
+        endpoints: list[str] = []
+        seen: set[str] = set()
         for node in candidates:
-            endpoint = RCABenchProcesser._extract_endpoint_from_component(node.component)
-            if endpoint and endpoint not in seen:
-                seen.add(endpoint)
-                endpoints.append(endpoint)
-
+            ep = RCABenchProcesser._extract_endpoint_from_component(node.component)
+            if ep and ep not in seen:
+                seen.add(ep)
+                endpoints.append(ep)
         if not endpoints:
             raise ValueError(f"No valid endpoints found in {source_path}")
-
         return endpoints
 
     async def judge_one(self, sample: EvaluationSample) -> EvaluationSample:
-        data = sample
-        response = data.response or ""
-        correct_answer = data.correct_answer or ""
+        meta = dict(sample.meta) if isinstance(sample.meta, dict) else {"previous_meta": sample.meta}
+        case_dir = self._resolve_case_dir(meta, sample)
 
-        trajectories = self._load_trajectories(data.trajectories)
-        (
-            tool_success_count,
-            tool_failure_count,
-        ) = self._compute_tool_usage_stats(trajectories)
-        tool_bonus = self._compute_tool_bonus(tool_success_count, tool_failure_count)
+        injection = self._load_json(case_dir / "injection.json") if case_dir else None
+        gt_graph = self._load_gt_graph(case_dir) if case_dir else None
 
-        # Parse CausalGraph from response
-        agent_graph, parse_error = self._parse_causal_graph(response)
+        if not case_dir or injection is None:
+            sample.update(
+                correct=False,
+                confidence=0.0,
+                reasoning="missing case dir or injection.json",
+                judged_response=None,
+            )
+            meta["eval_v2"] = {"error": "missing case dir or injection.json"}
+            sample.update(meta=meta)
+            return sample
 
-        # Evaluate the CausalGraph
-        score, evaluation_details = self._evaluate_causal_graph(agent_graph, correct_answer)
-        score_with_bonus = score + tool_bonus
+        result: EvaluationResultV2 = await evaluate_v2(
+            agent_output_raw=sample.response or "",
+            injection=injection,
+            parquet_dir=case_dir,
+            gt_graph=gt_graph,
+            llm_client=self.judge_client,
+            judge_model=self.judge_model,
+            case_name=sample.source,
+        )
 
-        if isinstance(data.meta, dict):
-            meta = dict(data.meta)
-        else:
-            meta = {"previous_meta": data.meta}
+        meta["eval_v2"] = result.model_dump(mode="json")
 
-        meta["tool_usage"] = {
-            "used": tool_success_count > 0,
-            "success_count": tool_success_count,
-            "failure_count": tool_failure_count,
-            "bonus": tool_bonus,
-            "base_score": score,
-            "final_score": score_with_bonus,
-        }
+        reasoning_bits: list[str] = []
+        reasoning_bits.append(
+            f"rc_f1={result.root_cause_f1:.2f} sql={result.sql_executable_rate:.2f} "
+            f"chain={result.chain_coherence:.2f} headline={result.headline:.2f}"
+        )
+        if result.parse_error:
+            reasoning_bits.append(f"parse_error={result.parse_error}")
+        if result.chain_judge and result.chain_judge.reasoning:
+            reasoning_bits.append(f"judge: {result.chain_judge.reasoning}")
 
-        meta["causal_graph_evaluation"] = evaluation_details
-        meta["parse_error"] = parse_error
-
-        # Load GT graph and compute new metrics
-        gt_graph = self._load_gt_causal_graph(data)
-        gt_root_cause_services = self._load_gt_root_cause_services(data)
-        if agent_graph and gt_graph:
-            # Check if GT has alarm_nodes before computing metrics
-            if not gt_graph.get_alarm_services():
-                data_path = data.meta.get("path") if isinstance(data.meta, dict) else None
-                print(f"  ⚠ Warning: GT data missing alarm_nodes (sample: {data.source}, path: {data_path})")
-
-            graph_result = await evaluate_graphs(agent_graph, gt_graph, gt_root_cause_services=gt_root_cause_services)
-            meta["graph_metrics"] = graph_result.model_dump()
-
-        # Print CausalGraph for debugging
-        if agent_graph:
-            print("\n" + "=" * 80)
-            print("CAUSAL GRAPH EVALUATION RESULT")
-            print("=" * 80)
-            print(f"Sample ID: {data.id}")
-            print(f"Correct Answer: {correct_answer}")
-            print("\nAgent Graph:")
-            print(f"  Nodes: {len(agent_graph.nodes)}")
-            for node in agent_graph.nodes:
-                print(f"    - {node.component}: {list(node.state)}")
-            print(f"  Edges: {len(agent_graph.edges)}")
-            for edge in agent_graph.edges:
-                print(f"    - {edge.source} → {edge.target}")
-            print(f"  Root Causes: {len(agent_graph.root_causes)}")
-            for rc in agent_graph.root_causes:
-                print(f"    - {rc.component}: {list(rc.state)}")
-            print("\nEvaluation:")
-            print(f"  Root Cause Services: {evaluation_details.get('root_cause_services', [])}")
-            print(f"  Correct: {evaluation_details.get('correct', False)}")
-            print(f"  Score: {score:.2f}")
-            print(f"  Score with Bonus: {score_with_bonus:.2f}")
-            print("=" * 80 + "\n")
-
-        # Enrich reasoning with fault injection context
-        base_reasoning = evaluation_details.get("reasoning") or ""
-        injection = self._load_injection_json(data)
-        if injection:
-            injection_context = self._format_injection_context(injection)
-            if injection_context:
-                reasoning_str = f"{base_reasoning} | Injection: {injection_context}"
-            else:
-                reasoning_str = base_reasoning
-        else:
-            reasoning_str = base_reasoning
-
-        data.update(
+        sample.update(
             judged_response=None,
-            correct=evaluation_details.get("correct", False),
-            confidence=score_with_bonus,
-            reasoning=reasoning_str or None,
+            correct=result.case_correct,
+            confidence=result.headline,
+            reasoning=" | ".join(reasoning_bits),
             extracted_final_answer=None,
             meta=meta,
         )
-
-        return data
-
-    @staticmethod
-    def _load_trajectories(raw_trajectories: Any) -> list[dict[str, Any]]:
-        if not raw_trajectories:
-            return []
-
-        if isinstance(raw_trajectories, str):
-            try:
-                parsed = json.loads(raw_trajectories)
-            except json.JSONDecodeError:
-                return []
-        else:
-            parsed = raw_trajectories
-
-        # Span format: {"trajectories": [{"trajectory_id", "agent_name", "messages"}]}
-        if isinstance(parsed, dict) and "trajectories" in parsed:
-            flat_messages: list[dict[str, Any]] = []
-            for traj in parsed.get("trajectories", []):
-                if isinstance(traj, dict):
-                    for msg in traj.get("messages", []):
-                        if isinstance(msg, dict):
-                            flat_messages.append(msg)
-            return flat_messages
-
-        # Legacy format: {"agent_trajectories": [...]}
-        if isinstance(parsed, dict) and "agent_trajectories" in parsed:
-            flat_messages = []
-            for agent_traj in parsed.get("agent_trajectories", []):
-                for turn in agent_traj.get("turns", []):
-                    for msg in turn.get("messages", []):
-                        if isinstance(msg, dict):
-                            flat_messages.append(msg)
-            return flat_messages
-
-        # Legacy format: [{"agent": ..., "trajectory": [...]}]
-        if isinstance(parsed, list):
-            flat_messages = []
-            for item in parsed:
-                if not isinstance(item, dict):
-                    continue
-                if "trajectory" in item and isinstance(item["trajectory"], list):
-                    flat_messages.extend(msg for msg in item["trajectory"] if isinstance(msg, dict))
-                else:
-                    flat_messages.append(item)
-            return flat_messages
-
-        return []
+        return sample
 
     @staticmethod
-    def _compute_tool_usage_stats(trajectories: list[dict[str, Any]]) -> tuple[int, int]:
-        assistant_call_ids: set[str] = set()
-        tool_outcomes: dict[str, bool] = {}
-
-        for message in trajectories:
-            role = message.get("role")
-
-            if role == "assistant":
-                tool_calls = message.get("tool_calls") or []
-                for tool_call in tool_calls:
-                    call_id = tool_call.get("id")
-                    if isinstance(call_id, str):
-                        assistant_call_ids.add(call_id)
-
-            if role == "tool":
-                tool_call_id = message.get("tool_call_id")
-                if not isinstance(tool_call_id, str):
-                    continue
-
-                content = message.get("content")
-                success = True
-                if isinstance(content, str) and ("An error occurred while running the tool." in content):
-                    success = False
-
-                if success:
-                    tool_outcomes[tool_call_id] = True
-                else:
-                    if tool_outcomes.get(tool_call_id) is not True:
-                        tool_outcomes[tool_call_id] = False
-
-        success_count = sum(1 for call_id in assistant_call_ids if tool_outcomes.get(call_id) is True)
-        failure_count = sum(1 for call_id in assistant_call_ids if tool_outcomes.get(call_id) is False)
-
-        return success_count, failure_count
+    def _resolve_case_dir(meta: dict[str, Any], sample: EvaluationSample) -> Path | None:
+        path = meta.get("path") or meta.get("source_data_dir")
+        if path:
+            p = Path(path)
+            if p.exists():
+                return p.resolve()
+        return None
 
     @staticmethod
-    def _compute_tool_bonus(success_count: int, failure_count: int) -> float:
-        if success_count == 0 and failure_count == 0:
-            return 0.0
-
-        total_calls = success_count + failure_count
-        if total_calls == 0 or success_count == 0:
-            return 0.0
-
-        ideal_calls = 10.0
-        max_bonus = 0.2
-
-        success_ratio = success_count / total_calls
-        failure_penalty = 1.0 - math.tanh(failure_count)
-        balance = 1.0 - math.tanh(abs(total_calls - ideal_calls) / max(ideal_calls, 1.0))
-
-        raw_score = success_ratio * failure_penalty * balance
-        bonus = max_bonus * raw_score
-
-        return bonus if bonus > 0 else 0.0
-
-    @staticmethod
-    def _parse_causal_graph(response: str) -> tuple[CausalGraph | None, str | None]:
-        """Parse CausalGraph from JSON response.
-
-        Args:
-            response: JSON string containing CausalGraph
-
-        Returns:
-            Tuple of (CausalGraph object or None, error message or None)
-        """
-        if not response:
-            return None, "Empty response"
-
-        try:
-            parsed_json = json.loads(response)
-        except json.JSONDecodeError as e:
-            return None, f"JSON decode error: {str(e)}"
-
-        try:
-            graph = CausalGraph.from_dict(parsed_json)
-            return graph, None
-        except Exception as e:
-            return None, f"Error parsing CausalGraph: {str(e)}"
-
-    @staticmethod
-    def _normalize_service_name(service_name: str) -> str:
-        """Normalize service name for comparison.
-
-        - Convert to lowercase
-        - Remove 'ts-' prefix if present
-        - Remove all hyphens
-        """
-        normalized = service_name.strip().lower()
-        if normalized.startswith("ts-"):
-            normalized = normalized[3:]
-        normalized = normalized.replace("-", "")
-        return normalized
-
-    def _evaluate_causal_graph(
-        self, agent_graph: CausalGraph | None, correct_answer: str
-    ) -> tuple[float, dict[str, Any]]:
-        """Evaluate CausalGraph against correct answer.
-
-        Args:
-            agent_graph: Parsed CausalGraph from agent response
-            correct_answer: Ground truth service name(s), comma-separated
-
-        Returns:
-            Tuple of (score, evaluation_details dict)
-        """
-        evaluation_details: dict[str, Any] = {
-            "correct": False,
-            "root_cause_services": [],
-            "reasoning": None,
-        }
-
-        score = 0.0
-
-        if not agent_graph:
-            evaluation_details["reasoning"] = "Failed to parse CausalGraph"
-            return score, evaluation_details
-
-        # Give base score for valid structure
-        score += 0.1
-
-        # Extract root cause services from agent graph
-        root_cause_services = agent_graph.get_root_cause_services()
-        evaluation_details["root_cause_services"] = list(root_cause_services)
-
-        if not root_cause_services:
-            evaluation_details["reasoning"] = "No root causes identified in graph"
-            return score, evaluation_details
-
-        # Normalize correct answers
-        correct_answers = [ans.strip() for ans in correct_answer.split(",")]
-        normalized_correct = {self._normalize_service_name(ans) for ans in correct_answers}
-
-        # Normalize agent root causes
-        normalized_agent = {self._normalize_service_name(rc) for rc in root_cause_services}
-
-        # Exact set matching (after normalization)
-        matched = normalized_agent & normalized_correct
-
-        if matched:
-            score += 1.0
-            evaluation_details["correct"] = True
-            evaluation_details["reasoning"] = f"Root cause services matched: {matched}"
-        else:
-            evaluation_details["reasoning"] = (
-                f"Root cause services {list(root_cause_services)} do not match correct answer(s): {correct_answers}"
-            )
-
-        return score, evaluation_details
-
-    def _load_gt_causal_graph(self, sample: EvaluationSample) -> CausalGraph | None:
-        """Load ground truth CausalGraph from causal_graph.json.
-
-        Args:
-            sample: The evaluation sample containing meta with path
-
-        Returns:
-            CausalGraph object or None if loading fails
-        """
-        if not sample.meta or "path" not in sample.meta:
+    def _load_json(path: Path) -> dict[str, Any] | None:
+        if not path.exists():
             return None
-
-        gt_path = Path(sample.meta["path"]) / "causal_graph.json"
-
-        if not gt_path.exists():
-            return None
-
         try:
-            with open(gt_path) as f:
-                parsed_json = json.load(f)
-            return CausalGraph.from_dict(parsed_json)
+            return json.loads(path.read_text())
         except Exception:
             return None
 
-    def _load_injection_json(self, sample: EvaluationSample) -> dict[str, Any] | None:
-        """Load injection.json for a sample.
-
-        Args:
-            sample: The evaluation sample containing meta with path
-
-        Returns:
-            Parsed injection dict, or None if unavailable
-        """
-        if not sample.meta or "path" not in sample.meta:
+    @staticmethod
+    def _load_gt_graph(case_dir: Path) -> CausalGraph | None:
+        cg = case_dir / "causal_graph.json"
+        if not cg.exists():
             return None
-
-        injection_path = Path(sample.meta["path"]) / "injection.json"
-
-        if not injection_path.exists():
-            return None
-
         try:
-            with open(injection_path) as f:
-                return json.load(f)
+            return CausalGraph.from_dict(json.loads(cg.read_text()))
         except Exception:
             return None
-
-    def _load_gt_root_cause_services(self, sample: EvaluationSample) -> set[str] | None:
-        """Load ground truth root cause services from injection.json.
-
-        injection.json's ground_truth.service is the authoritative source for
-        fault injection targets, supporting multiple root cause services.
-
-        Args:
-            sample: The evaluation sample containing meta with path
-
-        Returns:
-            Set of root cause service names, or None if unavailable
-        """
-        injection = self._load_injection_json(sample)
-        if not injection:
-            return None
-        # ``ground_truth`` is either a dict (RCABench schema) or a list of dicts
-        # (AegisLab batch schema, used by OpenRCA-2.0). Normalise to a list so
-        # we can support both without branching every reader.
-        gt_raw = injection.get("ground_truth") or {}
-        gt_list = gt_raw if isinstance(gt_raw, list) else [gt_raw]
-        services: set[str] = set()
-        for gt in gt_list:
-            if not isinstance(gt, dict):
-                continue
-            for svc in gt.get("service") or []:
-                if svc:
-                    services.add(svc)
-        return services or None
-
-    @staticmethod
-    def _format_injection_context(injection: dict[str, Any]) -> str:
-        """Format injection.json into a human-readable fault context string.
-
-        Extracts fault type, injection target, duration, and ground truth
-        to help downstream analysis understand what was injected.
-        """
-        parts: list[str] = []
-
-        # Fault type
-        fault_type = injection.get("fault_type")
-        if fault_type is not None:
-            parts.append(f"Fault type: {fault_type}")
-
-        # Parse display_config for injection point details
-        display_config_raw = injection.get("display_config")
-        if display_config_raw:
-            try:
-                dc = json.loads(display_config_raw) if isinstance(display_config_raw, str) else display_config_raw
-                ip = dc.get("injection_point", {})
-                if ip:
-                    target_parts = []
-                    if ip.get("app_name"):
-                        target_parts.append(f"service={ip['app_name']}")
-                    if ip.get("class_name"):
-                        target_parts.append(f"class={ip['class_name']}")
-                    if ip.get("method_name"):
-                        target_parts.append(f"method={ip['method_name']}")
-                    if target_parts:
-                        parts.append(f"Injection target: {', '.join(target_parts)}")
-                duration = dc.get("duration")
-                if duration:
-                    parts.append(f"Duration: {duration} min")
-                mem_type = dc.get("mem_type")
-                if mem_type is not None:
-                    label = "Heap" if mem_type == 1 else "Stack" if mem_type == 2 else str(mem_type)
-                    parts.append(f"Memory type: {label}")
-                namespace = dc.get("namespace")
-                if namespace:
-                    parts.append(f"Namespace: {namespace}")
-            except (json.JSONDecodeError, TypeError):
-                pass
-
-        # Ground truth summary — accept dict or list-of-dicts (AegisLab schema).
-        gt_raw = injection.get("ground_truth") or {}
-        gt_list = gt_raw if isinstance(gt_raw, list) else [gt_raw]
-        for kind in ("service", "function", "metric"):
-            values: list[str] = []
-            seen: set[str] = set()
-            for gt in gt_list:
-                if not isinstance(gt, dict):
-                    continue
-                vs = gt.get(kind)
-                if not vs:
-                    continue
-                vs_iter = vs if isinstance(vs, list) else [vs]
-                for v in vs_iter:
-                    if v and v not in seen:
-                        seen.add(v)
-                        values.append(str(v))
-            if values:
-                parts.append(f"Ground truth {kind}: {values}")
-
-        # Time window
-        start = injection.get("start_time")
-        end = injection.get("end_time")
-        if start and end:
-            parts.append(f"Time window: {start} ~ {end}")
-
-        return "; ".join(parts) if parts else ""
 
     def calculate_metrics(self, samples: list[EvaluationSample]) -> dict:
-        """Calculate metrics from the judged data."""
         if not samples:
-            return {"total_samples": 0, "accuracy": 0.0, "correct_count": 0, "incorrect_count": 0, "unknown_count": 0}
+            return {
+                "benchmark": self.name,
+                "total_samples": 0,
+                "case_correct_rate": 0.0,
+                "avg_root_cause_f1": 0.0,
+                "avg_sql_executable_rate": 0.0,
+                "avg_chain_coherence": 0.0,
+                "avg_headline": 0.0,
+                "avg_overclaim_rate": 0.0,
+            }
 
-        total_samples = len(samples)
-        correct_count = 0
-        incorrect_count = 0
-        unknown_count = 0
+        n = len(samples)
+        rc_f1 = 0.0
+        overclaim = 0.0
+        sql_ok = 0.0
+        chain = 0.0
+        headline = 0.0
+        node_f1 = 0.0
+        edge_f1 = 0.0
+        correct = 0
+        with_eval = 0
+        parse_errors = 0
+        zero_evidence = 0
 
-        # Accumulators for graph metrics
-        edge_f1_sum = 0.0
-        node_f1_sum = 0.0
-        root_cause_f1_sum = 0.0
-        component_f1_sum = 0.0
-        path_reachability_true_count = 0
-        path_reachability_applicable_count = 0
-        graph_metrics_count = 0
+        for s in samples:
+            if not isinstance(s.meta, dict):
+                continue
+            ev = s.meta.get("eval_v2")
+            if not isinstance(ev, dict) or "error" in ev:
+                continue
+            with_eval += 1
+            rc_f1 += float(ev.get("root_cause_f1") or 0.0)
+            overclaim += float(ev.get("overclaim_rate") or 0.0)
+            sql_ok += float(ev.get("sql_executable_rate") or 0.0)
+            chain += float(ev.get("chain_coherence") or 0.0)
+            headline += float(ev.get("headline") or 0.0)
+            node_f1 += float(ev.get("node_f1") or 0.0)
+            edge_f1 += float(ev.get("edge_f1") or 0.0)
+            if ev.get("case_correct"):
+                correct += 1
+            if ev.get("parse_error"):
+                parse_errors += 1
+            if not ev.get("per_evidence"):
+                zero_evidence += 1
 
-        for sample in samples:
-            if sample.correct is True:
-                correct_count += 1
-            elif sample.correct is False:
-                incorrect_count += 1
-            else:  # sample.correct is None
-                unknown_count += 1
-
-            # Aggregate graph metrics if available
-            if isinstance(sample.meta, dict) and "graph_metrics" in sample.meta:
-                gm = sample.meta["graph_metrics"]
-                primary = gm.get("primary", {})
-                secondary = gm.get("secondary", {})
-
-                edge_f1_sum += primary.get("edge_f1", 0.0)
-                node_f1_sum += primary.get("node_f1", 0.0)
-                root_cause_f1_sum += primary.get("root_cause_f1", 0.0)
-                component_f1_sum += secondary.get("component_f1", 0.0)
-
-                # Path reachability (bool | None)
-                # Treat None (no correct root cause) as False (path not reachable)
-                pr = primary.get("path_reachability")
-                path_reachability_applicable_count += 1
-                if pr is True:
-                    path_reachability_true_count += 1
-
-                graph_metrics_count += 1
-
-        # 计算正确率（排除未判断的样本）
-        judged_samples = correct_count + incorrect_count
-        accuracy = (correct_count / judged_samples * 100) if judged_samples > 0 else 0.0
-
-        # Calculate average graph metrics
-        avg_edge_f1 = round(edge_f1_sum / graph_metrics_count, 4) if graph_metrics_count > 0 else 0.0
-        avg_node_f1 = round(node_f1_sum / graph_metrics_count, 4) if graph_metrics_count > 0 else 0.0
-        avg_root_cause_f1 = round(root_cause_f1_sum / graph_metrics_count, 4) if graph_metrics_count > 0 else 0.0
-        avg_component_f1 = round(component_f1_sum / graph_metrics_count, 4) if graph_metrics_count > 0 else 0.0
-        # Path reachability: None (no correct root cause) is treated as False (0.0)
-        avg_path_reachability = (
-            round(path_reachability_true_count / path_reachability_applicable_count, 4)
-            if path_reachability_applicable_count > 0
-            else 0.0
-        )
-
+        denom = max(1, with_eval)
         return {
             "benchmark": self.name,
-            "total_samples": total_samples,
-            "accuracy": round(accuracy, 2),
-            "correct_count": correct_count,
-            "incorrect_count": incorrect_count,
-            "unknown_count": unknown_count,
-            "judged_samples": judged_samples,
-            "details": {
-                "correct_rate": f"{correct_count}/{judged_samples}" if judged_samples > 0 else "0/0",
-                "coverage": round((judged_samples / total_samples * 100), 2) if total_samples > 0 else 0.0,
-            },
-            "graph_metrics": {
-                "samples_with_metrics": graph_metrics_count,
-                "avg_edge_f1": avg_edge_f1,
-                "avg_node_f1": avg_node_f1,
-                "avg_root_cause_f1": avg_root_cause_f1,
-                "avg_component_f1": avg_component_f1,
-                "avg_path_reachability": avg_path_reachability,
-                "path_reachability_total_samples": path_reachability_applicable_count,
-            },
+            "total_samples": n,
+            "scored_samples": with_eval,
+            "case_correct": correct,
+            "case_correct_rate": round(correct / denom, 4),
+            "avg_root_cause_f1": round(rc_f1 / denom, 4),
+            "avg_overclaim_rate": round(overclaim / denom, 4),
+            "avg_sql_executable_rate": round(sql_ok / denom, 4),
+            "avg_chain_coherence": round(chain / denom, 4),
+            "avg_node_f1": round(node_f1 / denom, 4),
+            "avg_edge_f1": round(edge_f1 / denom, 4),
+            "avg_headline": round(headline / denom, 4),
+            "parse_errors": parse_errors,
+            "zero_evidence_outputs": zero_evidence,
         }

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/prompts/eval/augmentation_templates.yaml
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/prompts/eval/augmentation_templates.yaml
@@ -1,4 +1,4 @@
-# NOTE: template should include keys {question}
+# NOTE: template should include keys {question} OR ({reports}, {directory_path})
 
 default: |
   {question}
@@ -7,5 +7,82 @@ RCABench: |
   The following API endpoints are experiencing possible SLO violations and need investigation:
   {reports}
 
-  Please investigate the root cause of these SLO violations.
-  The telemetry data is stored in: `{directory_path}`
+  Telemetry parquets are stored in: `{directory_path}`
+  Available files: abnormal_metrics.parquet, abnormal_traces.parquet,
+  abnormal_logs.parquet, abnormal_metrics_histogram.parquet, abnormal_metrics_sum.parquet,
+  normal_metrics.parquet, normal_traces.parquet, normal_logs.parquet.
+
+  ## Task
+
+  Investigate and identify the root cause(s) of these SLO violations. You do
+  NOT know in advance whether this is a single fault or a hybrid (multiple
+  faults injected simultaneously) — list every root cause you find.
+
+  ## Output schema (return STRICT JSON, nothing else)
+
+  ```json
+  {{
+    "root_causes": [
+      {{
+        "service": "<canonical service name, e.g. ts-order-service>",
+        "fault_kind": "<one of the 14 enum values below>",
+        "direction": {{"src": "<service>", "dst": "<service>"}},
+        "method": "<class.method, optional>",
+        "confidence": 0.0,
+        "evidence": [
+          {{
+            "kind": "metric|trace|log",
+            "sql": "<DuckDB SQL re-executable on this case dir>",
+            "claim": "<what the SQL result demonstrates>"
+          }}
+        ]
+      }}
+    ],
+    "propagation": [
+      {{"from": "<service>", "to": "<service>", "evidence": [ ... ]}}
+    ]
+  }}
+  ```
+
+  ### `fault_kind` controlled vocabulary (pick exactly one per root cause)
+
+  - `pod_failure`     — pod kill / container kill / pod failure
+  - `cpu_stress`      — CPU pressure injection
+  - `mem_stress`      — memory pressure injection
+  - `network_delay`   — added latency on a link
+  - `network_loss`    — packet loss on a link
+  - `network_partition` — link partitioned
+  - `network_corrupt` — packet corruption on a link
+  - `network_duplicate` — packet duplication on a link
+  - `jvm_exception`   — JVM throws synthetic exception in a method
+  - `jvm_mutator`     — JVM mutates return value or runtime behavior
+  - `http_abort`      — HTTP request/response aborted by chaos
+  - `http_replace`    — HTTP method/code/body replaced by chaos
+  - `dns`             — DNS resolution chaos
+  - `time_skew`       — host clock skew
+
+  ### Field rules
+
+  - `direction` is REQUIRED for every `network_*` root cause; `src` is the
+    service the netem rule sits on, `dst` is the remote peer it shapes traffic
+    toward. Omit `direction` for non-network faults.
+  - `method` (`class.method`) is OPTIONAL bonus identification for `jvm_*` and
+    `http_*` faults; omit for the rest.
+  - Each `root_cause` AND each `propagation` edge MUST carry ≥1 `evidence`
+    item with a runnable DuckDB `sql` and a natural-language `claim`.
+
+  ### SQL constraints
+
+  - DuckDB dialect.
+  - Reference parquets via `read_parquet('<filename>.parquet')` — bare
+    filenames are resolved against this case dir; absolute paths or paths
+    containing `/` are rejected.
+  - SELECT only; DDL/DML/ATTACH/INSTALL/COPY/PRAGMA/SET are forbidden.
+  - One statement per `sql` field (no `;`-separated multi-statements).
+  - Use the column names: `time` (TIMESTAMP), `service_name`, `metric`,
+    `value`, `trace_id`, `span_id`, `parent_span_id`, `span_name`, `duration`,
+    `attr.status_code`, `level`, `message`.
+  - Restrict the time window using
+    `time BETWEEN TIMESTAMP '<start>' AND TIMESTAMP '<end>'`.
+
+  Return only the JSON object. No prose, no markdown fences.

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/prompts/eval/augmentation_templates.yaml
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/prompts/eval/augmentation_templates.yaml
@@ -4,85 +4,14 @@ default: |
   {question}
 
 RCABench: |
-  The following API endpoints are experiencing possible SLO violations and need investigation:
+  The following API endpoints are experiencing possible SLO violations and
+  need investigation:
   {reports}
 
   Telemetry parquets are stored in: `{directory_path}`
   Available files: abnormal_metrics.parquet, abnormal_traces.parquet,
-  abnormal_logs.parquet, abnormal_metrics_histogram.parquet, abnormal_metrics_sum.parquet,
-  normal_metrics.parquet, normal_traces.parquet, normal_logs.parquet.
+  abnormal_logs.parquet, abnormal_metrics_histogram.parquet,
+  abnormal_metrics_sum.parquet, normal_metrics.parquet,
+  normal_traces.parquet, normal_logs.parquet.
 
-  ## Task
-
-  Investigate and identify the root cause(s) of these SLO violations. You do
-  NOT know in advance whether this is a single fault or a hybrid (multiple
-  faults injected simultaneously) — list every root cause you find.
-
-  ## Output schema (return STRICT JSON, nothing else)
-
-  ```json
-  {{
-    "root_causes": [
-      {{
-        "service": "<canonical service name, e.g. ts-order-service>",
-        "fault_kind": "<one of the 14 enum values below>",
-        "direction": {{"src": "<service>", "dst": "<service>"}},
-        "method": "<class.method, optional>",
-        "confidence": 0.0,
-        "evidence": [
-          {{
-            "kind": "metric|trace|log",
-            "sql": "<DuckDB SQL re-executable on this case dir>",
-            "claim": "<what the SQL result demonstrates>"
-          }}
-        ]
-      }}
-    ],
-    "propagation": [
-      {{"from": "<service>", "to": "<service>", "evidence": [ ... ]}}
-    ]
-  }}
-  ```
-
-  ### `fault_kind` controlled vocabulary (pick exactly one per root cause)
-
-  - `pod_failure`     — pod kill / container kill / pod failure
-  - `cpu_stress`      — CPU pressure injection
-  - `mem_stress`      — memory pressure injection
-  - `network_delay`   — added latency on a link
-  - `network_loss`    — packet loss on a link
-  - `network_partition` — link partitioned
-  - `network_corrupt` — packet corruption on a link
-  - `network_duplicate` — packet duplication on a link
-  - `jvm_exception`   — JVM throws synthetic exception in a method
-  - `jvm_mutator`     — JVM mutates return value or runtime behavior
-  - `http_abort`      — HTTP request/response aborted by chaos
-  - `http_replace`    — HTTP method/code/body replaced by chaos
-  - `dns`             — DNS resolution chaos
-  - `time_skew`       — host clock skew
-
-  ### Field rules
-
-  - `direction` is REQUIRED for every `network_*` root cause; `src` is the
-    service the netem rule sits on, `dst` is the remote peer it shapes traffic
-    toward. Omit `direction` for non-network faults.
-  - `method` (`class.method`) is OPTIONAL bonus identification for `jvm_*` and
-    `http_*` faults; omit for the rest.
-  - Each `root_cause` AND each `propagation` edge MUST carry ≥1 `evidence`
-    item with a runnable DuckDB `sql` and a natural-language `claim`.
-
-  ### SQL constraints
-
-  - DuckDB dialect.
-  - Reference parquets via `read_parquet('<filename>.parquet')` — bare
-    filenames are resolved against this case dir; absolute paths or paths
-    containing `/` are rejected.
-  - SELECT only; DDL/DML/ATTACH/INSTALL/COPY/PRAGMA/SET are forbidden.
-  - One statement per `sql` field (no `;`-separated multi-statements).
-  - Use the column names: `time` (TIMESTAMP), `service_name`, `metric`,
-    `value`, `trace_id`, `span_id`, `parent_span_id`, `span_name`, `duration`,
-    `attr.status_code`, `level`, `message`.
-  - Restrict the time window using
-    `time BETWEEN TIMESTAMP '<start>' AND TIMESTAMP '<end>'`.
-
-  Return only the JSON object. No prose, no markdown fences.
+  Investigate the telemetry and identify the root cause(s) of the violation.

--- a/rcabench-platform/uv.lock
+++ b/rcabench-platform/uv.lock
@@ -3654,7 +3654,7 @@ wheels = [
 
 [[package]]
 name = "rcabench-platform"
-version = "0.4.23"
+version = "0.4.24"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary
- **Prompt rearrange** — investigation-time prompt no longer carries the v2 output JSON schema or SQL constraints; that lives only in the synthesis-time prompt. Drops simulation framing ("hybrid", "injected", "synthetic") so the agent sees a realistic SLO incident.
- **SQL sandbox opened** — `verify_evidence` now mounts every `*.parquet` in the case dir as a same-named view and runs the agent's SQL as-is (`OK` / `EMPTY` / `SQL_ERROR`). No keyword whitelist, no `read_parquet` enforcement, no time-window or service-alignment post-filter. Fixes the dominant failure mode where every evidence scored `UNSAFE_SQL` because the investigation tool teaches the agent `FROM abnormal_traces` but the verifier required `read_parquet(...)`.
- **Outcome split** — `OutcomeResult` now exposes both `service_*` P/R/F1 (matched on service alone) and `root_cause_*` (kind + direction; the strict HIT). Both share denominators. Lets us distinguish "right service, wrong fault kind" from "missed completely".
- **Naming uniform** — `_norm` / `_normalize_service` drop the `ts-` prefix strip. Same rule across ts/hs/otel-demo: lowercase + remove `-`/`_`. Agent must use names present in the data.
- **`chain_coherence` fallback removed** — when no LLM judge client is configured the function now raises `ValueError`. The previous fallback (return `sql_executable_rate`) made `headline` silently double-count SQL.
- Bump 0.4.23 → 0.4.24.

## Test plan
- [x] 26/26 unit tests pass (`v2_tests/test_eval_v2.py`)
- [x] 1-case smoke on dataset_v1_500 (ThinkDepthAI agent): `sql_executable_rate` went 0/0 → 1.0 on the case running under the new pipeline; `service_f1` newly distinguishable from `root_cause_f1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)