### PR TITLE
[codex] 记录 reasoning 输出质量优化需求

### DIFF
--- a/rcabench-platform/docs/reasoning-alarm-normalization-optimization.md
+++ b/rcabench-platform/docs/reasoning-alarm-normalization-optimization.md
@@ -1,0 +1,395 @@
+# Reasoning Alarm Normalization: Optimization Plan
+
+Status: proposal / audit-derived requirements
+Owner: reasoning pipeline
+Scope: `src/rcabench_platform/v3/internal/reasoning/`, `cli/reason.py`, exported `result.json`, `causal_graph.json`, and `conclusion.parquet` consumers
+
+## Motivation
+
+Recent manual audits show two alarm-accounting defects that make otherwise
+credible RCA outputs look inconsistent:
+
+1. Strong user-facing alarms in `conclusion.parquet` can be missed because the
+   conclusion row key does not match the graph component id.
+2. Alarm counts differ across `candidate`, `explained`, and `causal_graph`
+   fields because the fields use different scopes without an explicit schema
+   contract.
+
+These are primarily normalization/export problems, not evidence problems. The
+raw data and conclusion rows often contain enough information, but the reasoning
+export loses the mapping.
+
+## Audited examples
+
+### Example A: strong alarm missed by component-name mismatch
+
+Case:
+
+`/home/ddq/AoyangSpace/dataset/dataset_v3_beta_500_2026-05-04/cases/hs4-recommendation-pod-failure-lq9fmq`
+
+Fault:
+
+`PodFailure` on Hotel Reservation `recommendation`.
+
+Evidence:
+
+- `conclusion.parquet` contains a strong row for `HTTP /recommendations`.
+- The endpoint success rate drops from `1.0` to `0.0011655011655011655`.
+- Raw trace confirms `frontend::HTTP /recommendations` has 858 abnormal spans,
+  857 of which return HTTP 500.
+- The graph alarm component is `span|frontend::HTTP /recommendations`.
+
+Bad output:
+
+- `candidate_strong_alarm_count=0`.
+- The alarm strength reason is `conclusion_row_unavailable`.
+- The export treats the alarm as unknown even though the conclusion row is
+  present and strong.
+
+Root cause:
+
+The conclusion key is a bare span/endpoint name:
+
+```text
+HTTP /recommendations
+```
+
+The graph/candidate key is a normalized component id:
+
+```text
+span|frontend::HTTP /recommendations
+```
+
+The current matching logic does not canonicalize these two names to the same
+alarm identity.
+
+### Example B: three alarm scopes are mixed together
+
+Case:
+
+`/home/ddq/AoyangSpace/dataset/dataset_v3_beta_500_2026-05-04/cases/ts5-ts-travel-service-exception-mzjt7x`
+
+Fault:
+
+`JVMException` in `ts-travel-service`, method
+`TravelController.getTripAllDetailInfo`.
+
+Evidence:
+
+- The injected `trip_detail` path fails strongly: abnormal `136` calls, `134`
+  errors.
+- Two strong user-facing conclusion alarms are present:
+  - `preserveservice/preserve`: success rate `1.0 -> 0.0188679`.
+  - `travelplanservice/travelPlan/minStation`: success rate `1.0 -> 0.464286`.
+
+Bad output:
+
+- Candidate alarms: `13`.
+- Explained alarms: `5`.
+- `causal_graph.alarm_nodes`: `4`.
+
+This makes three different alarm sets appear in one result without a clear
+contract. A consumer cannot tell whether `causal_graph.alarm_nodes` means all
+candidate alarms, all explained alarms, or only terminal alarms rendered in the
+subgraph.
+
+Root cause:
+
+The pipeline has multiple legitimate scopes, but the export does not preserve
+those scopes explicitly:
+
+- candidate alarm surface: broad set of impacted nodes considered by reasoning;
+- explained alarm set: candidates that have accepted root-to-alarm paths;
+- path-terminal graph alarms: terminal nodes included in the visual causal graph.
+
+Using the same name, or nearly the same name, for these sets creates an apparent
+inconsistency.
+
+## Problem 1: strong alarm lookup is not canonicalized
+
+### Current behavior
+
+The reasoning export attempts to attach conclusion evidence to candidate graph
+components. If the exact key lookup fails, it emits:
+
+```json
+{
+  "issue_strength": "unknown",
+  "issue_strength_reason": "conclusion_row_unavailable",
+  "has_issues": false
+}
+```
+
+This is wrong when the conclusion row exists under an equivalent bare endpoint
+name.
+
+### Required behavior
+
+A graph component and a conclusion row must be matched through a canonical alarm
+identity, not by raw string equality.
+
+Canonicalization should handle at least these forms:
+
+| Source form | Example | Canonical fields |
+|---|---|---|
+| Graph component | `span|frontend::HTTP /recommendations` | kind=`span`, service=`frontend`, operation=`HTTP /recommendations` |
+| Conclusion bare span | `HTTP /recommendations` | operation=`HTTP /recommendations` |
+| Conclusion full URL | `HTTP GET http://ts-ui-dashboard:8080/api/v1/foodservice/foods/...` | method=`GET`, host/service hint=`ts-ui-dashboard`, path=`/api/v1/foodservice/foods/...` |
+| Trace span name | `GET /api/v1/foodservice/foods/{date}/...` | method=`GET`, path template=`/api/v1/foodservice/foods/{date}/...` |
+| Graph malformed endpoint | `span|ts-ui-dashboard:: /api/v1/foodservice/...` | service=`ts-ui-dashboard`, path=`/api/v1/foodservice/...`, method may be unknown |
+
+### Matching order
+
+Use deterministic, explainable matching instead of a single exact lookup:
+
+1. Exact component id match, if conclusion already stores canonical ids.
+2. Exact `(service, operation)` match after stripping `span|` and splitting
+   `service::operation`.
+3. Exact operation/span-name match for unique bare names in the case.
+4. HTTP endpoint match by `(service_or_host, method, normalized_path)`.
+5. HTTP endpoint match by `(method, normalized_path)` when unique.
+6. Bare path match when unique and method is missing from one side.
+7. If multiple rows match, mark `ambiguous_conclusion_match` and do not promote
+   to strong unless one row is clearly selected by service/host.
+
+Every match should export its method:
+
+```json
+{
+  "conclusion_match": {
+    "status": "matched",
+    "method": "bare_operation_unique",
+    "conclusion_span_name": "HTTP /recommendations"
+  }
+}
+```
+
+If no row matches, export the failed lookup keys:
+
+```json
+{
+  "conclusion_match": {
+    "status": "unmatched",
+    "attempted_keys": [
+      "span|frontend::HTTP /recommendations",
+      "frontend::HTTP /recommendations",
+      "HTTP /recommendations"
+    ]
+  }
+}
+```
+
+### Strong alarm definition
+
+A candidate alarm is strong when its matched conclusion row satisfies one of the
+configured detector rules. Initial rule for export consistency:
+
+- `Issues != {}`; or
+- success-rate drop crosses the existing alarm threshold; or
+- duration anomaly crosses the existing alarm threshold.
+
+For the `hs4-recommendation-pod-failure-lq9fmq` regression case,
+`span|frontend::HTTP /recommendations` must be matched to `HTTP /recommendations`
+and counted as strong.
+
+## Problem 2: alarm scope is ambiguous across result and graph exports
+
+### Current behavior
+
+Different fields expose different scopes:
+
+- `result.json.alarm_nodes`: broad candidate alarms.
+- `causal_graph.candidate_alarm_count`: candidate count.
+- `causal_graph.explained_alarm_count`: accepted explained count.
+- `causal_graph.alarm_nodes`: currently closer to path-terminal graph alarms.
+
+Because the names are not explicit, outputs such as candidate `13`, explained
+`5`, graph alarms `4` look like internal inconsistency rather than expected
+stage-by-stage narrowing.
+
+### Required schema contract
+
+Export alarm scopes as separate, lossless sets:
+
+```json
+{
+  "candidate_alarm_nodes": [
+    {
+      "node_id": 0,
+      "component": "span|...",
+      "issue_strength": "strong|weak|none|unknown",
+      "conclusion_match": {
+        "status": "matched|unmatched|ambiguous",
+        "method": "exact_component|service_operation|bare_operation_unique|http_endpoint|none"
+      }
+    }
+  ],
+  "explained_alarm_nodes": [
+    {
+      "node_id": 0,
+      "component": "span|...",
+      "path_ids": ["path-0"]
+    }
+  ],
+  "unexplained_alarm_nodes": [
+    {
+      "node_id": 0,
+      "component": "span|...",
+      "issue_strength": "strong|weak|none|unknown",
+      "drop_reason": "no_path_found|weak_noise|filtered_by_rank|max_hops|schema_unmatched|ambiguous_conclusion_match|unknown"
+    }
+  ],
+  "path_terminal_alarm_nodes": [
+    {
+      "node_id": 0,
+      "component": "span|..."
+    }
+  ]
+}
+```
+
+Keep `alarm_nodes` only as a backward-compatible alias if necessary, and add:
+
+```json
+{
+  "alarm_nodes_scope": "path_terminal_alarm_nodes"
+}
+```
+
+### Invariants
+
+The export should satisfy these set invariants:
+
+```text
+candidate_alarm_nodes = explained_alarm_nodes union unexplained_alarm_nodes
+explained_alarm_nodes = path_terminal_alarm_nodes union non_terminal_explained_alarm_nodes
+path_terminal_alarm_nodes subset explained_alarm_nodes
+```
+
+When an invariant is intentionally violated, the export must include a reason,
+for example `dropped_before_path_search` or `node_not_in_rendered_graph`.
+
+### Count fields
+
+Count fields should be derived from the exported sets, not independently written:
+
+```json
+{
+  "candidate_alarm_count": 13,
+  "explained_alarm_count": 5,
+  "unexplained_alarm_count": 8,
+  "path_terminal_alarm_count": 4,
+  "candidate_strong_alarm_count": 2,
+  "explained_strong_alarm_count": 2,
+  "strong_alarm_coverage": 1.0
+}
+```
+
+This makes the `ts5-ts-travel-service-exception-mzjt7x` output understandable:
+13 candidates, 5 explained candidates, and 4 terminal alarms can be valid only if
+all three scopes are named and linked.
+
+## Implementation plan
+
+### Step 1: introduce an alarm identity model
+
+Add a small normalization layer before alarm strength lookup and graph export.
+It should parse both conclusion rows and graph components into a common shape:
+
+```python
+@dataclass(frozen=True)
+class AlarmIdentity:
+    raw: str
+    kind: str | None
+    service: str | None
+    operation: str | None
+    http_method: str | None
+    http_path: str | None
+    host: str | None
+```
+
+Normalization rules:
+
+- Strip graph prefixes such as `span|`, `service|`, `container|`.
+- Split `service::operation` when present.
+- Normalize duplicate whitespace and leading spaces.
+- Parse HTTP method/path from both `HTTP GET http://host/path` and `GET /path`.
+- Treat `HTTP /path` as path-only with method unknown.
+- Preserve the raw string for debugging.
+
+### Step 2: build a conclusion index
+
+Build multiple indexes from `conclusion.parquet` rows:
+
+- by exact raw `SpanName`;
+- by canonical operation;
+- by `(service_hint, operation)` when service can be inferred from host;
+- by `(method, normalized_path)`;
+- by `normalized_path` for unique path-only fallback.
+
+The index must return one of three statuses: `matched`, `unmatched`, or
+`ambiguous`.
+
+### Step 3: attach conclusion evidence to every candidate alarm
+
+For every candidate alarm, export:
+
+- canonical identity;
+- conclusion match status and method;
+- matched conclusion row key if present;
+- `issue_strength` and `has_issues` derived from the matched row;
+- fallback reason if unmatched.
+
+Do not emit `conclusion_row_unavailable` until all canonical lookup strategies
+have failed.
+
+### Step 4: split alarm scopes in the schema
+
+Refactor export construction so each stage writes a distinct field:
+
+- detector/E-stage writes `candidate_alarm_nodes`;
+- path finder/M-stage writes `explained_alarm_nodes` and
+  `unexplained_alarm_nodes`;
+- rendered graph writer writes `path_terminal_alarm_nodes`;
+- compatibility layer may write `alarm_nodes` plus `alarm_nodes_scope`.
+
+### Step 5: add regression checks
+
+Add fixture-level checks for the audited bad cases:
+
+- `hs4-recommendation-pod-failure-lq9fmq`:
+  - `span|frontend::HTTP /recommendations` matches conclusion row
+    `HTTP /recommendations`;
+  - `candidate_strong_alarm_count >= 1`;
+  - issue strength for `/recommendations` is `strong`.
+- `ts5-ts-travel-service-exception-mzjt7x`:
+  - exported candidate count is `13`;
+  - explained count is `5`;
+  - path-terminal count is `4`;
+  - the three sets are separately exported and set-linked;
+  - no consumer has to infer graph alarm scope from the field name alone.
+
+## Acceptance criteria
+
+- Strong conclusion rows are not lost because of `span|service::` prefixes,
+  missing HTTP methods, full URL vs path-only representation, or harmless leading
+  spaces.
+- `conclusion_row_unavailable` means the row is truly unavailable after canonical
+  matching, not merely unavailable by exact string key.
+- `candidate_strong_alarm_count` is derived from matched conclusion evidence.
+- `candidate_alarm_nodes`, `explained_alarm_nodes`, `unexplained_alarm_nodes`,
+  and `path_terminal_alarm_nodes` are all explicit and auditable.
+- `causal_graph.alarm_nodes` is either removed or explicitly documented with
+  `alarm_nodes_scope`.
+- Existing labels such as `full causal chain` are not emitted unless all strong
+  candidate alarms are either explained or explicitly exported as
+  `strong_unexplained` with concrete reasons.
+
+## Expected impact
+
+- The `/recommendations` PodFailure case should no longer report
+  `candidate_strong_alarm_count=0`.
+- Cases with candidate/explained/graph count differences should become
+  explainable instead of appearing internally inconsistent.
+- Downstream evaluators can compute alarm recall, strong-alarm coverage, and weak
+  noise filtering from one export without reverse-engineering field meanings.

--- a/rcabench-platform/docs/reasoning-export-consistency-optimization.md
+++ b/rcabench-platform/docs/reasoning-export-consistency-optimization.md
@@ -1,0 +1,283 @@
+# Reasoning Export Consistency: Bad Cases and Optimization Requirements
+
+Status: proposal / audit-derived requirements
+Owner: reasoning pipeline
+Scope: `src/rcabench_platform/v3/internal/reasoning/`, `cli/reason.py`, exported `result.json` and `causal_graph.json`
+
+## Motivation
+
+A follow-up audit of the new causal graph export directory found that the export
+is cleaner than the older graph in several cases, but three schema/state issues
+remain recurring and can mislead downstream evaluators:
+
+1. `result.json.alarm_nodes` and `causal_graph.json.alarm_nodes` use different
+   effective scopes.
+2. The root component can be credible in `causal_graph.json`, while
+   `result.json.propagation_result.injection_states` still says `unknown`.
+3. Caller-side spans that are clearly erroring in raw traces can be exported as
+   `healthy, missing`.
+
+This document records concrete bad cases and defines optimization targets for
+these three issues.
+
+## Audited export set
+
+New graph export directory:
+
+`/home/ddq/AoyangSpace/dataset/dataset_v3_500_2026-05-03/causal_graph_export_new_reason_20260504_084535`
+
+Raw case directory:
+
+`/home/ddq/AoyangSpace/dataset/dataset_v3_500_2026-05-03/cases`
+
+## Problem 1: `result.json` alarm count and graph alarm count disagree
+
+### Symptom
+
+The raw `result.json` contains a broader `alarm_nodes` set, while the exported
+`causal_graph.json` contains only the explained/path-terminal alarm subset. The
+new graph is visually cleaner, but the field name `alarm_nodes` is ambiguous:
+consumers cannot tell whether it means all detected alarms or only alarms that
+survived path explanation.
+
+### Bad cases
+
+| Case | `result.json.alarm_nodes` | `causal_graph.json.alarm_nodes` | Interpretation |
+|---|---:|---:|---|
+| `otel-demo15-currency-pod-kill-xvmpqx` | 16 | 2 | 14 result alarms are hidden from the exported graph |
+| `hs0-user-pod-failure-cnf9cr` | 12 | 6 | graph keeps the explained frontend HTTP alarms only |
+| `hs1-recommendation-pod-failure-frllxg` | 6 | 2 | weak reservation/attractions candidates are hidden |
+| `hs31-recommendation-pod-failure-dn57db` | 3 | 2 | weak `NearbyRest` candidate is hidden |
+| `ts0-ts-preserve-service-response-replace-body-644lf4` | 7 | 1 | only the strong `/preserve` terminal alarm is exported |
+
+### Why this is a problem
+
+The graph may be intentionally exporting an explained subgraph, but the current
+schema does not make that contract explicit. A downstream evaluator reading only
+`causal_graph.json` may conclude that the case had only 1-2 alarms, while
+`result.json` shows a broader candidate set.
+
+This also blocks quality metrics such as alarm recall, strong-alarm coverage,
+and weak-noise filtering, because the reason for dropping each candidate is not
+carried into the graph export.
+
+### Optimization target
+
+Make alarm scope explicit and lossless across exports.
+
+Required fields or equivalent schema:
+
+```json
+{
+  "candidate_alarm_nodes": [],
+  "explained_alarm_nodes": [],
+  "unexplained_alarm_nodes": [
+    {
+      "node_id": 0,
+      "component": "span|...",
+      "issue_strength": "strong|weak|none|unknown",
+      "drop_reason": "no_path|weak_noise|filtered_by_rank|max_hops|schema_unmatched|unknown"
+    }
+  ],
+  "path_terminal_alarm_nodes": []
+}
+```
+
+Acceptance criteria:
+
+- `causal_graph.json` must not expose an ambiguous `alarm_nodes` field without a
+  documented scope. Prefer `path_terminal_alarm_nodes` for the current graph
+  subset.
+- Every `result.json.alarm_nodes` entry must be recoverable from either
+  `candidate_alarm_nodes`, `explained_alarm_nodes`, or `unexplained_alarm_nodes`.
+- If a node is hidden from the default graph because it is weak/noisy, export the
+  reason rather than silently dropping it.
+- Add a regression assertion for the five bad cases above: the exported graph
+  must report both the original candidate count and the explained count.
+
+## Problem 2: root is credible in the graph, but `injection_states` remains `unknown`
+
+### Symptom
+
+For PodFailure/PodKill cases, the new `causal_graph.json.root_causes` often has a
+concrete and correct state such as `unavailable`, while `result.json` still
+reports the corresponding injection state as `unknown`.
+
+### Bad cases
+
+| Case | Root in new graph | `result.json.propagation_result.injection_states` | Evidence-backed state |
+|---|---|---|---|
+| `hs0-user-pod-failure-cnf9cr` | `service|user`, `state=[unavailable]` | `[unknown]` | deployment available `1 -> 0`, container ready `1 -> 0`, service span disappears |
+| `hs1-recommendation-pod-failure-frllxg` | `service|recommendation`, `state=[unavailable]` | `[unknown]` | recommendation server span `725 -> 0`, container ready `1 -> 0` |
+| `hs31-recommendation-pod-failure-dn57db` | `service|recommendation`, `state=[unavailable]` | `[unknown]` | recommendation server span `601 -> 0`, frontend `/recommendations` 500 |
+| `otel-demo15-currency-pod-kill-xvmpqx` | `service|currency`, `state=[degraded, unavailable]` | `[unknown]` | pod kill event and ReplicaSet available transiently `1 -> 0` |
+
+Counterexample still failing even in the graph:
+
+| Case | Root in new graph | Problem |
+|---|---|---|
+| `ts0-ts-preserve-service-response-replace-body-644lf4` | `service|ts-preserve-service`, `state=[unknown]` | `state_resolution_reason=root_component_not_in_causal_graph`; root component is not included as a graph node |
+
+### Why this is a problem
+
+The same run exports two contradictory root-state stories:
+
+- `result.json`: injection state is unknown.
+- `causal_graph.json`: root is unavailable/degraded.
+
+The graph state is often correct, but the disagreement makes automated
+regression checks brittle and makes it unclear which artifact is authoritative.
+
+### Optimization target
+
+Define one canonical root-state source and use it consistently in all exports.
+
+Acceptance criteria:
+
+- If `causal_graph.root_causes[i].component` has a concrete state, the matching
+  `result.json.propagation_result.injection_states[i]` must be the same state or
+  must reference the same canonical root-state object.
+- `unknown` is allowed only with an explicit reason, for example:
+  - `root_component_not_in_causal_graph`
+  - `no_state_window_for_injection_node`
+  - `root_resolved_from_metadata_only`
+- For lifecycle faults (`PodKill`, `PodFailure`, `ContainerKill`), successful
+  injection plus K8s evidence should seed `unavailable` at the resolved root even
+  if no trace span exists.
+- Add a regression check: no PodFailure/PodKill case with `k8s.container.ready=0`
+  or deployment available `0` may export `injection_states=[unknown]` without a
+  reason.
+
+## Problem 3: caller-side span state is exported as `healthy, missing` despite raw errors
+
+### Symptom
+
+When a callee service is unavailable, the callee server span is truly missing.
+However, the caller-side client span often still exists and records errors. The
+new graph sometimes marks that caller span as `healthy, missing` instead of
+`erroring`.
+
+### Bad cases
+
+| Case | Caller span | Raw abnormal evidence | Exported state | Expected state |
+|---|---|---|---|---|
+| `hs1-recommendation-pod-failure-frllxg` | `span|frontend::recommendation.Recommendation/GetRecommendations` | 841 rows, 839 `Error` | `[healthy, missing]` | `erroring` |
+| `hs31-recommendation-pod-failure-dn57db` | `span|frontend::recommendation.Recommendation/GetRecommendations` | 671 rows, 671 `Error` | `[missing, healthy]` | `erroring` |
+| `hs0-user-pod-failure-cnf9cr` | `span|frontend::user.User/CheckUser` | 376 rows, 376 `Error` | `[healthy, missing]` | `erroring` |
+
+The callee-side server spans are correctly missing:
+
+- `recommendation::recommendation.Recommendation/GetRecommendations`: normal
+  725/601 rows in the two recommendation cases, abnormal 0 rows.
+- `user::user.User/CheckUser`: normal 301 rows, abnormal 0 rows.
+
+The caller-side spans are different: they are present and erroring.
+
+### Why this is a problem
+
+The state vocabulary conflates two distinct observations:
+
+- **callee server span missing**: request never reaches or is not served by the
+  failed service;
+- **caller client span erroring**: caller attempted the RPC and recorded failure.
+
+If both sides are marked `missing`, the graph loses the important fact that the
+frontend observed an explicit RPC failure. If a caller span is also marked
+`healthy`, the state set becomes contradictory and weakens path interpretation.
+
+### Optimization target
+
+State assignment must be side-aware for RPC edges.
+
+Acceptance criteria:
+
+- For caller/client spans, if abnormal rows exist and `attr.status_code=Error`
+  or HTTP status is 5xx above threshold, emit `erroring`.
+- Emit `missing` for a caller/client span only when the span is materially absent
+  relative to baseline and there is no stronger erroring evidence.
+- Do not co-export `healthy` with `erroring`, `unavailable`, or strong `missing`
+  for the same timestamp unless the states are explicitly separated by time
+  window.
+- For callee/server spans, retain `missing` when baseline rows exist and abnormal
+  rows drop to zero.
+- Add regression assertions:
+  - `hs1-recommendation-pod-failure-frllxg` frontend recommendation client span
+    must include `erroring`.
+  - `hs31-recommendation-pod-failure-dn57db` frontend recommendation client span
+    must include `erroring`.
+  - `hs0-user-pod-failure-cnf9cr` frontend user CheckUser client span must
+    include `erroring`.
+
+## Cross-cutting export requirements
+
+### Requirement A: graph export must be auditable without `result.json`
+
+`causal_graph.json` should either contain enough metadata for audit, or clearly
+state that it is an explained-subgraph view and point to the required source
+fields in `result.json`.
+
+Minimum useful metadata:
+
+- `case_name`
+- `fault_type`
+- `root_resolution_method`
+- `candidate_alarm_count`
+- `explained_alarm_count`
+- `unexplained_alarm_count`
+- `strong_alarm_coverage` with explicit zero-denominator handling
+
+### Requirement B: zero-denominator coverage must not report success silently
+
+If `candidate_strong_alarm_count=0`, export:
+
+```json
+{
+  "strong_alarm_coverage": null,
+  "strong_alarm_coverage_reason": "no_candidate_strong_alarms"
+}
+```
+
+Do not export `1.0` for an empty strong-alarm set.
+
+### Requirement C: confidence must distinguish rule admission from evidence quality
+
+For these bad cases, the path itself is often topologically plausible, but the
+state/alarm evidence is incomplete. Export either separate fields or an explicit
+breakdown:
+
+```json
+{
+  "rule_admission_confidence": 0.8,
+  "evidence_confidence": 0.0,
+  "alarm_coverage_confidence": 0.0,
+  "final_confidence": 0.0
+}
+```
+
+The exact scoring can be refined later; the immediate goal is to prevent a
+single `confidence=0.8` or `1.0` from implying full evidential certainty.
+
+## Minimal regression suite
+
+Use these cases to gate the export changes:
+
+```text
+/home/ddq/AoyangSpace/dataset/dataset_v3_500_2026-05-03/cases/hs0-user-pod-failure-cnf9cr
+/home/ddq/AoyangSpace/dataset/dataset_v3_500_2026-05-03/cases/hs1-recommendation-pod-failure-frllxg
+/home/ddq/AoyangSpace/dataset/dataset_v3_500_2026-05-03/cases/hs31-recommendation-pod-failure-dn57db
+/home/ddq/AoyangSpace/dataset/dataset_v3_500_2026-05-03/cases/otel-demo15-currency-pod-kill-xvmpqx
+/home/ddq/AoyangSpace/dataset/dataset_v3_500_2026-05-03/cases/ts0-ts-preserve-service-response-replace-body-644lf4
+```
+
+The regression tests should validate exported JSON only; they should not rerun
+fault injection.
+
+## Non-goals
+
+- This document does not require broad candidate alarm detection to be narrowed
+  immediately. Broad recall is useful; the requirement is to carry the drop and
+  explanation status into the export.
+- This document does not require all weak/noisy alarms to be graphed by default.
+  It requires them to be auditable.
+- This document does not redefine the canonical state lattice. It only requires
+  current states to be assigned to the correct side of an RPC edge.

--- a/rcabench-platform/docs/reasoning-output-quality-optimization.md
+++ b/rcabench-platform/docs/reasoning-output-quality-optimization.md
@@ -1,0 +1,306 @@
+# Reasoning Output Quality: Bad Cases and Optimization Goals
+
+Status: proposal / audit notes
+Owner: reasoning pipeline
+Scope: `src/rcabench_platform/v3/internal/reasoning/`, `cli/reason.py`, exported `result.json` and `causal_graph.json`
+
+## Motivation
+
+Manual audits of several TrainTicket RCA datapacks show that the reasoning
+pipeline usually finds a credible service-level root cause, but the exported
+explanation graph is hard to trust as-is. The recurring failures are not random:
+they cluster around root-state export, alarm accounting, missing strong alarms,
+and weak alarm/path noise.
+
+This document turns those audit findings into concrete optimization targets. The
+goal is not to change the underlying RCA philosophy; it is to make the exported
+artifacts (`result.json`, `causal_graph.json`) internally consistent and easier
+to evaluate automatically.
+
+## Audited bad cases
+
+The examples below are local datapacks from:
+
+`/home/ddq/AoyangSpace/dataset/rca/`
+
+| Case | Fault | Main verdict | Relevant output weakness |
+|---|---|---|---|
+| `ts4-ts-config-service-container-kill-f6w2x4` | `ContainerKill` on `ts-config-service` | Root service is correct; container restart evidence is strong | `root_causes` says `unknown`, alarm superset is wider than graph, weak/no-issue alarms are included |
+| `ts0-ts-station-service-partition-7z428n` | `NetworkPartition`, `ts-station-service <-> mysql` | Root symptom on station is correct; edge/root granularity is coarse | `root_causes` says `unknown`, only 3 UI alarms are graphed while 6 strong UI issues exist, weak alarms are mixed in |
+| `ts5-ts-seat-service-loss-5kglkt` | `NetworkLoss`, `ts-seat-service <-> ts-order-other-service` | Main seat/order-other network-loss chain is correct | Weak route/mysql branch is admitted despite `routes` not being a conclusion issue |
+| `ts2-ts-verification-code-service-container-kill-2lmcml` | `ContainerKill` on `ts-verification-code-service` | Root service is correct; pod metadata is stale | `root_causes` says `unknown`; one alarm id is not explained by paths/graph |
+
+## Problem 1: root state is exported as `unknown`
+
+### Symptom
+
+`causal_graph.json.root_causes` often contains:
+
+```json
+{
+  "timestamp": null,
+  "component": "service|...",
+  "state": ["unknown"]
+}
+```
+
+while the same component appears in `causal_graph.json.nodes` or
+`result.json.visualization_paths` with a concrete timestamp and state.
+
+### Bad cases
+
+| Case | `root_causes` export | Concrete state already available elsewhere |
+|---|---|---|
+| `ts4-ts-config-service-container-kill-f6w2x4` | `service|ts-config-service`, `timestamp=null`, `state=[unknown]` | `service|ts-config-service`, `timestamp=1754978417`, `state=[degraded, unavailable]` |
+| `ts0-ts-station-service-partition-7z428n` | `service|ts-station-service`, `timestamp=null`, `state=[unknown]` | `service|ts-station-service`, `timestamp=1752748144`, `state=[degraded, silent]` |
+| `ts2-ts-verification-code-service-container-kill-2lmcml` | `service|ts-verification-code-service`, `timestamp=null`, `state=[unknown]` | path root is `degraded, unavailable` |
+| `ts5-ts-seat-service-loss-5kglkt` | `service|ts-seat-service` / `service|ts-order-other-service`, `state=[unknown]` | paths show `ts-seat-service` as `degraded, silent` and `ts-order-other-service` as `silent` |
+
+### Diagnosis
+
+This is an exporter/bookkeeping bug, not a detector failure. State inference has
+already produced a concrete root state; the `root_causes` serializer is not
+joining it back to the graph node.
+
+### Optimization target
+
+Root cause exports must be state-complete when the component exists in the graph.
+
+Acceptance criteria:
+
+- For every `root_causes[i].component`, if an equivalent node exists in
+  `causal_graph.nodes`, copy the node's earliest `timestamp` and unioned `state`.
+- `state=["unknown"]` is allowed only when no stateful node exists and the reason
+  is explicitly exported as `state_resolution_reason`.
+- Add a regression check: no audited case above may export `timestamp=null` for a
+  root component that exists in `causal_graph.nodes`.
+
+## Problem 2: `alarm_nodes` is a candidate superset, but paths/graph only explain a subset
+
+### Symptom
+
+`result.json.alarm_nodes` contains many ids, while `visualization_paths` and
+`causal_graph.json.alarm_nodes` contain only some of them. The current schema does
+not say which alarms are explained, unexplained, or intentionally dropped.
+
+### Bad cases
+
+| Case | Candidate alarms | Explained by paths/graph | What is confusing |
+|---|---:|---:|---|
+| `ts4-ts-config-service-container-kill-f6w2x4` | 15 | 6 terminal UI alarms | 9 alarm ids are listed but not reachable in exported paths |
+| `ts0-ts-station-service-partition-7z428n` | 14 | 3 graph alarm nodes | 11 alarm ids are not represented in the causal graph |
+| `ts2-ts-verification-code-service-container-kill-2lmcml` | 2 | 1 strong verifycode path | One extra alarm id is present but not explained |
+| `ts5-ts-seat-service-loss-5kglkt` | 9 | 5 unique terminal alarms | Some candidate alarms are absent from graph while a weak route path is included |
+
+### Diagnosis
+
+The pipeline appears to have at least two stages with different semantics:
+
+- E-stage / alarm surface: broad candidate impacted nodes.
+- M-stage / path finding: subset that can be connected to the root by accepted
+  propagation paths.
+
+This split is reasonable, but the export flattens both into one field named
+`alarm_nodes`, which makes the output look inconsistent.
+
+### Optimization target
+
+Make alarm accounting explicit and lossless.
+
+Recommended schema:
+
+```json
+{
+  "candidate_alarm_nodes": [],
+  "explained_alarm_nodes": [],
+  "unexplained_alarm_nodes": [
+    {
+      "node_id": 0,
+      "component": "span|...",
+      "issue_strength": "strong|weak|none|unknown",
+      "reason": "no_path_found|filtered_weak_issue|missing_topology_edge|max_hops|unknown"
+    }
+  ],
+  "path_terminal_alarm_nodes": []
+}
+```
+
+Acceptance criteria:
+
+- `candidate_alarm_nodes = explained_alarm_nodes + unexplained_alarm_nodes` by
+  id set, unless a node is explicitly marked as `dropped_before_path_search`.
+- `causal_graph.alarm_nodes` must be documented as path-terminal alarms or be
+  renamed to `path_terminal_alarm_nodes`.
+- Every alarm id in `result.json` must be mappable to a component name in the
+  same export.
+
+## Problem 3: strong alarms can be missed by the causal graph
+
+### Symptom
+
+Some alarms with strong conclusion evidence do not appear in paths or
+`causal_graph.json`. This is different from harmless candidate-alarm noise.
+
+### Primary bad case
+
+`ts0-ts-station-service-partition-7z428n`
+
+`conclusion.parquet` reports six strong UI issues:
+
+| UI endpoint | Normal success | Abnormal success | Abnormal p99 |
+|---|---:|---:|---:|
+| `POST /api/v1/travelplanservice/travelPlan/quickest` | 1.0 | 0.0 | ~20.003s |
+| `POST /api/v1/travelplanservice/travelPlan/minStation` | 1.0 | 0.0 | ~20.001s |
+| `POST /api/v1/travelplanservice/travelPlan/cheapest` | 1.0 | 0.0 | ~20.001s |
+| `POST /api/v1/travelservice/trips/left` | 1.0 | 0.2 | ~20.003s |
+| `POST /api/v1/travel2service/trips/left` | 1.0 | 0.0 | ~20.004s |
+| `POST /api/v1/preserveservice/preserve` | 1.0 | 0.0 | ~20.001s |
+
+But `causal_graph.json.alarm_nodes` only contains:
+
+- `POST /api/v1/preserveservice/preserve`
+- `POST /api/v1/travelservice/trips/left`
+- `POST /api/v1/travel2service/trips/left`
+
+The three `travelPlan/*` endpoints are strong alarms and should not disappear
+without explanation.
+
+### Diagnosis
+
+The graph has a coverage gap. Possible causes to investigate:
+
+- missing or filtered topology edges from `station/basic` to `travel-plan`;
+- max-hop or path ranking pruning before all strong alarms are covered;
+- M-stage accepting only a subset of alarm clusters;
+- endpoint/span name mismatch between alarm detection and topology graph.
+
+### Optimization target
+
+Strong alarms must be either explained by a path or explicitly reported as
+strong-unexplained.
+
+Acceptance criteria:
+
+- Define `issue_strength=strong` from conclusion evidence. Initial rule:
+  `Issues != {}` OR success-rate drop crosses the same threshold used by alarm
+  detection OR p99/avg duration anomaly is above the alarm threshold.
+- For each strong candidate alarm, export one of:
+  - a path from a root to that alarm;
+  - an `unexplained_alarm_nodes` entry with a concrete failure reason.
+- Add a coverage metric:
+
+```text
+strong_alarm_coverage = explained_strong_alarm_count / candidate_strong_alarm_count
+```
+
+- Regression target for `ts0-ts-station-service-partition-7z428n`:
+  `travelPlan/quickest`, `travelPlan/minStation`, and `travelPlan/cheapest`
+  must be explained or explicitly marked `strong_unexplained`.
+
+## Problem 4: weak alarm noise is mixed with real alarms and sometimes enters high-confidence paths
+
+### Symptom
+
+Some candidate alarms have weak or no conclusion evidence, but are still listed
+as alarms. In one case, weak topology paths are admitted into the explanation
+graph with high confidence.
+
+### Bad cases
+
+| Case | Weak/noisy node | Evidence weakness | Current bad behavior |
+|---|---|---|---|
+| `ts5-ts-seat-service-loss-5kglkt` | `ts-ui-dashboard::GET /api/v1/routeservice/routes` via `ts-order-other-service -> mysql -> ts-route-service` | `Issues={}`, success rate `1.0 -> 1.0`, `ts-route-service` has no errors and service p99 is not degraded | Weak route/mysql branch is admitted as a full-confidence path |
+| `ts4-ts-config-service-container-kill-f6w2x4` | `orderservice/order/refresh` | `Issues={}`, success rate `1.0 -> 1.0`, latency change is small/outlier-like | Included in candidate alarm surface |
+| `ts4-ts-config-service-container-kill-f6w2x4` | `routeservice/routes` | `Issues={}`, success rate `1.0 -> 1.0` | Included as weak/no-issue alarm candidate in the broad surface |
+| `ts0-ts-station-service-partition-7z428n` | `auth`, `consign`, `cancel`, `trainservice/trains`, `inside_payment` candidates | not part of the station/basic/travel main propagation; several are not conclusion issues | Listed alongside strong travel/preserve alarms without strength labels |
+
+### Diagnosis
+
+The alarm surface is intentionally broad, but the graph does not consistently
+separate weak candidates from strong user-facing issues. Shared dependencies
+(e.g. MySQL) and global traffic drops can create plausible topology routes that
+are not specific to the injected fault.
+
+### Optimization target
+
+Weak candidates should not be indistinguishable from strong alarms, and weak
+paths should not receive maximum confidence without strong endpoint evidence.
+
+Acceptance criteria:
+
+- Add `issue_strength` to candidate alarms. Suggested values:
+  - `strong`: conclusion issue exists or success rate materially drops;
+  - `weak`: only small p99/avg shift, small sample, or heuristic-only signal;
+  - `none`: `Issues={}` and no material success/latency regression;
+  - `unknown`: conclusion row unavailable.
+- Default graph export includes strong alarms and paths first. Weak/no-issue
+  paths require `include_weak_paths=true` or must be separated under
+  `weak_paths`.
+- Path confidence must be penalized when the terminal alarm is weak/no-issue.
+- A path whose terminal endpoint has `Issues={}` and success rate is unchanged
+  cannot be exported with `confidence=1.0` unless another explicit evidence
+  source is attached.
+- Regression target for `ts5-ts-seat-service-loss-5kglkt`: the
+  `order-other -> mysql -> route-service -> routes` branch should be marked
+  `weak_path` or removed from the default causal graph.
+
+## Cross-cutting optimization goals
+
+### Goal A: Internal consistency of exports
+
+`result.json` and `causal_graph.json` must agree on component identity, root
+state, and alarm accounting.
+
+Checks:
+
+- every root component has a concrete state if it appears in graph nodes;
+- every alarm id maps to a component name;
+- every path-terminal alarm is included in `explained_alarm_nodes`;
+- `causal_graph.alarm_nodes` is a documented subset, not an ambiguous duplicate.
+
+### Goal B: Strong-alarm coverage before path count
+
+The graph should optimize for explaining distinct strong user-facing alarms, not
+for enumerating many similar span-level paths.
+
+Checks:
+
+- report `strong_alarm_coverage`;
+- report `unexplained_strong_alarm_count`;
+- fail or warn when strong coverage is below a threshold, initially 0.8 for
+  TrainTicket audits.
+
+### Goal C: Weak-signal isolation
+
+Weak/no-issue candidates should be visible for debugging but not mixed into the
+main RCA graph as if they were strong causal evidence.
+
+Checks:
+
+- no `Issues={}` terminal endpoint in default graph with `confidence=1.0`;
+- weak paths are exported under a separate section or require an explicit flag;
+- shared-dependency paths require endpoint issue evidence or client-side logs.
+
+### Goal D: Regression dataset for output quality
+
+Use these bad cases as a small output-quality regression suite.
+
+Minimum suite:
+
+```text
+/home/ddq/AoyangSpace/dataset/rca/ts4-ts-config-service-container-kill-f6w2x4
+/home/ddq/AoyangSpace/dataset/rca/ts0-ts-station-service-partition-7z428n
+/home/ddq/AoyangSpace/dataset/rca/ts5-ts-seat-service-loss-5kglkt
+/home/ddq/AoyangSpace/dataset/rca/ts2-ts-verification-code-service-container-kill-2lmcml
+```
+
+The suite should validate exported artifacts without rerunning injection.
+
+## Non-goals
+
+- Do not require MySQL/server-side traces to represent a DB/network-edge root.
+  Client-side evidence is valid, but the root metadata must preserve the target.
+- Do not remove the broad alarm detector. Broad detection is useful for recall;
+  the fix is to label and account for candidate strength.
+- Do not hide unexplained alarms. They are useful debugging signals, especially
+  when they are strong.


### PR DESCRIPTION
## What changed

- Add audit-derived optimization requirements for reasoning output quality.
- Document alarm normalization failures, export consistency gaps, and root/alarm graph bad cases.
- Keep this PR docs-only after PR #383 merged the implementation-side export fixes.

## Why

Recent v3/v4 dataset audits found recurring issues around strong alarm mapping, alarm scope semantics, root state export, unknown/unmatched terminals, and graph readability. These documents preserve the concrete bad cases and define follow-up optimization targets.

## Validation

- `git diff --check origin/main..HEAD`
