### PR TITLE
ci(publish): read Go version from go.mod instead of pinning 1.24

### DIFF
--- a/.github/workflows/_publish-ts-sdk.yml
+++ b/.github/workflows/_publish-ts-sdk.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version-file: "AegisLab/src/go.mod"
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version-file: "AegisLab/src/go.mod"
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true


### PR DESCRIPTION
## Summary
- Pinned `go-version: "1.24"` in `_publish-ts-sdk.yml` and `publish-pypi.yml` broke `go mod tidy` once `AegisLab/src/go.mod` bumped to require 1.26.0.
- Switch to `go-version-file: "AegisLab/src/go.mod"` — the same pattern `aegisctl-schema-diff.yml` already uses, so version pins live in one place.

## Test plan
- [ ] Merge → re-tag `release-ts-portal/v1.3.0` (delete + recreate) → publish run reaches the `Generate portal SDK` step