### PR TITLE
feat(execution): compare endpoint + LLM eval schema mirror (#389 L4)

### DIFF
--- a/AegisLab/src/app/http_modules_gen.go
+++ b/AegisLab/src/app/http_modules_gen.go
@@ -11,6 +11,7 @@ import (
 	group "aegis/module/group"
 	injection "aegis/module/injection"
 	label "aegis/module/label"
+	llmeval "aegis/module/llmeval"
 	metric "aegis/module/metric"
 	notification "aegis/module/notification"
 	pedestal "aegis/module/pedestal"
@@ -40,6 +41,7 @@ func producerHTTPModules() []fx.Option {
 		group.Module,
 		injection.Module,
 		label.Module,
+		llmeval.Module,
 		metric.Module,
 		notification.Module,
 		pedestal.Module,
@@ -69,6 +71,7 @@ func producerHTTPModuleNames() []string {
 		"group",
 		"injection",
 		"label",
+		"llmeval",
 		"metric",
 		"notification",
 		"pedestal",

--- a/AegisLab/src/go.mod
+++ b/AegisLab/src/go.mod
@@ -182,7 +182,7 @@ require (
 	github.com/in-toto/in-toto-golang v0.10.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
+	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
 	github.com/jackc/pgx/v5 v5.5.5 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
@@ -292,6 +292,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gorm.io/datatypes v1.2.7 // indirect
 	gorm.io/driver/clickhouse v0.7.0 // indirect
 	gorm.io/driver/postgres v1.5.11 // indirect
 	gotest.tools/v3 v3.5.1 // indirect

--- a/AegisLab/src/go.sum
+++ b/AegisLab/src/go.sum
@@ -378,6 +378,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 h1:L0QtFUgDarD7Fpv9jeVMgy/+Ec0mtnmYuImjTz6dtDA=
+github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgx/v5 v5.5.5 h1:amBjrZVmksIdNjxGW/IiIMzxMKZFelXbUoPNb+8sjQw=
 github.com/jackc/pgx/v5 v5.5.5/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
@@ -884,6 +886,8 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/datatypes v1.2.7 h1:ww9GAhF1aGXZY3EB3cJPJ7//JiuQo7DlQA7NNlVaTdk=
+gorm.io/datatypes v1.2.7/go.mod h1:M2iO+6S3hhi4nAyYe444Pcb0dcIiOMJ7QHaUXxyiNZY=
 gorm.io/driver/clickhouse v0.7.0 h1:BCrqvgONayvZRgtuA6hdya+eAW5P2QVagV3OlEp1vtA=
 gorm.io/driver/clickhouse v0.7.0/go.mod h1:TmNo0wcVTsD4BBObiRnCahUgHJHjBIwuRejHwYt3JRs=
 gorm.io/driver/mysql v1.6.0 h1:eNbLmNTpPpTOVZi8MMxCi2aaIm0ZpInbORNXDwyLGvg=

--- a/AegisLab/src/model/entity.go
+++ b/AegisLab/src/model/entity.go
@@ -8,6 +8,7 @@ import (
 	"aegis/utils"
 
 	chaos "github.com/OperationsPAI/chaos-experiment/handler"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -932,4 +933,72 @@ type UserPermission struct {
 	Container  *Container  `gorm:"foreignKey:ContainerID"`
 	Dataset    *Dataset    `gorm:"foreignKey:DatasetID"`
 	Project    *Project    `gorm:"foreignKey:ProjectID"`
+}
+
+// =====================================================================
+// LLM evaluation (mirrored from rcabench-platform/llm_eval)
+// =====================================================================
+
+// EvaluationSample mirrors rcabench_platform.v3.sdk.llm_eval.db.eval_datapoint.EvaluationSample
+// (table `evaluation_data`). Written by the Python LLM-eval pipeline; the Go
+// side currently only owns the schema/migration.
+type EvaluationSample struct {
+	ID        int       `gorm:"primaryKey;autoIncrement"`
+	CreatedAt time.Time `gorm:"autoCreateTime"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime"`
+
+	// base info
+	Dataset           string         `gorm:"column:dataset;not null;default:''"`
+	DatasetIndex      *int           `gorm:"column:dataset_index"`
+	Source            string         `gorm:"column:source;not null;default:''"`
+	RawQuestion       string         `gorm:"column:raw_question;type:text"`
+	Level             *int           `gorm:"column:level"`
+	AugmentedQuestion string         `gorm:"column:augmented_question;type:text"`
+	CorrectAnswer     string         `gorm:"column:correct_answer;type:text"`
+	FileName          string         `gorm:"column:file_name"`
+	Meta              datatypes.JSON `gorm:"column:meta"`
+
+	// rollout
+	TraceID      *string        `gorm:"column:trace_id"`
+	TraceURL     *string        `gorm:"column:trace_url"`
+	Response     string         `gorm:"column:response;type:text"`
+	TimeCost     *float64       `gorm:"column:time_cost"`
+	Trajectories datatypes.JSON `gorm:"column:trajectories"`
+
+	// judgement
+	ExtractedFinalAnswer string   `gorm:"column:extracted_final_answer;type:text"`
+	JudgedResponse       string   `gorm:"column:judged_response;type:text"`
+	Reasoning            string   `gorm:"column:reasoning;type:text"`
+	Correct              *bool    `gorm:"column:correct"`
+	Confidence           *float64 `gorm:"column:confidence"`
+
+	// v2 metrics
+	EvalMetrics datatypes.JSON `gorm:"column:eval_metrics"`
+
+	// identifiers
+	ExpID     string  `gorm:"column:exp_id;not null;default:'default';index"`
+	AgentType *string `gorm:"column:agent_type;index"`
+	ModelName *string `gorm:"column:model_name;index"`
+	Stage     string  `gorm:"column:stage;not null;default:'init';index"`
+}
+
+func (EvaluationSample) TableName() string {
+	return "evaluation_data"
+}
+
+// EvaluationRolloutStats mirrors rcabench_platform.v3.sdk.llm_eval.db.eval_datapoint.EvaluationRolloutStats
+// (table `evaluation_rollout_stats`). 1:1 with EvaluationSample via shared PK.
+type EvaluationRolloutStats struct {
+	ID               int  `gorm:"column:id;primaryKey"`
+	InputTokens      *int `gorm:"column:input_tokens"`
+	OutputTokens     *int `gorm:"column:output_tokens"`
+	CacheHitTokens   *int `gorm:"column:cache_hit_tokens"`
+	CacheWriteTokens *int `gorm:"column:cache_write_tokens"`
+	NLLMCalls        *int `gorm:"column:n_llm_calls"`
+
+	Sample *EvaluationSample `gorm:"foreignKey:ID;references:ID"`
+}
+
+func (EvaluationRolloutStats) TableName() string {
+	return "evaluation_rollout_stats"
 }

--- a/AegisLab/src/module/execution/api_types.go
+++ b/AegisLab/src/module/execution/api_types.go
@@ -290,6 +290,66 @@ func NewExecutionDetailResp(execution *model.Execution, labels []model.Label) *E
 	}
 }
 
+const compareExecutionsMaxIDs = 50
+
+type CompareExecutionsInclude string
+
+const (
+	CompareIncludeDetectorResults    CompareExecutionsInclude = "detector_results"
+	CompareIncludeGranularityResults CompareExecutionsInclude = "granularity_results"
+)
+
+type CompareExecutionsRequest struct {
+	ExecutionIDs []int                      `json:"execution_ids"`
+	Include      []CompareExecutionsInclude `json:"include"`
+}
+
+func (req *CompareExecutionsRequest) Validate() error {
+	if len(req.ExecutionIDs) == 0 {
+		return fmt.Errorf("execution_ids must not be empty")
+	}
+	if len(req.ExecutionIDs) > compareExecutionsMaxIDs {
+		return fmt.Errorf("execution_ids exceeds maximum of %d", compareExecutionsMaxIDs)
+	}
+	seen := make(map[int]struct{}, len(req.ExecutionIDs))
+	for i, id := range req.ExecutionIDs {
+		if id <= 0 {
+			return fmt.Errorf("invalid execution_id at index %d: %d", i, id)
+		}
+		if _, dup := seen[id]; dup {
+			return fmt.Errorf("duplicate execution_id at index %d: %d", i, id)
+		}
+		seen[id] = struct{}{}
+	}
+	for i, inc := range req.Include {
+		switch inc {
+		case CompareIncludeDetectorResults, CompareIncludeGranularityResults:
+		default:
+			return fmt.Errorf("invalid include[%d]: %q", i, inc)
+		}
+	}
+	return nil
+}
+
+func (req *CompareExecutionsRequest) Normalize() {
+	if len(req.Include) == 0 {
+		req.Include = []CompareExecutionsInclude{
+			CompareIncludeDetectorResults,
+			CompareIncludeGranularityResults,
+		}
+	}
+}
+
+type CompareExecutionItem struct {
+	ExecutionResp
+	DetectorResults    []DetectorResultItem    `json:"detector_results,omitempty"`
+	GranularityResults []GranularityResultItem `json:"granularity_results,omitempty"`
+}
+
+type CompareExecutionsResponse struct {
+	Results map[string]CompareExecutionItem `json:"results"`
+}
+
 // SubmitExecutionItem describes a single submitted execution task.
 type SubmitExecutionItem struct {
 	Index              int    `json:"index"`

--- a/AegisLab/src/module/execution/handler.go
+++ b/AegisLab/src/module/execution/handler.go
@@ -249,6 +249,42 @@ func (h *Handler) BatchDeleteExecutions(c *gin.Context) {
 	dto.JSONResponse[any](c, http.StatusNoContent, "Executions deleted successfully", nil)
 }
 
+// CompareExecutions returns a per-execution subset for cross-execution comparison.
+//
+//	@Summary		Compare executions
+//	@Description	Return a subset of execution details for the requested IDs, suitable for cross-execution comparison views
+//	@Tags			Executions
+//	@ID				compare_executions
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			request	body		CompareExecutionsRequest					true	"Compare request"
+//	@Success		200		{object}	dto.GenericResponse[CompareExecutionsResponse]	"Comparison results"
+//	@Failure		400		{object}	dto.GenericResponse[any]					"Invalid request"
+//	@Failure		401		{object}	dto.GenericResponse[any]					"Authentication required"
+//	@Failure		403		{object}	dto.GenericResponse[any]					"Permission denied"
+//	@Failure		404		{object}	dto.GenericResponse[any]					"Execution not found"
+//	@Failure		500		{object}	dto.GenericResponse[any]					"Internal server error"
+//	@Router			/api/v2/executions/compare [post]
+//	@x-api-type		{"sdk":"true"}
+func (h *Handler) CompareExecutions(c *gin.Context) {
+	var req CompareExecutionsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		dto.ErrorResponse(c, http.StatusBadRequest, "Invalid request format: "+err.Error())
+		return
+	}
+	req.Normalize()
+	if err := req.Validate(); err != nil {
+		dto.ErrorResponse(c, http.StatusBadRequest, "Validation failed: "+err.Error())
+		return
+	}
+	resp, err := h.service.CompareExecutions(c.Request.Context(), &req)
+	if httpx.HandleServiceError(c, err) {
+		return
+	}
+	dto.SuccessResponse(c, resp)
+}
+
 // UploadDetectorResults uploads detector results
 //
 //	@Summary		Upload detector results

--- a/AegisLab/src/module/execution/handler.go
+++ b/AegisLab/src/module/execution/handler.go
@@ -266,7 +266,7 @@ func (h *Handler) BatchDeleteExecutions(c *gin.Context) {
 //	@Failure		404		{object}	dto.GenericResponse[any]					"Execution not found"
 //	@Failure		500		{object}	dto.GenericResponse[any]					"Internal server error"
 //	@Router			/api/v2/executions/compare [post]
-//	@x-api-type		{"sdk":"true"}
+//	@x-api-type		{"portal":"true","sdk":"true"}
 func (h *Handler) CompareExecutions(c *gin.Context) {
 	var req CompareExecutionsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/AegisLab/src/module/execution/handler_service.go
+++ b/AegisLab/src/module/execution/handler_service.go
@@ -17,6 +17,7 @@ type HandlerService interface {
 	BatchDelete(context.Context, *BatchDeleteExecutionReq) error
 	UploadDetectorResults(context.Context, *UploadDetectorResultReq, int) (*UploadExecutionResultResp, error)
 	UploadGranularityResults(context.Context, *UploadGranularityResultReq, int) (*UploadExecutionResultResp, error)
+	CompareExecutions(context.Context, *CompareExecutionsRequest) (*CompareExecutionsResponse, error)
 }
 
 func AsHandlerService(service *Service) HandlerService {

--- a/AegisLab/src/module/execution/routes.go
+++ b/AegisLab/src/module/execution/routes.go
@@ -16,6 +16,7 @@ func RoutesPortal(handler *Handler) framework.RouteRegistrar {
 			{
 				executions.GET("/labels", middleware.RequireAPIKeyScopesAny("sdk:*", "sdk:executions:*", "sdk:executions:read"), handler.ListAvailableExecutionLabels)
 				executions.POST("/batch-delete", handler.BatchDeleteExecutions)
+				executions.POST("/compare", handler.CompareExecutions)
 			}
 		},
 	}

--- a/AegisLab/src/module/execution/service.go
+++ b/AegisLab/src/module/execution/service.go
@@ -196,6 +196,35 @@ func (s *Service) GetExecution(_ context.Context, id int) (*ExecutionDetailResp,
 	return resp, nil
 }
 
+func (s *Service) CompareExecutions(ctx context.Context, req *CompareExecutionsRequest) (*CompareExecutionsResponse, error) {
+	results := make(map[string]CompareExecutionItem, len(req.ExecutionIDs))
+	includeDetector := false
+	includeGranularity := false
+	for _, inc := range req.Include {
+		switch inc {
+		case CompareIncludeDetectorResults:
+			includeDetector = true
+		case CompareIncludeGranularityResults:
+			includeGranularity = true
+		}
+	}
+	for _, id := range req.ExecutionIDs {
+		detail, err := s.GetExecution(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		item := CompareExecutionItem{ExecutionResp: detail.ExecutionResp}
+		if includeDetector {
+			item.DetectorResults = detail.DetectorResults
+		}
+		if includeGranularity {
+			item.GranularityResults = detail.GranularityResults
+		}
+		results[fmt.Sprintf("%d", id)] = item
+	}
+	return &CompareExecutionsResponse{Results: results}, nil
+}
+
 func (s *Service) ListEvaluationExecutionsByDatapack(_ context.Context, req *EvaluationExecutionsByDatapackReq) ([]EvaluationExecutionItem, error) {
 	if req == nil {
 		return nil, fmt.Errorf("evaluation datapack query is nil")

--- a/AegisLab/src/module/llmeval/migrations.go
+++ b/AegisLab/src/module/llmeval/migrations.go
@@ -1,0 +1,16 @@
+package llmeval
+
+import (
+	"aegis/framework"
+	"aegis/model"
+)
+
+func Migrations() framework.MigrationRegistrar {
+	return framework.MigrationRegistrar{
+		Module: "llmeval",
+		Entities: []interface{}{
+			&model.EvaluationSample{},
+			&model.EvaluationRolloutStats{},
+		},
+	}
+}

--- a/AegisLab/src/module/llmeval/module.go
+++ b/AegisLab/src/module/llmeval/module.go
@@ -1,0 +1,9 @@
+package llmeval
+
+import "go.uber.org/fx"
+
+var Module = fx.Module("llmeval",
+	fx.Provide(
+		fx.Annotate(Migrations, fx.ResultTags(`group:"migrations"`)),
+	),
+)


### PR DESCRIPTION
## Summary

Two adjacent changes to support the experiment-observation page (umbrella #389):

1. **LLM eval schema mirror** — adds `evaluation_data` and `evaluation_rollout_stats` tables (mirrored from `rcabench-platform`). Aegis `FaultInjection` corresponds to rcabench-platform's `data` table; only the eval-side tables are mirrored. Go side remains for ML/RCA algorithms; eval data is for downstream LLM-eval consumers writing to the same DB.
2. **L4** `POST /executions/compare` — returns a per-execution subset for cross-execution comparison views (CompareSeries / PivotTable / MetricGrid components).

## Test plan

- [x] `go build -tags duckdb_arrow` clean
- [x] `golangci-lint run` clean
- [x] Octopus merge with sibling streams (#observation-injection-stream, #observation-observation-module) — no conflicts, builds clean
- [x] Schema migration auto-creates on boot (gorm AutoMigrate)
- [ ] Curl smoke against running server (pending CI)
- [ ] SDK regen (`make generate-typescript-sdk`) — out of scope, follow-up

Refs #389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)