### PR TITLE
feat(llm-eval/v2): typed eval_metrics column + SDK upload API + dashboard endpoints (0.4.41)

### DIFF
--- a/rcabench-platform/pyproject.toml
+++ b/rcabench-platform/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rcabench-platform"
-version = "0.4.40"
+version = "0.4.41"
 description = "An experiment framework for Root Cause Analysis"
 readme = "README.md"
 authors = [ #

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/v2_tests/test_eval_v2.py
@@ -1030,82 +1030,83 @@ def test_calculate_metrics_aggregation() -> None:
     no service-correct rcs don't smear the metric).
 
     Sample mix:
-      [0] perfect    f1=1.0 exact=True  kind_acc=1.0 sql=1.0 ev=1.0 path=True  any_hit=True
-      [1] partial    f1=0.5 exact=False kind_acc=0.5 sql=0.8 ev=0.6 path=False any_hit=True (HIT, no path)
-      [2] parse-err  zeros + parse_error=True (kind_acc=None, path=None excluded) any_hit=False
-      [3] judge-fail f1=1.0 ev=0.0 n_evidence_judge_failed=1 path=True any_hit=True
-      [4] eval-err   sample.meta['eval_v2'] = {'error': '...'}
+      [0] perfect    f1=1.0 exact=True  kind_acc=1.0 sql=1.0 ev=1.0 path=True  any_hit=True   (eval_metrics)
+      [1] partial    f1=0.5 exact=False kind_acc=0.5 sql=0.8 ev=0.6 path=False any_hit=True   (eval_metrics)
+      [2] parse-err  zeros + parse_error=True (kind_acc=None, path=None excluded) any_hit=False (eval_metrics)
+      [3] judge-fail f1=1.0 ev=0.0 n_evidence_judge_failed=1 path=True (legacy meta['eval_v2'] fallback)
+      [4] eval-err   sample.eval_metrics = {'error': '...'}
     """
     from rcabench_platform.v3.sdk.llm_eval.eval.processer.rcabench import RCABenchProcesser
 
     class _StubSample:
-        def __init__(self, meta: dict[str, Any]) -> None:
-            self.meta: dict[str, Any] = meta
+        def __init__(
+            self,
+            *,
+            eval_metrics: dict[str, Any] | None = None,
+            meta: dict[str, Any] | None = None,
+        ) -> None:
+            self.eval_metrics = eval_metrics
+            self.meta: dict[str, Any] | None = meta
 
     samples = [
         _StubSample(
-            {
-                "eval_v2": {
-                    "precision": 1.0,
-                    "recall": 1.0,
-                    "f1": 1.0,
-                    "exact_match": True,
-                    "fault_kind_accuracy": 1.0,
-                    "kind_accuracy_denom": 1,
-                    "sql_executable_rate": 1.0,
-                    "evidence_support_rate": 1.0,
-                    "node_f1": 1.0,
-                    "edge_f1": 1.0,
-                    "path_reachability": True,
-                    "any_root_cause_hit": True,
-                    "n_evidence_judge_failed": 0,
-                    "per_evidence": [{}],
-                }
+            eval_metrics={
+                "precision": 1.0,
+                "recall": 1.0,
+                "f1": 1.0,
+                "exact_match": True,
+                "fault_kind_accuracy": 1.0,
+                "kind_accuracy_denom": 1,
+                "sql_executable_rate": 1.0,
+                "evidence_support_rate": 1.0,
+                "node_f1": 1.0,
+                "edge_f1": 1.0,
+                "path_reachability": True,
+                "any_root_cause_hit": True,
+                "n_evidence_judge_failed": 0,
+                "per_evidence": [{}],
             }
         ),
         _StubSample(
-            {
-                "eval_v2": {
-                    "precision": 0.5,
-                    "recall": 0.5,
-                    "f1": 0.5,
-                    "exact_match": False,
-                    "fault_kind_accuracy": 0.5,
-                    "kind_accuracy_denom": 2,
-                    "sql_executable_rate": 0.8,
-                    "evidence_support_rate": 0.6,
-                    "node_f1": 0.4,
-                    "edge_f1": 0.2,
-                    "path_reachability": False,
-                    "any_root_cause_hit": True,
-                    "n_evidence_judge_failed": 0,
-                    "per_evidence": [{}],
-                }
+            eval_metrics={
+                "precision": 0.5,
+                "recall": 0.5,
+                "f1": 0.5,
+                "exact_match": False,
+                "fault_kind_accuracy": 0.5,
+                "kind_accuracy_denom": 2,
+                "sql_executable_rate": 0.8,
+                "evidence_support_rate": 0.6,
+                "node_f1": 0.4,
+                "edge_f1": 0.2,
+                "path_reachability": False,
+                "any_root_cause_hit": True,
+                "n_evidence_judge_failed": 0,
+                "per_evidence": [{}],
             }
         ),
         _StubSample(
-            {
-                "eval_v2": {
-                    "precision": 0.0,
-                    "recall": 0.0,
-                    "f1": 0.0,
-                    "exact_match": False,
-                    "fault_kind_accuracy": None,  # no service-correct rcs → excluded from mean
-                    "kind_accuracy_denom": 0,
-                    "sql_executable_rate": 0.0,
-                    "evidence_support_rate": 0.0,
-                    "node_f1": 0.0,
-                    "edge_f1": 0.0,
-                    "path_reachability": None,
-                    "any_root_cause_hit": False,
-                    "n_evidence_judge_failed": 0,
-                    "parse_error": "bad json",
-                    "per_evidence": [],
-                }
+            eval_metrics={
+                "precision": 0.0,
+                "recall": 0.0,
+                "f1": 0.0,
+                "exact_match": False,
+                "fault_kind_accuracy": None,  # no service-correct rcs → excluded from mean
+                "kind_accuracy_denom": 0,
+                "sql_executable_rate": 0.0,
+                "evidence_support_rate": 0.0,
+                "node_f1": 0.0,
+                "edge_f1": 0.0,
+                "path_reachability": None,
+                "any_root_cause_hit": False,
+                "n_evidence_judge_failed": 0,
+                "parse_error": "bad json",
+                "per_evidence": [],
             }
         ),
+        # Backward-compat: row written by older SDK still under meta["eval_v2"].
         _StubSample(
-            {
+            meta={
                 "eval_v2": {
                     "precision": 1.0,
                     "recall": 1.0,
@@ -1124,7 +1125,7 @@ def test_calculate_metrics_aggregation() -> None:
                 }
             }
         ),
-        _StubSample({"eval_v2": {"error": "missing case dir"}}),
+        _StubSample(eval_metrics={"error": "missing case dir"}),
     ]
 
     proc = RCABenchProcesser.__new__(RCABenchProcesser)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/__init__.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/__init__.py
@@ -1,7 +1,20 @@
 from typing import Literal, cast
 
+from .api import (
+    aggregate_experiment_summary,
+    list_experiment_cases,
+    upload_case_result,
+    upload_case_results,
+)
 from .utils import EnvUtils, setup_logging
 
 log_level = EnvUtils.get_env("LLM_EVAL_LOG_LEVEL", None) or EnvUtils.get_env("UTU_LOG_LEVEL", "WARNING")
 _level = cast(Literal["WARNING", "INFO", "DEBUG"], log_level or "WARNING")
 setup_logging(_level)
+
+__all__ = [
+    "upload_case_result",
+    "upload_case_results",
+    "list_experiment_cases",
+    "aggregate_experiment_summary",
+]

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/api.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/api.py
@@ -10,9 +10,15 @@ Designed for two writers:
 UPSERT keys on the logical identity ``(exp_id, dataset, dataset_index,
 model_name, agent_type)`` and is implemented as SELECT-then-update-or-insert
 in Python so SQLite and Postgres behave identically (no ``ON CONFLICT``
-dialect, no UNIQUE constraint required). ``eval_metrics`` and ``meta`` are
-shallow dict-merged on update; scalar fields follow "pass-to-update,
-None-to-keep".
+dialect). ``eval_metrics`` and ``meta`` are shallow dict-merged on update;
+scalar fields follow "pass-to-update, None-to-keep".
+
+A unique index on the logical identity (NULL-safe via COALESCE) closes the
+SELECT-then-INSERT race; if a concurrent writer beats us between the lookup
+and the INSERT, ``IntegrityError`` is caught and we retry the operation as
+an UPDATE on the now-existing row. This auto-recovery only fires when the
+session is owned by this call — when the caller passes their own session
+they handle the rollback themselves.
 
 Aggregation runs in Python over the row set so no SQL JSON-path syntax
 leaks into the SDK — consumers that want a SQL view can build one in their
@@ -25,6 +31,7 @@ import datetime
 from collections.abc import Iterable
 from typing import Any
 
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
 from .db.eval_datapoint import EvaluationRolloutStats, EvaluationSample
@@ -96,43 +103,52 @@ def upload_case_result(
     """
     own_session = session is None
     sess = session if session is not None else SQLModelUtils.create_session()
+    scalar_updates = {
+        "response": response,
+        "trace_id": trace_id,
+        "trace_url": trace_url,
+        "time_cost": time_cost,
+        "trajectories": trajectories,
+        "correct": correct,
+        "confidence": confidence,
+        "judged_response": judged_response,
+        "reasoning": reasoning,
+        "extracted_final_answer": extracted_final_answer,
+        "raw_question": raw_question,
+        "source": source,
+        "level": level,
+        "correct_answer": correct_answer,
+        "augmented_question": augmented_question,
+        "file_name": file_name,
+        "stage": stage,
+    }
+    identity = {
+        "exp_id": exp_id,
+        "dataset": dataset,
+        "dataset_index": dataset_index,
+        "model_name": model_name,
+        "agent_type": agent_type,
+    }
+
+    def _apply_update(row: EvaluationSample) -> None:
+        if eval_metrics:
+            row.eval_metrics = _shallow_merge(row.eval_metrics, eval_metrics)
+        if meta:
+            row.meta = _shallow_merge(row.meta, meta)
+        for k, v in scalar_updates.items():
+            if v is not None:
+                setattr(row, k, v)
+        row.updated_at = datetime.datetime.now()
+
     try:
-        existing = _find_existing(
-            sess,
-            exp_id=exp_id,
-            dataset=dataset,
-            dataset_index=dataset_index,
-            model_name=model_name,
-            agent_type=agent_type,
-        )
+        existing = _find_existing(sess, **identity)
 
-        scalar_updates = {
-            "response": response,
-            "trace_id": trace_id,
-            "trace_url": trace_url,
-            "time_cost": time_cost,
-            "trajectories": trajectories,
-            "correct": correct,
-            "confidence": confidence,
-            "judged_response": judged_response,
-            "reasoning": reasoning,
-            "extracted_final_answer": extracted_final_answer,
-            "raw_question": raw_question,
-            "source": source,
-            "level": level,
-            "correct_answer": correct_answer,
-            "augmented_question": augmented_question,
-            "file_name": file_name,
-            "stage": stage,
-        }
-
-        if existing is None:
+        if existing is not None:
+            row = existing
+            _apply_update(row)
+        else:
             row = EvaluationSample(
-                exp_id=exp_id,
-                dataset=dataset,
-                dataset_index=dataset_index,
-                model_name=model_name,
-                agent_type=agent_type,
+                **identity,
                 eval_metrics=dict(eval_metrics) if eval_metrics else None,
                 meta=dict(meta) if meta else None,
             )
@@ -140,17 +156,21 @@ def upload_case_result(
                 if v is not None:
                     setattr(row, k, v)
             sess.add(row)
-            sess.flush()  # populate row.id for FK in rollout_stats
-        else:
-            row = existing
-            if eval_metrics:
-                row.eval_metrics = _shallow_merge(row.eval_metrics, eval_metrics)
-            if meta:
-                row.meta = _shallow_merge(row.meta, meta)
-            for k, v in scalar_updates.items():
-                if v is not None:
-                    setattr(row, k, v)
-            row.updated_at = datetime.datetime.now()
+            try:
+                sess.flush()  # populate row.id for FK in rollout_stats
+            except IntegrityError:
+                # Concurrent writer beat us between SELECT and INSERT — covered
+                # by the ux_eval_logical_id unique index. Recover only when we
+                # own the session; an externally-provided session may have other
+                # pending state that the caller needs to manage.
+                if not own_session:
+                    raise
+                sess.rollback()
+                existing = _find_existing(sess, **identity)
+                if existing is None:
+                    raise
+                row = existing
+                _apply_update(row)
 
         if rollout_stats:
             _upsert_rollout_stats(sess, row.id, rollout_stats)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/api.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/api.py
@@ -1,0 +1,339 @@
+"""Public SDK surface for uploading and reading per-case evaluation results.
+
+Designed for two writers:
+
+  - the SDK's own evaluator pipeline (`eval/processer/*`), which writes the full
+    `EvaluationResultV2.model_dump()` into ``eval_metrics`` after each judge run.
+  - downstream agents that run rollout/eval in environments without LLM-API
+    access; they partial-UPSERT only the axes they can compute.
+
+UPSERT keys on the logical identity ``(exp_id, dataset, dataset_index,
+model_name, agent_type)`` and is implemented as SELECT-then-update-or-insert
+in Python so SQLite and Postgres behave identically (no ``ON CONFLICT``
+dialect, no UNIQUE constraint required). ``eval_metrics`` and ``meta`` are
+shallow dict-merged on update; scalar fields follow "pass-to-update,
+None-to-keep".
+
+Aggregation runs in Python over the row set so no SQL JSON-path syntax
+leaks into the SDK — consumers that want a SQL view can build one in their
+own dialect outside the SDK.
+"""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Iterable
+from typing import Any
+
+from sqlmodel import Session, select
+
+from .db.eval_datapoint import EvaluationRolloutStats, EvaluationSample
+from .utils import SQLModelUtils, get_logger
+
+logger = get_logger(__name__)
+
+
+_IDENTITY_FIELDS = ("exp_id", "dataset", "dataset_index", "model_name", "agent_type")
+_ROLLOUT_STATS_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_hit_tokens",
+    "cache_write_tokens",
+    "n_llm_calls",
+)
+
+
+def upload_case_result(
+    *,
+    # identity (composite logical key)
+    exp_id: str,
+    dataset: str,
+    dataset_index: int,
+    model_name: str | None,
+    agent_type: str | None = None,
+    # rollout
+    response: str | None = None,
+    trace_id: str | None = None,
+    trace_url: str | None = None,
+    time_cost: float | None = None,
+    trajectories: Any | None = None,
+    # judgement
+    eval_metrics: dict[str, Any] | None = None,
+    correct: bool | None = None,
+    confidence: float | None = None,
+    judged_response: str | None = None,
+    reasoning: str | None = None,
+    extracted_final_answer: str | None = None,
+    # rollout stats (sibling table; same partial-update semantics)
+    rollout_stats: dict[str, Any] | None = None,
+    # base info / meta
+    raw_question: str | None = None,
+    source: str | None = None,
+    level: int | None = None,
+    correct_answer: str | None = None,
+    augmented_question: str | None = None,
+    file_name: str | None = None,
+    meta: dict[str, Any] | None = None,
+    stage: str | None = None,
+    # session control
+    session: Session | None = None,
+) -> int:
+    """UPSERT one EvaluationSample row.
+
+    Returns the row id (auto-PK).
+
+    ``eval_metrics`` and ``meta`` are shallow-merged when updating an existing
+    row (new keys overwrite, existing keys are preserved). Scalar fields are
+    only updated when the caller passes a non-None value, so partial uploads
+    don't clobber state set by another writer.
+
+    ``rollout_stats`` accepts a dict subset of {input_tokens, output_tokens,
+    cache_hit_tokens, cache_write_tokens, n_llm_calls}; populates / updates
+    the sibling ``evaluation_rollout_stats`` row keyed on the same id.
+
+    If ``session`` is provided, the caller owns transaction lifecycle.
+    Otherwise this opens a session and commits on success.
+    """
+    own_session = session is None
+    sess = session if session is not None else SQLModelUtils.create_session()
+    try:
+        existing = _find_existing(
+            sess,
+            exp_id=exp_id,
+            dataset=dataset,
+            dataset_index=dataset_index,
+            model_name=model_name,
+            agent_type=agent_type,
+        )
+
+        scalar_updates = {
+            "response": response,
+            "trace_id": trace_id,
+            "trace_url": trace_url,
+            "time_cost": time_cost,
+            "trajectories": trajectories,
+            "correct": correct,
+            "confidence": confidence,
+            "judged_response": judged_response,
+            "reasoning": reasoning,
+            "extracted_final_answer": extracted_final_answer,
+            "raw_question": raw_question,
+            "source": source,
+            "level": level,
+            "correct_answer": correct_answer,
+            "augmented_question": augmented_question,
+            "file_name": file_name,
+            "stage": stage,
+        }
+
+        if existing is None:
+            row = EvaluationSample(
+                exp_id=exp_id,
+                dataset=dataset,
+                dataset_index=dataset_index,
+                model_name=model_name,
+                agent_type=agent_type,
+                eval_metrics=dict(eval_metrics) if eval_metrics else None,
+                meta=dict(meta) if meta else None,
+            )
+            for k, v in scalar_updates.items():
+                if v is not None:
+                    setattr(row, k, v)
+            sess.add(row)
+            sess.flush()  # populate row.id for FK in rollout_stats
+        else:
+            row = existing
+            if eval_metrics:
+                row.eval_metrics = _shallow_merge(row.eval_metrics, eval_metrics)
+            if meta:
+                row.meta = _shallow_merge(row.meta, meta)
+            for k, v in scalar_updates.items():
+                if v is not None:
+                    setattr(row, k, v)
+            row.updated_at = datetime.datetime.now()
+
+        if rollout_stats:
+            _upsert_rollout_stats(sess, row.id, rollout_stats)
+
+        if own_session:
+            sess.commit()
+            sess.refresh(row)
+
+        assert row.id is not None
+        return row.id
+    except Exception:
+        if own_session:
+            sess.rollback()
+        raise
+    finally:
+        if own_session:
+            sess.close()
+
+
+def upload_case_results(rows: Iterable[dict[str, Any]]) -> list[int]:
+    """Batch UPSERT. All rows go in one transaction; failure rolls back the batch."""
+    ids: list[int] = []
+    with SQLModelUtils.create_session() as sess:
+        try:
+            for r in rows:
+                ids.append(upload_case_result(session=sess, **r))
+            sess.commit()
+        except Exception:
+            sess.rollback()
+            raise
+    return ids
+
+
+def list_experiment_cases(
+    exp_id: str,
+    *,
+    model_name: str | None = None,
+    agent_type: str | None = None,
+    stage: str | None = None,
+    session: Session | None = None,
+) -> list[EvaluationSample]:
+    """Read raw case rows for review tooling."""
+    own_session = session is None
+    sess = session if session is not None else SQLModelUtils.create_session()
+    try:
+        q = select(EvaluationSample).where(EvaluationSample.exp_id == exp_id)
+        if model_name is not None:
+            q = q.where(EvaluationSample.model_name == model_name)
+        if agent_type is not None:
+            q = q.where(EvaluationSample.agent_type == agent_type)
+        if stage is not None:
+            q = q.where(EvaluationSample.stage == stage)
+        return list(sess.exec(q).all())
+    finally:
+        if own_session:
+            sess.close()
+
+
+def aggregate_experiment_summary(
+    exp_id: str | None = None,
+    *,
+    session: Session | None = None,
+) -> list[dict[str, Any]]:
+    """(exp_id × model_name × agent_type) rollup over judged rows.
+
+    Aggregates in Python so the same code works on SQLite and Postgres
+    without SQL JSON-path syntax. For each numeric key present in
+    ``eval_metrics`` (booleans count as 0/1) returns ``avg_<key>`` over rows
+    where the key was non-null. Token / call counts from
+    ``evaluation_rollout_stats`` are summed under ``total_<field>``.
+    """
+    own_session = session is None
+    sess = session if session is not None else SQLModelUtils.create_session()
+    try:
+        q = select(EvaluationSample).where(EvaluationSample.stage == "judged")
+        if exp_id is not None:
+            q = q.where(EvaluationSample.exp_id == exp_id)
+        rows = list(sess.exec(q).all())
+
+        groups: dict[tuple[str, str | None, str | None], list[EvaluationSample]] = {}
+        for r in rows:
+            key = (r.exp_id, r.model_name, r.agent_type)
+            groups.setdefault(key, []).append(r)
+
+        all_ids = [r.id for r in rows if r.id is not None]
+        stats_by_id: dict[int, EvaluationRolloutStats] = {}
+        if all_ids:
+            stats_q = select(EvaluationRolloutStats).where(EvaluationRolloutStats.id.in_(all_ids))  # type: ignore[attr-defined]
+            for s in sess.exec(stats_q).all():
+                if s.id is not None:
+                    stats_by_id[s.id] = s
+
+        summaries: list[dict[str, Any]] = []
+        for (xid, model, agent), members in groups.items():
+            summary: dict[str, Any] = {
+                "exp_id": xid,
+                "model_name": model,
+                "agent_type": agent,
+                "n_cases": len(members),
+            }
+
+            metric_acc: dict[str, list[float]] = {}
+            for m in members:
+                em = m.eval_metrics
+                if not isinstance(em, dict):
+                    continue
+                for k, v in em.items():
+                    if isinstance(v, bool):
+                        metric_acc.setdefault(k, []).append(1.0 if v else 0.0)
+                    elif isinstance(v, (int, float)):
+                        metric_acc.setdefault(k, []).append(float(v))
+            for k, vals in metric_acc.items():
+                if vals:
+                    summary[f"avg_{k}"] = sum(vals) / len(vals)
+
+            for fld in _ROLLOUT_STATS_FIELDS:
+                total = 0
+                seen = False
+                for m in members:
+                    s = stats_by_id.get(m.id) if m.id is not None else None
+                    if s is None:
+                        continue
+                    val = getattr(s, fld, None)
+                    if val is not None:
+                        total += int(val)
+                        seen = True
+                if seen:
+                    summary[f"total_{fld}"] = total
+
+            summaries.append(summary)
+        return summaries
+    finally:
+        if own_session:
+            sess.close()
+
+
+# ── internals ─────────────────────────────────────────────────────────────
+
+
+def _find_existing(
+    sess: Session,
+    *,
+    exp_id: str,
+    dataset: str,
+    dataset_index: int,
+    model_name: str | None,
+    agent_type: str | None,
+) -> EvaluationSample | None:
+    q = (
+        select(EvaluationSample)
+        .where(EvaluationSample.exp_id == exp_id)
+        .where(EvaluationSample.dataset == dataset)
+        .where(EvaluationSample.dataset_index == dataset_index)
+    )
+    if model_name is None:
+        q = q.where(EvaluationSample.model_name.is_(None))  # type: ignore[union-attr]
+    else:
+        q = q.where(EvaluationSample.model_name == model_name)
+    if agent_type is None:
+        q = q.where(EvaluationSample.agent_type.is_(None))  # type: ignore[union-attr]
+    else:
+        q = q.where(EvaluationSample.agent_type == agent_type)
+    return sess.exec(q).first()
+
+
+def _shallow_merge(
+    existing: dict[str, Any] | None | Any,
+    incoming: dict[str, Any],
+) -> dict[str, Any]:
+    base: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+    base.update(incoming)
+    return base
+
+
+def _upsert_rollout_stats(sess: Session, row_id: int | None, fields: dict[str, Any]) -> None:
+    if row_id is None:
+        return
+    clean = {k: v for k, v in fields.items() if k in _ROLLOUT_STATS_FIELDS and v is not None}
+    if not clean:
+        return
+    existing = sess.get(EvaluationRolloutStats, row_id)
+    if existing is None:
+        sess.add(EvaluationRolloutStats(id=row_id, **clean))
+    else:
+        for k, v in clean.items():
+            setattr(existing, k, v)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/db/__init__.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/db/__init__.py
@@ -1,8 +1,9 @@
 from .db_service import DBService
-from .eval_datapoint import DatasetSample, EvaluationSample
+from .eval_datapoint import DatasetSample, EvaluationRolloutStats, EvaluationSample
 
 __all__ = [
     "DatasetSample",
     "EvaluationSample",
+    "EvaluationRolloutStats",
     "DBService",
 ]

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/db/eval_datapoint.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/db/eval_datapoint.py
@@ -56,6 +56,8 @@ class EvaluationSample(EvalBaseModel, SQLModel, table=True):
     reasoning: str | None = Field(default=None)
     correct: bool | None = Field(default=None)
     confidence: float | None = Field(default=None)
+    # v2 metrics namespace; v1 path leaves NULL. correct/confidence above retain v1 semantics.
+    eval_metrics: Any | None = Field(default=None, sa_column=Column(JSON))
     # id
     exp_id: str = Field(default="default", index=True)
     agent_type: str | None = Field(default=None, index=True)  # agent type: simple, orchestra, orchestrator, etc.
@@ -82,5 +84,23 @@ class EvaluationSample(EvalBaseModel, SQLModel, table=True):
             "judged_response",
             "correct",
             "confidence",
+            "eval_metrics",
         ]
         return {k: getattr(self, k) for k in keys if getattr(self, k) is not None}
+
+
+class EvaluationRolloutStats(SQLModel, table=True):
+    """Token / call-count telemetry for one rollout. 1:1 with EvaluationSample.
+
+    Lives in a sibling table because the writer is the agent runtime, not the
+    judge — different lifecycle from the metric columns on evaluation_data.
+    """
+
+    __tablename__: ClassVar[str] = "evaluation_rollout_stats"  # type: ignore[assignment]
+
+    id: int | None = Field(default=None, foreign_key="evaluation_data.id", primary_key=True)
+    input_tokens: int | None = Field(default=None)
+    output_tokens: int | None = Field(default=None)
+    cache_hit_tokens: int | None = Field(default=None)
+    cache_write_tokens: int | None = Field(default=None)
+    n_llm_calls: int | None = Field(default=None)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/dashboard.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/dashboard.py
@@ -17,6 +17,9 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
+from ..api import aggregate_experiment_summary
+from ..db.eval_datapoint import EvaluationSample
+from ..utils import SQLModelUtils
 from .tracker import EvalTracker
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
@@ -168,6 +171,38 @@ def create_eval_dashboard(
             if isinstance(service, list):
                 info["root_cause_services"] = [str(s) for s in service if str(s).strip()]
         return info
+
+    @app.get("/api/eval/experiments")
+    async def eval_experiments(exp_id: str | None = None) -> dict[str, Any]:
+        """Per-(exp_id × model_name × agent_type) rollup over judged rows."""
+        if not SQLModelUtils.check_db_available():
+            return {"summaries": [], "db_available": False}
+        summaries = aggregate_experiment_summary(exp_id=exp_id)
+        return {"summaries": summaries, "db_available": True}
+
+    @app.get("/api/eval/cases/{row_id}/metrics")
+    async def eval_case_metrics(row_id: int) -> dict[str, Any]:
+        """Per-case judged surface for review tooling, keyed by EvaluationSample.id."""
+        if not SQLModelUtils.check_db_available():
+            return {"error": "db unavailable"}
+        with SQLModelUtils.create_session() as sess:
+            row = sess.get(EvaluationSample, row_id)
+            if row is None:
+                return {"error": "not found"}
+            return {
+                "id": row.id,
+                "exp_id": row.exp_id,
+                "model_name": row.model_name,
+                "agent_type": row.agent_type,
+                "dataset": row.dataset,
+                "dataset_index": row.dataset_index,
+                "stage": row.stage,
+                "eval_metrics": row.eval_metrics,
+                "correct": row.correct,
+                "confidence": row.confidence,
+                "judged_response": row.judged_response,
+                "reasoning": row.reasoning,
+            }
 
     @app.get("/api/eval/samples/{sample_id}/events")
     async def eval_sample_events(sample_id: str, after: int = 0) -> dict[str, Any]:

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/rcabench.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/eval/processer/rcabench.py
@@ -131,11 +131,11 @@ class RCABenchProcesser(BaseMatchProcesser):
             sample.update(
                 correct=False,
                 confidence=0.0,
-                reasoning="missing case dir or injection.json",
+                reasoning=None,
                 judged_response=None,
+                eval_metrics={"error": "missing case dir or injection.json"},
+                meta=meta,
             )
-            meta["eval_v2"] = {"error": "missing case dir or injection.json"}
-            sample.update(meta=meta)
             return sample
 
         result: EvaluationResultV2 = await evaluate_v2(
@@ -148,25 +148,8 @@ class RCABenchProcesser(BaseMatchProcesser):
             case_name=sample.source,
         )
 
-        meta["eval_v2"] = result.model_dump(mode="json")
-
-        kind_str = f"{result.fault_kind_accuracy:.2f}" if result.fault_kind_accuracy is not None else "n/a"
-        ev_str = f"{result.evidence_support_rate:.2f}" if result.evidence_support_rate is not None else "n/a"
-        path_str = "n/a" if result.path_reachability is None else str(int(result.path_reachability))
-        reasoning_bits: list[str] = [
-            f"f1={result.f1:.2f} exact={int(result.exact_match)} "
-            f"kind_acc={kind_str} sql={result.sql_executable_rate:.2f} "
-            f"ev_support={ev_str} path={path_str} "
-            f"node_f1={result.node_f1:.2f} edge_f1={result.edge_f1:.2f}"
-        ]
-        if result.parse_error:
-            reasoning_bits.append(f"parse_error={result.parse_error}")
-        if result.n_evidence_judge_failed:
-            reasoning_bits.append(f"judge_failed={result.n_evidence_judge_failed}/{result.n_evidence}")
-
-        # Surface per-evidence judge reasoning lines on `judged_response` so
-        # the dashboard can render them alongside the agent response. One
-        # line per evidence keeps the diff readable for cases with many.
+        # Per-evidence judge prose lives on `judged_response`; one line per
+        # evidence keeps it readable for cases with many.
         judge_lines: list[str] = []
         for rec in result.per_evidence:
             if rec.supported is None and not rec.judge_reasoning:
@@ -179,8 +162,9 @@ class RCABenchProcesser(BaseMatchProcesser):
             judged_response=judged_response,
             correct=result.exact_match,
             confidence=result.f1,
-            reasoning=" | ".join(reasoning_bits),
+            reasoning=None,
             extracted_final_answer=None,
+            eval_metrics=result.model_dump(mode="json"),
             meta=meta,
         )
         return sample
@@ -264,9 +248,10 @@ class RCABenchProcesser(BaseMatchProcesser):
         judge_failed_evidences = 0
 
         for s in samples:
-            if not isinstance(s.meta, dict):
-                continue
-            ev = s.meta.get("eval_v2")
+            ev = s.eval_metrics
+            if not isinstance(ev, dict):
+                # Pre-eval_metrics rows: fall back to legacy meta["eval_v2"] location.
+                ev = s.meta.get("eval_v2") if isinstance(s.meta, dict) else None
             if not isinstance(ev, dict) or "error" in ev:
                 continue
             scored += 1

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/utils/sqlmodel_utils.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/utils/sqlmodel_utils.py
@@ -116,6 +116,8 @@ class SQLModelUtils:
             ("data", "tags", "JSON"),
             # Add tags column to evaluation_data table
             ("evaluation_data", "tags", "JSON"),
+            # v2 metrics namespace
+            ("evaluation_data", "eval_metrics", "JSON"),
         ]
 
         # Index migrations: (index_name, create_sql)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/utils/sqlmodel_utils.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/llm_eval/utils/sqlmodel_utils.py
@@ -122,10 +122,17 @@ class SQLModelUtils:
 
         # Index migrations: (index_name, create_sql)
         _t = "evaluation_data"
+        # COALESCE columns: SQLite/Postgres treat NULL as distinct in unique indexes,
+        # which would let two writers both insert when model_name/agent_type is NULL.
         index_migrations = [
             ("ix_eval_exp_id", f"CREATE INDEX IF NOT EXISTS ix_eval_exp_id ON {_t} (exp_id)"),
             ("ix_eval_stage", f"CREATE INDEX IF NOT EXISTS ix_eval_stage ON {_t} (stage)"),
             ("ix_eval_exp_stage", f"CREATE INDEX IF NOT EXISTS ix_eval_exp_stage ON {_t} (exp_id, stage)"),
+            (
+                "ux_eval_logical_id",
+                f"CREATE UNIQUE INDEX IF NOT EXISTS ux_eval_logical_id ON {_t} "
+                f"(exp_id, dataset, dataset_index, COALESCE(model_name, ''), COALESCE(agent_type, ''))",
+            ),
         ]
 
         with engine.connect() as conn:

--- a/rcabench-platform/uv.lock
+++ b/rcabench-platform/uv.lock
@@ -3654,7 +3654,7 @@ wheels = [
 
 [[package]]
 name = "rcabench-platform"
-version = "0.4.40"
+version = "0.4.41"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Closes #386.

## Summary

Stops spilling `EvaluationResultV2` into `meta['eval_v2']` and gives downstream agents (which run rollout/eval in environments without LLM-API access) a typed entry point to UPSERT partial case results. Aligns with the converged design discussed on the issue: one JSON column instead of 16 typed ones, Python-side aggregation instead of a dialect-bound SQL view, partial-write API instead of forcing every consumer to roll its own.

## Changes

### Schema (cross-engine; SQLite + Postgres)

- **`eval_metrics: JSON`** on `evaluation_data` — evaluator-owned namespace; `EvaluationResultV2.model_dump()` lands here whole. Added via existing `_run_migrations` (idempotent).
- **`evaluation_rollout_stats`** sibling table (`id` FK to `evaluation_data.id` + `input_tokens` / `output_tokens` / `cache_hit_tokens` / `cache_write_tokens` / `n_llm_calls`). Different writer (agent runtime, not the judge) and lifecycle, so it doesn't belong on `EvaluationSample`.

### SDK API (`rcabench_platform.v3.sdk.llm_eval.api`, exported from package root)

```python
upload_case_result(*, exp_id, dataset, dataset_index, model_name, agent_type=None,
                   eval_metrics=None, rollout_stats=None, meta=None, ...) -> int
upload_case_results(rows: Iterable[dict]) -> list[int]
list_experiment_cases(exp_id, *, model_name=None, agent_type=None, stage=None) -> list[EvaluationSample]
aggregate_experiment_summary(exp_id=None) -> list[dict]
```

- UPSERT keyed on `(exp_id, dataset, dataset_index, model_name, agent_type)` via SELECT-then-update-or-insert. No `ON CONFLICT` dialect, no UNIQUE constraint — SQLite and Postgres behave identically.
- `eval_metrics` and `meta` are shallow dict-merged on update so partial writers don't clobber each other. Scalar fields follow "pass-to-update, None-to-keep".
- `aggregate_experiment_summary` rolls up `(exp_id × model_name × agent_type)` in Python. Numeric metric keys → `avg_<key>` (booleans count as 0/1); rollout stats → `total_<field>` only when present (no fake zeros).
- Auth = existing `LLM_EVAL_DB_URL` / `UTU_DB_URL`. No new config surface.

### `RCABenchProcesser` cleanup

- `judge_one` writes `eval_metrics=result.model_dump(...)` directly; stops packing metric tags into `reasoning`. The redundant one-line tag string is gone — `reasoning` reverts to its v1 meaning (judge prose; v2 path leaves it NULL since per-evidence prose lives on `judged_response`).
- `calculate_metrics` reads `eval_metrics` first and falls back to legacy `meta['eval_v2']` for rows written by older SDK builds. Backward compatible.

### Dashboard

- `eval/dashboard.py` gets two read-only endpoints; **zero JS changes** (the existing real-time tracker UI doesn't query `evaluation_data`):
  - `GET /api/eval/experiments[?exp_id=…]` → aggregate summaries
  - `GET /api/eval/cases/{row_id}/metrics` → per-case judged surface
- Endpoint sits under `/cases/` rather than `/samples/` to avoid collision with the existing `/api/eval/samples/{tracker_sample_id}` namespace (which uses the in-memory `EvalTracker` string id, not the DB integer id).

## Test plan

- [x] `uv run ruff check` / `uv run ruff format --check` clean on all touched files
- [x] `uv run pyright` clean on all touched files
- [x] `uv run pytest` — **479/479 pass**. `test_calculate_metrics_aggregation` updated: 4 of 5 stubs use `eval_metrics`, 1 uses legacy `meta['eval_v2']` so the backward-compat fallback is exercised.
- [x] End-to-end smoke test against file-backed SQLite:
  - engine init → `_run_migrations` adds `eval_metrics` column cleanly
  - composite-key UPSERT hits the same row on second call
  - shallow-merge preserves earlier `eval_metrics` keys across partial writes
  - bool `exact_match` aggregates as 0/1
  - rollout stats omitted when no row in sibling table (no fake zeros)
  - re-init is idempotent
- [ ] Reviewer to verify against a Postgres DB (not part of CI here)

## Out of scope (separate PRs as discussed on the issue)

- UI consumers for the new endpoints (Metrics tab on case detail, Experiments page).
- `EvalTracker.register_sample` accepting `exp_id` / `model_name` so the live tracker can bridge to DB rows by composite key.
- `correct` / `confidence` resolved-property option (B); kept as option (A) — docstring update only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)