### PR TITLE
feat(llm-eval/v2): add any_root_cause_hit, unify path_reachability denom (0.4.40)

### DIFF
--- a/rcabench-platform/pyproject.toml
+++ b/rcabench-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rcabench-platform"
-version = "0.4.39"
+version = "0.4.40"
 description = "An experiment framework for Root Cause Analysis"
 readme = "README.md"
 authors = [ #

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/evaluator.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2/evaluator.py
@@ -28,6 +28,7 @@ from .ground_truth import GTContext, extract_gt_faults
 from .matcher import (
     FaultMatchResult,
     GraphMetrics,
+    MatchStatus,
     OutcomeResult,
     compute_graph_metrics,
     compute_outcome,
@@ -77,6 +78,7 @@ class EvaluationResultV2(BaseModel):
     evidence_support_rate: float | None
 
     path_reachability: bool | None = None
+    any_root_cause_hit: bool = False
 
     node_f1: float = 0.0
     edge_f1: float = 0.0
@@ -163,6 +165,7 @@ async def evaluate_v2(
     outcome: OutcomeResult = compute_outcome(agent, gt_ctx.faults)
     graph: GraphMetrics = compute_graph_metrics(agent, gt_graph)
     path_reachable: bool | None = compute_path_reachability(agent, outcome, gt_graph)
+    any_hit: bool = any(m.status == MatchStatus.HIT for m in outcome.per_fault)
 
     per_evidence: list[PerEvidenceRecord] = []
     judge_inputs: list[tuple[int, str, str, Evidence, EvidenceVerifyResult]] = []
@@ -265,6 +268,7 @@ async def evaluate_v2(
         sql_executable_rate=sql_executable_rate,
         evidence_support_rate=evidence_support_rate,
         path_reachability=path_reachable,
+        any_root_cause_hit=any_hit,
         node_f1=graph.node_f1,
         edge_f1=graph.edge_f1,
         node_precision=graph.node_precision,

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
@@ -631,6 +631,50 @@ def test_path_reachability_no_alarm_services_is_none() -> None:
 
 
 # ──────────────────────────────────────────────────────────────────────
+# any_root_cause_hit — supplement to path_reachability
+#
+# Per-case invariant: any_root_cause_hit ≥ path_reachability (treating True/False
+# as 1/0). path_reachability=True implies a HIT exists; the converse can fail
+# when the agent identifies the root cause but its propagation chain doesn't
+# reach a GT alarm.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_any_root_cause_hit_disconnected_path() -> None:
+    """HIT rc but agent edges don't reach the alarm → any_hit=True, path_reach=False."""
+    gt_faults = [GTFault(service="a", fault_kind=FaultKind.POD_FAILURE)]
+    gt = _gt_graph(["a", "b", "c"], [("a", "b"), ("b", "c")], alarms=["c"])
+    agent = _agent(
+        [{"service": "a", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV]}],
+        propagation=[{"from": "a", "to": "b", "evidence": [_DUMMY_EV]}],
+    )
+    outcome = compute_outcome(agent, gt_faults)
+    any_hit = any(m.status == MatchStatus.HIT for m in outcome.per_fault)
+    assert any_hit is True
+    assert compute_path_reachability(agent, outcome, gt) is False
+
+
+def test_any_root_cause_hit_all_miss() -> None:
+    """No HITs → any_hit=False (path_reach is also False)."""
+    gt_faults = [GTFault(service="a", fault_kind=FaultKind.POD_FAILURE)]
+    gt = _gt_graph(["a", "b", "c"], [("a", "b"), ("b", "c")], alarms=["c"])
+    agent = _agent([{"service": "x", "fault_kind": "pod_failure", "evidence": [_DUMMY_EV]}])
+    outcome = compute_outcome(agent, gt_faults)
+    any_hit = any(m.status == MatchStatus.HIT for m in outcome.per_fault)
+    assert any_hit is False
+    assert compute_path_reachability(agent, outcome, gt) is False
+
+
+def test_any_root_cause_hit_wrong_kind_does_not_count() -> None:
+    """Service-correct but wrong fault_kind is WRONG_KIND, not HIT → any_hit=False."""
+    gt_faults = [GTFault(service="a", fault_kind=FaultKind.POD_FAILURE)]
+    agent = _agent([{"service": "a", "fault_kind": "cpu_stress", "evidence": [_DUMMY_EV]}])
+    outcome = compute_outcome(agent, gt_faults)
+    any_hit = any(m.status == MatchStatus.HIT for m in outcome.per_fault)
+    assert any_hit is False
+
+
+# ──────────────────────────────────────────────────────────────────────
 # DuckDB SQL evidence verification
 # ──────────────────────────────────────────────────────────────────────
 
@@ -982,14 +1026,14 @@ def test_evidence_judge_no_response_format_param() -> None:
 
 def test_calculate_metrics_aggregation() -> None:
     """5 stub samples → aggregator divides by total n=5, except
-    ``avg_fault_kind_accuracy`` (uses ``kind_accuracy_denom``) and
-    ``avg_path_reachability`` (uses ``path_reachability_denom``).
+    ``avg_fault_kind_accuracy`` (uses ``kind_accuracy_denom`` so cases with
+    no service-correct rcs don't smear the metric).
 
     Sample mix:
-      [0] perfect      f1=1.0  exact=True  kind_acc=1.0  sql=1.0  ev_support=1.0  path=True
-      [1] partial      f1=0.5  exact=False kind_acc=0.5  sql=0.8  ev_support=0.6  path=False
-      [2] parse-err    zeros + parse_error=True (kind_acc=None, path=None → both excluded)
-      [3] judge-fail   f1=1.0  ev_support=0.0  n_evidence_judge_failed=1        path=True
+      [0] perfect      f1=1.0  exact=True  kind_acc=1.0  sql=1.0  ev_support=1.0  path=True   any_hit=True
+      [1] partial      f1=0.5  exact=False kind_acc=0.5  sql=0.8  ev_support=0.6  path=False  any_hit=True (HIT but no path)
+      [2] parse-err    zeros + parse_error=True (kind_acc=None, path=None → both excluded)   any_hit=False
+      [3] judge-fail   f1=1.0  ev_support=0.0  n_evidence_judge_failed=1        path=True    any_hit=True
       [4] eval-err     sample.meta['eval_v2'] = {'error': '...'}
     """
     from rcabench_platform.v3.sdk.llm_eval.eval.processer.rcabench import RCABenchProcesser
@@ -1013,6 +1057,7 @@ def test_calculate_metrics_aggregation() -> None:
                     "node_f1": 1.0,
                     "edge_f1": 1.0,
                     "path_reachability": True,
+                    "any_root_cause_hit": True,
                     "n_evidence_judge_failed": 0,
                     "per_evidence": [{}],
                 }
@@ -1032,6 +1077,7 @@ def test_calculate_metrics_aggregation() -> None:
                     "node_f1": 0.4,
                     "edge_f1": 0.2,
                     "path_reachability": False,
+                    "any_root_cause_hit": True,
                     "n_evidence_judge_failed": 0,
                     "per_evidence": [{}],
                 }
@@ -1051,6 +1097,7 @@ def test_calculate_metrics_aggregation() -> None:
                     "node_f1": 0.0,
                     "edge_f1": 0.0,
                     "path_reachability": None,
+                    "any_root_cause_hit": False,
                     "n_evidence_judge_failed": 0,
                     "parse_error": "bad json",
                     "per_evidence": [],
@@ -1071,6 +1118,7 @@ def test_calculate_metrics_aggregation() -> None:
                     "node_f1": 1.0,
                     "edge_f1": 1.0,
                     "path_reachability": True,
+                    "any_root_cause_hit": True,
                     "n_evidence_judge_failed": 1,
                     "per_evidence": [{}],
                 }
@@ -1101,6 +1149,11 @@ def test_calculate_metrics_aggregation() -> None:
     # fault_kind_accuracy excludes the parse-err case (denom=0); 3 cases contribute.
     assert metrics["kind_accuracy_denom"] == 3
     assert metrics["avg_fault_kind_accuracy"] == round((1.0 + 0.5 + 1.0) / 3, 4)
-    # path_reachability excludes the parse-err case (None); 3 cases contribute, 2 reachable.
-    assert metrics["path_reachability_denom"] == 3
-    assert metrics["avg_path_reachability"] == round(2 / 3, 4)
+    # path_reachability divides by total n=5; None / parse-err / eval-err count as 0.
+    # 2 of 5 samples are reachable.
+    assert metrics["avg_path_reachability"] == round(2 / 5, 4)
+    # any_root_cause_hit also divides by n=5. 3 of 5 samples have a HIT.
+    # Per-case invariant any_hit ≥ path_reach now lifts to rate level: 3/5 ≥ 2/5.
+    assert metrics["any_root_cause_hit_count"] == 3
+    assert metrics["avg_any_root_cause_hit"] == round(3 / 5, 4)
+    assert metrics["avg_any_root_cause_hit"] >= metrics["avg_path_reachability"]

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
@@ -1030,11 +1030,11 @@ def test_calculate_metrics_aggregation() -> None:
     no service-correct rcs don't smear the metric).
 
     Sample mix:
-      [0] perfect      f1=1.0  exact=True  kind_acc=1.0  sql=1.0  ev_support=1.0  path=True   any_hit=True
-      [1] partial      f1=0.5  exact=False kind_acc=0.5  sql=0.8  ev_support=0.6  path=False  any_hit=True (HIT but no path)
-      [2] parse-err    zeros + parse_error=True (kind_acc=None, path=None → both excluded)   any_hit=False
-      [3] judge-fail   f1=1.0  ev_support=0.0  n_evidence_judge_failed=1        path=True    any_hit=True
-      [4] eval-err     sample.meta['eval_v2'] = {'error': '...'}
+      [0] perfect    f1=1.0 exact=True  kind_acc=1.0 sql=1.0 ev=1.0 path=True  any_hit=True
+      [1] partial    f1=0.5 exact=False kind_acc=0.5 sql=0.8 ev=0.6 path=False any_hit=True (HIT, no path)
+      [2] parse-err  zeros + parse_error=True (kind_acc=None, path=None excluded) any_hit=False
+      [3] judge-fail f1=1.0 ev=0.0 n_evidence_judge_failed=1 path=True any_hit=True
+      [4] eval-err   sample.meta['eval_v2'] = {'error': '...'}
     """
     from rcabench_platform.v3.sdk.llm_eval.eval.processer.rcabench import RCABenchProcesser
 

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/rcabench.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/rcabench.py
@@ -229,7 +229,8 @@ class RCABenchProcesser(BaseMatchProcesser):
                 "avg_sql_executable_rate": 0.0,
                 "avg_evidence_support_rate": 0.0,
                 "avg_path_reachability": 0.0,
-                "path_reachability_denom": 0,
+                "avg_any_root_cause_hit": 0.0,
+                "any_root_cause_hit_count": 0,
                 "avg_node_f1": 0.0,
                 "avg_edge_f1": 0.0,
                 "parse_errors": 0,
@@ -256,7 +257,7 @@ class RCABenchProcesser(BaseMatchProcesser):
         kind_acc_sum = 0.0
         kind_acc_cases = 0
         path_reach_sum = 0
-        path_reach_cases = 0
+        any_hit_sum = 0
         scored = 0
         parse_errors = 0
         zero_evidence = 0
@@ -289,9 +290,11 @@ class RCABenchProcesser(BaseMatchProcesser):
                 kind_acc_cases += 1
 
             path_reach = ev.get("path_reachability")
-            if path_reach is not None:
-                path_reach_sum += int(path_reach)
-                path_reach_cases += 1
+            if path_reach:
+                path_reach_sum += 1
+
+            if ev.get("any_root_cause_hit"):
+                any_hit_sum += 1
 
             if ev.get("exact_match"):
                 exact_count += 1
@@ -303,7 +306,6 @@ class RCABenchProcesser(BaseMatchProcesser):
 
         denom = max(1, n)
         kind_denom = max(1, kind_acc_cases)
-        path_denom = max(1, path_reach_cases)
         return {
             "benchmark": self.name,
             "total_samples": n,
@@ -317,8 +319,9 @@ class RCABenchProcesser(BaseMatchProcesser):
             "kind_accuracy_denom": kind_acc_cases,
             "avg_sql_executable_rate": round(sql_sum / denom, 4),
             "avg_evidence_support_rate": round(ev_support_sum / denom, 4),
-            "avg_path_reachability": round(path_reach_sum / path_denom, 4),
-            "path_reachability_denom": path_reach_cases,
+            "avg_path_reachability": round(path_reach_sum / denom, 4),
+            "avg_any_root_cause_hit": round(any_hit_sum / denom, 4),
+            "any_root_cause_hit_count": any_hit_sum,
             "avg_node_f1": round(node_f1_sum / denom, 4),
             "avg_edge_f1": round(edge_f1_sum / denom, 4),
             "parse_errors": parse_errors,

--- a/rcabench-platform/uv.lock
+++ b/rcabench-platform/uv.lock
@@ -3654,7 +3654,7 @@ wheels = [
 
 [[package]]
 name = "rcabench-platform"
-version = "0.4.39"
+version = "0.4.40"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- Adds `any_root_cause_hit` (bool per case) — at least one HIT in `outcome.per_fault`. Supplements `path_reachability` since `any_hit ≥ path_reach` per case (path_reach=True ⇒ HIT exists).
- Unifies `avg_path_reachability` denominator to `total_samples` (was `path_reachability_denom = non-None case count`). Now consistent with how `avg_f1` / `avg_precision` / `avg_recall` are aggregated; `any_hit ≥ path_reach` holds at the rate level too.
- `path_reachability_denom` field removed from `calculate_metrics` summary dict (it equaled `scored` under the GT-always-has-alarms assumption).
- Bumps `rcabench-platform` to 0.4.40 + `uv.lock`.

## Behavior change

`avg_path_reachability` now divides parse-failed / no-GT-alarm cases as 0 instead of excluding them. Numbers will shift down for any dashboard that was tracking the old value — one-time step, no ongoing semantics change.

## Test plan

- [x] `pytest src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py` — 47 passed
- [x] `uv sync --all-extras --locked` clean
- [ ] Watch CI rcabench-platform on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)