### PR TITLE
chore(sdk): switch frontend to @OperationsPAI/portal v1.3.0

### DIFF
--- a/AegisLab-frontend/.pnpmfile.cjs
+++ b/AegisLab-frontend/.pnpmfile.cjs
@@ -2,9 +2,9 @@
 function readPackage(pkg, context) {
   if (
     process.env.LOCAL_API === 'true' &&
-    pkg.dependencies['@rcabench/client']
+    pkg.dependencies['@OperationsPAI/portal']
   ) {
-    pkg.dependencies['@rcabench/client'] = 'link:../AegisLab/client/typescript';
+    pkg.dependencies['@OperationsPAI/portal'] = 'link:../AegisLab/sdk/typescript/portal';
   }
   return pkg;
 }

--- a/AegisLab-frontend/CLAUDE.md
+++ b/AegisLab-frontend/CLAUDE.md
@@ -101,7 +101,7 @@ at desktop AND ≤768 px width.
    NPM_TOKEN=<your_github_token> pnpm install
    ```
 
-> **重要**: 项目依赖私有包 `@OperationsPAI/client`（托管在 GitHub Packages）。安装时必须设置 `NPM_TOKEN` 环境变量为有 `read:packages` 权限的 GitHub Personal Access Token。Token 配置在 `.npmrc` 中通过 `${NPM_TOKEN}` 引用。
+> **重要**: 项目依赖私有包 `@OperationsPAI/portal`（托管在 GitHub Packages）。安装时必须设置 `NPM_TOKEN` 环境变量为有 `read:packages` 权限的 GitHub Personal Access Token。Token 配置在 `.npmrc` 中通过 `${NPM_TOKEN}` 引用。
 
 ## Essential Commands
 
@@ -318,7 +318,7 @@ grep -rn "mock\|Mock\|MOCK\|hardcoded\|TODO.*api\|fake.*data\|stub\|Stub" \
 ## Cross-Repo Rules
 
 - **零 Mock**: 必须调用真实后端 API，不允许 hardcoded data
-- **SDK 同步**: 后端 API 变更后，更新 `@rcabench/client` 并 `pnpm install`
+- **SDK 同步**: 后端 API 变更后，更新 `@OperationsPAI/portal` 并 `pnpm install`
 - **Type 对齐**: `src/types/api.ts` 手写类型不能与 SDK 生成类型矛盾
 - **用户验收**: UI 变更标记 tested 前请求用户在浏览器验证
 <!-- auto-harness:end -->

--- a/AegisLab-frontend/package.json
+++ b/AegisLab-frontend/package.json
@@ -27,7 +27,7 @@
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
-    "@rcabench/client": "npm:@OperationsPAI/client@^1.2.0",
+    "@OperationsPAI/portal": "^1.3.0",
     "@tanstack/react-query": "^5.28.0",
     "@types/react-window": "^2.0.0",
     "ansi-to-html": "^0.7.2",

--- a/AegisLab-frontend/pnpm-lock.yaml
+++ b/AegisLab-frontend/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   .:
     dependencies:
+      '@OperationsPAI/portal':
+        specifier: ^1.3.0
+        version: 1.3.0
       '@ant-design/icons':
         specifier: ^5.3.0
         version: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -37,9 +40,6 @@ importers:
       '@fontsource-variable/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8
-      '@rcabench/client':
-        specifier: npm:@OperationsPAI/client@^1.2.0
-        version: '@OperationsPAI/client@1.2.0'
       '@tanstack/react-query':
         specifier: ^5.28.0
         version: 5.100.9(react@18.3.1)
@@ -182,8 +182,8 @@ importers:
 
 packages:
 
-  '@OperationsPAI/client@1.2.0':
-    resolution: {integrity: sha512-9DKAlCWCjpMwxlXsF6JBN/E08lTbB6iHq669f1GTINj6LkmyEC+r7jMbK+L8qBmBX7AaI3OYn+NoYnfdG0uuOw==, tarball: https://npm.pkg.github.com/download/@OperationsPAI/client/1.2.0/d648870acf6840d81ff81ff8fcf324446c713d6e}
+  '@OperationsPAI/portal@1.3.0':
+    resolution: {integrity: sha512-MVu5YkoyLYRd4JfMASWNBAKG0y8gHtveuMhq7Pb5C+IIZm3C1Ej0EtLkbKmQTbg5aq+kZOTbyI3me0p1HkQU/A==, tarball: https://npm.pkg.github.com/download/@OperationsPAI/portal/1.3.0/c246311bdde1a4100c66804319994c2ce07f3989}
 
   '@ant-design/colors@7.2.1':
     resolution: {integrity: sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==}
@@ -3966,7 +3966,7 @@ packages:
 
 snapshots:
 
-  '@OperationsPAI/client@1.2.0':
+  '@OperationsPAI/portal@1.3.0':
     dependencies:
       axios: 1.16.0
     transitivePeerDependencies:

--- a/AegisLab/CLAUDE.md
+++ b/AegisLab/CLAUDE.md
@@ -370,7 +370,7 @@ cd frontend && npm install
 ```
 
 ### SDK Files Location
-- **TypeScript SDK**: `sdk/typescript/` - Used by frontend via `@rcabench/client`
+- **TypeScript SDK**: `sdk/typescript/` - Used by frontend via `@OperationsPAI/portal`
 - **Python SDK**: `sdk/python/` - Used by CLI tools
 
 ### API Filtering Logic

--- a/AegisLab/docs/frontend-redesign.md
+++ b/AegisLab/docs/frontend-redesign.md
@@ -266,7 +266,7 @@ FaultInjection CRD → HandleCRDSucceeded → BuildDatapack Job → HandleJobSuc
   - DetectorResults: 表格展示每个 span 的 normal vs abnormal 指标 (avg_duration, succ_rate)
   - 可展开的 Percentile 列: p90, p95, p99 (通过 "Show Percentiles" 按钮切换)
   - GranularityResults: 按 rank 排序展示定位结果 (level, result, confidence progress bar)
-  - 类型对齐 SDK: 使用 `DetectorResultItem` 和 `GranularityResultItem` from `@rcabench/client`
+  - 类型对齐 SDK: 使用 `DetectorResultItem` 和 `GranularityResultItem` from `@OperationsPAI/portal`
 - 其他 Tab: Overview, Logs, Files
 
 ### 5.9 Algorithm Benchmark (`/:teamName/:projectName/executions/new`)
@@ -506,12 +506,12 @@ FaultInjection CRD → HandleCRDSucceeded → BuildDatapack Job → HandleJobSuc
 
 ### 7.4 Type Migration
 
-`types/api.ts` 中手写的 `Team`, `TeamMember` 等类型需迁移到 SDK 生成类型 (`@rcabench/client`)。
+`types/api.ts` 中手写的 `Team`, `TeamMember` 等类型需迁移到 SDK 生成类型 (`@OperationsPAI/portal`)。
 
 步骤：
 1. 确保 OpenAPI3 中相关接口带有正确的 `x-api-type` audience 标记（如 `portal` / `admin`）
 2. `just swag-init && just generate-typescript-sdk`
-3. 前端 `import type { ... } from '@rcabench/client'` 替换手写类型
+3. 前端 `import type { ... } from '@OperationsPAI/portal'` 替换手写类型
 
 ## 8. UI/UX Guidelines
 

--- a/AegisLab/project-index.yaml
+++ b/AegisLab/project-index.yaml
@@ -1642,7 +1642,7 @@ requirements:
     description: >
       TypeScript SDK auto-generated from Swagger/OpenAPI specs for frontend
       consumption. Not always present in repo (generated on demand).
-      Used by frontend via @rcabench/client package.
+      Used by frontend via @OperationsPAI/portal package.
     priority: P1
     status: implemented
     confidence: inferred
@@ -2349,7 +2349,7 @@ requirements:
     description: >
       Vite 5 build configuration with React plugin, TypeScript strict mode,
       path aliases (@/ for src/), API proxy to backend, ESLint, and Prettier.
-      Devbox provides pnpm 8 for package management. Private @OperationsPAI/client
+      Devbox provides pnpm 8 for package management. Private @OperationsPAI/portal
       package requires NPM_TOKEN for GitHub Packages authentication.
     priority: P1
     status: implemented
@@ -2741,7 +2741,7 @@ requirements:
 #   - (none — traceApi.getTrace confirmed working as of 2026-04-13 audit)
 #
 # SDK USAGE:
-#   - @rcabench/client used for TYPE IMPORTS and direct types (DetectorResultItem, GranularityResultItem)
+#   - @OperationsPAI/portal used for TYPE IMPORTS and direct types (DetectorResultItem, GranularityResultItem)
 #   - All HTTP calls use raw axios via src/api/client.ts
 #
 # DATA INCONSISTENCIES:

--- a/docs/code-topology/reference.md
+++ b/docs/code-topology/reference.md
@@ -286,7 +286,7 @@ clients.runtime.target       (legacy: runtime_worker.grpc.target)   ← note und
 ## 11. Frontend → backend endpoint usage (from `AegisLab-frontend/src/api/`)
 
 `BASE_PATH = '/api/v2'`. Flat URLs — **the router's audience split (admin/portal/public/sdk)
-is URL-transparent**. Hand-rolled `apiClient.<method>('/path')` mixed with `@rcabench/client` SDK
+is URL-transparent**. Hand-rolled `apiClient.<method>('/path')` mixed with `@OperationsPAI/portal` SDK
 via `sdkAxios`.
 
 Deduped endpoint list (alphabetical, deduped): see `slices/07-data-crosscut-seams.md §10`.

--- a/docs/code-topology/slices/07-data-crosscut-seams.md
+++ b/docs/code-topology/slices/07-data-crosscut-seams.md
@@ -256,7 +256,7 @@ No removed files vs pre-refactor list. No standalone CORS/HTTP helper (CORS is w
 
 ## 10. Frontend → backend `/api/v2/*` usage
 
-Base path is `BASE_PATH = '/api/v2'` in `AegisLab-frontend/src/api/client.ts:4`. All hand-rolled modules call `apiClient.get('/xxx')` relative. There are also `@rcabench/client` SDK calls (auth.ts, sdk.ts) that go through the same axios via `sdkAxios`, but those target whatever paths the generated SDK encodes (separate concern).
+Base path is `BASE_PATH = '/api/v2'` in `AegisLab-frontend/src/api/client.ts:4`. All hand-rolled modules call `apiClient.get('/xxx')` relative. There are also `@OperationsPAI/portal` SDK calls (auth.ts, sdk.ts) that go through the same axios via `sdkAxios`, but those target whatever paths the generated SDK encodes (separate concern).
 
 **Deduped endpoint path list** (relative paths, alpha-sorted). All live under the implicit `/api/v2/` prefix. Parametrised segments shown as `{id}` / `{name}`:
 

--- a/project-index.yaml
+++ b/project-index.yaml
@@ -1605,7 +1605,7 @@ requirements:
   contracts: []
 - id: REQ-601
   title: TypeScript SDK (Auto-generated)
-  description: 'TypeScript SDK auto-generated from Swagger/OpenAPI specs for frontend consumption. Not always present in repo (generated on demand). Used by frontend via @rcabench/client package.
+  description: 'TypeScript SDK auto-generated from Swagger/OpenAPI specs for frontend consumption. Not always present in repo (generated on demand). Used by frontend via @OperationsPAI/portal package.
 
     '
   priority: P1
@@ -2223,7 +2223,7 @@ requirements:
   contracts: []
 - id: REQ-809
   title: Frontend Build Tooling (Vite)
-  description: 'Vite 5 build configuration with React plugin, TypeScript strict mode, path aliases (@/ for src/), API proxy to backend, ESLint, and Prettier. Devbox provides pnpm 8 for package management. Private @OperationsPAI/client package requires NPM_TOKEN for GitHub Packages authentication.
+  description: 'Vite 5 build configuration with React plugin, TypeScript strict mode, path aliases (@/ for src/), API proxy to backend, ESLint, and Prettier. Devbox provides pnpm 8 for package management. Private @OperationsPAI/portal package requires NPM_TOKEN for GitHub Packages authentication.
 
     '
   priority: P1


### PR DESCRIPTION
## Summary
- Drop the `@rcabench/client` → `@OperationsPAI/client` alias; depend directly on `@OperationsPAI/portal@^1.3.0` (audience-filtered SDK published from this repo via `release-ts-portal/v*`).
- Frontend has 0 imports of either old name (business code stripped in `5654549`), so the dep swap is bookkeeping — no code changes needed.
- `.pnpmfile.cjs`: update both the package key and the `link:` target (old path `../AegisLab/client/typescript` didn't exist; new path is `../AegisLab/sdk/typescript/portal`).
- Sweep prose in `AegisLab/CLAUDE.md`, `AegisLab-frontend/CLAUDE.md`, both `project-index.yaml` files, and the topology snapshots.

## Test plan
- [x] `NPM_TOKEN=$(gh auth token) pnpm install` — lockfile only swaps the SDK entry
- [x] `pnpm type-check` — passes
- [x] `pnpm build` — passes