### PR TITLE
feat(llm-eval/v2): judge blind to GT, score=None on failure, expand env refs in YAML

### DIFF
--- a/rcabench-platform/pyproject.toml
+++ b/rcabench-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rcabench-platform"
-version = "0.4.24"
+version = "0.4.25"
 description = "An experiment framework for Root Cause Analysis"
 readme = "README.md"
 authors = [ #

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/chain_judge.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/chain_judge.py
@@ -1,50 +1,59 @@
-"""LLM-as-judge for causal-chain coherence.
+"""LLM-as-judge for evidence–claim coherence.
 
-Inputs the agent's structured output, the executed SQL preview, and the GT
-causal_graph; asks the LLM whether the agent's claims are mutually coherent
-AND consistent with the GT graph. Returns a 0–1 coherence score plus a short
-explanation. The score is informational; the deterministic outcome metrics
-remain primary.
+The judge looks ONLY at internal consistency: does each natural-language
+claim hold up against the rows the evidence SQL actually returned? It is
+deliberately blind to the ground-truth causal graph — GT alignment is
+already covered by the deterministic ``root_cause_f1`` / ``node_f1`` /
+``edge_f1`` metrics, so re-judging it here would duplicate work and inject
+LLM noise into the headline.
+
+Returns a 0–1 score (or ``None`` when the judge call itself failed, e.g.
+network outage after retries are exhausted) plus a short explanation.
+``None`` lets aggregators distinguish "couldn't judge" from "judged poorly"
+instead of conflating both as 0.0.
 """
 
 from __future__ import annotations
 
 import json
-from typing import Any
 
 from openai import AsyncOpenAI
 from pydantic import BaseModel, Field
 
-from ..causal_graph import CausalGraph
 from .schema import AgentRCAOutput
 from .sql_verify import EvidenceVerifyResult
 
 
 class ChainJudgeResult(BaseModel):
-    score: float = Field(0.0, ge=0.0, le=1.0)
+    score: float | None = Field(default=None, ge=0.0, le=1.0)
+    """0–1 coherence score, or None when the judge call itself failed."""
     reasoning: str = ""
     raw_response: str | None = None
 
 
-_JUDGE_PROMPT = """You are scoring whether an RCA agent's reasoning chain is coherent
-and consistent with the ground-truth causal graph.
+_JUDGE_PROMPT = """You are scoring whether an RCA agent's reasoning chain is internally
+coherent: does each natural-language claim hold up against the rows the
+evidence SQL actually returned when re-executed?
 
 You will be given:
   • the agent's structured output (root_causes + propagation edges, each with
     an evidence SQL and a natural-language claim);
-  • a preview (first rows) of what each SQL actually returned when re-executed;
-  • the ground-truth causal_graph at service granularity.
+  • a preview (sample rows) of what each SQL actually returned.
 
 Score on a single 0.0–1.0 scale:
-  1.0 — every claim is internally consistent, the evidence rows demonstrably
-        support it, AND the propagation chain is reachable in the GT graph.
-  0.0 — the chain is incoherent, or contradicts the GT graph, or the SQL
-        results disprove the claims.
-  Intermediate values are allowed; calibrate so 0.5 means "half the chain is
-  supported."
+  1.0 — every claim is plausibly supported by the SQL rows shown, and the
+        chain is internally consistent (claimed root cause feeds the
+        claimed propagation, etc.).
+  0.0 — the chain is incoherent, or the SQL results clearly contradict the
+        claims (e.g. the agent says "p99 latency spiked" but the rows show
+        no such pattern, or the propagation edge has no supporting
+        evidence at all).
+  Intermediate values are allowed; calibrate so 0.5 means "half the chain
+  is supported, the other half is asserted without backing rows."
 
-You must NOT use any prior knowledge of which case this is. Judge only what is
-shown.
+You are NOT given the ground-truth answer. Do not try to infer which case
+this is or whether the agent's named services match a "correct" set —
+that is judged separately. Your job is only claim-vs-data consistency.
 
 Respond with strict JSON: {{"score": <float 0..1>, "reasoning": "<=80 words>"}}.
 
@@ -53,14 +62,18 @@ Respond with strict JSON: {{"score": <float 0..1>, "reasoning": "<=80 words>"}}.
 
 == Evidence executions (status + sample rows) ==
 {evidence_block}
-
-== Ground truth causal graph (service-level) ==
-{gt_block}
 """
 
 
 def _format_evidence_block(agent: AgentRCAOutput, results: list[tuple[str, EvidenceVerifyResult]]) -> str:
-    """Pair each evidence with its verifier result; truncate sample rows."""
+    """Pair each evidence with its verifier result.
+
+    Shows up to 5 rows per evidence and 200 chars per cell — wider than the
+    older 3-row × 80-char preview so claims like "p99 increased N×" or
+    "error count spiked" actually have enough signal in the preview to be
+    judged. The trade-off is a bigger prompt; cases with many evidence rows
+    will lean harder on the model's context window.
+    """
     if not results:
         return "(no evidence)"
     lines: list[str] = []
@@ -70,29 +83,25 @@ def _format_evidence_block(agent: AgentRCAOutput, results: list[tuple[str, Evide
             lines.append(f"{head} error={vr.error[:200]}")
             continue
         lines.append(head)
-        for row in vr.sample_rows[:3]:
-            shrunk = {k: (str(v)[:80] if v is not None else None) for k, v in row.items()}
+        for row in vr.sample_rows[:5]:
+            shrunk = {k: (str(v)[:200] if v is not None else None) for k, v in row.items()}
             lines.append(f"    {json.dumps(shrunk, ensure_ascii=False, default=str)}")
     return "\n".join(lines)
-
-
-def _format_gt_block(gt_graph: CausalGraph | None) -> str:
-    if gt_graph is None:
-        return "(no ground-truth graph available)"
-    nodes = sorted(gt_graph.get_service_nodes())
-    edges = sorted(gt_graph.get_service_edges())
-    roots = sorted(gt_graph.get_root_cause_services())
-    alarms = sorted(gt_graph.get_alarm_services())
-    return f"services: {nodes}\nedges: {edges}\nroot_cause_services: {roots}\nalarm_services: {alarms}"
 
 
 async def chain_coherence(
     agent: AgentRCAOutput,
     evidence_results: list[tuple[str, EvidenceVerifyResult]],
-    gt_graph: CausalGraph | None,
     llm_client: AsyncOpenAI | None,
     model: str = "gpt-4o-mini",
 ) -> ChainJudgeResult:
+    """Judge whether agent claims are supported by their evidence SQL rows.
+
+    On any exception (network outage, malformed JSON, etc.) returns
+    ``ChainJudgeResult(score=None, ...)`` so callers can distinguish
+    "couldn't judge" from "judged as incoherent". Aggregators are expected
+    to drop None values from the average; do not silently coerce to 0.0.
+    """
     if llm_client is None:
         raise ValueError(
             "chain_coherence requires an LLM client; configure judge_model in "
@@ -102,7 +111,6 @@ async def chain_coherence(
     prompt = _JUDGE_PROMPT.format(
         agent_output=agent.model_dump_json(by_alias=True, indent=2),
         evidence_block=_format_evidence_block(agent, evidence_results),
-        gt_block=_format_gt_block(gt_graph),
     )
 
     try:
@@ -114,14 +122,16 @@ async def chain_coherence(
             response_format={"type": "json_object"},
         )
     except Exception as exc:
-        return ChainJudgeResult(score=0.0, reasoning=f"(judge error: {exc!s:.200})")
+        return ChainJudgeResult(score=None, reasoning=f"(judge error: {exc!s:.200})")
 
     content = response.choices[0].message.content or ""
     try:
         parsed = json.loads(content)
     except json.JSONDecodeError:
-        return ChainJudgeResult(score=0.0, reasoning="(judge returned non-JSON)", raw_response=content)
-    score = float(parsed.get("score") or 0.0)
-    score = max(0.0, min(1.0, score))
+        return ChainJudgeResult(score=None, reasoning="(judge returned non-JSON)", raw_response=content)
+    raw_score = parsed.get("score")
+    if raw_score is None:
+        return ChainJudgeResult(score=None, reasoning="(judge omitted score)", raw_response=content)
+    score = max(0.0, min(1.0, float(raw_score)))
     reasoning = str(parsed.get("reasoning") or "")
     return ChainJudgeResult(score=score, reasoning=reasoning, raw_response=content)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/evaluator.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/evaluator.py
@@ -43,21 +43,26 @@ class EvaluationResultV2(BaseModel):
       - root_cause_f1:     type-aware match against engine_config faults
       - overclaim_rate:    agent root_causes that did not align to any GT fault
       - sql_executable_rate: evidence SQL that ran, returned rows, and aligned
-      - chain_coherence:   LLM judge over (claims + SQL preview + GT graph)
+      - chain_coherence:   LLM judge over (claims + SQL preview); blind to GT
       - node_f1 / edge_f1: agent's claimed graph vs GT causal_graph (service-level)
 
     `headline = root_cause_f1 × sql_executable_rate × chain_coherence`
+
+    ``chain_coherence`` and ``headline`` are ``None`` when the LLM judge call
+    itself failed (e.g. network outage). Aggregators are expected to drop
+    those samples from the headline average rather than treat them as 0.0,
+    so a transient outage doesn't infect the case-level score.
     """
 
     root_cause_f1: float
     overclaim_rate: float
     sql_executable_rate: float
-    chain_coherence: float
+    chain_coherence: float | None
 
     node_f1: float = 0.0
     edge_f1: float = 0.0
 
-    headline: float = Field(..., description="root_cause_f1 × sql_executable_rate × chain_coherence")
+    headline: float | None = Field(..., description="root_cause_f1 × sql_executable_rate × chain_coherence")
     case_correct: bool = False
 
     service_precision: float = 0.0
@@ -174,12 +179,14 @@ async def evaluate_v2(
     judge_result = await chain_coherence(
         agent=agent,
         evidence_results=sql_evidence_results,
-        gt_graph=gt_graph,
         llm_client=llm_client,
         model=judge_model,
     )
 
-    headline = outcome.root_cause_f1 * sql_executable_rate * judge_result.score
+    if judge_result.score is None:
+        headline: float | None = None
+    else:
+        headline = outcome.root_cause_f1 * sql_executable_rate * judge_result.score
 
     return EvaluationResultV2(
         root_cause_f1=outcome.root_cause_f1,

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
@@ -650,20 +650,85 @@ def test_evaluate_v2_requires_llm_client(tmp_path: Path) -> None:
         asyncio.run(evaluate_v2(agent, _injection(), case, gt_graph=None, llm_client=None))
 
 
+class _RaisingCompletions:
+    async def create(self, **_kwargs: Any) -> Any:
+        raise RuntimeError("simulated outage")
+
+
+class _RaisingChat:
+    def __init__(self) -> None:
+        self.completions = _RaisingCompletions()
+
+
+class _StubLLMClientFails:
+    """Stub that raises on every call — simulates a judge outage so we can
+    verify the score=None / headline=None propagation path.
+    """
+
+    def __init__(self) -> None:
+        self.chat = _RaisingChat()
+
+
+def test_evaluate_v2_judge_failure_returns_none(tmp_path: Path) -> None:
+    """When the judge call fails, chain_coherence and headline are None
+    (not 0.0). This lets aggregators distinguish 'couldn't judge' from
+    'judged poorly' instead of conflating both as a zero score.
+    """
+    case = _make_case(tmp_path)
+    agent = json.dumps(
+        {
+            "root_causes": [
+                {
+                    "service": "shipping",
+                    "fault_kind": "network_delay",
+                    "direction": {"src": "shipping", "dst": "quote"},
+                    "evidence": [
+                        {
+                            "kind": "metric",
+                            "sql": (
+                                "SELECT * FROM read_parquet('abnormal_metrics.parquet') WHERE service_name='shipping'"
+                            ),
+                            "claim": "x",
+                        }
+                    ],
+                }
+            ],
+            "propagation": [],
+        }
+    )
+    res = asyncio.run(
+        evaluate_v2(
+            agent,
+            _injection(),
+            case,
+            gt_graph=None,
+            llm_client=_StubLLMClientFails(),  # type: ignore[arg-type]
+        )
+    )
+    assert res.root_cause_f1 == 1.0
+    assert res.sql_executable_rate == 1.0
+    assert res.chain_coherence is None
+    assert res.headline is None
+    assert res.case_correct is True
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Batch aggregation via RCABenchProcesser.calculate_metrics
 # ──────────────────────────────────────────────────────────────────────
 
 
 def test_calculate_metrics_aggregation() -> None:
-    """4 stub samples → aggregate is the mean over the 3 successfully scored.
+    """5 stub samples → aggregates split avg_chain/avg_headline (judge-aware).
 
     Sample mix:
-      [0] perfect    rc_f1=1.0  sql=1.0  chain=1.0  headline=1.0  correct=True
-      [1] partial    rc_f1=0.5  sql=0.8  chain=0.6  headline=0.24
-      [2] parse-err  zeros + parse_error=True
-      [3] eval-err   sample.meta['eval_v2'] = {'error': '...'}  → excluded
-    Expected averages over the 3 scored samples (excluding [3]).
+      [0] perfect      rc_f1=1.0  sql=1.0  chain=1.0   headline=1.0   correct=True
+      [1] partial      rc_f1=0.5  sql=0.8  chain=0.6   headline=0.24
+      [2] parse-err    zeros + parse_error=True
+      [3] judge-fail   rc_f1=1.0  sql=1.0  chain=None  headline=None
+      [4] eval-err     sample.meta['eval_v2'] = {'error': '...'}  → excluded
+    The deterministic axes (rc_f1, sql, etc.) average over the 4 scored samples
+    (0,1,2,3). The judge-affected axes (chain, headline) average over the 3
+    that produced a real score (0,1,2) and report `judge_failed=1`.
     """
     from rcabench_platform.v3.sdk.llm_eval.eval.processer.rcabench import RCABenchProcesser
 
@@ -721,6 +786,22 @@ def test_calculate_metrics_aggregation() -> None:
                 }
             }
         ),
+        _StubSample(
+            {
+                "eval_v2": {
+                    "service_f1": 1.0,
+                    "root_cause_f1": 1.0,
+                    "overclaim_rate": 0.0,
+                    "sql_executable_rate": 1.0,
+                    "chain_coherence": None,
+                    "node_f1": 1.0,
+                    "edge_f1": 1.0,
+                    "headline": None,
+                    "case_correct": True,
+                    "per_evidence": [{}],
+                }
+            }
+        ),
         _StubSample({"eval_v2": {"error": "missing case dir"}}),
     ]
 
@@ -728,16 +809,19 @@ def test_calculate_metrics_aggregation() -> None:
     proc.name = "RCABench"
     metrics = proc.calculate_metrics(samples)  # type: ignore[arg-type]
 
-    assert metrics["total_samples"] == 4
-    assert metrics["scored_samples"] == 3
-    assert metrics["case_correct"] == 1
-    assert metrics["case_correct_rate"] == round(1 / 3, 4)
+    assert metrics["total_samples"] == 5
+    assert metrics["scored_samples"] == 4
+    assert metrics["case_correct"] == 2
+    assert metrics["case_correct_rate"] == round(2 / 4, 4)
     assert metrics["parse_errors"] == 1
     assert metrics["zero_evidence_outputs"] == 1
-    assert metrics["avg_service_f1"] == round((1.0 + 0.7 + 0.0) / 3, 4)
-    assert metrics["avg_root_cause_f1"] == round((1.0 + 0.5 + 0.0) / 3, 4)
-    assert metrics["avg_sql_executable_rate"] == round((1.0 + 0.8 + 0.0) / 3, 4)
+    assert metrics["judge_failed"] == 1
+    # Deterministic axes average over all 4 scored samples.
+    assert metrics["avg_service_f1"] == round((1.0 + 0.7 + 0.0 + 1.0) / 4, 4)
+    assert metrics["avg_root_cause_f1"] == round((1.0 + 0.5 + 0.0 + 1.0) / 4, 4)
+    assert metrics["avg_sql_executable_rate"] == round((1.0 + 0.8 + 0.0 + 1.0) / 4, 4)
+    assert metrics["avg_node_f1"] == round((1.0 + 0.4 + 0.0 + 1.0) / 4, 4)
+    assert metrics["avg_edge_f1"] == round((1.0 + 0.2 + 0.0 + 1.0) / 4, 4)
+    # Judge-affected axes average over only the 3 that produced a real score.
     assert metrics["avg_chain_coherence"] == round((1.0 + 0.6 + 0.0) / 3, 4)
-    assert metrics["avg_node_f1"] == round((1.0 + 0.4 + 0.0) / 3, 4)
-    assert metrics["avg_edge_f1"] == round((1.0 + 0.2 + 0.0) / 3, 4)
     assert metrics["avg_headline"] == round((1.0 + 0.24 + 0.0) / 3, 4)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/config/loader.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/config/loader.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import yaml
 
+from ..utils import expand_env_refs
 from .eval_config import EvalConfig
 
 
@@ -12,6 +13,11 @@ class ConfigLoader:
     def load_eval_config(cls, path: str | Path) -> EvalConfig:
         """Load EvalConfig from a YAML file.
 
+        ``${VAR}`` references in any string field are expanded from the process
+        environment (after ``.env`` is loaded). Unset references raise a
+        ``ValueError`` rather than being passed through, so misconfiguration
+        surfaces at load time instead of as a downstream connection error.
+
         Args:
             path: Path to the YAML config file.
 
@@ -20,4 +26,5 @@ class ConfigLoader:
         """
         with open(path) as f:
             data = yaml.safe_load(f)
+        data = expand_env_refs(data)
         return EvalConfig(**data)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/base_llm_processor.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/base_llm_processor.py
@@ -28,6 +28,7 @@ class BaseLLMJudgeProcesser(BaseProcesser):
         self._judge_client: AsyncOpenAI | None = None
         provider_config = config.judge_model.model_provider.model_dump()
         self._judge_provider_config = provider_config
+        self._judge_max_retries = int(config.judge_model.rate_limit.max_retries)
         self.judge_model = str(provider_config.get("model") or "gpt-4o-mini")
 
     @property
@@ -37,6 +38,7 @@ class BaseLLMJudgeProcesser(BaseProcesser):
             self._judge_client = AsyncOpenAI(
                 base_url=self._judge_provider_config.get("base_url") or None,
                 api_key=self._judge_provider_config.get("api_key") or None,
+                max_retries=self._judge_max_retries,
             )
         return self._judge_client
 

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/rcabench.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/rcabench.py
@@ -141,11 +141,12 @@ class RCABenchProcesser(BaseMatchProcesser):
 
         meta["eval_v2"] = result.model_dump(mode="json")
 
-        reasoning_bits: list[str] = []
-        reasoning_bits.append(
+        chain_str = f"{result.chain_coherence:.2f}" if result.chain_coherence is not None else "n/a"
+        headline_str = f"{result.headline:.2f}" if result.headline is not None else "n/a"
+        reasoning_bits: list[str] = [
             f"rc_f1={result.root_cause_f1:.2f} sql={result.sql_executable_rate:.2f} "
-            f"chain={result.chain_coherence:.2f} headline={result.headline:.2f}"
-        )
+            f"chain={chain_str} headline={headline_str}"
+        ]
         if result.parse_error:
             reasoning_bits.append(f"parse_error={result.parse_error}")
         if result.chain_judge and result.chain_judge.reasoning:
@@ -154,7 +155,7 @@ class RCABenchProcesser(BaseMatchProcesser):
         sample.update(
             judged_response=None,
             correct=result.case_correct,
-            confidence=result.headline,
+            confidence=result.headline if result.headline is not None else 0.0,
             reasoning=" | ".join(reasoning_bits),
             extracted_final_answer=None,
             meta=meta,
@@ -208,14 +209,17 @@ class RCABenchProcesser(BaseMatchProcesser):
         rc_f1 = 0.0
         overclaim = 0.0
         sql_ok = 0.0
-        chain = 0.0
-        headline = 0.0
+        chain_sum = 0.0
+        chain_count = 0
+        headline_sum = 0.0
+        headline_count = 0
         node_f1 = 0.0
         edge_f1 = 0.0
         correct = 0
         with_eval = 0
         parse_errors = 0
         zero_evidence = 0
+        judge_failed = 0
 
         for s in samples:
             if not isinstance(s.meta, dict):
@@ -228,10 +232,22 @@ class RCABenchProcesser(BaseMatchProcesser):
             rc_f1 += float(ev.get("root_cause_f1") or 0.0)
             overclaim += float(ev.get("overclaim_rate") or 0.0)
             sql_ok += float(ev.get("sql_executable_rate") or 0.0)
-            chain += float(ev.get("chain_coherence") or 0.0)
-            headline += float(ev.get("headline") or 0.0)
             node_f1 += float(ev.get("node_f1") or 0.0)
             edge_f1 += float(ev.get("edge_f1") or 0.0)
+            # chain_coherence / headline are None when the LLM judge call
+            # failed (e.g. transient outage). Skip those samples in the
+            # average so a couple of network blips don't drag the score
+            # down — count them separately as `judge_failed`.
+            chain_val = ev.get("chain_coherence")
+            if chain_val is not None:
+                chain_sum += float(chain_val)
+                chain_count += 1
+            else:
+                judge_failed += 1
+            headline_val = ev.get("headline")
+            if headline_val is not None:
+                headline_sum += float(headline_val)
+                headline_count += 1
             if ev.get("case_correct"):
                 correct += 1
             if ev.get("parse_error"):
@@ -240,6 +256,8 @@ class RCABenchProcesser(BaseMatchProcesser):
                 zero_evidence += 1
 
         denom = max(1, with_eval)
+        chain_denom = max(1, chain_count)
+        headline_denom = max(1, headline_count)
         return {
             "benchmark": self.name,
             "total_samples": n,
@@ -250,10 +268,11 @@ class RCABenchProcesser(BaseMatchProcesser):
             "avg_root_cause_f1": round(rc_f1 / denom, 4),
             "avg_overclaim_rate": round(overclaim / denom, 4),
             "avg_sql_executable_rate": round(sql_ok / denom, 4),
-            "avg_chain_coherence": round(chain / denom, 4),
+            "avg_chain_coherence": round(chain_sum / chain_denom, 4),
             "avg_node_f1": round(node_f1 / denom, 4),
             "avg_edge_f1": round(edge_f1 / denom, 4),
-            "avg_headline": round(headline / denom, 4),
+            "avg_headline": round(headline_sum / headline_denom, 4),
+            "judge_failed": judge_failed,
             "parse_errors": parse_errors,
             "zero_evidence_outputs": zero_evidence,
         }

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/utils/__init__.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/utils/__init__.py
@@ -1,4 +1,4 @@
-from .env import EnvUtils
+from .env import EnvUtils, expand_env_refs
 from .log import get_logger, setup_logging
 from .path import FileUtils
 from .sqlmodel_utils import SQLModelUtils
@@ -9,4 +9,5 @@ __all__ = [
     "SQLModelUtils",
     "FileUtils",
     "EnvUtils",
+    "expand_env_refs",
 ]

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/utils/env.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/utils/env.py
@@ -1,11 +1,51 @@
 import importlib.metadata
 import os
+import re
+from typing import Any
 
 from dotenv import find_dotenv, load_dotenv
 
 # Load .env file but don't override existing environment variables
 # This allows command-line env vars to take precedence
 load_dotenv(find_dotenv(raise_error_if_not_found=False), verbose=True, override=False)
+
+
+_ENV_REF_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _expand_one(value: str) -> str:
+    """Replace ``${VAR}`` references with the env var's value.
+
+    Unset references raise a ValueError so misconfiguration fails loudly
+    instead of being silently passed through to a downstream API client.
+    """
+
+    def repl(match: re.Match[str]) -> str:
+        key = match.group(1)
+        env = os.getenv(key)
+        if env is None:
+            raise ValueError(
+                f"Config references env var ${{{key}}} but it is not set (check your .env / shell environment)."
+            )
+        return env
+
+    return _ENV_REF_RE.sub(repl, value)
+
+
+def expand_env_refs(data: Any) -> Any:
+    """Recursively expand ``${VAR}`` references in any string leaves.
+
+    Walks dicts and lists; non-string scalars are passed through. Designed for
+    YAML-loaded config trees so users can write ``base_url: ${UTU_LLM_BASE_URL}``
+    in a config file and have it resolved at load time.
+    """
+    if isinstance(data, dict):
+        return {k: expand_env_refs(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [expand_env_refs(v) for v in data]
+    if isinstance(data, str):
+        return _expand_one(data)
+    return data
 
 
 class EnvUtils:

--- a/rcabench-platform/uv.lock
+++ b/rcabench-platform/uv.lock
@@ -3654,7 +3654,7 @@ wheels = [
 
 [[package]]
 name = "rcabench-platform"
-version = "0.4.24"
+version = "0.4.25"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Three principled fixes to the chain-coherence judge plus two adjacent bugs found while walking the fresh-clone install path.

### chain_judge.py — three semantic fixes

1. **Judge no longer sees the GT causal graph.** GT alignment is already covered deterministically by `root_cause_f1` / `node_f1` / `edge_f1`. Feeding GT to the LLM duplicated that work and injected judge noise into the headline. The prompt now asks only "does each evidence SQL's actual rows support the natural-language claim?" — orthogonal to the deterministic axes, so the multiplicative `headline = rc_f1 × sql × chain` actually composes.
2. **Evidence preview widened** from 3 rows × 80 chars to 5 rows × 200 chars. Old width was "did this return data" granularity — too thin for claims like "p99 latency rose Nx" or "error count spiked".
3. **`score` is now `Optional[float]`.** Transient outage (network, rate-limit, malformed JSON) returns `score=None` instead of silently coercing to `0.0`. `EvaluationResultV2.chain_coherence` and `.headline` are likewise `Optional[float]` when the judge couldn't run. The aggregator excludes `None` from `avg_chain_coherence` / `avg_headline` and reports `judge_failed` count separately.

### Adjacent fixes uncovered by fresh-clone walkthrough

- **YAML env-var substitution.** `ConfigLoader.load_eval_config` now runs `expand_env_refs()` over loaded YAML so `${UTU_LLM_BASE_URL}` etc. resolve at load. Previously they were loaded as literal strings → judge client constructed with `base_url="${UTU_LLM_BASE_URL}"` → `Connection error` → silently scored `0.0` by the old fallback. Unset refs now raise loudly.
- **`max_retries` plumbing.** `BaseLLMJudgeProcesser` passes `judge_model.rate_limit.max_retries` (default 20) to `AsyncOpenAI`. Previously stuck at SDK default of 2.

## Verification

- 27/27 v2 tests pass; new `test_evaluate_v2_judge_failure_returns_none` covers the None propagation; aggregation test now includes a judge-failed sample.
- End-to-end smoke against `lincyaw/openrca2-v1-500` (1 sample) post-fix:
  - `case_correct=1`, `chain_coherence=0.95`, `headline=0.7773` (= 1.0 × 0.8182 × 0.95).
  - Judge reasoning is now "claims supported by SQL rows" — never references GT.

## Test plan
- [x] `uv run pytest src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py` — 27 pass
- [x] `uv run ruff format` + `uv run ruff check` — clean
- [x] End-to-end smoke (ThinkDepthAI agent, 1 case from openrca2-v1-500) — sensible chain_coherence + headline

🤖 Generated with [Claude Code](https://claude.com/claude-code)