### PR TITLE
feat(observation): metrics, spans, service-map endpoints (#389 L2/L3)

### DIFF
--- a/AegisLab/src/app/http_modules_gen.go
+++ b/AegisLab/src/app/http_modules_gen.go
@@ -13,6 +13,7 @@ import (
 	label "aegis/module/label"
 	metric "aegis/module/metric"
 	notification "aegis/module/notification"
+	observation "aegis/module/observation"
 	pedestal "aegis/module/pedestal"
 	project "aegis/module/project"
 	ratelimiter "aegis/module/ratelimiter"
@@ -42,6 +43,7 @@ func producerHTTPModules() []fx.Option {
 		label.Module,
 		metric.Module,
 		notification.Module,
+		observation.Module,
 		pedestal.Module,
 		project.Module,
 		ratelimiter.Module,
@@ -71,6 +73,7 @@ func producerHTTPModuleNames() []string {
 		"label",
 		"metric",
 		"notification",
+		"observation",
 		"pedestal",
 		"project",
 		"ratelimiter",

--- a/AegisLab/src/module/injection/client.go
+++ b/AegisLab/src/module/injection/client.go
@@ -11,6 +11,7 @@ import (
 // Reader exposes the injection-owned reads that other modules depend on.
 type Reader interface {
 	ResolveDatapacks(datapackName *string, datasetRef *dto.DatasetRef, userID int, taskType consts.TaskType) ([]model.FaultInjection, *int, error)
+	GetReadyDatapackName(ctx context.Context, id int) (string, error)
 }
 
 // Writer exposes the injection-owned runtime writes that consumer code depends on.

--- a/AegisLab/src/module/injection/service.go
+++ b/AegisLab/src/module/injection/service.go
@@ -1205,6 +1205,14 @@ func (s *Service) getReadyDatapack(id int) (*model.FaultInjection, error) {
 	return injection, nil
 }
 
+func (s *Service) GetReadyDatapackName(_ context.Context, id int) (string, error) {
+	injection, err := s.getReadyDatapack(id)
+	if err != nil {
+		return "", err
+	}
+	return injection.Name, nil
+}
+
 func (s *Service) batchDeleteByIDs(injectionIDs []int) error {
 	if len(injectionIDs) == 0 {
 		return nil

--- a/AegisLab/src/module/observation/api_types.go
+++ b/AegisLab/src/module/observation/api_types.go
@@ -1,0 +1,114 @@
+package observation
+
+// MetricsCatalogResp is the response for GET /injections/:id/metrics/catalog.
+type MetricsCatalogResp struct {
+	Metrics []MetricCatalogItem `json:"metrics"`
+}
+
+type MetricCatalogItem struct {
+	Name        string    `json:"name"`
+	Unit        string    `json:"unit,omitempty"`
+	Description string    `json:"description,omitempty"`
+	Dimensions  []string  `json:"dimensions"`
+	Quantiles   []float64 `json:"quantiles,omitempty"`
+}
+
+// MetricsSeriesReq captures the query parameters for GET /injections/:id/metrics/series.
+type MetricsSeriesReq struct {
+	Metric  string `form:"metric" binding:"required"`
+	Start   string `form:"start"`
+	End     string `form:"end"`
+	Step    string `form:"step"`
+	GroupBy string `form:"group_by"`
+	Filter  string `form:"filter"`
+}
+
+type MetricsSeriesResp struct {
+	Series []MetricSeries `json:"series"`
+	Step   string         `json:"step"`
+}
+
+type MetricSeries struct {
+	Labels map[string]string `json:"labels"`
+	Points []MetricPoint     `json:"points"`
+}
+
+type MetricPoint struct {
+	TS    string  `json:"ts"`
+	Value float64 `json:"value"`
+}
+
+// ListSpansReq captures GET /injections/:id/spans query parameters.
+type ListSpansReq struct {
+	Service     string `form:"service"`
+	Op          string `form:"op"`
+	MinDuration int64  `form:"min_duration"`
+	Start       string `form:"start"`
+	End         string `form:"end"`
+	Status      string `form:"status"`
+	Limit       int    `form:"limit"`
+	Cursor      string `form:"cursor"`
+}
+
+type ListSpansResp struct {
+	Spans      []SpanSummary `json:"spans"`
+	NextCursor string        `json:"next_cursor,omitempty"`
+}
+
+type SpanSummary struct {
+	TraceID     string `json:"trace_id"`
+	RootService string `json:"root_service"`
+	RootOp      string `json:"root_op"`
+	StartTS     string `json:"start_ts"`
+	DurationNS  int64  `json:"duration_ns"`
+	Status      string `json:"status"`
+	ErrorCount  int64  `json:"error_count"`
+}
+
+// SpanTreeResp is the response for GET /injections/:id/spans/:trace_id.
+type SpanTreeResp struct {
+	Spans []SpanNode `json:"spans"`
+}
+
+type SpanNode struct {
+	SpanID   string                 `json:"span_id"`
+	ParentID string                 `json:"parent_id"`
+	Service  string                 `json:"service"`
+	Op       string                 `json:"op"`
+	StartTS  string                 `json:"start_ts"`
+	EndTS    string                 `json:"end_ts"`
+	Attrs    map[string]interface{} `json:"attrs,omitempty"`
+	Events   []SpanEvent            `json:"events,omitempty"`
+	Status   string                 `json:"status"`
+}
+
+type SpanEvent struct {
+	TS         string                 `json:"ts"`
+	Name       string                 `json:"name"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+}
+
+// ServiceMapReq captures GET /injections/:id/service-map query parameters.
+type ServiceMapReq struct {
+	Window string `form:"window"`
+}
+
+type ServiceMapResp struct {
+	Nodes []ServiceMapNode `json:"nodes"`
+	Edges []ServiceMapEdge `json:"edges"`
+}
+
+type ServiceMapNode struct {
+	Service   string  `json:"service"`
+	SpanCount int64   `json:"span_count"`
+	ErrorRate float64 `json:"error_rate"`
+}
+
+type ServiceMapEdge struct {
+	From      string  `json:"from"`
+	To        string  `json:"to"`
+	CallCount int64   `json:"call_count"`
+	ErrorRate float64 `json:"error_rate"`
+	P50MS     float64 `json:"p50_ms"`
+	P99MS     float64 `json:"p99_ms"`
+}

--- a/AegisLab/src/module/observation/handler.go
+++ b/AegisLab/src/module/observation/handler.go
@@ -38,7 +38,7 @@ func parsePositiveID(c *gin.Context, key, label string) (int, bool) {
 //	@Failure		404	{object}	dto.GenericResponse[any]				"Datapack not found or not ready"
 //	@Failure		500	{object}	dto.GenericResponse[any]				"Internal server error"
 //	@Router			/api/v2/injections/{id}/metrics/catalog [get]
-//	@x-api-type		{"sdk":"true"}
+//	@x-api-type		{"portal":"true","sdk":"true"}
 func (h *Handler) GetMetricsCatalog(c *gin.Context) {
 	id, ok := parsePositiveID(c, consts.URLPathID, "injection ID")
 	if !ok {
@@ -73,7 +73,7 @@ func (h *Handler) GetMetricsCatalog(c *gin.Context) {
 //	@Failure		404			{object}	dto.GenericResponse[any]				"Datapack not found or not ready"
 //	@Failure		500			{object}	dto.GenericResponse[any]				"Internal server error"
 //	@Router			/api/v2/injections/{id}/metrics/series [get]
-//	@x-api-type		{"sdk":"true"}
+//	@x-api-type		{"portal":"true","sdk":"true"}
 func (h *Handler) GetMetricsSeries(c *gin.Context) {
 	id, ok := parsePositiveID(c, consts.URLPathID, "injection ID")
 	if !ok {
@@ -115,7 +115,7 @@ func (h *Handler) GetMetricsSeries(c *gin.Context) {
 //	@Failure		404				{object}	dto.GenericResponse[any]			"Datapack not found or not ready"
 //	@Failure		500				{object}	dto.GenericResponse[any]			"Internal server error"
 //	@Router			/api/v2/injections/{id}/spans [get]
-//	@x-api-type		{"sdk":"true"}
+//	@x-api-type		{"portal":"true","sdk":"true"}
 func (h *Handler) ListSpans(c *gin.Context) {
 	id, ok := parsePositiveID(c, consts.URLPathID, "injection ID")
 	if !ok {
@@ -150,7 +150,7 @@ func (h *Handler) ListSpans(c *gin.Context) {
 //	@Failure		404			{object}	dto.GenericResponse[any]			"Datapack not found or trace not found"
 //	@Failure		500			{object}	dto.GenericResponse[any]			"Internal server error"
 //	@Router			/api/v2/injections/{id}/spans/{trace_id} [get]
-//	@x-api-type		{"sdk":"true"}
+//	@x-api-type		{"portal":"true","sdk":"true"}
 func (h *Handler) GetSpanTree(c *gin.Context) {
 	id, ok := parsePositiveID(c, consts.URLPathID, "injection ID")
 	if !ok {
@@ -185,7 +185,7 @@ func (h *Handler) GetSpanTree(c *gin.Context) {
 //	@Failure		404		{object}	dto.GenericResponse[any]			"Datapack not found or not ready"
 //	@Failure		500		{object}	dto.GenericResponse[any]			"Internal server error"
 //	@Router			/api/v2/injections/{id}/service-map [get]
-//	@x-api-type		{"sdk":"true"}
+//	@x-api-type		{"portal":"true","sdk":"true"}
 func (h *Handler) GetServiceMap(c *gin.Context) {
 	id, ok := parsePositiveID(c, consts.URLPathID, "injection ID")
 	if !ok {

--- a/AegisLab/src/module/observation/handler.go
+++ b/AegisLab/src/module/observation/handler.go
@@ -1,0 +1,204 @@
+package observation
+
+import (
+	"net/http"
+
+	"aegis/consts"
+	"aegis/dto"
+	"aegis/httpx"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Handler struct {
+	service HandlerService
+}
+
+func NewHandler(service HandlerService) *Handler {
+	return &Handler{service: service}
+}
+
+func parsePositiveID(c *gin.Context, key, label string) (int, bool) {
+	return httpx.ParsePositiveID(c, c.Param(key), label)
+}
+
+// GetMetricsCatalog returns the discoverable metric catalog of an injection's datapack.
+//
+//	@Summary		Get metrics catalog
+//	@Description	Discover available metrics in the injection's datapack
+//	@Tags			Observation
+//	@ID				get_observation_metrics_catalog
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id	path		int										true	"Injection ID"
+//	@Success		200	{object}	dto.GenericResponse[MetricsCatalogResp]	"Metrics catalog"
+//	@Failure		400	{object}	dto.GenericResponse[any]				"Invalid injection ID"
+//	@Failure		401	{object}	dto.GenericResponse[any]				"Authentication required"
+//	@Failure		403	{object}	dto.GenericResponse[any]				"Permission denied"
+//	@Failure		404	{object}	dto.GenericResponse[any]				"Datapack not found or not ready"
+//	@Failure		500	{object}	dto.GenericResponse[any]				"Internal server error"
+//	@Router			/api/v2/injections/{id}/metrics/catalog [get]
+//	@x-api-type		{"sdk":"true"}
+func (h *Handler) GetMetricsCatalog(c *gin.Context) {
+	id, ok := parsePositiveID(c, consts.URLPathID, "injection ID")
+	if !ok {
+		return
+	}
+	resp, err := h.service.GetMetricsCatalog(c.Request.Context(), id)
+	if httpx.HandleServiceError(c, err) {
+		return
+	}
+	dto.SuccessResponse(c, resp)
+}
+
+// GetMetricsSeries returns time-series data for a metric in an injection's datapack.
+//
+//	@Summary		Get metric time series
+//	@Description	Time series for a metric, optionally bucketed and grouped
+//	@Tags			Observation
+//	@ID				get_observation_metrics_series
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id			path		int										true	"Injection ID"
+//	@Param			metric		query		string									true	"Metric name"
+//	@Param			start		query		string									false	"RFC3339 start"
+//	@Param			end			query		string									false	"RFC3339 end"
+//	@Param			step		query		string									false	"Step duration (e.g. 30s, 1m)"
+//	@Param			group_by	query		string									false	"Dimension name to group by"
+//	@Param			filter		query		string									false	"dim=value filter"
+//	@Success		200			{object}	dto.GenericResponse[MetricsSeriesResp]	"Metric time series"
+//	@Failure		400			{object}	dto.GenericResponse[any]				"Invalid request"
+//	@Failure		401			{object}	dto.GenericResponse[any]				"Authentication required"
+//	@Failure		403			{object}	dto.GenericResponse[any]				"Permission denied"
+//	@Failure		404			{object}	dto.GenericResponse[any]				"Datapack not found or not ready"
+//	@Failure		500			{object}	dto.GenericResponse[any]				"Internal server error"
+//	@Router			/api/v2/injections/{id}/metrics/series [get]
+//	@x-api-type		{"sdk":"true"}
+func (h *Handler) GetMetricsSeries(c *gin.Context) {
+	id, ok := parsePositiveID(c, consts.URLPathID, "injection ID")
+	if !ok {
+		return
+	}
+	var req MetricsSeriesReq
+	if err := c.ShouldBindQuery(&req); err != nil {
+		dto.ErrorResponse(c, http.StatusBadRequest, "Invalid request: "+err.Error())
+		return
+	}
+	resp, err := h.service.GetMetricsSeries(c.Request.Context(), id, &req)
+	if httpx.HandleServiceError(c, err) {
+		return
+	}
+	dto.SuccessResponse(c, resp)
+}
+
+// ListSpans returns trace summaries for the injection's datapack.
+//
+//	@Summary		List trace summaries
+//	@Description	Trace summaries for an injection (one row per trace_id, root span)
+//	@Tags			Observation
+//	@ID				list_observation_spans
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id				path		int									true	"Injection ID"
+//	@Param			service			query		string								false	"Filter by root service"
+//	@Param			op				query		string								false	"Filter by root operation"
+//	@Param			min_duration	query		int									false	"Minimum duration in ms"
+//	@Param			start			query		string								false	"RFC3339 start"
+//	@Param			end				query		string								false	"RFC3339 end"
+//	@Param			status			query		string								false	"ok|error"
+//	@Param			limit			query		int									false	"Page size, default 50, max 500"
+//	@Param			cursor			query		string								false	"Opaque pagination cursor"
+//	@Success		200				{object}	dto.GenericResponse[ListSpansResp]	"Trace summaries"
+//	@Failure		400				{object}	dto.GenericResponse[any]			"Invalid request"
+//	@Failure		401				{object}	dto.GenericResponse[any]			"Authentication required"
+//	@Failure		403				{object}	dto.GenericResponse[any]			"Permission denied"
+//	@Failure		404				{object}	dto.GenericResponse[any]			"Datapack not found or not ready"
+//	@Failure		500				{object}	dto.GenericResponse[any]			"Internal server error"
+//	@Router			/api/v2/injections/{id}/spans [get]
+//	@x-api-type		{"sdk":"true"}
+func (h *Handler) ListSpans(c *gin.Context) {
+	id, ok := parsePositiveID(c, consts.URLPathID, "injection ID")
+	if !ok {
+		return
+	}
+	var req ListSpansReq
+	if err := c.ShouldBindQuery(&req); err != nil {
+		dto.ErrorResponse(c, http.StatusBadRequest, "Invalid request: "+err.Error())
+		return
+	}
+	resp, err := h.service.ListSpans(c.Request.Context(), id, &req)
+	if httpx.HandleServiceError(c, err) {
+		return
+	}
+	dto.SuccessResponse(c, resp)
+}
+
+// GetSpanTree returns the full span tree for one trace.
+//
+//	@Summary		Get span tree
+//	@Description	Full span tree for one trace_id in the injection's datapack
+//	@Tags			Observation
+//	@ID				get_observation_span_tree
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id			path		int									true	"Injection ID"
+//	@Param			trace_id	path		string								true	"Trace ID"
+//	@Success		200			{object}	dto.GenericResponse[SpanTreeResp]	"Span tree"
+//	@Failure		400			{object}	dto.GenericResponse[any]			"Invalid request"
+//	@Failure		401			{object}	dto.GenericResponse[any]			"Authentication required"
+//	@Failure		403			{object}	dto.GenericResponse[any]			"Permission denied"
+//	@Failure		404			{object}	dto.GenericResponse[any]			"Datapack not found or trace not found"
+//	@Failure		500			{object}	dto.GenericResponse[any]			"Internal server error"
+//	@Router			/api/v2/injections/{id}/spans/{trace_id} [get]
+//	@x-api-type		{"sdk":"true"}
+func (h *Handler) GetSpanTree(c *gin.Context) {
+	id, ok := parsePositiveID(c, consts.URLPathID, "injection ID")
+	if !ok {
+		return
+	}
+	traceID := c.Param("trace_id")
+	if traceID == "" {
+		dto.ErrorResponse(c, http.StatusBadRequest, "trace_id is required")
+		return
+	}
+	resp, err := h.service.GetSpanTree(c.Request.Context(), id, traceID)
+	if httpx.HandleServiceError(c, err) {
+		return
+	}
+	dto.SuccessResponse(c, resp)
+}
+
+// GetServiceMap returns service dependency edges aggregated from spans.
+//
+//	@Summary		Get service map
+//	@Description	Service dependency edges and node summaries
+//	@Tags			Observation
+//	@ID				get_observation_service_map
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id		path		int									true	"Injection ID"
+//	@Param			window	query		string								false	"fault|normal|both (default fault)"
+//	@Success		200		{object}	dto.GenericResponse[ServiceMapResp]	"Service map"
+//	@Failure		400		{object}	dto.GenericResponse[any]			"Invalid request"
+//	@Failure		401		{object}	dto.GenericResponse[any]			"Authentication required"
+//	@Failure		403		{object}	dto.GenericResponse[any]			"Permission denied"
+//	@Failure		404		{object}	dto.GenericResponse[any]			"Datapack not found or not ready"
+//	@Failure		500		{object}	dto.GenericResponse[any]			"Internal server error"
+//	@Router			/api/v2/injections/{id}/service-map [get]
+//	@x-api-type		{"sdk":"true"}
+func (h *Handler) GetServiceMap(c *gin.Context) {
+	id, ok := parsePositiveID(c, consts.URLPathID, "injection ID")
+	if !ok {
+		return
+	}
+	var req ServiceMapReq
+	if err := c.ShouldBindQuery(&req); err != nil {
+		dto.ErrorResponse(c, http.StatusBadRequest, "Invalid request: "+err.Error())
+		return
+	}
+	resp, err := h.service.GetServiceMap(c.Request.Context(), id, &req)
+	if httpx.HandleServiceError(c, err) {
+		return
+	}
+	dto.SuccessResponse(c, resp)
+}

--- a/AegisLab/src/module/observation/module.go
+++ b/AegisLab/src/module/observation/module.go
@@ -1,0 +1,12 @@
+package observation
+
+import "go.uber.org/fx"
+
+var Module = fx.Module("observation",
+	fx.Provide(NewService),
+	fx.Provide(AsHandlerService),
+	fx.Provide(NewHandler),
+	fx.Provide(
+		fx.Annotate(RoutesPortal, fx.ResultTags(`group:"routes"`)),
+	),
+)

--- a/AegisLab/src/module/observation/query_arrow.go
+++ b/AegisLab/src/module/observation/query_arrow.go
@@ -232,8 +232,45 @@ func parseSpanEvents(s string) []SpanEvent {
 
 var errNotImplemented = errors.New("observation endpoint not yet implemented")
 
-func (s *Service) GetMetricsCatalog(_ context.Context, _ int) (*MetricsCatalogResp, error) {
-	return nil, errNotImplemented
+// L3.1 — metrics catalog
+//
+// Strategy: pick the abnormal_metrics.parquet file, run DESCRIBE, expose every
+// column as either a metric (numeric) or a dimension (textual). For a richer
+// catalog the parquet would need explicit metric metadata; here we surface
+// what duckdb sees so the frontend can drive selectors honestly without
+// fabricated quantiles or descriptions.
+func (s *Service) GetMetricsCatalog(ctx context.Context, id int) (*MetricsCatalogResp, error) {
+	parquet, err := s.resolveDatapackParquet(ctx, id, abnormalMetricsFile)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := openDuckDB()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+
+	cols, order, err := describeColumns(ctx, db, parquet)
+	if err != nil {
+		return nil, err
+	}
+
+	dims := []string{}
+	metrics := []MetricCatalogItem{}
+	for _, name := range order {
+		typ := cols[name]
+		if isNumericDuckType(typ) && !isTimestampDuckType(typ) {
+			metrics = append(metrics, MetricCatalogItem{Name: name})
+		} else if !isTimestampDuckType(typ) {
+			dims = append(dims, name)
+		}
+	}
+	for i := range metrics {
+		metrics[i].Dimensions = dims
+	}
+
+	return &MetricsCatalogResp{Metrics: metrics}, nil
 }
 
 func (s *Service) GetMetricsSeries(_ context.Context, _ int, _ *MetricsSeriesReq) (*MetricsSeriesResp, error) {

--- a/AegisLab/src/module/observation/query_arrow.go
+++ b/AegisLab/src/module/observation/query_arrow.go
@@ -451,8 +451,179 @@ func (s *Service) GetMetricsSeries(ctx context.Context, id int, req *MetricsSeri
 	return &MetricsSeriesResp{Series: out, Step: step}, nil
 }
 
-func (s *Service) ListSpans(_ context.Context, _ int, _ *ListSpansReq) (*ListSpansResp, error) {
-	return nil, errNotImplemented
+// L2.1 — list trace summaries (root span per trace_id)
+//
+// Strategy: rank spans within each trace by (parent-is-null first, start_ts asc),
+// take rank 1 as root. Aggregate error_count across all spans of the trace and
+// LEFT JOIN. Pagination is keyset on trace_id (lexicographic) — stable across
+// repeated calls. limit defaults to 50, capped at 500.
+func (s *Service) ListSpans(ctx context.Context, id int, req *ListSpansReq) (*ListSpansResp, error) {
+	parquet, err := s.resolveDatapackParquet(ctx, id, abnormalTracesFile)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := openDuckDB()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+
+	cols, _, err := describeColumns(ctx, db, parquet)
+	if err != nil {
+		return nil, err
+	}
+
+	sc, err := resolveSpanColumns(cols)
+	if err != nil {
+		return nil, err
+	}
+
+	startExpr := timestampExpr(quoteIdent(sc.startTS), cols[sc.startTS])
+	durationExpr := spanDurationExpr(sc, cols)
+	errorExpr := spanErrorPredicate(sc)
+	statusExpr := spanStatusExpr(sc)
+
+	parentExpr := "NULL"
+	if sc.parentID != "" {
+		parentExpr = quoteIdent(sc.parentID)
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+
+	args := []interface{}{}
+	conds := []string{}
+	if req.Service != "" {
+		conds = append(conds, "r.service = ?")
+		args = append(args, req.Service)
+	}
+	if req.Op != "" {
+		conds = append(conds, "r.op = ?")
+		args = append(args, req.Op)
+	}
+	if req.Start != "" {
+		t, err := time.Parse(time.RFC3339, req.Start)
+		if err != nil {
+			return nil, fmt.Errorf("invalid start: %w", err)
+		}
+		conds = append(conds, "r.start_ts >= ?")
+		args = append(args, t.UTC())
+	}
+	if req.End != "" {
+		t, err := time.Parse(time.RFC3339, req.End)
+		if err != nil {
+			return nil, fmt.Errorf("invalid end: %w", err)
+		}
+		conds = append(conds, "r.start_ts < ?")
+		args = append(args, t.UTC())
+	}
+	if req.MinDuration > 0 {
+		conds = append(conds, "r.duration_ns >= ?")
+		args = append(args, req.MinDuration*1_000_000)
+	}
+	if req.Status != "" {
+		switch strings.ToLower(req.Status) {
+		case "error":
+			conds = append(conds, "r.status = 'error'")
+		case "ok":
+			conds = append(conds, "r.status = 'ok'")
+		default:
+			return nil, fmt.Errorf("invalid status %q (must be ok|error)", req.Status)
+		}
+	}
+	if req.Cursor != "" {
+		conds = append(conds, "r.trace_id > ?")
+		args = append(args, req.Cursor)
+	}
+
+	where := ""
+	if len(conds) > 0 {
+		where = "WHERE " + strings.Join(conds, " AND ")
+	}
+
+	q := fmt.Sprintf(`WITH ranked AS (
+	SELECT %s AS trace_id,
+	       %s AS service,
+	       %s AS op,
+	       %s AS start_ts,
+	       %s AS duration_ns,
+	       %s AS status,
+	       row_number() OVER (
+	         PARTITION BY %s
+	         ORDER BY (CASE WHEN %s IS NULL OR CAST(%s AS VARCHAR) = '' THEN 0 ELSE 1 END), %s ASC
+	       ) AS rn
+	FROM read_parquet('%s')
+),
+roots AS (SELECT * FROM ranked WHERE rn = 1),
+errs AS (
+	SELECT %s AS trace_id, sum(CASE WHEN %s THEN 1 ELSE 0 END) AS error_count
+	FROM read_parquet('%s')
+	GROUP BY %s
+)
+SELECT r.trace_id, r.service, r.op, r.start_ts, r.duration_ns, r.status, COALESCE(e.error_count, 0)
+FROM roots r LEFT JOIN errs e ON r.trace_id = e.trace_id
+%s
+ORDER BY r.trace_id ASC
+LIMIT %d`,
+		quoteIdent(sc.traceID),
+		quoteIdent(sc.service),
+		quoteIdent(sc.op),
+		startExpr,
+		durationExpr,
+		statusExpr,
+		quoteIdent(sc.traceID),
+		parentExpr, parentExpr,
+		startExpr,
+		parquet,
+		quoteIdent(sc.traceID), errorExpr,
+		parquet,
+		quoteIdent(sc.traceID),
+		where,
+		limit+1,
+	)
+
+	rows, err := db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list spans query failed: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := []SpanSummary{}
+	for rows.Next() {
+		var traceID, service, op, status string
+		var startTS time.Time
+		var duration int64
+		var errCount int64
+		if err := rows.Scan(&traceID, &service, &op, &startTS, &duration, &status, &errCount); err != nil {
+			return nil, err
+		}
+		out = append(out, SpanSummary{
+			TraceID:     traceID,
+			RootService: service,
+			RootOp:      op,
+			StartTS:     startTS.UTC().Format(time.RFC3339Nano),
+			DurationNS:  duration,
+			Status:      status,
+			ErrorCount:  errCount,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	resp := &ListSpansResp{Spans: out}
+	if len(out) > limit {
+		last := out[limit-1]
+		resp.Spans = out[:limit]
+		resp.NextCursor = last.TraceID
+	}
+	return resp, nil
 }
 
 func (s *Service) GetSpanTree(_ context.Context, _ int, _ string) (*SpanTreeResp, error) {

--- a/AegisLab/src/module/observation/query_arrow.go
+++ b/AegisLab/src/module/observation/query_arrow.go
@@ -1,0 +1,253 @@
+//go:build duckdb_arrow
+
+package observation
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/duckdb/duckdb-go/v2"
+)
+
+// Parquet filename conventions used inside a datapack. These are the only
+// inputs observation reads, mirroring datapack_store.go validParquetFiles.
+const (
+	abnormalMetricsFile = "abnormal_metrics.parquet"
+	normalMetricsFile   = "normal_metrics.parquet"
+	abnormalTracesFile  = "abnormal_traces.parquet"
+	normalTracesFile    = "normal_traces.parquet"
+)
+
+// resolveDatapackParquet returns the absolute path of fileName within the
+// datapack of the given injection id, or an error if the datapack is not
+// ready or the file is missing.
+func (s *Service) resolveDatapackParquet(ctx context.Context, id int, fileName string) (string, error) {
+	name, err := s.injections.GetReadyDatapackName(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	return s.store.ResolveFilePath(name, fileName)
+}
+
+// describeColumns returns the column types of a parquet file via duckdb's
+// `DESCRIBE SELECT *` introspection. The returned map keys are column names
+// (verbatim) and values are normalised (uppercase) duckdb type strings.
+func describeColumns(ctx context.Context, db *sql.DB, parquet string) (map[string]string, []string, error) {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf("DESCRIBE SELECT * FROM read_parquet('%s')", parquet))
+	if err != nil {
+		return nil, nil, fmt.Errorf("describe parquet failed: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	cols := make(map[string]string)
+	order := []string{}
+	for rows.Next() {
+		var name, typ, null, key, def, extra string
+		if err := rows.Scan(&name, &typ, &null, &key, &def, &extra); err != nil {
+			return nil, nil, err
+		}
+		cols[name] = strings.ToUpper(strings.TrimSpace(typ))
+		order = append(order, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+	return cols, order, nil
+}
+
+func quoteIdent(name string) string {
+	return fmt.Sprintf("\"%s\"", strings.ReplaceAll(name, "\"", "\"\""))
+}
+
+func openDuckDB() (*sql.DB, error) {
+	connector, err := duckdb.NewConnector("", nil)
+	if err != nil {
+		return nil, err
+	}
+	return sql.OpenDB(connector), nil
+}
+
+func isNumericDuckType(t string) bool {
+	switch {
+	case strings.HasPrefix(t, "DECIMAL"), t == "FLOAT", t == "DOUBLE", t == "REAL",
+		t == "TINYINT", t == "SMALLINT", t == "INTEGER", t == "BIGINT", t == "HUGEINT",
+		t == "UTINYINT", t == "USMALLINT", t == "UINTEGER", t == "UBIGINT", t == "UHUGEINT":
+		return true
+	}
+	return false
+}
+
+func isTimestampDuckType(t string) bool {
+	return strings.HasPrefix(t, "TIMESTAMP") || t == "DATE" || t == "TIME"
+}
+
+// pickColumn returns the first column name from candidates that exists in cols.
+func pickColumn(cols map[string]string, candidates ...string) string {
+	for _, c := range candidates {
+		if _, ok := cols[c]; ok {
+			return c
+		}
+	}
+	return ""
+}
+
+// timestampExpr returns a duckdb expression that converts the column to a
+// TIMESTAMP regardless of its on-disk type. Integer columns are assumed to be
+// nanoseconds since epoch (matching the OTel time_unix_nano convention).
+func timestampExpr(quoted string, typ string) string {
+	switch {
+	case strings.HasPrefix(typ, "TIMESTAMP"):
+		return quoted
+	case typ == "DATE":
+		return fmt.Sprintf("CAST(%s AS TIMESTAMP)", quoted)
+	case typ == "BIGINT" || typ == "UBIGINT" || typ == "HUGEINT" || typ == "UHUGEINT":
+		return fmt.Sprintf("make_timestamp(CAST(%s AS BIGINT) / 1000)", quoted)
+	default:
+		return fmt.Sprintf("CAST(%s AS TIMESTAMP)", quoted)
+	}
+}
+
+// span column lookup encapsulates the assumed parquet schema. We resolve real
+// column names through DESCRIBE rather than hardcoding so the same code works
+// across collector versions, but the candidate sets reflect the OTel→Parquet
+// conventions used by AegisLab's datapack builder.
+type spanColumns struct {
+	traceID    string
+	spanID     string
+	parentID   string
+	service    string
+	op         string
+	startTS    string
+	endTS      string
+	statusCode string
+	statusType string
+	attrs      string
+	events     string
+	durationNS string
+}
+
+func resolveSpanColumns(cols map[string]string) (*spanColumns, error) {
+	sc := &spanColumns{
+		traceID:    pickColumn(cols, "trace_id", "TraceId", "TraceID"),
+		spanID:     pickColumn(cols, "span_id", "SpanId", "SpanID"),
+		parentID:   pickColumn(cols, "parent_span_id", "parent_id", "ParentSpanId", "ParentSpanID"),
+		service:    pickColumn(cols, "service_name", "ServiceName", "service"),
+		op:         pickColumn(cols, "name", "operation_name", "SpanName", "span_name"),
+		startTS:    pickColumn(cols, "start_time", "start_time_unix_nano", "Timestamp", "timestamp"),
+		endTS:      pickColumn(cols, "end_time", "end_time_unix_nano", "EndTimestamp"),
+		statusCode: pickColumn(cols, "status_code", "StatusCode"),
+		statusType: pickColumn(cols, "status_message", "StatusMessage"),
+		attrs:      pickColumn(cols, "span_attributes", "attributes", "SpanAttributes", "Attributes"),
+		events:     pickColumn(cols, "events", "Events"),
+		durationNS: pickColumn(cols, "duration", "Duration", "duration_ns", "duration_nano"),
+	}
+	if sc.traceID == "" || sc.spanID == "" || sc.service == "" || sc.op == "" || sc.startTS == "" {
+		return nil, fmt.Errorf("traces parquet missing required columns (need trace_id, span_id, service, op, start_ts)")
+	}
+	return sc, nil
+}
+
+// spanDurationExpr returns a duckdb expression yielding the span duration in
+// nanoseconds. If the parquet exposes an explicit duration column we use it,
+// otherwise we compute end - start.
+func spanDurationExpr(sc *spanColumns, cols map[string]string) string {
+	if sc.durationNS != "" {
+		t := cols[sc.durationNS]
+		if strings.HasPrefix(t, "INTERVAL") {
+			return fmt.Sprintf("epoch_ns(%s)", quoteIdent(sc.durationNS))
+		}
+		return fmt.Sprintf("CAST(%s AS BIGINT)", quoteIdent(sc.durationNS))
+	}
+	if sc.endTS == "" {
+		return "0"
+	}
+	startExpr := timestampExpr(quoteIdent(sc.startTS), cols[sc.startTS])
+	endExpr := timestampExpr(quoteIdent(sc.endTS), cols[sc.endTS])
+	return fmt.Sprintf("(epoch_ns(%s) - epoch_ns(%s))", endExpr, startExpr)
+}
+
+// spanErrorPredicate returns a boolean SQL predicate that identifies
+// error-status spans. Tries status_code (textual) first, falls back to never.
+func spanErrorPredicate(sc *spanColumns) string {
+	if sc.statusCode != "" {
+		return fmt.Sprintf("UPPER(CAST(%s AS VARCHAR)) IN ('STATUS_CODE_ERROR', 'ERROR', '2')", quoteIdent(sc.statusCode))
+	}
+	return "FALSE"
+}
+
+// spanStatusExpr returns a SQL expression yielding the textual status (ok|error).
+func spanStatusExpr(sc *spanColumns) string {
+	if sc.statusCode == "" {
+		return "'ok'"
+	}
+	return fmt.Sprintf("CASE WHEN UPPER(CAST(%s AS VARCHAR)) IN ('STATUS_CODE_ERROR', 'ERROR', '2') THEN 'error' ELSE 'ok' END", quoteIdent(sc.statusCode))
+}
+
+// parseJSONOrPairs accepts a JSON object string and returns it as a map; for
+// other duckdb stringifications (MAP / STRUCT) it returns a single-key wrapper
+// so the frontend always sees an object.
+func parseJSONOrPairs(s string) map[string]interface{} {
+	if s == "" {
+		return nil
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &m); err == nil {
+		return m
+	}
+	return map[string]interface{}{"raw": s}
+}
+
+func parseSpanEvents(s string) []SpanEvent {
+	if s == "" {
+		return nil
+	}
+	var raw []map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &raw); err != nil {
+		return []SpanEvent{{Name: "raw", Attributes: map[string]interface{}{"value": s}}}
+	}
+	out := make([]SpanEvent, 0, len(raw))
+	for _, r := range raw {
+		ev := SpanEvent{}
+		if v, ok := r["ts"]; ok {
+			ev.TS = fmt.Sprint(v)
+		} else if v, ok := r["timestamp"]; ok {
+			ev.TS = fmt.Sprint(v)
+		}
+		if v, ok := r["name"]; ok {
+			ev.Name = fmt.Sprint(v)
+		}
+		if v, ok := r["attributes"]; ok {
+			if m, ok := v.(map[string]interface{}); ok {
+				ev.Attributes = m
+			}
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+var errNotImplemented = errors.New("observation endpoint not yet implemented")
+
+func (s *Service) GetMetricsCatalog(_ context.Context, _ int) (*MetricsCatalogResp, error) {
+	return nil, errNotImplemented
+}
+
+func (s *Service) GetMetricsSeries(_ context.Context, _ int, _ *MetricsSeriesReq) (*MetricsSeriesResp, error) {
+	return nil, errNotImplemented
+}
+
+func (s *Service) ListSpans(_ context.Context, _ int, _ *ListSpansReq) (*ListSpansResp, error) {
+	return nil, errNotImplemented
+}
+
+func (s *Service) GetSpanTree(_ context.Context, _ int, _ string) (*SpanTreeResp, error) {
+	return nil, errNotImplemented
+}
+
+func (s *Service) GetServiceMap(_ context.Context, _ int, _ *ServiceMapReq) (*ServiceMapResp, error) {
+	return nil, errNotImplemented
+}

--- a/AegisLab/src/module/observation/query_arrow.go
+++ b/AegisLab/src/module/observation/query_arrow.go
@@ -8,7 +8,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/duckdb/duckdb-go/v2"
 )
@@ -273,8 +276,179 @@ func (s *Service) GetMetricsCatalog(ctx context.Context, id int) (*MetricsCatalo
 	return &MetricsCatalogResp{Metrics: metrics}, nil
 }
 
-func (s *Service) GetMetricsSeries(_ context.Context, _ int, _ *MetricsSeriesReq) (*MetricsSeriesResp, error) {
-	return nil, errNotImplemented
+// L3.2 — metrics time series
+//
+// Strategy: parse start/end (RFC3339), bucket by step using duckdb's time_bucket,
+// average the metric column per bucket. Hardcoded assumption: the metrics parquet
+// has a timestamp column named one of {time, timestamp, ts, time_unix_nano}. If
+// the requested metric or timestamp column is absent we return an explicit error
+// rather than mocking. group_by selects an additional GROUP BY dimension; filter
+// is parsed as `dim=value` and added to the WHERE clause via parameterised SQL.
+func (s *Service) GetMetricsSeries(ctx context.Context, id int, req *MetricsSeriesReq) (*MetricsSeriesResp, error) {
+	parquet, err := s.resolveDatapackParquet(ctx, id, abnormalMetricsFile)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := openDuckDB()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+
+	cols, _, err := describeColumns(ctx, db, parquet)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := cols[req.Metric]; !ok {
+		return nil, fmt.Errorf("metric %q not found in %s", req.Metric, filepath.Base(parquet))
+	}
+	if !isNumericDuckType(cols[req.Metric]) {
+		return nil, fmt.Errorf("metric %q is not numeric (type %s)", req.Metric, cols[req.Metric])
+	}
+
+	tsCol := pickColumn(cols, "time", "timestamp", "ts", "time_unix_nano")
+	if tsCol == "" {
+		return nil, fmt.Errorf("no timestamp column found in %s (expected one of: time, timestamp, ts, time_unix_nano)", filepath.Base(parquet))
+	}
+
+	step := strings.TrimSpace(req.Step)
+	if step == "" {
+		step = "30s"
+	}
+	stepDur, err := time.ParseDuration(step)
+	if err != nil {
+		return nil, fmt.Errorf("invalid step %q: %w", step, err)
+	}
+	stepSeconds := int64(stepDur.Seconds())
+	if stepSeconds <= 0 {
+		return nil, fmt.Errorf("step must be at least 1 second, got %q", step)
+	}
+
+	tsExpr := timestampExpr(quoteIdent(tsCol), cols[tsCol])
+
+	var conds []string
+	args := []interface{}{}
+	if req.Start != "" {
+		t, err := time.Parse(time.RFC3339, req.Start)
+		if err != nil {
+			return nil, fmt.Errorf("invalid start: %w", err)
+		}
+		conds = append(conds, fmt.Sprintf("%s >= ?", tsExpr))
+		args = append(args, t.UTC())
+	}
+	if req.End != "" {
+		t, err := time.Parse(time.RFC3339, req.End)
+		if err != nil {
+			return nil, fmt.Errorf("invalid end: %w", err)
+		}
+		conds = append(conds, fmt.Sprintf("%s < ?", tsExpr))
+		args = append(args, t.UTC())
+	}
+
+	if req.Filter != "" {
+		dim, val, ok := strings.Cut(req.Filter, "=")
+		if !ok {
+			return nil, fmt.Errorf("filter must be dim=value, got %q", req.Filter)
+		}
+		dim = strings.TrimSpace(dim)
+		val = strings.TrimSpace(val)
+		if _, exists := cols[dim]; !exists {
+			return nil, fmt.Errorf("filter dimension %q not found", dim)
+		}
+		conds = append(conds, fmt.Sprintf("%s = ?", quoteIdent(dim)))
+		args = append(args, val)
+	}
+
+	groupBy := strings.TrimSpace(req.GroupBy)
+	if groupBy != "" {
+		if _, exists := cols[groupBy]; !exists {
+			return nil, fmt.Errorf("group_by dimension %q not found", groupBy)
+		}
+	}
+
+	groupColExpr := ""
+	if groupBy != "" {
+		groupColExpr = fmt.Sprintf(", CAST(%s AS VARCHAR) AS grp", quoteIdent(groupBy))
+	}
+
+	where := ""
+	if len(conds) > 0 {
+		where = "WHERE " + strings.Join(conds, " AND ")
+	}
+
+	groupClause := ""
+	if groupBy != "" {
+		groupClause = ", grp"
+	}
+
+	query := fmt.Sprintf(
+		`SELECT time_bucket(INTERVAL %d SECOND, %s) AS bucket, avg(CAST(%s AS DOUBLE)) AS value%s
+		 FROM read_parquet('%s')
+		 %s
+		 GROUP BY bucket%s
+		 ORDER BY bucket`,
+		stepSeconds,
+		tsExpr,
+		quoteIdent(req.Metric),
+		groupColExpr,
+		parquet,
+		where,
+		groupClause,
+	)
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("metrics series query failed: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	seriesByLabel := map[string]*MetricSeries{}
+	for rows.Next() {
+		var bucket time.Time
+		var value sql.NullFloat64
+		var grp sql.NullString
+		if groupBy != "" {
+			if err := rows.Scan(&bucket, &value, &grp); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := rows.Scan(&bucket, &value); err != nil {
+				return nil, err
+			}
+		}
+		key := ""
+		labels := map[string]string{}
+		if groupBy != "" {
+			key = grp.String
+			labels[groupBy] = grp.String
+		}
+		series, ok := seriesByLabel[key]
+		if !ok {
+			series = &MetricSeries{Labels: labels, Points: []MetricPoint{}}
+			seriesByLabel[key] = series
+		}
+		v := 0.0
+		if value.Valid {
+			v = value.Float64
+		}
+		series.Points = append(series.Points, MetricPoint{TS: bucket.UTC().Format(time.RFC3339Nano), Value: v})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]MetricSeries, 0, len(seriesByLabel))
+	keys := make([]string, 0, len(seriesByLabel))
+	for k := range seriesByLabel {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		out = append(out, *seriesByLabel[k])
+	}
+	return &MetricsSeriesResp{Series: out, Step: step}, nil
 }
 
 func (s *Service) ListSpans(_ context.Context, _ int, _ *ListSpansReq) (*ListSpansResp, error) {

--- a/AegisLab/src/module/observation/query_arrow.go
+++ b/AegisLab/src/module/observation/query_arrow.go
@@ -626,8 +626,109 @@ LIMIT %d`,
 	return resp, nil
 }
 
-func (s *Service) GetSpanTree(_ context.Context, _ int, _ string) (*SpanTreeResp, error) {
-	return nil, errNotImplemented
+// L2.2 — full span tree for one trace_id.
+func (s *Service) GetSpanTree(ctx context.Context, id int, traceID string) (*SpanTreeResp, error) {
+	if strings.TrimSpace(traceID) == "" {
+		return nil, fmt.Errorf("trace_id required")
+	}
+	parquet, err := s.resolveDatapackParquet(ctx, id, abnormalTracesFile)
+	if err != nil {
+		return nil, err
+	}
+	db, err := openDuckDB()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+
+	cols, _, err := describeColumns(ctx, db, parquet)
+	if err != nil {
+		return nil, err
+	}
+	sc, err := resolveSpanColumns(cols)
+	if err != nil {
+		return nil, err
+	}
+
+	startExpr := timestampExpr(quoteIdent(sc.startTS), cols[sc.startTS])
+	var endExpr string
+	if sc.endTS != "" {
+		endExpr = timestampExpr(quoteIdent(sc.endTS), cols[sc.endTS])
+	} else {
+		endExpr = fmt.Sprintf("%s + (CAST((%s) / 1000 AS BIGINT)) * INTERVAL 1 MICROSECOND", startExpr, spanDurationExpr(sc, cols))
+	}
+	parentExpr := "NULL"
+	if sc.parentID != "" {
+		parentExpr = quoteIdent(sc.parentID)
+	}
+	statusExpr := spanStatusExpr(sc)
+	attrsExpr := "NULL"
+	if sc.attrs != "" {
+		attrsExpr = fmt.Sprintf("CAST(%s AS VARCHAR)", quoteIdent(sc.attrs))
+	}
+	eventsExpr := "NULL"
+	if sc.events != "" {
+		eventsExpr = fmt.Sprintf("CAST(%s AS VARCHAR)", quoteIdent(sc.events))
+	}
+
+	q := fmt.Sprintf(`SELECT %s AS span_id, %s AS parent_id, %s AS service, %s AS op,
+		%s AS start_ts, %s AS end_ts, %s AS attrs, %s AS events, %s AS status
+	FROM read_parquet('%s')
+	WHERE %s = ?
+	ORDER BY %s ASC`,
+		quoteIdent(sc.spanID),
+		parentExpr,
+		quoteIdent(sc.service),
+		quoteIdent(sc.op),
+		startExpr,
+		endExpr,
+		attrsExpr,
+		eventsExpr,
+		statusExpr,
+		parquet,
+		quoteIdent(sc.traceID),
+		startExpr,
+	)
+
+	rows, err := db.QueryContext(ctx, q, traceID)
+	if err != nil {
+		return nil, fmt.Errorf("span tree query failed: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := []SpanNode{}
+	for rows.Next() {
+		var spanID, service, op, status string
+		var parentID sql.NullString
+		var startTS, endTS time.Time
+		var attrsRaw, eventsRaw sql.NullString
+		if err := rows.Scan(&spanID, &parentID, &service, &op, &startTS, &endTS, &attrsRaw, &eventsRaw, &status); err != nil {
+			return nil, err
+		}
+		node := SpanNode{
+			SpanID:   spanID,
+			ParentID: parentID.String,
+			Service:  service,
+			Op:       op,
+			StartTS:  startTS.UTC().Format(time.RFC3339Nano),
+			EndTS:    endTS.UTC().Format(time.RFC3339Nano),
+			Status:   status,
+		}
+		if attrsRaw.Valid {
+			node.Attrs = parseJSONOrPairs(attrsRaw.String)
+		}
+		if eventsRaw.Valid {
+			node.Events = parseSpanEvents(eventsRaw.String)
+		}
+		out = append(out, node)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("trace %q not found", traceID)
+	}
+	return &SpanTreeResp{Spans: out}, nil
 }
 
 func (s *Service) GetServiceMap(_ context.Context, _ int, _ *ServiceMapReq) (*ServiceMapResp, error) {

--- a/AegisLab/src/module/observation/query_arrow.go
+++ b/AegisLab/src/module/observation/query_arrow.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -232,8 +231,6 @@ func parseSpanEvents(s string) []SpanEvent {
 	}
 	return out
 }
-
-var errNotImplemented = errors.New("observation endpoint not yet implemented")
 
 // L3.1 — metrics catalog
 //
@@ -731,6 +728,143 @@ func (s *Service) GetSpanTree(ctx context.Context, id int, traceID string) (*Spa
 	return &SpanTreeResp{Spans: out}, nil
 }
 
-func (s *Service) GetServiceMap(_ context.Context, _ int, _ *ServiceMapReq) (*ServiceMapResp, error) {
-	return nil, errNotImplemented
+// L2.3 — service map: nodes (per service span_count + error_rate) and edges
+// (parent_service → child_service with call_count, error_rate, p50/p99 ms).
+//
+// Strategy: self-join the spans parquet on parent_span_id = span_id (within
+// the same trace) to form caller→callee pairs, then GROUP BY (parent_service,
+// child_service). For nodes, group the same parquet by service. The window
+// query parameter selects which parquet(s) feed the input: fault →
+// abnormal_traces, normal → normal_traces, both → UNION ALL.
+func (s *Service) GetServiceMap(ctx context.Context, id int, req *ServiceMapReq) (*ServiceMapResp, error) {
+	window := strings.ToLower(strings.TrimSpace(req.Window))
+	if window == "" {
+		window = "fault"
+	}
+	if window != "fault" && window != "normal" && window != "both" {
+		return nil, fmt.Errorf("invalid window %q (must be fault|normal|both)", req.Window)
+	}
+
+	name, err := s.injections.GetReadyDatapackName(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	files := []string{}
+	switch window {
+	case "fault":
+		files = append(files, abnormalTracesFile)
+	case "normal":
+		files = append(files, normalTracesFile)
+	case "both":
+		files = append(files, abnormalTracesFile, normalTracesFile)
+	}
+
+	resolved := []string{}
+	for _, f := range files {
+		path, err := s.store.ResolveFilePath(name, f)
+		if err != nil {
+			if window == "both" {
+				continue
+			}
+			return nil, err
+		}
+		resolved = append(resolved, path)
+	}
+	if len(resolved) == 0 {
+		return nil, fmt.Errorf("no traces parquet available for window %s", window)
+	}
+
+	db, err := openDuckDB()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+
+	cols, _, err := describeColumns(ctx, db, resolved[0])
+	if err != nil {
+		return nil, err
+	}
+	sc, err := resolveSpanColumns(cols)
+	if err != nil {
+		return nil, err
+	}
+	if sc.parentID == "" {
+		return nil, fmt.Errorf("traces parquet missing parent_span_id column; cannot build service map")
+	}
+
+	durationNS := spanDurationExpr(sc, cols)
+	errorExpr := spanErrorPredicate(sc)
+
+	unionParts := []string{}
+	for _, p := range resolved {
+		unionParts = append(unionParts, fmt.Sprintf(
+			`SELECT %s AS trace_id, %s AS span_id, %s AS parent_id, %s AS service, %s AS op, (%s) AS duration_ns, (%s) AS is_error FROM read_parquet('%s')`,
+			quoteIdent(sc.traceID), quoteIdent(sc.spanID), quoteIdent(sc.parentID), quoteIdent(sc.service), quoteIdent(sc.op), durationNS, errorExpr, p,
+		))
+	}
+	spansCTE := strings.Join(unionParts, " UNION ALL ")
+
+	nodesQ := fmt.Sprintf(`WITH spans AS (%s)
+SELECT service, count(*) AS span_count,
+       sum(CASE WHEN is_error THEN 1 ELSE 0 END)::DOUBLE / count(*) AS error_rate
+FROM spans
+GROUP BY service
+ORDER BY service`, spansCTE)
+
+	nrows, err := db.QueryContext(ctx, nodesQ)
+	if err != nil {
+		return nil, fmt.Errorf("service-map nodes query failed: %w", err)
+	}
+	nodes := []ServiceMapNode{}
+	for nrows.Next() {
+		var n ServiceMapNode
+		if err := nrows.Scan(&n.Service, &n.SpanCount, &n.ErrorRate); err != nil {
+			_ = nrows.Close()
+			return nil, err
+		}
+		nodes = append(nodes, n)
+	}
+	_ = nrows.Close()
+
+	edgesQ := fmt.Sprintf(`WITH spans AS (%s),
+pairs AS (
+    SELECT p.service AS from_svc, c.service AS to_svc, c.duration_ns AS dur, c.is_error AS is_error
+    FROM spans c
+    JOIN spans p ON c.parent_id = p.span_id AND c.trace_id = p.trace_id
+    WHERE c.service != p.service
+)
+SELECT from_svc, to_svc, count(*) AS call_count,
+       sum(CASE WHEN is_error THEN 1 ELSE 0 END)::DOUBLE / count(*) AS error_rate,
+       quantile_cont(dur / 1e6, 0.5) AS p50_ms,
+       quantile_cont(dur / 1e6, 0.99) AS p99_ms
+FROM pairs
+GROUP BY from_svc, to_svc
+ORDER BY from_svc, to_svc`, spansCTE)
+
+	erows, err := db.QueryContext(ctx, edgesQ)
+	if err != nil {
+		return nil, fmt.Errorf("service-map edges query failed: %w", err)
+	}
+	defer func() { _ = erows.Close() }()
+	edges := []ServiceMapEdge{}
+	for erows.Next() {
+		var e ServiceMapEdge
+		var p50, p99 sql.NullFloat64
+		if err := erows.Scan(&e.From, &e.To, &e.CallCount, &e.ErrorRate, &p50, &p99); err != nil {
+			return nil, err
+		}
+		if p50.Valid {
+			e.P50MS = p50.Float64
+		}
+		if p99.Valid {
+			e.P99MS = p99.Float64
+		}
+		edges = append(edges, e)
+	}
+	if err := erows.Err(); err != nil {
+		return nil, err
+	}
+
+	return &ServiceMapResp{Nodes: nodes, Edges: edges}, nil
 }

--- a/AegisLab/src/module/observation/query_noarrow.go
+++ b/AegisLab/src/module/observation/query_noarrow.go
@@ -1,0 +1,30 @@
+//go:build !duckdb_arrow
+
+package observation
+
+import (
+	"context"
+	"errors"
+)
+
+var errNoArrow = errors.New("observation queries require building with -tags duckdb_arrow")
+
+func (s *Service) GetMetricsCatalog(_ context.Context, _ int) (*MetricsCatalogResp, error) {
+	return nil, errNoArrow
+}
+
+func (s *Service) GetMetricsSeries(_ context.Context, _ int, _ *MetricsSeriesReq) (*MetricsSeriesResp, error) {
+	return nil, errNoArrow
+}
+
+func (s *Service) ListSpans(_ context.Context, _ int, _ *ListSpansReq) (*ListSpansResp, error) {
+	return nil, errNoArrow
+}
+
+func (s *Service) GetSpanTree(_ context.Context, _ int, _ string) (*SpanTreeResp, error) {
+	return nil, errNoArrow
+}
+
+func (s *Service) GetServiceMap(_ context.Context, _ int, _ *ServiceMapReq) (*ServiceMapResp, error) {
+	return nil, errNoArrow
+}

--- a/AegisLab/src/module/observation/routes.go
+++ b/AegisLab/src/module/observation/routes.go
@@ -1,0 +1,25 @@
+package observation
+
+import (
+	"aegis/framework"
+	"aegis/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RoutesPortal(handler *Handler) framework.RouteRegistrar {
+	return framework.RouteRegistrar{
+		Audience: framework.AudiencePortal,
+		Name:     "observation-portal",
+		Register: func(v2 *gin.RouterGroup) {
+			injections := v2.Group("/injections", middleware.JWTAuth(), middleware.RequireProjectRead)
+			{
+				injections.GET("/:id/metrics/catalog", handler.GetMetricsCatalog)
+				injections.GET("/:id/metrics/series", handler.GetMetricsSeries)
+				injections.GET("/:id/spans", handler.ListSpans)
+				injections.GET("/:id/spans/:trace_id", handler.GetSpanTree)
+				injections.GET("/:id/service-map", handler.GetServiceMap)
+			}
+		},
+	}
+}

--- a/AegisLab/src/module/observation/service.go
+++ b/AegisLab/src/module/observation/service.go
@@ -1,0 +1,29 @@
+package observation
+
+import (
+	"context"
+
+	injection "aegis/module/injection"
+)
+
+type Service struct {
+	injections injection.Reader
+	store      *injection.DatapackStore
+}
+
+func NewService(injections injection.Reader, store *injection.DatapackStore) *Service {
+	return &Service{injections: injections, store: store}
+}
+
+// HandlerService is the surface consumed by the HTTP handler.
+type HandlerService interface {
+	GetMetricsCatalog(ctx context.Context, id int) (*MetricsCatalogResp, error)
+	GetMetricsSeries(ctx context.Context, id int, req *MetricsSeriesReq) (*MetricsSeriesResp, error)
+	ListSpans(ctx context.Context, id int, req *ListSpansReq) (*ListSpansResp, error)
+	GetSpanTree(ctx context.Context, id int, traceID string) (*SpanTreeResp, error)
+	GetServiceMap(ctx context.Context, id int, req *ServiceMapReq) (*ServiceMapResp, error)
+}
+
+func AsHandlerService(s *Service) HandlerService { return s }
+
+var _ HandlerService = (*Service)(nil)


### PR DESCRIPTION
## Summary

New `observation` module exposing 5 GET endpoints over the injection's datapack parquet files (queried via DuckDB). Unblocks the experiment-observation page (umbrella #389):

- **L3.1** `GET /injections/:id/metrics/catalog` — discoverable metrics catalog
- **L3.2** `GET /injections/:id/metrics/series` — bucketed metric time-series with optional group-by/filter
- **L2.1** `GET /injections/:id/spans` — paginated trace summaries (root spans only)
- **L2.2** `GET /injections/:id/spans/:trace_id` — full span tree for one trace
- **L2.3** `GET /injections/:id/service-map` — service dependency graph aggregated from spans

Thin wrappers over `abnormal_traces.parquet` and metrics parquet already in the datapack. No new infrastructure.

DuckDB Arrow build is conditional on the `duckdb_arrow` tag — non-Arrow builds get stub responses.

## Test plan

- [x] `go build -tags duckdb_arrow` clean
- [x] `golangci-lint run` clean
- [x] Octopus merge with sibling streams (#observation-injection-stream, #observation-execution-stream) — no conflicts, builds clean
- [ ] Curl smoke against running server (pending CI, requires datapack)
- [ ] SDK regen (`make generate-typescript-sdk`) — out of scope, follow-up

Refs #389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)