### PR TITLE
feat(blob): module/blob + cmd/aegis-blob 6-role skeleton

### DIFF
--- a/AegisLab/docs/rfcs/api-gateway.md
+++ b/AegisLab/docs/rfcs/api-gateway.md
@@ -1,0 +1,291 @@
+# RFC: API Gateway (`cmd/aegis-gateway`)
+
+- Status: **Draft**
+- Owners: aegis-backend
+- Stakeholders: every downstream service (sso, notify, blob, monolith
+  api), aegis-ui (single base URL)
+- Related: `helm/templates/edge-proxy.yaml` (current Caddy proxy that
+  this replaces in front of api-gateway), `module/ssoclient`,
+  `module/ratelimiter`, `module/configcenter` RFC
+
+---
+
+## Summary
+
+Replace the current Caddy "edge-proxy" + monolith `cmd/api-gateway`
+pattern with a proper L7 application gateway: `cmd/aegis-gateway`,
+default `:8086`. It owns route → upstream mapping, JWT pre-auth (via
+`ssoclient`), global per-route rate limit (via `ratelimiter`), CORS,
+request logging, and per-upstream health. Caddy retreats to TLS
+termination + static asset serving only.
+
+The current `cmd/api-gateway` is renamed to `cmd/aegis-api` (it was
+always the monolith API binary; calling it a gateway misled both
+operators and new contributors).
+
+## Motivation
+
+Right now "API gateway" means two unrelated things:
+
+| Layer | What it is | Problem |
+| --- | --- | --- |
+| `helm/templates/edge-proxy.yaml` (Caddy) | Pure reverse proxy: `:80 → api-gateway-svc:80` and `:9096 → api-gateway-svc:9096` | No auth, no rate limit, no route awareness. Just a port forwarder. |
+| `cmd/api-gateway` + `app/gateway/options.go` | "The single API binary: it owns every module" | Misnamed. It's the monolith. As we extract sso / notify / blob into independent binaries, the "gateway" name leaks the wrong mental model. |
+
+Concretely:
+
+- A request hitting `/api/v2/inbox/...` should land on `aegis-notify`,
+  not the monolith. Today Caddy doesn't know that.
+- A request hitting `/api/v2/blob/...` should land on `aegis-blob`.
+- JWT verification is duplicated in every backend service. Verifying
+  once at the gateway would let services trust headers
+  (`X-Aegis-User-Id`, `X-Aegis-Roles`) instead of re-running the
+  ssoclient pipeline.
+- Rate limiting is per-process, which means per-pod. A real gateway
+  gives us a single chokepoint that's easier to operate.
+
+## Non-goals
+
+- Service mesh (mTLS between services, sidecar injection, observability
+  spans across hops). If we go there, it's Istio/Linkerd, not a gateway.
+- Layer-4 load balancing. Kubernetes Services do that.
+- Caching. CDN handles caching for static assets.
+- API composition / GraphQL stitching. Out of scope.
+- WAF rules beyond CORS + simple header checks. Buy a real WAF if/when
+  needed.
+
+## Proposed design
+
+### Topology
+
+```
+                ┌──────────────────────────────────────────────────────┐
+                │                  Caddy (TLS termination)             │
+                │  - cert mgmt                                         │
+                │  - static asset serving (apps/console build)         │
+                │  - forwards everything else to aegis-gateway         │
+                └────────────────────┬─────────────────────────────────┘
+                                     │
+                              ┌──────▼───────┐
+                              │ aegis-gateway│   (this RFC)
+                              │   :8086      │
+                              └──────┬───────┘
+            ┌───────────┬────────────┼────────────┬─────────────┐
+            │           │            │            │             │
+       ┌────▼─────┐ ┌───▼────┐ ┌─────▼─────┐ ┌────▼─────┐ ┌─────▼────┐
+       │ aegis-sso│ │aegis-  │ │aegis-blob │ │aegis-    │ │ aegis-api│
+       │  :8083   │ │notify  │ │  :8085    │ │notify    │ │  (monolith)│
+       │          │ │ :8084  │ │           │ │  :8084   │ │   :8080  │
+       └──────────┘ └────────┘ └───────────┘ └──────────┘ └──────────┘
+```
+
+### Route table
+
+Routes are config-driven (and once `configcenter` lands, hot-
+reloadable from etcd). Initial table:
+
+```toml
+[[gateway.routes]]
+prefix     = "/v1/"            # OIDC endpoints
+upstream   = "aegis-sso:8083"
+auth       = "none"             # SSO itself owns these endpoints
+
+[[gateway.routes]]
+prefix     = "/.well-known/"
+upstream   = "aegis-sso:8083"
+auth       = "none"
+
+[[gateway.routes]]
+prefix     = "/api/v2/inbox/"
+upstream   = "aegis-notify:8084"
+auth       = "jwt"
+audiences  = ["portal"]
+
+[[gateway.routes]]
+prefix     = "/api/v2/notifications/"
+upstream   = "aegis-notify:8084"
+auth       = "jwt"
+
+[[gateway.routes]]
+prefix     = "/api/v2/blob/"
+upstream   = "aegis-blob:8085"
+auth       = "jwt"
+
+[[gateway.routes]]
+prefix     = "/api/v2/auth/"     # human-user login/register via monolith
+upstream   = "aegis-api:8080"
+auth       = "none"
+
+[[gateway.routes]]
+prefix     = "/"                  # everything else → monolith
+upstream   = "aegis-api:8080"
+auth       = "jwt"
+```
+
+Match order is first-match. Per-route options:
+
+- `auth`: `none` | `jwt` | `service-token` | `jwt-or-service`
+- `audiences`: optional, restricts JWT audience
+- `rate_limit`: `{rps, burst}` — overrides global default
+- `strip_prefix`: bool, default false
+- `timeout_seconds`: int, default 30
+- `retry`: `{attempts, on_status: [502, 503, 504]}` — default 0
+
+### JWT pre-auth
+
+Verify once at the gateway via `ssoclient` (same library every backend
+uses today). On success, **inject headers** the upstream can trust:
+
+```
+X-Aegis-User-Id: 42
+X-Aegis-User-Email: alice@aegis.example
+X-Aegis-Roles: admin,operator
+X-Aegis-Token-Aud: portal
+X-Aegis-Token-Jti: abc123
+```
+
+The upstream's `middleware/auth` is updated to:
+
+1. If `X-Aegis-User-Id` present **and** the request arrived on the
+   intra-cluster network (configurable IP whitelist or mTLS), trust
+   it directly — skip re-verification.
+2. Otherwise, run the existing ssoclient verification path (for
+   anyone hitting the upstream directly during development or
+   tests).
+
+This is intentionally additive: the upstream still works without
+the gateway. The gateway is an optimization + policy point, not a
+hard dependency.
+
+### Rate limiting
+
+Global limiter in front of every route, configurable per route. Use
+`module/ratelimiter` as the limiter implementation; in v1 it remains
+in-process (per gateway pod). When we run multiple gateway replicas:
+either accept per-pod limits (typical for L7 gateways) or back the
+limiter with Redis (`ratelimiter` already supports a Redis backend —
+flip via config).
+
+### CORS
+
+Single CORS policy applied at the gateway:
+
+```toml
+[gateway.cors]
+allowed_origins  = ["http://localhost:3101", "https://aegis.example"]
+allowed_methods  = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+allowed_headers  = ["Authorization", "Content-Type"]
+allow_credentials = true
+max_age_seconds  = 86400
+```
+
+Upstreams no longer add CORS headers (they were inconsistent — we
+remove that code in a follow-up).
+
+### Logging + observability
+
+- One access log line per request: `ts | route | upstream | method |
+  path | status | latency_ms | user_id | request_id`
+- Trace span per request, propagated via `traceparent` header to the
+  upstream (reuse `infra/tracing`).
+- Metrics: `gateway_requests_total{route, status}`,
+  `gateway_request_duration_seconds{route}`,
+  `gateway_upstream_errors_total{route, kind}`,
+  `gateway_ratelimit_drops_total{route}`.
+
+### Health
+
+- `GET /healthz` on gateway → 200 if the gateway is alive.
+- `GET /readyz` on gateway → 200 if it can reach a configurable
+  subset of upstreams (the gateway holds a short-lived TCP probe
+  pool per upstream).
+- Per-upstream circuit breaker (open after N consecutive 5xx) ships
+  in v2; v1 just retries per route config.
+
+### Configuration
+
+Driven by:
+
+1. `[gateway.routes]` table in `config.<env>.toml` (static).
+2. Once `configcenter` lands: `/aegis/<env>/gateway/routes` in etcd
+   overrides + adds. Hot reload, no restart.
+
+### Failure modes
+
+- Upstream unreachable → 502 with request_id; metric bumped; retry
+  per route policy.
+- JWT verification fails → 401; never reaches upstream.
+- Rate limit exceeded → 429 with `Retry-After`.
+- Gateway pod crash → kube replaces it; route table is config so
+  no state to recover.
+
+### What about gRPC?
+
+The current edge-proxy also forwards `:9096` for the runtime-intake
+gRPC. v1 of `aegis-gateway` does **not** terminate gRPC — we keep
+Caddy or a dedicated gRPC proxy for that one path until we have a
+second gRPC service worth gatewaying. Premature otherwise.
+
+## Migration plan
+
+1. **Phase A (this PR)**: rename `cmd/api-gateway` → `cmd/aegis-api`,
+   `app/gateway` → `app/monolith` (the existing options file).
+   Land `cmd/aegis-gateway` + `app/gateway` (the new gateway). Wire
+   route table in TOML. No production traffic yet.
+2. **Phase B**: Helm chart adds the gateway deployment + service. The
+   existing `edge-proxy` Caddy starts pointing at `aegis-gateway`
+   instead of `aegis-api`.
+3. **Phase C**: trusted-header upstream short-circuit lands in
+   each backend (`module/auth`). Re-test that direct upstream access
+   still works (for dev / `pnpm dev` proxy fallback).
+4. **Phase D**: once `configcenter` is live, move the route table to
+   etcd for hot reload.
+
+## Alternatives considered
+
+- **Use Caddy as the gateway (Caddyfile routes + plugins).** Possible,
+  but JWT verification needs a Caddy plugin written in Go anyway, and
+  we lose the ability to reuse `ssoclient` and `ratelimiter`
+  directly. Easier to own the gateway as a Go binary.
+- **Use Envoy / Kong / Traefik.** All capable; all add an
+  operational component the team doesn't run. JWT plugins exist
+  (Envoy JWT filter) but mapping our specific audience/role
+  semantics is non-trivial. Defer until we outgrow a Go gateway.
+- **Stay on Caddy reverse proxy + per-service auth.** Cheapest, but
+  every new service re-runs the ssoclient pipeline, CORS gets
+  duplicated, rate-limit policy fragments. The whole point of
+  pulling sso/notify/blob into independent services is to make this
+  the natural extraction point.
+- **Build into the monolith ("monolith dispatches to RPCs").** That's
+  what we have today, modulo the missing RPCs. The monolith binary
+  shouldn't grow more responsibilities; it should shed them.
+
+## Open questions
+
+1. **Service-token issuance for upstreams.** When the gateway calls
+   an upstream with trusted-header injection, does the upstream
+   require a service token in addition? Proposal: no for v1 — IP
+   allowlist + signed header (HMAC over user_id+ts+jti) is enough.
+   mTLS as a v2 hardening step.
+2. **mTLS between gateway and upstreams.** Skip in v1 (rely on
+   network policies). Add in v2 if compliance demands it.
+3. **Where do we run a /admin route?** Proposal: route `prefix =
+   "/api/v2/admin/"` → monolith, `auth = "jwt"`, `roles = ["admin"]`
+   (new field), and the monolith trusts the role header.
+
+## Acceptance criteria
+
+- `aegis-gateway serve --port 8086` boots, loads route table from
+  TOML, passes `/healthz`.
+- Hitting `http://gateway/api/v2/inbox` from a logged-in browser
+  reaches `aegis-notify` with `X-Aegis-User-Id` injected, and the
+  inbox returns the user's items.
+- Hitting `http://gateway/api/v2/inbox` without a JWT returns 401
+  from the gateway (never reaches notify).
+- Rate-limit headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`)
+  present on every response.
+- `pnpm dev` proxy in `apps/console/vite.config.ts` points at
+  `aegis-gateway` instead of the SSO target directly, and both the
+  /authorize flow AND the inbox flow work end-to-end.
+- The monolith's existing tests still pass when called directly
+  (not via the gateway).

--- a/AegisLab/docs/rfcs/blob-storage.md
+++ b/AegisLab/docs/rfcs/blob-storage.md
@@ -1,0 +1,359 @@
+# RFC: Blob storage (`module/blob` + `cmd/aegis-blob`)
+
+- Status: **Draft**
+- Owners: aegis-backend
+- Stakeholders: dataset, user (avatars), evaluation (report export),
+  injection (artifacts), notification (rich payload assets), frontend
+  (direct upload via presigned URL)
+- Related: `module/notification` RFC, `module/sso` (issues service
+  tokens), `infra/etcd` (configuration source)
+
+---
+
+## Summary
+
+Add a first-class blob storage service to the platform. Ship it as
+`module/blob` (in-process producer surface), `module/blobclient`
+(local + remote dual-mode SDK matching the notification pattern), and
+`cmd/aegis-blob` (standalone microservice, default `:8085`). Default
+driver is `localfs`; production drivers (RustFS-compatible S3, MinIO,
+AWS S3, Aliyun OSS) plug in behind one `Driver` interface.
+
+Frontend uploads go **straight to the storage backend** via short-lived
+presigned URLs — blob service issues the signature, never proxies the
+bytes.
+
+## Motivation
+
+We currently have no abstraction for object storage. Today this is
+ad-hoc per module:
+
+| Need | Current state |
+| --- | --- |
+| Dataset artifacts | written to PVC inside the workload pod, opaque to other services |
+| User avatars | not implemented; `users.avatar_url` would be free-text today |
+| Evaluation report export | not implemented; would dump to pod local FS |
+| Injection bundle attachments | not implemented |
+| Notification rich payload | RFC explicitly punts |
+
+Every one of these would otherwise re-invent: bucket selection,
+authn for upload, retention, ACL, presigning, error handling. Pulling
+it into one module + one binary makes them additive.
+
+This RFC mirrors the shape of `module/notification` so the team
+already knows the pattern: thin core, plugin-driven extension points,
+in-process + remote dual-mode SDK, standalone binary deferrable until
+load demands it.
+
+## Non-goals
+
+- CDN front-cache. Out of scope; downstream consumers add CDN per
+  bucket if they need it (avatar bucket would; dataset wouldn't).
+- Object-level full-text search / metadata indexing. We store enough
+  metadata for "find my objects by entity_kind/entity_id"; anything
+  richer goes through a dedicated search service.
+- Versioning / WORM. Drivers may support it; the platform doesn't
+  expose it in v1.
+- Multipart-upload-resume across server restarts. v1 lets drivers
+  handle it natively (S3 multipart) but the service doesn't persist
+  upload state.
+
+## Proposed design
+
+### Six roles (mirrors notification skeleton)
+
+```
+Ingestion → Authorization → Routing (bucket) → Driver → Lifecycle → Observability
+```
+
+1. **Ingestion** — `PresignPut` / `Put` (small inline) / `Stat` /
+   `Get` (small inline) / `PresignGet` / `Delete` over HTTP and via
+   the in-process `Client` SDK.
+2. **Authorization** — JWT verified by the same `ssoclient` everyone
+   uses. Per-bucket policy: who can write, who can read, max object
+   size, allowed content-types.
+3. **Routing** — bucket name → driver instance. Buckets are config-
+   driven (TOML in v1, optionally promoted to DB later).
+4. **Driver** — pluggable interface; concretes: `localfs`, `s3`. RustFS
+   reuses `s3` driver with custom endpoint.
+5. **Lifecycle** — TTL / retention / archive. Hourly job lists
+   metadata rows, deletes expired objects via driver.
+6. **Observability** — `objects_uploaded`, `bytes_in/out`, p95 presign
+   latency, driver error rate (per bucket).
+
+### Driver interface
+
+```go
+package blob
+
+type Driver interface {
+    Name() string
+    PresignPut(ctx context.Context, key string, opts PutOpts) (PresignedRequest, error)
+    PresignGet(ctx context.Context, key string, opts GetOpts) (PresignedRequest, error)
+    Put(ctx context.Context, key string, r io.Reader, opts PutOpts) (*ObjectMeta, error)
+    Get(ctx context.Context, key string) (io.ReadCloser, *ObjectMeta, error)
+    Stat(ctx context.Context, key string) (*ObjectMeta, error)
+    Delete(ctx context.Context, key string) error
+    List(ctx context.Context, prefix string, cursor string, limit int) (ListResult, error)
+}
+
+type PresignedRequest struct {
+    Method  string            // PUT or GET
+    URL     string            // signed URL — frontend hits this directly
+    Headers map[string]string // headers client must send (Content-Type, x-amz-*)
+    Expires time.Time
+}
+
+type PutOpts struct {
+    ContentType   string
+    ContentLength int64
+    Metadata      map[string]string // arbitrary x-amz-meta-* equivalents
+    CacheControl  string
+}
+
+type ObjectMeta struct {
+    Key         string
+    Size        int64
+    ContentType string
+    ETag        string
+    UpdatedAt   time.Time
+    Metadata    map[string]string
+}
+```
+
+`localfs` driver presigning: sign a JWT containing `{key, op, exp}`
+and return a URL pointed at our own `/v2/blob/raw/:key?token=…`
+handler — same UX as S3 presigning, no driver-specific frontend code.
+
+### Bucket model
+
+Buckets are declared in config:
+
+```toml
+[blob.buckets.dataset-artifacts]
+driver = "s3"
+endpoint = "http://rustfs:9000"
+region = "us-east-1"
+access_key_env = "RUSTFS_ACCESS_KEY"
+secret_key_env = "RUSTFS_SECRET_KEY"
+bucket = "aegis-dataset"
+max_object_bytes = 5_368_709_120        # 5 GiB
+allowed_content_types = ["application/x-tar", "application/zip", "application/octet-stream"]
+public_read = false
+retention_days = 365
+
+[blob.buckets.user-avatars]
+driver = "s3"
+endpoint = "http://rustfs:9000"
+bucket = "aegis-avatars"
+max_object_bytes = 5_242_880            # 5 MiB
+allowed_content_types = ["image/png", "image/jpeg", "image/webp"]
+public_read = true
+cdn_base = "https://cdn.aegis.example/avatars"
+
+[blob.buckets.scratch]
+driver = "localfs"
+root = "/var/lib/aegis/blob/scratch"
+retention_days = 7
+```
+
+DB-driven buckets (admin UI for "create a bucket") is a v2 follow-up
+and explicitly NOT in v1. Config-driven matches GitOps and lets dev
+boxes work without any infra.
+
+Producers reference buckets by **stable name**, never by driver
+specifics. The producer signature is `client.PresignPut(ctx, bucket,
+PutReq{...})` — no S3 endpoint leaking out.
+
+### Data model
+
+```sql
+CREATE TABLE blob_objects (
+  id              BIGINT       PRIMARY KEY AUTO_INCREMENT,
+  bucket          VARCHAR(64)  NOT NULL,
+  storage_key     VARCHAR(512) NOT NULL,  -- the driver-side key
+  size_bytes      BIGINT       NOT NULL,
+  content_type    VARCHAR(128) NOT NULL,
+  etag            VARCHAR(128),
+  uploaded_by     INT,                    -- users.id, null for service writes
+  entity_kind     VARCHAR(64),            -- e.g. dataset, injection, user
+  entity_id       VARCHAR(128),
+  metadata        JSON,
+  created_at      DATETIME(3)  NOT NULL,
+  expires_at      DATETIME(3),            -- driven by bucket.retention_days
+  deleted_at      DATETIME(3),
+  INDEX idx_bucket_key (bucket, storage_key),
+  INDEX idx_entity   (entity_kind, entity_id),
+  INDEX idx_uploader (uploaded_by, created_at DESC)
+);
+```
+
+The DB stores **metadata only** — bytes live in the driver. This
+table is what the lifecycle worker walks, what audit/list endpoints
+hit, and what enforces per-user quota.
+
+### HTTP surface
+
+Mounted at `/api/v2/blob/*`. JWT required, audience = `portal` or
+service-token. Bucket-level RBAC enforced before driver call.
+
+| Method & path | Description |
+| --- | --- |
+| `POST /buckets/:bucket/presign-put` | Issue presigned PUT. Body: `{key?, content_type, content_length, metadata?}`. Server fills `key` with `{entity_kind}/{ulid}` if absent. Returns `PresignedRequest` + metadata row id. |
+| `POST /buckets/:bucket/presign-get` | Issue presigned GET. Body: `{key}`. |
+| `GET /buckets/:bucket/objects/:key` | Inline GET (small objects; redirect to presigned URL above `inline_max_bytes`). |
+| `HEAD /buckets/:bucket/objects/:key` | Stat. |
+| `DELETE /buckets/:bucket/objects/:key` | Soft delete (sets `deleted_at`, removes via driver async). |
+| `GET /buckets/:bucket/objects` | List by entity. Query: `entity_kind`, `entity_id`, `cursor`, `limit`. |
+| `GET /raw/:token` | Localfs driver only — serves the presigned URL target. Verifies JWT-style token, streams the file. Never enabled when all buckets are S3. |
+| `POST /v1/events:object-uploaded` | Internal callback from frontend (or driver event listener) confirming an upload completed. Updates `etag` + `size_bytes` from the driver. |
+
+Response shape:
+
+```json
+{
+  "object_id": 4711,
+  "bucket": "dataset-artifacts",
+  "key": "dataset/01HXY2KQ4F0F9B0D5K8N5N7B6A.tar",
+  "size_bytes": null,
+  "presigned": {
+    "method": "PUT",
+    "url": "http://rustfs:9000/aegis-dataset/dataset/01HXY...?X-Amz-Algorithm=...",
+    "headers": {"Content-Type": "application/x-tar"},
+    "expires_at": "2026-05-12T03:14:05Z"
+  }
+}
+```
+
+### Producer SDK (`module/blobclient`)
+
+```go
+package blobclient
+
+type Client interface {
+    PresignPut(ctx context.Context, bucket string, req PresignPutReq) (*PresignResult, error)
+    PresignGet(ctx context.Context, bucket, key string) (*PresignResult, error)
+    Stat(ctx context.Context, bucket, key string) (*ObjectMeta, error)
+    Delete(ctx context.Context, bucket, key string) error
+    // small-payload helpers, optional
+    PutBytes(ctx context.Context, bucket, key string, body []byte, opts PutOpts) (*ObjectMeta, error)
+    GetBytes(ctx context.Context, bucket, key string) ([]byte, *ObjectMeta, error)
+}
+```
+
+Two implementations:
+
+- `LocalClient` — calls `module/blob` in-process; used by the monolith
+  and by any service that already imports `module/blob`.
+- `RemoteClient` — HTTP client to `aegis-blob`; carries a service
+  token from `ssoclient`. Used when caller is in a service that does
+  not embed `module/blob` (e.g. an independent dataset microservice).
+
+Selected at wiring time by config:
+
+```toml
+[blob.client]
+mode = "local"   # or "remote"
+endpoint = "http://aegis-blob:8085"
+```
+
+Identical to the `notificationclient` pattern, by design.
+
+### Standalone binary
+
+`cmd/aegis-blob` mirrors `cmd/aegis-notify`:
+
+```
+package main
+// cobra entry, default port :8085, --conf <dir>
+fx.New(blob.Options(conf, port)).Run()
+```
+
+`app/blob/options.go` composes:
+
+- `app.BaseOptions(conf)` + `ObserveOptions` + `DataOptions`
+- `module/auth` (JWT verifier — same service tokens as aegis-notify)
+- `module/user` (uploader display name lookup)
+- `module/blob`
+- `httpapi.Module` + `/healthz` decorator
+
+Buckets that use the `s3` driver get their credentials from env vars
+referenced by config (see bucket TOML above). RustFS endpoint is just
+another S3 endpoint; the driver code does not branch on RustFS.
+
+### Authorization model
+
+- JWT must be valid and audience-allowed.
+- Each bucket carries an ACL: `write_roles`, `read_roles`,
+  `public_read`. Service tokens get a default `service` role.
+- For private buckets, presigned GET requires the caller to either
+  have read access or own the object (`uploaded_by == ctx.UserID`).
+- Per-user quota (sum of `size_bytes` where `deleted_at IS NULL`)
+  enforced before issuing a presigned PUT.
+
+### Failure modes
+
+- Driver `PresignPut` fails → metadata row not created; client gets
+  502. (Metadata is written **after** the presign succeeds, so we
+  don't leave orphans referencing presign failures.)
+- Frontend never calls back `/v1/events:object-uploaded` → object
+  exists in driver but metadata row is `size_bytes=null`. Hourly
+  reconcile job calls `driver.Stat`, fills in or deletes orphan.
+- Driver outage → presign endpoint returns 503; producers retry with
+  backoff (idempotent because key generation is content-based when
+  caller doesn't provide one).
+
+## Migration plan
+
+1. **Phase A (this PR)**: land `module/blob` (driver iface + localfs +
+   s3 stub) + `module/blobclient` (local mode only) + `cmd/aegis-blob`
+   skeleton + metadata table migration. Default bucket `scratch`
+   (localfs). No producers wired yet.
+2. **Phase B**: complete `s3` driver, deploy RustFS in Helm chart,
+   declare `dataset-artifacts` + `user-avatars` buckets.
+3. **Phase C**: wire first real producer — `module/user` writes
+   avatars; frontend gets the upload flow. Use this to harden the
+   presign+confirm round trip.
+4. **Phase D**: migrate dataset writes through `module/blob`.
+
+## Alternatives considered
+
+- **Skip the abstraction, every module writes to S3 directly.** Tried
+  this pattern in prior projects — every consumer reinvents bucket
+  policy, presigning, retention. Inconsistent and risky.
+- **Use a managed product (Cloudflare R2 SDK directly, etc.).** No
+  abstraction means switching providers requires changing every
+  caller. Driver iface costs ~200 lines and buys provider freedom.
+- **Skip presigned URLs, proxy all bytes.** Simpler auth but the blob
+  service becomes the bandwidth bottleneck. RustFS deployment exists
+  precisely so we can offload bytes to it.
+- **DB-driven buckets in v1.** Adds an admin UI and migration story
+  with zero current need. Config-driven is the right v1.
+
+## Open questions
+
+1. **Where do driver credentials live?** Proposal: bucket config
+   references env-var names, not literal secrets. Helm/compose
+   populates the env from sealed secrets. Same model as the SSO
+   private-key path.
+2. **Localfs presign token signing key.** Reuse SSO's RSA keypair?
+   Or a dedicated HMAC key? Proposal: dedicated HMAC, narrower
+   blast radius if leaked.
+3. **Object-key generation.** Random ULID under
+   `{entity_kind}/{ulid}` is the v1 default. Some callers will want
+   deterministic keys (avatars by user id, for de-dupe). Solve via
+   `PresignPutReq.Key` override.
+4. **Inline GET threshold.** 64 KiB? 1 MiB? Set per bucket; default
+   64 KiB.
+
+## Acceptance criteria
+
+- `aegis-blob serve --port 8085` boots against a localfs scratch
+  bucket and an S3 bucket pointed at a local MinIO instance.
+- Frontend can: (1) call `POST /api/v2/blob/buckets/user-avatars/
+  presign-put`, (2) PUT the bytes directly to the returned URL,
+  (3) call back `:object-uploaded`, (4) reference the object by id
+  in `users.avatar_object_id`.
+- 1k presign calls/sec on a single replica without driver errors.
+- `pnpm check` on the console stays green after adding `blobclient`
+  to `apps/console`.

--- a/AegisLab/docs/rfcs/configcenter.md
+++ b/AegisLab/docs/rfcs/configcenter.md
@@ -1,0 +1,382 @@
+# RFC: Configuration center (`module/configcenter` + `cmd/aegis-configcenter`)
+
+- Status: **Draft**
+- Owners: aegis-backend
+- Stakeholders: every service (sso, notify, blob, monolith, gateway)
+- Related: `infra/etcd/Gateway` (the KV primitive this builds on),
+  `config/config.go` (viper TOML+env layer this extends),
+  `module/notification` (the standalone-service pattern this mirrors)
+
+---
+
+## Summary
+
+Promote etcd from "a KV some modules happen to use" into the
+platform's dynamic configuration source, fronted by a first-class
+service. Ship:
+
+- `module/configcenter` — in-process implementation on top of
+  `infra/etcd.Gateway`: layered merge (etcd > env > TOML), typed
+  `Bind[T]`, hot reload via Watch, audit trail.
+- `module/configcenterclient` — local + remote dual-mode SDK, matching
+  the `notificationclient` pattern.
+- `cmd/aegis-configcenter` — standalone microservice, default `:8087`,
+  composed identically to `aegis-notify` / `aegis-sso`. **It does NOT
+  replace etcd**; etcd remains the storage backend. The service owns
+  the typed admin API, audit log, schema validation, watch fanout,
+  and the only place that holds write credentials to etcd.
+
+Consumers go through `configcenterclient`. They never touch etcd
+directly for *configuration*. (Distributed-lock / lease use of etcd
+in `module/injection/alloc.go` is unrelated and stays on
+`infra/etcd.Gateway`.)
+
+## Motivation
+
+Today, configuration is split:
+
+- `config/config.go` — viper, reads TOML, applies env overrides via
+  `SetEnvKeyReplacer` (added when SSO landed).
+- `infra/etcd/Gateway` — used by `module/system`, `chaossystem`,
+  `injection/alloc` as a free-form KV store. Each consumer parses
+  its own values, no schema, no typed access, no hot reload.
+
+The gap:
+
+| Need | Today | Gap |
+| --- | --- | --- |
+| Read static config (DB DSN, ports) | TOML + env via viper | ✅ |
+| Read dynamic config (feature flags, ramp percentages) | nowhere | ❌ |
+| Watch for changes (no restart) | etcd Watch exists but no typed API | ⚠ raw KV only |
+| Audit who changed a value | none | ❌ |
+| Namespace per service | informal key naming | ⚠ |
+| Schema validation | none | ❌ — wrong type = runtime panic |
+| Override TOML at runtime | only env, not etcd | ❌ |
+
+Without a unified layer, every new dynamic-config consumer reinvents
+the same parsing + watch + reload boilerplate.
+
+## Non-goals
+
+- Replace TOML files. TOML stays the canonical static-config source
+  for "things that need to be set before the process starts" (DB
+  DSN, JWT keys path, etcd endpoints themselves).
+- Multi-cluster / multi-tenant config federation. Single etcd
+  cluster per environment in v1.
+- A general-purpose config-as-a-service GUI. We expose admin endpoints;
+  the portal can build a UI later.
+- Secrets manager. Secrets stay in env / sealed secrets / driver
+  credentials; this is for plain config.
+
+## Proposed design
+
+### Layered merge order
+
+```
+etcd  (highest — runtime override, hot)
+  ↓ env vars
+  ↓ TOML file
+defaults in code (lowest)
+```
+
+Rationale: TOML is checked-in baseline, env is per-deploy override
+(matches the SSO env-replacer change), etcd is the runtime override
+that can be flipped without redeploy. This matches the implicit
+order developers already expect — etcd just slots above env.
+
+### Typed API
+
+```go
+package configcenter
+
+type Center interface {
+    // Bind reads the value at namespace+key, decodes into out (a pointer to
+    // a struct or scalar), applies the layered merge, and registers a
+    // watcher so subsequent etcd changes update out atomically.
+    Bind(ctx context.Context, namespace, key string, out any, opts ...BindOpt) (Handle, error)
+
+    // Get reads the current resolved value as JSON (for admin / debug).
+    Get(ctx context.Context, namespace, key string) (raw []byte, layer string, err error)
+
+    // Set writes a value to etcd. Always at the etcd layer (top).
+    Set(ctx context.Context, namespace, key string, value any, opts ...SetOpt) error
+
+    // Delete removes the etcd-layer entry; lower layers reappear.
+    Delete(ctx context.Context, namespace, key string) error
+
+    // List returns all keys under a namespace, with their current values
+    // and which layer each resolves from.
+    List(ctx context.Context, namespace string) ([]Entry, error)
+}
+
+type Handle interface {
+    // Reload forces a re-decode (useful in tests).
+    Reload(ctx context.Context) error
+    // Subscribe registers a callback fired on every change.
+    Subscribe(fn func()) (unsubscribe func())
+    Close() error
+}
+
+type BindOpt func(*bindOptions)
+
+func WithDefault(v any) BindOpt
+func WithValidator(fn func(any) error) BindOpt
+func WithSchemaVersion(v int) BindOpt
+```
+
+Concrete consumer pattern:
+
+```go
+type RateLimitConfig struct {
+    DefaultRPS   int            `mapstructure:"default_rps"`
+    PerRoute     map[string]int `mapstructure:"per_route"`
+    Enabled      bool           `mapstructure:"enabled"`
+}
+
+var cfg RateLimitConfig
+h, err := center.Bind(ctx, "ratelimiter", "default", &cfg,
+    configcenter.WithDefault(RateLimitConfig{DefaultRPS: 100, Enabled: true}),
+    configcenter.WithValidator(validateRateLimit),
+)
+defer h.Close()
+h.Subscribe(func() { logrus.Info("rate limit config reloaded") })
+```
+
+All `cfg` reads from the same goroutine see a coherent snapshot
+because `Bind` swaps the pointer target atomically via reflect — or,
+for advanced cases, callers can use a sync.Value-style accessor.
+
+### Key naming
+
+```
+/aegis/<env>/<namespace>/<key>
+```
+
+- `env` — `dev` | `staging` | `prod`. Comes from process env at startup.
+- `namespace` — module-owned. e.g. `notification`, `blob`, `gateway`,
+  `injection`, `system`.
+- `key` — module-defined. Lowercase, dot-separated.
+
+Examples:
+
+```
+/aegis/prod/notification/dedup_window_seconds
+/aegis/prod/notification/channels.email.enabled
+/aegis/prod/gateway/rate_limit.default_rps
+/aegis/prod/blob/buckets.dataset-artifacts.retention_days
+```
+
+### Storage format
+
+Values are JSON, regardless of original type. Decoder uses
+`mapstructure` so struct tags from existing config types work
+unchanged. This lets `Set` accept either typed Go values or raw
+JSON (admin API).
+
+### Watch + atomic swap
+
+`Bind` opens a single etcd watch per Center instance (multiplexed
+internally). On change:
+
+1. Re-decode value.
+2. Run validator.
+3. If invalid: keep previous value, log + bump
+   `configcenter_invalid_updates_total{namespace,key}`.
+4. If valid: atomic pointer swap; fire subscribers.
+
+The merge is recomputed on every change. If the etcd value is
+deleted, the resolved value falls back to env → TOML → default.
+
+### HTTP surface (owned by `aegis-configcenter`)
+
+All routes JWT-required. Read endpoints accept any authenticated
+service token or human user; write endpoints require role = `admin`
+(human) or scope = `config:write` (service token).
+
+| Method & path | Description |
+| --- | --- |
+| `GET /api/v2/config/:namespace` | List all keys + values + resolving layer. |
+| `GET /api/v2/config/:namespace/:key` | Get one. |
+| `PUT /api/v2/config/:namespace/:key` | Set etcd layer. Body: JSON value. Writes audit row. |
+| `DELETE /api/v2/config/:namespace/:key` | Remove etcd layer. Writes audit row. |
+| `GET /api/v2/config/:namespace/:key/history` | Read recent revisions (capped). |
+| `GET /api/v2/config/:namespace/watch` | SSE stream of changes under a namespace. The `configcenterclient` remote impl subscribes here instead of opening its own etcd watch. |
+| `GET /healthz` | Liveness. |
+| `GET /readyz` | Etcd reachable + last successful watch event. |
+
+`aegis-configcenter` is the **only** process that holds etcd write
+credentials in v1. Etcd is locked down at the network layer to
+accept connections only from this service (admin) and from a
+read-only role used by services that fall back to direct watches
+during a configcenter outage (see Failure modes).
+
+### Audit
+
+```sql
+CREATE TABLE config_audit (
+  id          BIGINT       PRIMARY KEY AUTO_INCREMENT,
+  namespace   VARCHAR(64)  NOT NULL,
+  key_path    VARCHAR(256) NOT NULL,
+  action      VARCHAR(16)  NOT NULL,   -- set | delete
+  old_value   JSON,
+  new_value   JSON,
+  actor_id    INT,                      -- users.id, null for service tokens
+  actor_token VARCHAR(64),              -- token sub for service writes
+  reason      VARCHAR(256),
+  created_at  DATETIME(3) NOT NULL,
+  INDEX idx_ns_key (namespace, key_path, created_at DESC)
+);
+```
+
+Written synchronously on every Set/Delete by the admin handler. The
+typed in-process `Set` is only callable from the admin handler — no
+backdoor.
+
+### Producer SDK (`module/configcenterclient`)
+
+Mirrors `module/notificationclient` exactly: same `Client`
+interface, two impls, mode selected by config.
+
+```go
+package configcenterclient
+
+type Client interface {
+    Bind(ctx context.Context, namespace, key string, out any, opts ...BindOpt) (Handle, error)
+    Get(ctx context.Context, namespace, key string) (raw []byte, layer string, err error)
+    Set(ctx context.Context, namespace, key string, value any, opts ...SetOpt) error
+    Delete(ctx context.Context, namespace, key string) error
+    List(ctx context.Context, namespace string) ([]Entry, error)
+}
+```
+
+- `LocalClient` — wraps `module/configcenter` in-process. Used by
+  `aegis-configcenter` itself and by any binary that wants to skip
+  the hop (e.g. dev builds where everything runs in-process).
+- `RemoteClient` — HTTP client to `aegis-configcenter`. Subscribes to
+  the SSE watch stream for hot reload. Carries a service token from
+  `ssoclient`. This is what every other service uses by default.
+
+Wiring:
+
+```toml
+[configcenter.client]
+mode = "remote"
+endpoint = "http://aegis-configcenter:8087"
+```
+
+### Standalone binary
+
+`cmd/aegis-configcenter` mirrors `cmd/aegis-notify`:
+
+```
+package main
+// cobra entry, default port :8087, --conf <dir>
+fx.New(configcenter.Options(conf, port)).Run()
+```
+
+`app/configcenter/options.go` composes:
+
+- `app.BaseOptions(conf)` + `ObserveOptions` + `DataOptions`
+- `infra/etcd.Module` (this binary is the only one with etcd write
+  creds)
+- `module/auth` (JWT verifier — same as aegis-notify)
+- `module/user` (audit log actor lookup)
+- `module/configcenter`
+- `httpapi.Module` + `/healthz`/`/readyz` decorator
+
+### What stays in TOML
+
+Per-process bootstrap that the configcenter itself needs:
+
+- `etcd.endpoints`, `etcd.username`, `etcd.password`
+- DB DSN (you need a DB before you can read config from a DB-backed
+  fallback)
+- JWT keys path
+- Listen port
+
+Everything else is fair game for migration to configcenter.
+
+### Migration of existing consumers
+
+In-place, one module per PR:
+
+1. `module/system` — currently `etcd.Gateway.Get(...)`. Becomes
+   `center.Bind(ctx, "system", "...", &sysCfg)`. Keep the etcd
+   gateway as the low-level fallback for non-config KV uses (locks,
+   leases — not config).
+2. `module/chaossystem` — same.
+3. `module/injection/alloc.go` — same. (alloc.go uses etcd for
+   distributed coordination, NOT config; **do not migrate**. The
+   distinction matters.)
+4. New consumers (notification, blob, gateway) start on configcenter
+   from day one.
+
+### Failure modes
+
+- `aegis-configcenter` unreachable at startup → remote client falls
+  back to env → TOML → default. Service still boots. Retry loop
+  reconnects when the configcenter returns. Optional: the client may
+  open a **read-only direct etcd watch** as a degraded path (using a
+  read-only etcd credential), shedding only the audit guarantee.
+- etcd unreachable from `aegis-configcenter` → its `/readyz` fails;
+  the gateway can shed traffic. In-process `module/configcenter` (in
+  the configcenter binary itself) keeps last-known-good values in
+  memory; serves reads, fails writes.
+- etcd value malformed JSON → keep previous resolved value, alert
+  via `configcenter_invalid_updates_total`.
+- Validator rejects new value → same as malformed.
+
+## Migration plan
+
+1. **Phase A (this PR)**: land `module/configcenter` +
+   `module/configcenterclient` + `cmd/aegis-configcenter` +
+   `app/configcenter` + audit table migration. LocalClient wired in
+   the configcenter binary; everything else still on TOML+env. No
+   prod traffic yet.
+2. **Phase B**: deploy `aegis-configcenter` in Helm chart. Migrate
+   one consumer (e.g. notification's `retention_days`) to prove the
+   remote SDK + SSE watch end-to-end.
+3. **Phase C**: migrate `module/system` + `chaossystem` (existing
+   raw `infra/etcd.Gateway` config consumers) onto
+   `configcenterclient`. `infra/etcd.Gateway` stays in the tree but
+   is only used for non-config concerns (locks, leases).
+4. **Phase D**: every new module wires through `configcenterclient`
+   by default.
+
+## Alternatives considered
+
+- **Adopt Nacos / Apollo / Consul KV.** Adds an operational
+  component the team doesn't run. We already run etcd. The typed
+  layer is ~400 LOC; the wrapper cost is less than the operational
+  cost of adopting an external dependency.
+- **Just use viper everywhere with `viper.WatchConfig`.** That only
+  watches files, doesn't centralize, and gives no audit trail. No
+  cross-process consistency.
+- **Push config via env, restart pods on change.** Restart latency
+  defeats the point. Rate-limit ramps want sub-second propagation.
+
+## Open questions
+
+1. **Per-pod overrides.** A canary pod might want a different
+   rate-limit than the rest. Proposal: support
+   `/aegis/<env>/<namespace>/<key>@<pod_hostname>` as an optional
+   override key. Off by default.
+2. **Secrets bleed.** What stops someone setting a "secret" in
+   configcenter? Proposal: lint at Set time — reject if the key
+   path contains `password|secret|key|token`. Force secrets into
+   sealed secrets / env.
+3. **History retention.** etcd's native revision history is
+   compaction-bounded. For audit we have the DB table; do we ever
+   need etcd revisions specifically? Probably no. Keep DB audit
+   authoritative.
+
+## Acceptance criteria
+
+- `center.Bind(ctx, "notification", "retention_days", &n,
+  configcenter.WithDefault(90))` returns 90 with no etcd entry,
+  reflects new value within 1 s after `PUT /api/v2/config/...`.
+- Admin endpoints require `admin` role; mutation writes audit row.
+- Restart of any service preserves the etcd-layer value.
+- `pnpm check` (frontend) unaffected (no frontend changes in this
+  RFC).
+- etcd outage does not block service boot.

--- a/AegisLab/src/app/blob/options.go
+++ b/AegisLab/src/app/blob/options.go
@@ -1,0 +1,63 @@
+// Package blob hosts the fx composition for the standalone blob
+// microservice (aegis-blob). Mirrors `app/notify/options.go`.
+//
+// What's in this binary:
+//
+//   - module/blob   — driver registry, repository, handler, lifecycle
+//   - module/auth   — JWT verifier (service & human-user tokens)
+//   - infra (db, redis, jwtkeys)
+//   - http server   — exposes only the blob routes + /healthz
+//
+// What's NOT in this binary: chaos/k8s/dataset/injection/business
+// modules. Producers live elsewhere and reach this binary through
+// module/blobclient with `mode = "remote"`.
+package blob
+
+import (
+	"strings"
+
+	"aegis/app"
+	httpapi "aegis/interface/http"
+	"aegis/module/auth"
+	"aegis/module/blob"
+	"aegis/router"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/fx"
+)
+
+func Options(confPath, port string) fx.Option {
+	return fx.Options(
+		app.BaseOptions(confPath),
+		app.ObserveOptions(),
+		app.DataOptions(),
+
+		auth.Module,
+		blob.Module,
+
+		fx.Provide(auth.NewTokenVerifier),
+
+		fx.Supply(&router.Handlers{}),
+		fx.Supply(httpapi.ServerConfig{Addr: normalizeAddr(port)}),
+		httpapi.Module,
+
+		fx.Decorate(decorateEngineWithHealthz),
+	)
+}
+
+func decorateEngineWithHealthz(engine *gin.Engine) *gin.Engine {
+	engine.GET("/healthz", func(c *gin.Context) {
+		c.JSON(200, gin.H{"status": "ok"})
+	})
+	return engine
+}
+
+func normalizeAddr(port string) string {
+	if port == "" {
+		return ":8085"
+	}
+	if strings.HasPrefix(port, ":") {
+		return port
+	}
+	return ":" + port
+}

--- a/AegisLab/src/cmd/aegis-blob/README.md
+++ b/AegisLab/src/cmd/aegis-blob/README.md
@@ -1,0 +1,41 @@
+# aegis-blob
+
+Standalone blob storage microservice. Hosts `module/blob` (driver
+registry, metadata repository, presign/inline handlers, lifecycle
+worker) plus the minimum auth surface needed to accept
+service-token-signed requests.
+
+## Run locally
+
+```bash
+docker compose up -d mysql aegis-sso
+cd src
+go build -tags duckdb_arrow -o /tmp/aegis-blob ./cmd/aegis-blob
+ENV_MODE=dev /tmp/aegis-blob serve --port 8085 --conf /etc/rcabench
+curl http://localhost:8085/healthz
+```
+
+Default port `8085`. Endpoints (`/api/v2/blob/*`):
+
+- `POST   /buckets/:bucket/presign-put`
+- `POST   /buckets/:bucket/presign-get`
+- `GET    /buckets/:bucket/objects/:key`        — inline get
+- `HEAD   /buckets/:bucket/objects/:key`        — stat
+- `DELETE /buckets/:bucket/objects/:key`
+- `GET    /buckets/:bucket/objects`             — list by entity
+- `GET|PUT /raw/:token`                          — localfs signed-token endpoint
+
+Producers in `aegis-backend` import `module/blobclient` and flip
+`[blob.client] mode = "remote"` + `endpoint = "http://aegis-blob:8085"`
+to talk to this binary instead of the in-process service. No producer
+code changes.
+
+## Buckets
+
+Declared in TOML — see `[blob.buckets.<name>]` in `config.dev.toml`.
+v1 supports two drivers:
+
+- `localfs` — bytes on disk; presign mints HMAC-signed token URLs
+  served by `/raw/:token` on this binary.
+- `s3` — stub returning `ErrDriverNotImplemented`. Real
+  implementation lands in Phase B (see RFC).

--- a/AegisLab/src/cmd/aegis-blob/main.go
+++ b/AegisLab/src/cmd/aegis-blob/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+
+	blobapp "aegis/app/blob"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/fx"
+)
+
+func main() {
+	var port, conf string
+
+	rootCmd := &cobra.Command{Use: "aegis-blob", Short: "Aegis blob storage microservice"}
+	rootCmd.PersistentFlags().StringVarP(&port, "port", "p", "8085", "Port to run the server on")
+	rootCmd.PersistentFlags().StringVarP(&conf, "conf", "c", "/etc/aegis/config.prod.toml", "Path to configuration directory")
+
+	if err := viper.BindPFlag("port", rootCmd.PersistentFlags().Lookup("port")); err != nil {
+		logrus.Fatalf("failed to bind flag: %v", err)
+	}
+	if err := viper.BindPFlag("conf", rootCmd.PersistentFlags().Lookup("conf")); err != nil {
+		logrus.Fatalf("failed to bind flag: %v", err)
+	}
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "serve",
+		Short: "Run the blob storage server",
+		Run: func(cmd *cobra.Command, args []string) {
+			fx.New(blobapp.Options(viper.GetString("conf"), viper.GetString("port"))).Run()
+		},
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		logrus.Println(err.Error())
+		os.Exit(1)
+	}
+}

--- a/AegisLab/src/config.dev.toml
+++ b/AegisLab/src/config.dev.toml
@@ -104,3 +104,25 @@ console_redirect_uris = "http://localhost:3101/auth/callback,http://127.0.0.1:31
 # OIDC params (incl. PKCE) back to /login unchanged.
 # Override per deploy with env SSO_LOGIN_REDIRECT.
 login_redirect = "http://localhost:3101/auth/login"
+
+# ---------------------------------------------------------------------
+# Blob storage — see RFC docs/rfcs/blob-storage.md and cmd/aegis-blob.
+# In dev we only declare the localfs `scratch` bucket; real buckets
+# (dataset-artifacts, user-avatars) come online in Phase B.
+# ---------------------------------------------------------------------
+[blob]
+# HMAC key used by the localfs driver to sign /raw/:token URLs.
+# Override per deploy via env (set blob.signing_key_env = "BLOB_SIGNING_KEY").
+signing_key = "dev-only-blob-signing-key-change-me"
+
+[blob.client]
+mode = "local"
+# endpoint = "http://aegis-blob:8085"   # only used when mode = "remote"
+max_retries = 2
+
+[blob.buckets.scratch]
+driver = "localfs"
+root = "/tmp/aegis-blob/scratch"
+max_object_bytes = 5_368_709_120
+retention_days = 7
+inline_max_bytes = 65_536

--- a/AegisLab/src/module/blob/acl.go
+++ b/AegisLab/src/module/blob/acl.go
@@ -1,0 +1,67 @@
+package blob
+
+// Authorizer enforces the per-bucket ACL — role 2 of the six-role
+// breakdown. v1 is intentionally narrow: role lists in config, plus a
+// public_read flag. Real RBAC integration (via module/auth roles)
+// lands once a producer needs it.
+type Authorizer struct{}
+
+func NewAuthorizer() *Authorizer { return &Authorizer{} }
+
+// Subject is what the handler passes in after JWT verification.
+type Subject struct {
+	UserID    int
+	Roles     []string
+	IsService bool
+}
+
+// CanWrite returns true when the caller is allowed to issue a PUT /
+// presign-put against this bucket. Empty write_roles means "any
+// authenticated caller can write" — fine for the scratch bucket; real
+// production buckets always declare roles.
+func (a *Authorizer) CanWrite(b *BucketConfig, s Subject) bool {
+	if len(b.WriteRoles) == 0 {
+		return true
+	}
+	if s.IsService {
+		for _, r := range b.WriteRoles {
+			if r == "service" {
+				return true
+			}
+		}
+	}
+	return hasAnyRole(s.Roles, b.WriteRoles)
+}
+
+// CanRead returns true for public_read buckets, or when the caller's
+// role intersects read_roles, or when the caller is the uploader.
+func (a *Authorizer) CanRead(b *BucketConfig, s Subject, uploadedBy *int) bool {
+	if b.PublicRead {
+		return true
+	}
+	if uploadedBy != nil && *uploadedBy == s.UserID && s.UserID != 0 {
+		return true
+	}
+	if len(b.ReadRoles) == 0 {
+		return s.UserID != 0 || s.IsService
+	}
+	if s.IsService {
+		for _, r := range b.ReadRoles {
+			if r == "service" {
+				return true
+			}
+		}
+	}
+	return hasAnyRole(s.Roles, b.ReadRoles)
+}
+
+func hasAnyRole(have, want []string) bool {
+	for _, h := range have {
+		for _, w := range want {
+			if h == w {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/AegisLab/src/module/blob/driver_localfs.go
+++ b/AegisLab/src/module/blob/driver_localfs.go
@@ -1,0 +1,278 @@
+package blob
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// LocalFSDriver stores bytes on the local filesystem under Root. The
+// presign methods do not return a URL the frontend can hit directly
+// (there is no S3-style signature support in the OS) — instead they
+// mint an HMAC-signed token URL that points back at the blob handler's
+// /raw/:token endpoint, which decodes the token and streams from / to
+// disk. Same UX as S3 presign, no driver-specific frontend code.
+type LocalFSDriver struct {
+	cfg        BucketConfig
+	signingKey []byte
+	// publicBaseURL is empty in v1; the handler builds absolute URLs
+	// from c.Request.Host. Tokens themselves carry every claim the
+	// handler needs to authorise the request.
+}
+
+// NewLocalFSDriver constructs the localfs driver and ensures the root
+// directory exists.
+func NewLocalFSDriver(cfg BucketConfig, signingKey []byte) (*LocalFSDriver, error) {
+	if cfg.Root == "" {
+		return nil, fmt.Errorf("localfs driver requires root")
+	}
+	if len(signingKey) == 0 {
+		return nil, fmt.Errorf("localfs driver requires a non-empty signing key (blob.signing_key)")
+	}
+	if err := os.MkdirAll(cfg.Root, 0o755); err != nil {
+		return nil, fmt.Errorf("create localfs root %q: %w", cfg.Root, err)
+	}
+	return &LocalFSDriver{cfg: cfg, signingKey: signingKey}, nil
+}
+
+func (d *LocalFSDriver) Name() string { return "localfs" }
+
+// Token is the signed payload encoded into /raw/:token URLs. The
+// handler decodes and verifies it before serving / accepting bytes.
+type Token struct {
+	Bucket string    `json:"b"`
+	Key    string    `json:"k"`
+	Op     Operation `json:"o"`
+	Exp    int64     `json:"e"`
+}
+
+// EncodeToken returns "<base64url(payload)>.<base64url(hmac)>".
+func EncodeToken(signingKey []byte, t Token) (string, error) {
+	body, err := json.Marshal(t)
+	if err != nil {
+		return "", err
+	}
+	enc := base64.RawURLEncoding.EncodeToString(body)
+	mac := hmac.New(sha256.New, signingKey)
+	mac.Write([]byte(enc))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return enc + "." + sig, nil
+}
+
+// DecodeToken verifies the HMAC, decodes the payload and rejects
+// expired tokens.
+func DecodeToken(signingKey []byte, raw string) (*Token, error) {
+	parts := strings.SplitN(raw, ".", 2)
+	if len(parts) != 2 {
+		return nil, ErrTokenInvalid
+	}
+	mac := hmac.New(sha256.New, signingKey)
+	mac.Write([]byte(parts[0]))
+	expected := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(expected), []byte(parts[1])) {
+		return nil, ErrTokenInvalid
+	}
+	body, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, ErrTokenInvalid
+	}
+	var t Token
+	if err := json.Unmarshal(body, &t); err != nil {
+		return nil, ErrTokenInvalid
+	}
+	if time.Now().Unix() > t.Exp {
+		return nil, ErrTokenInvalid
+	}
+	return &t, nil
+}
+
+func (d *LocalFSDriver) presign(op Operation, key string, ttl time.Duration) (*PresignedRequest, error) {
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+	exp := time.Now().Add(ttl)
+	tok, err := EncodeToken(d.signingKey, Token{
+		Bucket: d.cfg.Name, Key: key, Op: op, Exp: exp.Unix(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	method := "PUT"
+	if op == OpGet {
+		method = "GET"
+	}
+	return &PresignedRequest{
+		Method:  method,
+		URL:     "/api/v2/blob/raw/" + url.PathEscape(tok),
+		Headers: map[string]string{},
+		Expires: exp,
+	}, nil
+}
+
+func (d *LocalFSDriver) PresignPut(_ context.Context, key string, opts PutOpts) (*PresignedRequest, error) {
+	req, err := d.presign(OpPut, key, opts.TTL)
+	if err != nil {
+		return nil, err
+	}
+	if opts.ContentType != "" {
+		req.Headers["Content-Type"] = opts.ContentType
+	}
+	return req, nil
+}
+
+func (d *LocalFSDriver) PresignGet(_ context.Context, key string, opts GetOpts) (*PresignedRequest, error) {
+	return d.presign(OpGet, key, opts.TTL)
+}
+
+func (d *LocalFSDriver) resolve(key string) (string, error) {
+	clean := filepath.Clean("/" + key)
+	if strings.Contains(clean, "..") {
+		return "", fmt.Errorf("invalid key %q", key)
+	}
+	return filepath.Join(d.cfg.Root, clean), nil
+}
+
+func (d *LocalFSDriver) Put(_ context.Context, key string, r io.Reader, opts PutOpts) (*ObjectMeta, error) {
+	path, err := d.resolve(key)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	n, err := io.Copy(f, r)
+	if err != nil {
+		return nil, err
+	}
+	ct := opts.ContentType
+	if ct == "" {
+		ct = mime.TypeByExtension(filepath.Ext(path))
+	}
+	return &ObjectMeta{
+		Key:         key,
+		Size:        n,
+		ContentType: ct,
+		UpdatedAt:   time.Now(),
+	}, nil
+}
+
+func (d *LocalFSDriver) Get(_ context.Context, key string) (io.ReadCloser, *ObjectMeta, error) {
+	path, err := d.resolve(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, ErrObjectNotFound
+		}
+		return nil, nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, nil, err
+	}
+	return f, &ObjectMeta{
+		Key:         key,
+		Size:        info.Size(),
+		ContentType: mime.TypeByExtension(filepath.Ext(path)),
+		UpdatedAt:   info.ModTime(),
+	}, nil
+}
+
+func (d *LocalFSDriver) Stat(_ context.Context, key string) (*ObjectMeta, error) {
+	path, err := d.resolve(key)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrObjectNotFound
+		}
+		return nil, err
+	}
+	return &ObjectMeta{
+		Key:         key,
+		Size:        info.Size(),
+		ContentType: mime.TypeByExtension(filepath.Ext(path)),
+		UpdatedAt:   info.ModTime(),
+	}, nil
+}
+
+func (d *LocalFSDriver) Delete(_ context.Context, key string) error {
+	path, err := d.resolve(key)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return ErrObjectNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func (d *LocalFSDriver) List(_ context.Context, prefix, cursor string, limit int) (*ListResult, error) {
+	if limit <= 0 || limit > 1000 {
+		limit = 100
+	}
+	root := d.cfg.Root
+	if prefix != "" {
+		clean := filepath.Clean("/" + prefix)
+		root = filepath.Join(d.cfg.Root, clean)
+	}
+	var items []ObjectMeta
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(d.cfg.Root, path)
+		if relErr != nil {
+			return relErr
+		}
+		key := filepath.ToSlash(rel)
+		if cursor != "" && key <= cursor {
+			return nil
+		}
+		items = append(items, ObjectMeta{
+			Key: key, Size: info.Size(), UpdatedAt: info.ModTime(),
+			ContentType: mime.TypeByExtension(filepath.Ext(path)),
+		})
+		if len(items) >= limit {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	res := &ListResult{Items: items}
+	if len(items) == limit {
+		res.NextCursor = items[len(items)-1].Key
+	}
+	return res, nil
+}

--- a/AegisLab/src/module/blob/driver_s3.go
+++ b/AegisLab/src/module/blob/driver_s3.go
@@ -1,0 +1,55 @@
+package blob
+
+import (
+	"context"
+	"io"
+)
+
+// S3Driver is the placeholder for the S3-compatible driver
+// (RustFS/MinIO/AWS/Aliyun OSS). Phase A (this PR) keeps it as a stub
+// that returns ErrDriverNotImplemented for every operation so the
+// binary compiles with `driver = "s3"` buckets declared but cannot
+// silently swallow producer calls. Phase B (see RFC) drops in the real
+// implementation behind this same interface — no caller changes.
+//
+// TODO(blob/s3): implement using aws-sdk-go-v2 once Phase B starts.
+type S3Driver struct {
+	cfg BucketConfig
+}
+
+// NewS3Driver returns the stub driver; it doesn't error on
+// construction so the boot path can compose a registry of mixed
+// localfs + s3 buckets in dev today.
+func NewS3Driver(cfg BucketConfig) (*S3Driver, error) {
+	return &S3Driver{cfg: cfg}, nil
+}
+
+func (d *S3Driver) Name() string { return "s3" }
+
+func (d *S3Driver) PresignPut(_ context.Context, _ string, _ PutOpts) (*PresignedRequest, error) {
+	return nil, ErrDriverNotImplemented
+}
+
+func (d *S3Driver) PresignGet(_ context.Context, _ string, _ GetOpts) (*PresignedRequest, error) {
+	return nil, ErrDriverNotImplemented
+}
+
+func (d *S3Driver) Put(_ context.Context, _ string, _ io.Reader, _ PutOpts) (*ObjectMeta, error) {
+	return nil, ErrDriverNotImplemented
+}
+
+func (d *S3Driver) Get(_ context.Context, _ string) (io.ReadCloser, *ObjectMeta, error) {
+	return nil, nil, ErrDriverNotImplemented
+}
+
+func (d *S3Driver) Stat(_ context.Context, _ string) (*ObjectMeta, error) {
+	return nil, ErrDriverNotImplemented
+}
+
+func (d *S3Driver) Delete(_ context.Context, _ string) error {
+	return ErrDriverNotImplemented
+}
+
+func (d *S3Driver) List(_ context.Context, _, _ string, _ int) (*ListResult, error) {
+	return nil, ErrDriverNotImplemented
+}

--- a/AegisLab/src/module/blob/handler.go
+++ b/AegisLab/src/module/blob/handler.go
@@ -1,0 +1,287 @@
+package blob
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"aegis/dto"
+	"aegis/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler hosts the HTTP surface — the ingestion role. Auth happens
+// upstream in middleware; per-bucket ACL happens here via Authorizer.
+type Handler struct {
+	svc        *Service
+	signingKey []byte
+	auth       *Authorizer
+}
+
+func NewHandler(svc *Service, auth *Authorizer, deps RegistryDeps) *Handler {
+	return &Handler{svc: svc, auth: auth, signingKey: deps.SigningKey}
+}
+
+func subjectFromContext(c *gin.Context) Subject {
+	uid, _ := middleware.GetCurrentUserID(c)
+	return Subject{UserID: uid}
+}
+
+// ---- Request / response shapes ----
+
+type presignPutReq struct {
+	Key           string            `json:"key,omitempty"`
+	ContentType   string            `json:"content_type"`
+	ContentLength int64             `json:"content_length,omitempty"`
+	EntityKind    string            `json:"entity_kind,omitempty"`
+	EntityID      string            `json:"entity_id,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	TTLSeconds    int               `json:"ttl_seconds,omitempty"`
+}
+
+type presignGetReq struct {
+	Key                 string `json:"key" binding:"required"`
+	ResponseContentType string `json:"response_content_type,omitempty"`
+	TTLSeconds          int    `json:"ttl_seconds,omitempty"`
+}
+
+type listResp struct {
+	Items      []ObjectRecord `json:"items"`
+	NextCursor string         `json:"next_cursor,omitempty"`
+}
+
+// ---- Endpoints ----
+
+func (h *Handler) PresignPut(c *gin.Context) {
+	bucket := c.Param("bucket")
+	var req presignPutReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		dto.ErrorResponse(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	b, err := h.svc.Registry().Lookup(bucket)
+	if err != nil {
+		dto.ErrorResponse(c, http.StatusNotFound, err.Error())
+		return
+	}
+	sub := subjectFromContext(c)
+	if !h.auth.CanWrite(&b.Config, sub) {
+		dto.ErrorResponse(c, http.StatusForbidden, ErrUnauthorized.Error())
+		return
+	}
+	uid := sub.UserID
+	in := PresignPutInput{
+		Bucket: bucket, Key: req.Key,
+		ContentType: req.ContentType, ContentLength: req.ContentLength,
+		EntityKind: req.EntityKind, EntityID: req.EntityID,
+		Metadata: req.Metadata,
+		TTL:      time.Duration(req.TTLSeconds) * time.Second,
+	}
+	if uid > 0 {
+		in.UploadedBy = &uid
+	}
+	res, err := h.svc.PresignPut(c.Request.Context(), in)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, res)
+}
+
+func (h *Handler) PresignGet(c *gin.Context) {
+	bucket := c.Param("bucket")
+	var req presignGetReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		dto.ErrorResponse(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	b, err := h.svc.Registry().Lookup(bucket)
+	if err != nil {
+		dto.ErrorResponse(c, http.StatusNotFound, err.Error())
+		return
+	}
+	rec, err := h.svc.repo.FindByKey(c.Request.Context(), bucket, req.Key)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	if !h.auth.CanRead(&b.Config, subjectFromContext(c), rec.UploadedBy) {
+		dto.ErrorResponse(c, http.StatusForbidden, ErrUnauthorized.Error())
+		return
+	}
+	pr, err := h.svc.PresignGet(c.Request.Context(), bucket, req.Key, GetOpts{
+		ResponseContentType: req.ResponseContentType,
+		TTL:                 time.Duration(req.TTLSeconds) * time.Second,
+	})
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, pr)
+}
+
+func (h *Handler) InlineGet(c *gin.Context) {
+	bucket := c.Param("bucket")
+	key := c.Param("key")
+	b, err := h.svc.Registry().Lookup(bucket)
+	if err != nil {
+		dto.ErrorResponse(c, http.StatusNotFound, err.Error())
+		return
+	}
+	rec, err := h.svc.repo.FindByKey(c.Request.Context(), bucket, key)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	if !h.auth.CanRead(&b.Config, subjectFromContext(c), rec.UploadedBy) {
+		dto.ErrorResponse(c, http.StatusForbidden, ErrUnauthorized.Error())
+		return
+	}
+	rc, meta, err := h.svc.Get(c.Request.Context(), bucket, key)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	defer func() { _ = rc.Close() }()
+	if meta.ContentType != "" {
+		c.Header("Content-Type", meta.ContentType)
+	}
+	c.Header("Content-Length", strconv.FormatInt(meta.Size, 10))
+	_, _ = io.Copy(c.Writer, rc)
+}
+
+func (h *Handler) Stat(c *gin.Context) {
+	bucket := c.Param("bucket")
+	key := c.Param("key")
+	meta, err := h.svc.Stat(c.Request.Context(), bucket, key)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, meta)
+}
+
+func (h *Handler) Delete(c *gin.Context) {
+	bucket := c.Param("bucket")
+	key := c.Param("key")
+	b, err := h.svc.Registry().Lookup(bucket)
+	if err != nil {
+		dto.ErrorResponse(c, http.StatusNotFound, err.Error())
+		return
+	}
+	rec, err := h.svc.repo.FindByKey(c.Request.Context(), bucket, key)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	if !h.auth.CanWrite(&b.Config, subjectFromContext(c)) &&
+		(rec.UploadedBy == nil || *rec.UploadedBy != subjectFromContext(c).UserID) {
+		dto.ErrorResponse(c, http.StatusForbidden, ErrUnauthorized.Error())
+		return
+	}
+	if err := h.svc.Delete(c.Request.Context(), bucket, key); err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *Handler) List(c *gin.Context) {
+	bucket := c.Param("bucket")
+	f := ListFilter{
+		Bucket:     bucket,
+		EntityKind: c.Query("entity_kind"),
+		EntityID:   c.Query("entity_id"),
+	}
+	if s := c.Query("cursor"); s != "" {
+		if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+			f.Cursor = v
+		}
+	}
+	if s := c.Query("limit"); s != "" {
+		if v, err := strconv.Atoi(s); err == nil {
+			f.Limit = v
+		}
+	}
+	rows, err := h.svc.List(c.Request.Context(), f)
+	if err != nil {
+		h.writeServiceError(c, err)
+		return
+	}
+	resp := listResp{Items: rows}
+	if len(rows) > 0 && len(rows) == f.Limit {
+		resp.NextCursor = strconv.FormatInt(rows[len(rows)-1].ID, 10)
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// Raw serves the localfs driver's signed token URLs. Verifies the
+// HMAC + expiry, then either streams the file (GET) or persists the
+// body (PUT). Buckets backed by s3 never produce these tokens.
+func (h *Handler) Raw(c *gin.Context) {
+	raw := c.Param("token")
+	tok, err := DecodeToken(h.signingKey, raw)
+	if err != nil {
+		dto.ErrorResponse(c, http.StatusForbidden, err.Error())
+		return
+	}
+	b, err := h.svc.Registry().Lookup(tok.Bucket)
+	if err != nil {
+		dto.ErrorResponse(c, http.StatusNotFound, err.Error())
+		return
+	}
+	switch tok.Op {
+	case OpGet:
+		if c.Request.Method != http.MethodGet {
+			dto.ErrorResponse(c, http.StatusMethodNotAllowed, "token is GET-only")
+			return
+		}
+		rc, meta, err := b.Driver.Get(c.Request.Context(), tok.Key)
+		if err != nil {
+			h.writeServiceError(c, err)
+			return
+		}
+		defer func() { _ = rc.Close() }()
+		if meta.ContentType != "" {
+			c.Header("Content-Type", meta.ContentType)
+		}
+		c.Header("Content-Length", strconv.FormatInt(meta.Size, 10))
+		_, _ = io.Copy(c.Writer, rc)
+	case OpPut:
+		if c.Request.Method != http.MethodPut {
+			dto.ErrorResponse(c, http.StatusMethodNotAllowed, "token is PUT-only")
+			return
+		}
+		_, err := b.Driver.Put(c.Request.Context(), tok.Key, c.Request.Body, PutOpts{
+			ContentType:   c.GetHeader("Content-Type"),
+			ContentLength: c.Request.ContentLength,
+		})
+		if err != nil {
+			h.writeServiceError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	default:
+		dto.ErrorResponse(c, http.StatusBadRequest, "unknown token op")
+	}
+}
+
+func (h *Handler) writeServiceError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, ErrBucketNotFound), errors.Is(err, ErrObjectNotFound):
+		dto.ErrorResponse(c, http.StatusNotFound, err.Error())
+	case errors.Is(err, ErrDriverNotImplemented):
+		dto.ErrorResponse(c, http.StatusNotImplemented, err.Error())
+	case errors.Is(err, ErrTokenInvalid), errors.Is(err, ErrUnauthorized):
+		dto.ErrorResponse(c, http.StatusForbidden, err.Error())
+	case errors.Is(err, ErrObjectTooLarge):
+		dto.ErrorResponse(c, http.StatusRequestEntityTooLarge, err.Error())
+	case errors.Is(err, ErrContentTypeRejected):
+		dto.ErrorResponse(c, http.StatusUnsupportedMediaType, err.Error())
+	default:
+		dto.ErrorResponse(c, http.StatusInternalServerError, err.Error())
+	}
+}

--- a/AegisLab/src/module/blob/lifecycle.go
+++ b/AegisLab/src/module/blob/lifecycle.go
@@ -1,0 +1,32 @@
+package blob
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+)
+
+// DeletionWorker is the lifecycle role's v1 stub. The full worker
+// (hourly job, retention sweep, orphan reconcile against driver Stat)
+// is Phase B+ — until then we just expose a Run() method so the fx
+// graph compiles and a future cron wires it in.
+//
+// TODO(blob/lifecycle): walk blob_objects where
+//   - deleted_at IS NOT NULL → driver.Delete, then hard-delete the row.
+//   - expires_at <= now      → soft-delete then queue for driver delete.
+//   - size_bytes = 0 AND created_at < now-1h → driver.Stat to reconcile
+//     orphan presigns (frontend never confirmed upload).
+type DeletionWorker struct {
+	svc *Service
+}
+
+func NewDeletionWorker(svc *Service) *DeletionWorker {
+	return &DeletionWorker{svc: svc}
+}
+
+// Run is a no-op in v1 — keeping the surface so producers / cron can
+// invoke it once the real sweep lands.
+func (w *DeletionWorker) Run(_ context.Context) error {
+	logrus.Debug("blob: DeletionWorker.Run is a stub (no retention sweep yet)")
+	return nil
+}

--- a/AegisLab/src/module/blob/migrations.go
+++ b/AegisLab/src/module/blob/migrations.go
@@ -1,0 +1,11 @@
+package blob
+
+import "aegis/framework"
+
+// Migrations registers the blob_objects table.
+func Migrations() framework.MigrationRegistrar {
+	return framework.MigrationRegistrar{
+		Module:   "blob",
+		Entities: []any{&ObjectRecord{}},
+	}
+}

--- a/AegisLab/src/module/blob/model.go
+++ b/AegisLab/src/module/blob/model.go
@@ -1,0 +1,25 @@
+package blob
+
+import "time"
+
+// ObjectRecord is the DB row for one stored object. The DB stores
+// metadata only — bytes live in the driver. The lifecycle worker walks
+// this table to delete expired objects; the list endpoint queries it
+// by (entity_kind, entity_id) and by uploader.
+type ObjectRecord struct {
+	ID          int64     `gorm:"primaryKey;autoIncrement"`
+	Bucket      string    `gorm:"not null;size:64;index:idx_bucket_key,priority:1"`
+	StorageKey  string    `gorm:"not null;size:512;index:idx_bucket_key,priority:2"`
+	SizeBytes   int64     `gorm:"not null;default:0"`
+	ContentType string    `gorm:"size:128"`
+	ETag        string    `gorm:"size:128"`
+	UploadedBy  *int      `gorm:"index:idx_uploader,priority:1"`
+	EntityKind  string    `gorm:"size:64;index:idx_entity,priority:1"`
+	EntityID    string    `gorm:"size:128;index:idx_entity,priority:2"`
+	Metadata    []byte    `gorm:"type:json;serializer:json"`
+	CreatedAt   time.Time `gorm:"autoCreateTime;index:idx_uploader,priority:2,sort:desc"`
+	ExpiresAt   *time.Time
+	DeletedAt   *time.Time
+}
+
+func (ObjectRecord) TableName() string { return "blob_objects" }

--- a/AegisLab/src/module/blob/module.go
+++ b/AegisLab/src/module/blob/module.go
@@ -1,0 +1,60 @@
+package blob
+
+import (
+	"fmt"
+	"os"
+
+	"aegis/config"
+
+	"go.uber.org/fx"
+)
+
+// Module wires the six-role blob skeleton:
+//
+//	Ingestion (Handler) → Authorization (Authorizer) → Routing (Registry)
+//	  → Driver (localfs, s3-stub) → Lifecycle (DeletionWorker stub)
+//	  → Observability (counters live in existing infra; TODO wire metrics)
+//
+// Two consumers depend on this:
+//   - the monolith — Service is injected by producers in-process via
+//     module/blobclient's LocalClient.
+//   - the standalone microservice (app/blob) — same wiring, HTTP
+//     handler is the only ingestion path.
+var Module = fx.Module("blob",
+	fx.Provide(NewClock),
+	fx.Provide(NewAuthorizer),
+	fx.Provide(NewRepository),
+	fx.Provide(provideRegistryDeps),
+	fx.Provide(provideRegistry),
+	fx.Provide(NewService),
+	fx.Provide(NewHandler),
+	fx.Provide(NewDeletionWorker),
+
+	fx.Provide(
+		fx.Annotate(RoutesPortal, fx.ResultTags(`group:"routes"`)),
+		fx.Annotate(RoutesSDK, fx.ResultTags(`group:"routes"`)),
+		fx.Annotate(Migrations, fx.ResultTags(`group:"migrations"`)),
+	),
+)
+
+// provideRegistryDeps reads the HMAC signing key. Order of precedence:
+// `[blob] signing_key_env` → env var named there, then literal
+// `[blob] signing_key`. Fails fast if no key is configured AND any
+// localfs bucket is declared (checked inside provideRegistry).
+func provideRegistryDeps() RegistryDeps {
+	key := config.GetString("blob.signing_key")
+	if envName := config.GetString("blob.signing_key_env"); envName != "" {
+		if v := os.Getenv(envName); v != "" {
+			key = v
+		}
+	}
+	return RegistryDeps{SigningKey: []byte(key)}
+}
+
+func provideRegistry(deps RegistryDeps) (*Registry, error) {
+	reg, err := NewRegistryFromConfig(deps)
+	if err != nil {
+		return nil, fmt.Errorf("blob: build registry: %w", err)
+	}
+	return reg, nil
+}

--- a/AegisLab/src/module/blob/registry.go
+++ b/AegisLab/src/module/blob/registry.go
@@ -1,0 +1,149 @@
+package blob
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// BucketConfig is the per-bucket policy + driver pointer parsed from
+// `[blob.buckets.<name>]` in config.
+type BucketConfig struct {
+	Name string
+
+	Driver string // "localfs" | "s3"
+
+	// localfs
+	Root string
+
+	// s3 family — endpoint, region, credentials env-var names
+	Endpoint     string
+	Region       string
+	AccessKeyEnv string
+	SecretKeyEnv string
+	Bucket       string
+
+	// policy
+	MaxObjectBytes      int64
+	AllowedContentTypes []string
+	PublicRead          bool
+	RetentionDays       int
+	InlineMaxBytes      int64
+
+	// ACL — simple role lists; service tokens get the "service" role.
+	WriteRoles []string
+	ReadRoles  []string
+}
+
+// AllowsContentType returns true if the bucket has no allowlist or the
+// given content type is on it.
+func (b *BucketConfig) AllowsContentType(ct string) bool {
+	if len(b.AllowedContentTypes) == 0 {
+		return true
+	}
+	ct = strings.ToLower(strings.TrimSpace(ct))
+	for _, allowed := range b.AllowedContentTypes {
+		if strings.EqualFold(allowed, ct) {
+			return true
+		}
+	}
+	return false
+}
+
+// Bucket bundles a parsed config with the live Driver instance the
+// handler routes through.
+type Bucket struct {
+	Config BucketConfig
+	Driver Driver
+}
+
+// Registry maps stable bucket name → Driver. Producers only reference
+// bucket names; the registry is the routing role.
+type Registry struct {
+	buckets map[string]*Bucket
+}
+
+func (r *Registry) Lookup(name string) (*Bucket, error) {
+	b, ok := r.buckets[name]
+	if !ok {
+		return nil, ErrBucketNotFound
+	}
+	return b, nil
+}
+
+// Names returns all configured bucket names — used by health checks
+// and the lifecycle worker.
+func (r *Registry) Names() []string {
+	out := make([]string, 0, len(r.buckets))
+	for n := range r.buckets {
+		out = append(out, n)
+	}
+	return out
+}
+
+// RegistryDeps lets the fx wiring inject the signing key (used by
+// localfs presign).
+type RegistryDeps struct {
+	SigningKey []byte
+}
+
+// NewRegistryFromConfig assembles the registry from
+// `[blob.buckets.*]`. Unknown drivers fail boot loudly — a typo in a
+// bucket's driver name should not silently fall back to localfs.
+func NewRegistryFromConfig(deps RegistryDeps) (*Registry, error) {
+	raw := viper.GetStringMap("blob.buckets")
+	buckets := make(map[string]*Bucket, len(raw))
+
+	for name := range raw {
+		cfg, err := parseBucketConfig(name)
+		if err != nil {
+			return nil, fmt.Errorf("blob: bucket %q: %w", name, err)
+		}
+		drv, err := buildDriver(cfg, deps)
+		if err != nil {
+			return nil, fmt.Errorf("blob: bucket %q driver: %w", name, err)
+		}
+		buckets[name] = &Bucket{Config: cfg, Driver: drv}
+	}
+	return &Registry{buckets: buckets}, nil
+}
+
+func parseBucketConfig(name string) (BucketConfig, error) {
+	prefix := "blob.buckets." + name
+	cfg := BucketConfig{
+		Name:                name,
+		Driver:              viper.GetString(prefix + ".driver"),
+		Root:                viper.GetString(prefix + ".root"),
+		Endpoint:            viper.GetString(prefix + ".endpoint"),
+		Region:              viper.GetString(prefix + ".region"),
+		AccessKeyEnv:        viper.GetString(prefix + ".access_key_env"),
+		SecretKeyEnv:        viper.GetString(prefix + ".secret_key_env"),
+		Bucket:              viper.GetString(prefix + ".bucket"),
+		MaxObjectBytes:      viper.GetInt64(prefix + ".max_object_bytes"),
+		AllowedContentTypes: viper.GetStringSlice(prefix + ".allowed_content_types"),
+		PublicRead:          viper.GetBool(prefix + ".public_read"),
+		RetentionDays:       viper.GetInt(prefix + ".retention_days"),
+		InlineMaxBytes:      viper.GetInt64(prefix + ".inline_max_bytes"),
+		WriteRoles:          viper.GetStringSlice(prefix + ".write_roles"),
+		ReadRoles:           viper.GetStringSlice(prefix + ".read_roles"),
+	}
+	if cfg.Driver == "" {
+		return cfg, fmt.Errorf("driver is required")
+	}
+	if cfg.InlineMaxBytes == 0 {
+		cfg.InlineMaxBytes = 64 * 1024
+	}
+	return cfg, nil
+}
+
+func buildDriver(cfg BucketConfig, deps RegistryDeps) (Driver, error) {
+	switch cfg.Driver {
+	case "localfs":
+		return NewLocalFSDriver(cfg, deps.SigningKey)
+	case "s3":
+		return NewS3Driver(cfg)
+	default:
+		return nil, fmt.Errorf("unknown driver %q", cfg.Driver)
+	}
+}

--- a/AegisLab/src/module/blob/repository.go
+++ b/AegisLab/src/module/blob/repository.go
@@ -1,0 +1,97 @@
+package blob
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// Repository is the metadata-table access surface. The DB stores
+// metadata only; bytes live in the driver.
+type Repository struct {
+	DB *gorm.DB
+}
+
+func NewRepository(db *gorm.DB) *Repository { return &Repository{DB: db} }
+
+// Create inserts a new ObjectRecord. Called when a presign is issued
+// (size_bytes=0, etag empty) and again — via Update — when the upload
+// completion callback fires.
+func (r *Repository) Create(ctx context.Context, rec *ObjectRecord) error {
+	return r.DB.WithContext(ctx).Create(rec).Error
+}
+
+func (r *Repository) FindByKey(ctx context.Context, bucket, key string) (*ObjectRecord, error) {
+	var rec ObjectRecord
+	err := r.DB.WithContext(ctx).
+		Where("bucket = ? AND storage_key = ? AND deleted_at IS NULL", bucket, key).
+		First(&rec).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrObjectNotFound
+	}
+	return &rec, err
+}
+
+// MarkUploaded patches in the actual size + etag from the driver after
+// the frontend confirms the upload (or the reconcile job spots an
+// orphan).
+func (r *Repository) MarkUploaded(ctx context.Context, id int64, size int64, etag string) error {
+	return r.DB.WithContext(ctx).
+		Model(&ObjectRecord{}).
+		Where("id = ?", id).
+		Updates(map[string]any{"size_bytes": size, "etag": etag}).Error
+}
+
+// SoftDelete sets deleted_at; the lifecycle worker drives the
+// driver-side delete asynchronously.
+func (r *Repository) SoftDelete(ctx context.Context, bucket, key string) error {
+	now := time.Now()
+	res := r.DB.WithContext(ctx).
+		Model(&ObjectRecord{}).
+		Where("bucket = ? AND storage_key = ? AND deleted_at IS NULL", bucket, key).
+		Update("deleted_at", now)
+	if res.RowsAffected == 0 && res.Error == nil {
+		return ErrObjectNotFound
+	}
+	return res.Error
+}
+
+// ListByEntity is the inverse-index lookup ("show me everything dataset
+// 42 owns").
+type ListFilter struct {
+	Bucket     string
+	EntityKind string
+	EntityID   string
+	UploadedBy *int
+	Cursor     int64
+	Limit      int
+}
+
+func (r *Repository) List(ctx context.Context, f ListFilter) ([]ObjectRecord, error) {
+	if f.Limit <= 0 || f.Limit > 200 {
+		f.Limit = 50
+	}
+	q := r.DB.WithContext(ctx).Where("deleted_at IS NULL")
+	if f.Bucket != "" {
+		q = q.Where("bucket = ?", f.Bucket)
+	}
+	if f.EntityKind != "" {
+		q = q.Where("entity_kind = ?", f.EntityKind)
+	}
+	if f.EntityID != "" {
+		q = q.Where("entity_id = ?", f.EntityID)
+	}
+	if f.UploadedBy != nil {
+		q = q.Where("uploaded_by = ?", *f.UploadedBy)
+	}
+	if f.Cursor > 0 {
+		q = q.Where("id < ?", f.Cursor)
+	}
+	var rows []ObjectRecord
+	if err := q.Order("id desc").Limit(f.Limit).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/AegisLab/src/module/blob/routes.go
+++ b/AegisLab/src/module/blob/routes.go
@@ -1,0 +1,55 @@
+package blob
+
+import (
+	"aegis/framework"
+	"aegis/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RoutesPortal mounts the human-portal-facing blob endpoints.
+// Authentication is JWT human-user; per-bucket ACL is enforced by the
+// handler.
+func RoutesPortal(handler *Handler) framework.RouteRegistrar {
+	return framework.RouteRegistrar{
+		Audience: framework.AudiencePortal,
+		Name:     "blob.portal",
+		Register: func(v2 *gin.RouterGroup) {
+			g := v2.Group("/blob", middleware.JWTAuth())
+			{
+				g.POST("/buckets/:bucket/presign-put", handler.PresignPut)
+				g.POST("/buckets/:bucket/presign-get", handler.PresignGet)
+				g.GET("/buckets/:bucket/objects/:key", handler.InlineGet)
+				g.HEAD("/buckets/:bucket/objects/:key", handler.Stat)
+				g.DELETE("/buckets/:bucket/objects/:key", handler.Delete)
+				g.GET("/buckets/:bucket/objects", handler.List)
+			}
+
+			// /raw/:token is auth-free (the HMAC token IS the auth).
+			// Mounted under /blob so it sits alongside the rest of the
+			// surface but bypasses JWTAuth.
+			v2.GET("/blob/raw/:token", handler.Raw)
+			v2.PUT("/blob/raw/:token", handler.Raw)
+		},
+	}
+}
+
+// RoutesSDK mounts the cross-service blob endpoints (same handlers,
+// service-token auth). Producers calling the standalone aegis-blob
+// binary land here.
+func RoutesSDK(handler *Handler) framework.RouteRegistrar {
+	return framework.RouteRegistrar{
+		Audience: framework.AudienceSDK,
+		Name:     "blob.sdk",
+		Register: func(v2 *gin.RouterGroup) {
+			g := v2.Group("/blob", middleware.JWTAuth())
+			{
+				g.POST("/buckets/:bucket/presign-put", handler.PresignPut)
+				g.POST("/buckets/:bucket/presign-get", handler.PresignGet)
+				g.HEAD("/buckets/:bucket/objects/:key", handler.Stat)
+				g.DELETE("/buckets/:bucket/objects/:key", handler.Delete)
+				g.GET("/buckets/:bucket/objects", handler.List)
+			}
+		},
+	}
+}

--- a/AegisLab/src/module/blob/service.go
+++ b/AegisLab/src/module/blob/service.go
@@ -1,0 +1,214 @@
+package blob
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// Service is the in-process producer API. The HTTP handler is a thin
+// translator that calls these methods; the LocalClient SDK in
+// module/blobclient calls them directly.
+//
+// Service composes registry (routing), repository (metadata), clock
+// (testability) and is the single seam producers depend on.
+type Service struct {
+	registry *Registry
+	repo     *Repository
+	clock    Clock
+}
+
+func NewService(reg *Registry, repo *Repository, clock Clock) *Service {
+	return &Service{registry: reg, repo: repo, clock: clock}
+}
+
+// PresignPutInput captures everything a caller needs to mint a put URL.
+type PresignPutInput struct {
+	Bucket        string
+	Key           string // optional — service fills with {entity_kind}/{ulid}
+	ContentType   string
+	ContentLength int64
+	EntityKind    string
+	EntityID      string
+	UploadedBy    *int
+	Metadata      map[string]string
+	TTL           time.Duration
+}
+
+// PresignPutResult is what the handler returns to the producer.
+type PresignPutResult struct {
+	ObjectID  int64             `json:"object_id"`
+	Bucket    string            `json:"bucket"`
+	Key       string            `json:"key"`
+	Presigned *PresignedRequest `json:"presigned"`
+}
+
+// PresignPut routes to the bucket's driver, mints the presigned URL,
+// then writes a placeholder metadata row. Metadata is written after
+// the presign succeeds so failures don't leave orphan rows.
+func (s *Service) PresignPut(ctx context.Context, in PresignPutInput) (*PresignPutResult, error) {
+	b, err := s.registry.Lookup(in.Bucket)
+	if err != nil {
+		return nil, err
+	}
+	if in.ContentLength > 0 && b.Config.MaxObjectBytes > 0 && in.ContentLength > b.Config.MaxObjectBytes {
+		return nil, ErrObjectTooLarge
+	}
+	if !b.Config.AllowsContentType(in.ContentType) {
+		return nil, ErrContentTypeRejected
+	}
+	if in.Key == "" {
+		in.Key = GenerateKey(in.EntityKind)
+	}
+
+	pr, err := b.Driver.PresignPut(ctx, in.Key, PutOpts{
+		ContentType:   in.ContentType,
+		ContentLength: in.ContentLength,
+		Metadata:      in.Metadata,
+		TTL:           in.TTL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("presign put: %w", err)
+	}
+
+	rec := &ObjectRecord{
+		Bucket:      in.Bucket,
+		StorageKey:  in.Key,
+		SizeBytes:   in.ContentLength,
+		ContentType: in.ContentType,
+		EntityKind:  in.EntityKind,
+		EntityID:    in.EntityID,
+		UploadedBy:  in.UploadedBy,
+	}
+	if b.Config.RetentionDays > 0 {
+		exp := s.clock.Now().Add(time.Duration(b.Config.RetentionDays) * 24 * time.Hour)
+		rec.ExpiresAt = &exp
+	}
+	if err := s.repo.Create(ctx, rec); err != nil {
+		return nil, fmt.Errorf("persist metadata: %w", err)
+	}
+	return &PresignPutResult{
+		ObjectID:  rec.ID,
+		Bucket:    in.Bucket,
+		Key:       in.Key,
+		Presigned: pr,
+	}, nil
+}
+
+// PresignGet routes to the bucket's driver after a metadata check.
+func (s *Service) PresignGet(ctx context.Context, bucket, key string, opts GetOpts) (*PresignedRequest, error) {
+	b, err := s.registry.Lookup(bucket)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.repo.FindByKey(ctx, bucket, key); err != nil {
+		return nil, err
+	}
+	return b.Driver.PresignGet(ctx, key, opts)
+}
+
+// Stat returns metadata for a single object — DB row enriched with
+// the driver's live stat.
+func (s *Service) Stat(ctx context.Context, bucket, key string) (*ObjectMeta, error) {
+	b, err := s.registry.Lookup(bucket)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.repo.FindByKey(ctx, bucket, key); err != nil {
+		return nil, err
+	}
+	return b.Driver.Stat(ctx, key)
+}
+
+// Get streams bytes back from the driver. Used by the inline-GET
+// handler for small objects.
+func (s *Service) Get(ctx context.Context, bucket, key string) (io.ReadCloser, *ObjectMeta, error) {
+	b, err := s.registry.Lookup(bucket)
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, err := s.repo.FindByKey(ctx, bucket, key); err != nil {
+		return nil, nil, err
+	}
+	return b.Driver.Get(ctx, key)
+}
+
+// Delete soft-deletes the metadata row and best-effort removes the
+// driver-side bytes synchronously. The lifecycle worker (DeletionWorker)
+// re-runs the driver delete for rows where the inline call failed.
+func (s *Service) Delete(ctx context.Context, bucket, key string) error {
+	b, err := s.registry.Lookup(bucket)
+	if err != nil {
+		return err
+	}
+	if err := s.repo.SoftDelete(ctx, bucket, key); err != nil {
+		return err
+	}
+	return b.Driver.Delete(ctx, key)
+}
+
+// List returns metadata rows matching the filter. Driver-side listing
+// is not exposed through this method because the DB is the source of
+// truth for "what objects exist as far as the platform knows".
+func (s *Service) List(ctx context.Context, f ListFilter) ([]ObjectRecord, error) {
+	return s.repo.List(ctx, f)
+}
+
+// PutBytes is the small-payload helper used by LocalClient.
+func (s *Service) PutBytes(ctx context.Context, in PresignPutInput, body io.Reader) (*ObjectRecord, *ObjectMeta, error) {
+	b, err := s.registry.Lookup(in.Bucket)
+	if err != nil {
+		return nil, nil, err
+	}
+	if in.Key == "" {
+		in.Key = GenerateKey(in.EntityKind)
+	}
+	if !b.Config.AllowsContentType(in.ContentType) {
+		return nil, nil, ErrContentTypeRejected
+	}
+	meta, err := b.Driver.Put(ctx, in.Key, body, PutOpts{
+		ContentType:   in.ContentType,
+		ContentLength: in.ContentLength,
+		Metadata:      in.Metadata,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	rec := &ObjectRecord{
+		Bucket: in.Bucket, StorageKey: in.Key, SizeBytes: meta.Size,
+		ContentType: meta.ContentType, ETag: meta.ETag,
+		EntityKind: in.EntityKind, EntityID: in.EntityID, UploadedBy: in.UploadedBy,
+	}
+	if b.Config.RetentionDays > 0 {
+		exp := s.clock.Now().Add(time.Duration(b.Config.RetentionDays) * 24 * time.Hour)
+		rec.ExpiresAt = &exp
+	}
+	if err := s.repo.Create(ctx, rec); err != nil {
+		return nil, nil, err
+	}
+	return rec, meta, nil
+}
+
+// Registry exposes the routing role for the handler to look up bucket
+// policy without going through every service method.
+func (s *Service) Registry() *Registry { return s.registry }
+
+// GenerateKey is the default key generator: `{entity_kind}/{ulid}`.
+// Producers may override by setting PresignPutInput.Key.
+func GenerateKey(entityKind string) string {
+	id := ulid.MustNew(ulid.Timestamp(time.Now()), randReader{})
+	kind := strings.TrimSpace(entityKind)
+	if kind == "" {
+		kind = "object"
+	}
+	return kind + "/" + id.String()
+}
+
+type randReader struct{}
+
+func (randReader) Read(p []byte) (int, error) { return rand.Read(p) }

--- a/AegisLab/src/module/blob/types.go
+++ b/AegisLab/src/module/blob/types.go
@@ -1,0 +1,108 @@
+// Package blob is the in-process producer surface for object storage.
+// Mirrors module/notification: a small interface + a registry + a set
+// of pluggable drivers, fronted by a thin HTTP handler so the package
+// works equally well in the monolith and in the standalone aegis-blob
+// microservice.
+//
+// Six-role separation (see RFC docs/rfcs/blob-storage.md):
+//
+//	Ingestion → Authorization → Routing (bucket) → Driver → Lifecycle → Observability
+package blob
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+// Driver is the pluggable backend surface. v1 ships localfs (signed
+// token URLs handled by /raw/:token) and an s3 stub. RustFS / MinIO
+// / AWS / Aliyun OSS all reuse the s3 driver once it lands.
+type Driver interface {
+	Name() string
+	PresignPut(ctx context.Context, key string, opts PutOpts) (*PresignedRequest, error)
+	PresignGet(ctx context.Context, key string, opts GetOpts) (*PresignedRequest, error)
+	Put(ctx context.Context, key string, r io.Reader, opts PutOpts) (*ObjectMeta, error)
+	Get(ctx context.Context, key string) (io.ReadCloser, *ObjectMeta, error)
+	Stat(ctx context.Context, key string) (*ObjectMeta, error)
+	Delete(ctx context.Context, key string) error
+	List(ctx context.Context, prefix, cursor string, limit int) (*ListResult, error)
+}
+
+// PresignedRequest is what a driver returns from PresignPut/PresignGet
+// — the frontend hits URL directly with Method + Headers.
+type PresignedRequest struct {
+	Method  string            `json:"method"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Expires time.Time         `json:"expires_at"`
+}
+
+// PutOpts captures everything a producer can ask of a Put / PresignPut.
+type PutOpts struct {
+	ContentType   string
+	ContentLength int64
+	Metadata      map[string]string
+	CacheControl  string
+	// TTL is how long the presigned URL stays valid. Driver may clamp.
+	TTL time.Duration
+}
+
+// GetOpts captures PresignGet knobs (response headers, inline vs
+// attachment, TTL).
+type GetOpts struct {
+	ResponseContentType        string
+	ResponseContentDisposition string
+	TTL                        time.Duration
+}
+
+// ObjectMeta is the storage-side metadata for one object. The DB row
+// (ObjectRecord) carries the same fields plus platform-side
+// bookkeeping (entity_kind/entity_id, uploaded_by, soft delete).
+type ObjectMeta struct {
+	Key         string            `json:"key"`
+	Size        int64             `json:"size_bytes"`
+	ContentType string            `json:"content_type"`
+	ETag        string            `json:"etag,omitempty"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// ListResult is one page of a List call.
+type ListResult struct {
+	Items      []ObjectMeta `json:"items"`
+	NextCursor string       `json:"next_cursor,omitempty"`
+}
+
+// Operation tags a signed token's intent. Localfs driver embeds this
+// in the HMAC payload so a GET token cannot be replayed as a PUT.
+type Operation string
+
+const (
+	OpPut Operation = "put"
+	OpGet Operation = "get"
+)
+
+// Common errors. Producers and the HTTP handler both branch on these.
+var (
+	ErrBucketNotFound       = errors.New("bucket not found")
+	ErrObjectNotFound       = errors.New("object not found")
+	ErrDriverNotImplemented = errors.New("driver not implemented")
+	ErrTokenInvalid         = errors.New("invalid or expired token")
+	ErrUnauthorized         = errors.New("unauthorized for bucket")
+	ErrObjectTooLarge       = errors.New("object exceeds bucket size limit")
+	ErrContentTypeRejected  = errors.New("content type not allowed for bucket")
+)
+
+// Clock is injectable so tests can pin time. Default impl is realClock.
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// NewClock returns the wall-clock implementation.
+func NewClock() Clock { return realClock{} }

--- a/AegisLab/src/module/blobclient/local.go
+++ b/AegisLab/src/module/blobclient/local.go
@@ -1,0 +1,106 @@
+package blobclient
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"time"
+
+	"aegis/module/blob"
+)
+
+// LocalClient is the in-process implementation. It maps the
+// producer-facing requests onto module/blob.Service.
+type LocalClient struct {
+	svc *blob.Service
+}
+
+func NewLocalClient(svc *blob.Service) *LocalClient {
+	return &LocalClient{svc: svc}
+}
+
+func (c *LocalClient) PresignPut(ctx context.Context, bucket string, req PresignPutReq) (*PresignPutResult, error) {
+	res, err := c.svc.PresignPut(ctx, blob.PresignPutInput{
+		Bucket: bucket, Key: req.Key,
+		ContentType: req.ContentType, ContentLength: req.ContentLength,
+		EntityKind: req.EntityKind, EntityID: req.EntityID,
+		Metadata: req.Metadata,
+		TTL:      time.Duration(req.TTLSeconds) * time.Second,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &PresignPutResult{
+		ObjectID: res.ObjectID, Bucket: res.Bucket, Key: res.Key,
+		Presigned: toClientPresigned(res.Presigned),
+	}, nil
+}
+
+func (c *LocalClient) PresignGet(ctx context.Context, bucket, key string, req PresignGetReq) (*PresignedURL, error) {
+	pr, err := c.svc.PresignGet(ctx, bucket, key, blob.GetOpts{
+		ResponseContentType: req.ResponseContentType,
+		TTL:                 time.Duration(req.TTLSeconds) * time.Second,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return toClientPresigned(pr), nil
+}
+
+func (c *LocalClient) Stat(ctx context.Context, bucket, key string) (*ObjectMeta, error) {
+	m, err := c.svc.Stat(ctx, bucket, key)
+	if err != nil {
+		return nil, err
+	}
+	return toClientMeta(m), nil
+}
+
+func (c *LocalClient) Delete(ctx context.Context, bucket, key string) error {
+	return c.svc.Delete(ctx, bucket, key)
+}
+
+func (c *LocalClient) PutBytes(ctx context.Context, bucket string, body []byte, req PresignPutReq) (*ObjectMeta, error) {
+	_, meta, err := c.svc.PutBytes(ctx, blob.PresignPutInput{
+		Bucket: bucket, Key: req.Key,
+		ContentType: req.ContentType, ContentLength: int64(len(body)),
+		EntityKind: req.EntityKind, EntityID: req.EntityID, Metadata: req.Metadata,
+	}, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	return toClientMeta(meta), nil
+}
+
+func (c *LocalClient) GetBytes(ctx context.Context, bucket, key string) ([]byte, *ObjectMeta, error) {
+	rc, meta, err := c.svc.Get(ctx, bucket, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = rc.Close() }()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, nil, err
+	}
+	return body, toClientMeta(meta), nil
+}
+
+func toClientPresigned(pr *blob.PresignedRequest) *PresignedURL {
+	if pr == nil {
+		return nil
+	}
+	return &PresignedURL{
+		Method: pr.Method, URL: pr.URL, Headers: pr.Headers, Expires: pr.Expires,
+	}
+}
+
+func toClientMeta(m *blob.ObjectMeta) *ObjectMeta {
+	if m == nil {
+		return nil
+	}
+	return &ObjectMeta{
+		Key: m.Key, Size: m.Size, ContentType: m.ContentType, ETag: m.ETag,
+		UpdatedAt: m.UpdatedAt, Metadata: m.Metadata,
+	}
+}
+
+var _ Client = (*LocalClient)(nil)

--- a/AegisLab/src/module/blobclient/module.go
+++ b/AegisLab/src/module/blobclient/module.go
@@ -1,0 +1,50 @@
+package blobclient
+
+import (
+	"fmt"
+
+	"aegis/config"
+	"aegis/module/blob"
+
+	"go.uber.org/fx"
+)
+
+// Module wires a blobclient.Client into the fx graph. The concrete
+// implementation is chosen by `[blob.client] mode`:
+//
+//	mode = "local"  (default) → LocalClient over module/blob.Service
+//	mode = "remote"           → RemoteClient over HTTP
+//
+// Producers always inject blobclient.Client and learn nothing about
+// which mode is in effect.
+var Module = fx.Module("blobclient",
+	fx.Provide(provideClient),
+)
+
+func provideClient(
+	svc *blob.Service, // available iff module/blob is also loaded
+	tokenSrc TokenSource, // available iff app wires an adapter
+) (Client, error) {
+	mode := config.GetString("blob.client.mode")
+	if mode == "" {
+		mode = "local"
+	}
+	switch mode {
+	case "local":
+		if svc == nil {
+			return nil, fmt.Errorf("blobclient mode=local but no blob.Service in graph")
+		}
+		return NewLocalClient(svc), nil
+	case "remote":
+		base := config.GetString("blob.client.endpoint")
+		if base == "" {
+			return nil, fmt.Errorf("blobclient mode=remote requires [blob.client] endpoint")
+		}
+		return NewRemoteClient(RemoteClientConfig{
+			BaseURL:    base,
+			MaxRetries: config.GetInt("blob.client.max_retries"),
+		}, tokenSrc)
+	default:
+		return nil, fmt.Errorf("blobclient: unknown mode %q (want local|remote)", mode)
+	}
+}

--- a/AegisLab/src/module/blobclient/remote.go
+++ b/AegisLab/src/module/blobclient/remote.go
@@ -1,0 +1,209 @@
+package blobclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// TokenSource produces a fresh Bearer token for cross-service calls.
+// Same pattern as notificationclient.TokenSource — app/blob wires a
+// concrete implementation (typically a wrapper over ssoclient).
+type TokenSource interface {
+	Token(ctx context.Context) (string, error)
+}
+
+// RemoteClient POSTs producer requests to aegis-blob's HTTP surface.
+type RemoteClient struct {
+	baseURL    *url.URL
+	http       *http.Client
+	tokenSrc   TokenSource
+	maxRetries int
+}
+
+type RemoteClientConfig struct {
+	BaseURL    string
+	Timeout    time.Duration
+	MaxRetries int
+}
+
+func NewRemoteClient(cfg RemoteClientConfig, tokenSrc TokenSource) (*RemoteClient, error) {
+	u, err := url.Parse(cfg.BaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse blob base url: %w", err)
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 5 * time.Second
+	}
+	if cfg.MaxRetries == 0 {
+		cfg.MaxRetries = 2
+	}
+	return &RemoteClient{
+		baseURL:    u,
+		http:       &http.Client{Timeout: cfg.Timeout},
+		tokenSrc:   tokenSrc,
+		maxRetries: cfg.MaxRetries,
+	}, nil
+}
+
+func trimSlash(s string) string {
+	for len(s) > 0 && s[len(s)-1] == '/' {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+func (c *RemoteClient) endpoint(path string) string {
+	u := *c.baseURL
+	u.Path = trimSlash(u.Path) + path
+	return u.String()
+}
+
+func (c *RemoteClient) do(ctx context.Context, method, path string, body any, out any) error {
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("encode request: %w", err)
+		}
+		rdr = bytes.NewReader(b)
+	}
+	var lastErr error
+	for attempt := 0; attempt <= c.maxRetries; attempt++ {
+		var token string
+		if c.tokenSrc != nil {
+			t, err := c.tokenSrc.Token(ctx)
+			if err != nil {
+				return fmt.Errorf("acquire service token: %w", err)
+			}
+			token = t
+		}
+		req, err := http.NewRequestWithContext(ctx, method, c.endpoint(path), rdr)
+		if err != nil {
+			return err
+		}
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		resp, err := c.http.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("blob service responded %d", resp.StatusCode)
+			_ = resp.Body.Close()
+			continue
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode == http.StatusNoContent {
+			return nil
+		}
+		if resp.StatusCode >= 400 {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("blob request failed (%d): %s", resp.StatusCode, string(b))
+		}
+		if out != nil {
+			if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+				return fmt.Errorf("decode response: %w", err)
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("blob request failed after %d retries: %w", c.maxRetries, lastErr)
+}
+
+func (c *RemoteClient) PresignPut(ctx context.Context, bucket string, req PresignPutReq) (*PresignPutResult, error) {
+	var out PresignPutResult
+	if err := c.do(ctx, http.MethodPost, "/api/v2/blob/buckets/"+url.PathEscape(bucket)+"/presign-put", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *RemoteClient) PresignGet(ctx context.Context, bucket, key string, req PresignGetReq) (*PresignedURL, error) {
+	body := struct {
+		Key string `json:"key"`
+		PresignGetReq
+	}{Key: key, PresignGetReq: req}
+	var out PresignedURL
+	if err := c.do(ctx, http.MethodPost, "/api/v2/blob/buckets/"+url.PathEscape(bucket)+"/presign-get", body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *RemoteClient) Stat(ctx context.Context, bucket, key string) (*ObjectMeta, error) {
+	var out ObjectMeta
+	path := "/api/v2/blob/buckets/" + url.PathEscape(bucket) + "/objects/" + url.PathEscape(key)
+	if err := c.do(ctx, http.MethodHead, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *RemoteClient) Delete(ctx context.Context, bucket, key string) error {
+	path := "/api/v2/blob/buckets/" + url.PathEscape(bucket) + "/objects/" + url.PathEscape(key)
+	return c.do(ctx, http.MethodDelete, path, nil, nil)
+}
+
+// PutBytes for the remote client: presign-put, then PUT the bytes to
+// the returned URL. Phase A keeps this simple; full multipart support
+// lands when the s3 driver does.
+func (c *RemoteClient) PutBytes(ctx context.Context, bucket string, body []byte, req PresignPutReq) (*ObjectMeta, error) {
+	req.ContentLength = int64(len(body))
+	pres, err := c.PresignPut(ctx, bucket, req)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, pres.Presigned.Method, pres.Presigned.URL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range pres.Presigned.Headers {
+		httpReq.Header.Set(k, v)
+	}
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("upload failed (%d)", resp.StatusCode)
+	}
+	return &ObjectMeta{Key: pres.Key, Size: int64(len(body)), ContentType: req.ContentType, UpdatedAt: time.Now()}, nil
+}
+
+func (c *RemoteClient) GetBytes(ctx context.Context, bucket, key string) ([]byte, *ObjectMeta, error) {
+	pres, err := c.PresignGet(ctx, bucket, key, PresignGetReq{})
+	if err != nil {
+		return nil, nil, err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, pres.Method, pres.URL, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		return nil, nil, fmt.Errorf("download failed (%d)", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	return body, &ObjectMeta{Key: key, Size: int64(len(body)), UpdatedAt: time.Now()}, nil
+}
+
+var _ Client = (*RemoteClient)(nil)

--- a/AegisLab/src/module/blobclient/types.go
+++ b/AegisLab/src/module/blobclient/types.go
@@ -1,0 +1,72 @@
+// Package blobclient is the producer-side surface for object storage.
+// Producers (dataset, user avatars, evaluation export, injection
+// artifacts, …) depend ONLY on this package.
+//
+// Two interchangeable implementations are wired via fx:
+//
+//   - Local — calls module/blob.Service in-process. Used in the
+//     monolith.
+//   - Remote — POSTs to aegis-blob's `/api/v2/blob/*` endpoints over
+//     HTTP, authenticated with a service token from SSO's
+//     client_credentials grant.
+//
+// Switching modes is a config flip — no producer code changes. Mirrors
+// the notificationclient pattern by design.
+package blobclient
+
+import (
+	"context"
+	"time"
+)
+
+// Client is the only type producers reference.
+type Client interface {
+	PresignPut(ctx context.Context, bucket string, req PresignPutReq) (*PresignPutResult, error)
+	PresignGet(ctx context.Context, bucket, key string, req PresignGetReq) (*PresignedURL, error)
+	Stat(ctx context.Context, bucket, key string) (*ObjectMeta, error)
+	Delete(ctx context.Context, bucket, key string) error
+	// Small-payload helpers — useful for service-side writes that don't
+	// need the presign round trip.
+	PutBytes(ctx context.Context, bucket string, body []byte, req PresignPutReq) (*ObjectMeta, error)
+	GetBytes(ctx context.Context, bucket, key string) ([]byte, *ObjectMeta, error)
+}
+
+// PresignPutReq is the producer-facing payload, kept simple — JSON-ish
+// fields, no internal types.
+type PresignPutReq struct {
+	Key           string            `json:"key,omitempty"`
+	ContentType   string            `json:"content_type"`
+	ContentLength int64             `json:"content_length,omitempty"`
+	EntityKind    string            `json:"entity_kind,omitempty"`
+	EntityID      string            `json:"entity_id,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	TTLSeconds    int               `json:"ttl_seconds,omitempty"`
+}
+
+type PresignGetReq struct {
+	ResponseContentType string `json:"response_content_type,omitempty"`
+	TTLSeconds          int    `json:"ttl_seconds,omitempty"`
+}
+
+type PresignPutResult struct {
+	ObjectID  int64         `json:"object_id"`
+	Bucket    string        `json:"bucket"`
+	Key       string        `json:"key"`
+	Presigned *PresignedURL `json:"presigned"`
+}
+
+type PresignedURL struct {
+	Method  string            `json:"method"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Expires time.Time         `json:"expires_at"`
+}
+
+type ObjectMeta struct {
+	Key         string            `json:"key"`
+	Size        int64             `json:"size_bytes"`
+	ContentType string            `json:"content_type"`
+	ETag        string            `json:"etag,omitempty"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}


### PR DESCRIPTION
## Summary
- `module/blob`: Driver iface (localfs full, s3 stub), BucketRegistry from `[blob.buckets.*]`, ObjectRecord GORM model, HMAC-signed presign for localfs, full HTTP handler.
- `module/blobclient`: local + remote dual-mode SDK (mirrors `notificationclient`).
- `cmd/aegis-blob`: standalone service binary, default `:8085` (mirrors `aegis-notify`).

RFC: `docs/rfcs/blob-storage.md`.

## TODO follow-ups
- s3 driver is stub → Phase B (aws-sdk-go-v2).
- `DeletionWorker` is no-op → retention/orphan reconcile.
- Observability counters not wired yet.

## Test plan
- [x] `go build ./module/blob/... ./module/blobclient/... ./app/blob/... ./cmd/aegis-blob/...` clean.
- [ ] Manual: `aegis-blob serve --port 8085` boots against localfs scratch bucket.
- [ ] Manual: presign-put → PUT bytes → :object-uploaded round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)