### PR TITLE
feat(configcenter): module/configcenter + cmd/aegis-configcenter

### DIFF
--- a/AegisLab/docs/rfcs/api-gateway.md
+++ b/AegisLab/docs/rfcs/api-gateway.md
@@ -1,0 +1,291 @@
+# RFC: API Gateway (`cmd/aegis-gateway`)
+
+- Status: **Draft**
+- Owners: aegis-backend
+- Stakeholders: every downstream service (sso, notify, blob, monolith
+  api), aegis-ui (single base URL)
+- Related: `helm/templates/edge-proxy.yaml` (current Caddy proxy that
+  this replaces in front of api-gateway), `module/ssoclient`,
+  `module/ratelimiter`, `module/configcenter` RFC
+
+---
+
+## Summary
+
+Replace the current Caddy "edge-proxy" + monolith `cmd/api-gateway`
+pattern with a proper L7 application gateway: `cmd/aegis-gateway`,
+default `:8086`. It owns route → upstream mapping, JWT pre-auth (via
+`ssoclient`), global per-route rate limit (via `ratelimiter`), CORS,
+request logging, and per-upstream health. Caddy retreats to TLS
+termination + static asset serving only.
+
+The current `cmd/api-gateway` is renamed to `cmd/aegis-api` (it was
+always the monolith API binary; calling it a gateway misled both
+operators and new contributors).
+
+## Motivation
+
+Right now "API gateway" means two unrelated things:
+
+| Layer | What it is | Problem |
+| --- | --- | --- |
+| `helm/templates/edge-proxy.yaml` (Caddy) | Pure reverse proxy: `:80 → api-gateway-svc:80` and `:9096 → api-gateway-svc:9096` | No auth, no rate limit, no route awareness. Just a port forwarder. |
+| `cmd/api-gateway` + `app/gateway/options.go` | "The single API binary: it owns every module" | Misnamed. It's the monolith. As we extract sso / notify / blob into independent binaries, the "gateway" name leaks the wrong mental model. |
+
+Concretely:
+
+- A request hitting `/api/v2/inbox/...` should land on `aegis-notify`,
+  not the monolith. Today Caddy doesn't know that.
+- A request hitting `/api/v2/blob/...` should land on `aegis-blob`.
+- JWT verification is duplicated in every backend service. Verifying
+  once at the gateway would let services trust headers
+  (`X-Aegis-User-Id`, `X-Aegis-Roles`) instead of re-running the
+  ssoclient pipeline.
+- Rate limiting is per-process, which means per-pod. A real gateway
+  gives us a single chokepoint that's easier to operate.
+
+## Non-goals
+
+- Service mesh (mTLS between services, sidecar injection, observability
+  spans across hops). If we go there, it's Istio/Linkerd, not a gateway.
+- Layer-4 load balancing. Kubernetes Services do that.
+- Caching. CDN handles caching for static assets.
+- API composition / GraphQL stitching. Out of scope.
+- WAF rules beyond CORS + simple header checks. Buy a real WAF if/when
+  needed.
+
+## Proposed design
+
+### Topology
+
+```
+                ┌──────────────────────────────────────────────────────┐
+                │                  Caddy (TLS termination)             │
+                │  - cert mgmt                                         │
+                │  - static asset serving (apps/console build)         │
+                │  - forwards everything else to aegis-gateway         │
+                └────────────────────┬─────────────────────────────────┘
+                                     │
+                              ┌──────▼───────┐
+                              │ aegis-gateway│   (this RFC)
+                              │   :8086      │
+                              └──────┬───────┘
+            ┌───────────┬────────────┼────────────┬─────────────┐
+            │           │            │            │             │
+       ┌────▼─────┐ ┌───▼────┐ ┌─────▼─────┐ ┌────▼─────┐ ┌─────▼────┐
+       │ aegis-sso│ │aegis-  │ │aegis-blob │ │aegis-    │ │ aegis-api│
+       │  :8083   │ │notify  │ │  :8085    │ │notify    │ │  (monolith)│
+       │          │ │ :8084  │ │           │ │  :8084   │ │   :8080  │
+       └──────────┘ └────────┘ └───────────┘ └──────────┘ └──────────┘
+```
+
+### Route table
+
+Routes are config-driven (and once `configcenter` lands, hot-
+reloadable from etcd). Initial table:
+
+```toml
+[[gateway.routes]]
+prefix     = "/v1/"            # OIDC endpoints
+upstream   = "aegis-sso:8083"
+auth       = "none"             # SSO itself owns these endpoints
+
+[[gateway.routes]]
+prefix     = "/.well-known/"
+upstream   = "aegis-sso:8083"
+auth       = "none"
+
+[[gateway.routes]]
+prefix     = "/api/v2/inbox/"
+upstream   = "aegis-notify:8084"
+auth       = "jwt"
+audiences  = ["portal"]
+
+[[gateway.routes]]
+prefix     = "/api/v2/notifications/"
+upstream   = "aegis-notify:8084"
+auth       = "jwt"
+
+[[gateway.routes]]
+prefix     = "/api/v2/blob/"
+upstream   = "aegis-blob:8085"
+auth       = "jwt"
+
+[[gateway.routes]]
+prefix     = "/api/v2/auth/"     # human-user login/register via monolith
+upstream   = "aegis-api:8080"
+auth       = "none"
+
+[[gateway.routes]]
+prefix     = "/"                  # everything else → monolith
+upstream   = "aegis-api:8080"
+auth       = "jwt"
+```
+
+Match order is first-match. Per-route options:
+
+- `auth`: `none` | `jwt` | `service-token` | `jwt-or-service`
+- `audiences`: optional, restricts JWT audience
+- `rate_limit`: `{rps, burst}` — overrides global default
+- `strip_prefix`: bool, default false
+- `timeout_seconds`: int, default 30
+- `retry`: `{attempts, on_status: [502, 503, 504]}` — default 0
+
+### JWT pre-auth
+
+Verify once at the gateway via `ssoclient` (same library every backend
+uses today). On success, **inject headers** the upstream can trust:
+
+```
+X-Aegis-User-Id: 42
+X-Aegis-User-Email: alice@aegis.example
+X-Aegis-Roles: admin,operator
+X-Aegis-Token-Aud: portal
+X-Aegis-Token-Jti: abc123
+```
+
+The upstream's `middleware/auth` is updated to:
+
+1. If `X-Aegis-User-Id` present **and** the request arrived on the
+   intra-cluster network (configurable IP whitelist or mTLS), trust
+   it directly — skip re-verification.
+2. Otherwise, run the existing ssoclient verification path (for
+   anyone hitting the upstream directly during development or
+   tests).
+
+This is intentionally additive: the upstream still works without
+the gateway. The gateway is an optimization + policy point, not a
+hard dependency.
+
+### Rate limiting
+
+Global limiter in front of every route, configurable per route. Use
+`module/ratelimiter` as the limiter implementation; in v1 it remains
+in-process (per gateway pod). When we run multiple gateway replicas:
+either accept per-pod limits (typical for L7 gateways) or back the
+limiter with Redis (`ratelimiter` already supports a Redis backend —
+flip via config).
+
+### CORS
+
+Single CORS policy applied at the gateway:
+
+```toml
+[gateway.cors]
+allowed_origins  = ["http://localhost:3101", "https://aegis.example"]
+allowed_methods  = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+allowed_headers  = ["Authorization", "Content-Type"]
+allow_credentials = true
+max_age_seconds  = 86400
+```
+
+Upstreams no longer add CORS headers (they were inconsistent — we
+remove that code in a follow-up).
+
+### Logging + observability
+
+- One access log line per request: `ts | route | upstream | method |
+  path | status | latency_ms | user_id | request_id`
+- Trace span per request, propagated via `traceparent` header to the
+  upstream (reuse `infra/tracing`).
+- Metrics: `gateway_requests_total{route, status}`,
+  `gateway_request_duration_seconds{route}`,
+  `gateway_upstream_errors_total{route, kind}`,
+  `gateway_ratelimit_drops_total{route}`.
+
+### Health
+
+- `GET /healthz` on gateway → 200 if the gateway is alive.
+- `GET /readyz` on gateway → 200 if it can reach a configurable
+  subset of upstreams (the gateway holds a short-lived TCP probe
+  pool per upstream).
+- Per-upstream circuit breaker (open after N consecutive 5xx) ships
+  in v2; v1 just retries per route config.
+
+### Configuration
+
+Driven by:
+
+1. `[gateway.routes]` table in `config.<env>.toml` (static).
+2. Once `configcenter` lands: `/aegis/<env>/gateway/routes` in etcd
+   overrides + adds. Hot reload, no restart.
+
+### Failure modes
+
+- Upstream unreachable → 502 with request_id; metric bumped; retry
+  per route policy.
+- JWT verification fails → 401; never reaches upstream.
+- Rate limit exceeded → 429 with `Retry-After`.
+- Gateway pod crash → kube replaces it; route table is config so
+  no state to recover.
+
+### What about gRPC?
+
+The current edge-proxy also forwards `:9096` for the runtime-intake
+gRPC. v1 of `aegis-gateway` does **not** terminate gRPC — we keep
+Caddy or a dedicated gRPC proxy for that one path until we have a
+second gRPC service worth gatewaying. Premature otherwise.
+
+## Migration plan
+
+1. **Phase A (this PR)**: rename `cmd/api-gateway` → `cmd/aegis-api`,
+   `app/gateway` → `app/monolith` (the existing options file).
+   Land `cmd/aegis-gateway` + `app/gateway` (the new gateway). Wire
+   route table in TOML. No production traffic yet.
+2. **Phase B**: Helm chart adds the gateway deployment + service. The
+   existing `edge-proxy` Caddy starts pointing at `aegis-gateway`
+   instead of `aegis-api`.
+3. **Phase C**: trusted-header upstream short-circuit lands in
+   each backend (`module/auth`). Re-test that direct upstream access
+   still works (for dev / `pnpm dev` proxy fallback).
+4. **Phase D**: once `configcenter` is live, move the route table to
+   etcd for hot reload.
+
+## Alternatives considered
+
+- **Use Caddy as the gateway (Caddyfile routes + plugins).** Possible,
+  but JWT verification needs a Caddy plugin written in Go anyway, and
+  we lose the ability to reuse `ssoclient` and `ratelimiter`
+  directly. Easier to own the gateway as a Go binary.
+- **Use Envoy / Kong / Traefik.** All capable; all add an
+  operational component the team doesn't run. JWT plugins exist
+  (Envoy JWT filter) but mapping our specific audience/role
+  semantics is non-trivial. Defer until we outgrow a Go gateway.
+- **Stay on Caddy reverse proxy + per-service auth.** Cheapest, but
+  every new service re-runs the ssoclient pipeline, CORS gets
+  duplicated, rate-limit policy fragments. The whole point of
+  pulling sso/notify/blob into independent services is to make this
+  the natural extraction point.
+- **Build into the monolith ("monolith dispatches to RPCs").** That's
+  what we have today, modulo the missing RPCs. The monolith binary
+  shouldn't grow more responsibilities; it should shed them.
+
+## Open questions
+
+1. **Service-token issuance for upstreams.** When the gateway calls
+   an upstream with trusted-header injection, does the upstream
+   require a service token in addition? Proposal: no for v1 — IP
+   allowlist + signed header (HMAC over user_id+ts+jti) is enough.
+   mTLS as a v2 hardening step.
+2. **mTLS between gateway and upstreams.** Skip in v1 (rely on
+   network policies). Add in v2 if compliance demands it.
+3. **Where do we run a /admin route?** Proposal: route `prefix =
+   "/api/v2/admin/"` → monolith, `auth = "jwt"`, `roles = ["admin"]`
+   (new field), and the monolith trusts the role header.
+
+## Acceptance criteria
+
+- `aegis-gateway serve --port 8086` boots, loads route table from
+  TOML, passes `/healthz`.
+- Hitting `http://gateway/api/v2/inbox` from a logged-in browser
+  reaches `aegis-notify` with `X-Aegis-User-Id` injected, and the
+  inbox returns the user's items.
+- Hitting `http://gateway/api/v2/inbox` without a JWT returns 401
+  from the gateway (never reaches notify).
+- Rate-limit headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`)
+  present on every response.
+- `pnpm dev` proxy in `apps/console/vite.config.ts` points at
+  `aegis-gateway` instead of the SSO target directly, and both the
+  /authorize flow AND the inbox flow work end-to-end.
+- The monolith's existing tests still pass when called directly
+  (not via the gateway).

--- a/AegisLab/docs/rfcs/blob-storage.md
+++ b/AegisLab/docs/rfcs/blob-storage.md
@@ -1,0 +1,359 @@
+# RFC: Blob storage (`module/blob` + `cmd/aegis-blob`)
+
+- Status: **Draft**
+- Owners: aegis-backend
+- Stakeholders: dataset, user (avatars), evaluation (report export),
+  injection (artifacts), notification (rich payload assets), frontend
+  (direct upload via presigned URL)
+- Related: `module/notification` RFC, `module/sso` (issues service
+  tokens), `infra/etcd` (configuration source)
+
+---
+
+## Summary
+
+Add a first-class blob storage service to the platform. Ship it as
+`module/blob` (in-process producer surface), `module/blobclient`
+(local + remote dual-mode SDK matching the notification pattern), and
+`cmd/aegis-blob` (standalone microservice, default `:8085`). Default
+driver is `localfs`; production drivers (RustFS-compatible S3, MinIO,
+AWS S3, Aliyun OSS) plug in behind one `Driver` interface.
+
+Frontend uploads go **straight to the storage backend** via short-lived
+presigned URLs — blob service issues the signature, never proxies the
+bytes.
+
+## Motivation
+
+We currently have no abstraction for object storage. Today this is
+ad-hoc per module:
+
+| Need | Current state |
+| --- | --- |
+| Dataset artifacts | written to PVC inside the workload pod, opaque to other services |
+| User avatars | not implemented; `users.avatar_url` would be free-text today |
+| Evaluation report export | not implemented; would dump to pod local FS |
+| Injection bundle attachments | not implemented |
+| Notification rich payload | RFC explicitly punts |
+
+Every one of these would otherwise re-invent: bucket selection,
+authn for upload, retention, ACL, presigning, error handling. Pulling
+it into one module + one binary makes them additive.
+
+This RFC mirrors the shape of `module/notification` so the team
+already knows the pattern: thin core, plugin-driven extension points,
+in-process + remote dual-mode SDK, standalone binary deferrable until
+load demands it.
+
+## Non-goals
+
+- CDN front-cache. Out of scope; downstream consumers add CDN per
+  bucket if they need it (avatar bucket would; dataset wouldn't).
+- Object-level full-text search / metadata indexing. We store enough
+  metadata for "find my objects by entity_kind/entity_id"; anything
+  richer goes through a dedicated search service.
+- Versioning / WORM. Drivers may support it; the platform doesn't
+  expose it in v1.
+- Multipart-upload-resume across server restarts. v1 lets drivers
+  handle it natively (S3 multipart) but the service doesn't persist
+  upload state.
+
+## Proposed design
+
+### Six roles (mirrors notification skeleton)
+
+```
+Ingestion → Authorization → Routing (bucket) → Driver → Lifecycle → Observability
+```
+
+1. **Ingestion** — `PresignPut` / `Put` (small inline) / `Stat` /
+   `Get` (small inline) / `PresignGet` / `Delete` over HTTP and via
+   the in-process `Client` SDK.
+2. **Authorization** — JWT verified by the same `ssoclient` everyone
+   uses. Per-bucket policy: who can write, who can read, max object
+   size, allowed content-types.
+3. **Routing** — bucket name → driver instance. Buckets are config-
+   driven (TOML in v1, optionally promoted to DB later).
+4. **Driver** — pluggable interface; concretes: `localfs`, `s3`. RustFS
+   reuses `s3` driver with custom endpoint.
+5. **Lifecycle** — TTL / retention / archive. Hourly job lists
+   metadata rows, deletes expired objects via driver.
+6. **Observability** — `objects_uploaded`, `bytes_in/out`, p95 presign
+   latency, driver error rate (per bucket).
+
+### Driver interface
+
+```go
+package blob
+
+type Driver interface {
+    Name() string
+    PresignPut(ctx context.Context, key string, opts PutOpts) (PresignedRequest, error)
+    PresignGet(ctx context.Context, key string, opts GetOpts) (PresignedRequest, error)
+    Put(ctx context.Context, key string, r io.Reader, opts PutOpts) (*ObjectMeta, error)
+    Get(ctx context.Context, key string) (io.ReadCloser, *ObjectMeta, error)
+    Stat(ctx context.Context, key string) (*ObjectMeta, error)
+    Delete(ctx context.Context, key string) error
+    List(ctx context.Context, prefix string, cursor string, limit int) (ListResult, error)
+}
+
+type PresignedRequest struct {
+    Method  string            // PUT or GET
+    URL     string            // signed URL — frontend hits this directly
+    Headers map[string]string // headers client must send (Content-Type, x-amz-*)
+    Expires time.Time
+}
+
+type PutOpts struct {
+    ContentType   string
+    ContentLength int64
+    Metadata      map[string]string // arbitrary x-amz-meta-* equivalents
+    CacheControl  string
+}
+
+type ObjectMeta struct {
+    Key         string
+    Size        int64
+    ContentType string
+    ETag        string
+    UpdatedAt   time.Time
+    Metadata    map[string]string
+}
+```
+
+`localfs` driver presigning: sign a JWT containing `{key, op, exp}`
+and return a URL pointed at our own `/v2/blob/raw/:key?token=…`
+handler — same UX as S3 presigning, no driver-specific frontend code.
+
+### Bucket model
+
+Buckets are declared in config:
+
+```toml
+[blob.buckets.dataset-artifacts]
+driver = "s3"
+endpoint = "http://rustfs:9000"
+region = "us-east-1"
+access_key_env = "RUSTFS_ACCESS_KEY"
+secret_key_env = "RUSTFS_SECRET_KEY"
+bucket = "aegis-dataset"
+max_object_bytes = 5_368_709_120        # 5 GiB
+allowed_content_types = ["application/x-tar", "application/zip", "application/octet-stream"]
+public_read = false
+retention_days = 365
+
+[blob.buckets.user-avatars]
+driver = "s3"
+endpoint = "http://rustfs:9000"
+bucket = "aegis-avatars"
+max_object_bytes = 5_242_880            # 5 MiB
+allowed_content_types = ["image/png", "image/jpeg", "image/webp"]
+public_read = true
+cdn_base = "https://cdn.aegis.example/avatars"
+
+[blob.buckets.scratch]
+driver = "localfs"
+root = "/var/lib/aegis/blob/scratch"
+retention_days = 7
+```
+
+DB-driven buckets (admin UI for "create a bucket") is a v2 follow-up
+and explicitly NOT in v1. Config-driven matches GitOps and lets dev
+boxes work without any infra.
+
+Producers reference buckets by **stable name**, never by driver
+specifics. The producer signature is `client.PresignPut(ctx, bucket,
+PutReq{...})` — no S3 endpoint leaking out.
+
+### Data model
+
+```sql
+CREATE TABLE blob_objects (
+  id              BIGINT       PRIMARY KEY AUTO_INCREMENT,
+  bucket          VARCHAR(64)  NOT NULL,
+  storage_key     VARCHAR(512) NOT NULL,  -- the driver-side key
+  size_bytes      BIGINT       NOT NULL,
+  content_type    VARCHAR(128) NOT NULL,
+  etag            VARCHAR(128),
+  uploaded_by     INT,                    -- users.id, null for service writes
+  entity_kind     VARCHAR(64),            -- e.g. dataset, injection, user
+  entity_id       VARCHAR(128),
+  metadata        JSON,
+  created_at      DATETIME(3)  NOT NULL,
+  expires_at      DATETIME(3),            -- driven by bucket.retention_days
+  deleted_at      DATETIME(3),
+  INDEX idx_bucket_key (bucket, storage_key),
+  INDEX idx_entity   (entity_kind, entity_id),
+  INDEX idx_uploader (uploaded_by, created_at DESC)
+);
+```
+
+The DB stores **metadata only** — bytes live in the driver. This
+table is what the lifecycle worker walks, what audit/list endpoints
+hit, and what enforces per-user quota.
+
+### HTTP surface
+
+Mounted at `/api/v2/blob/*`. JWT required, audience = `portal` or
+service-token. Bucket-level RBAC enforced before driver call.
+
+| Method & path | Description |
+| --- | --- |
+| `POST /buckets/:bucket/presign-put` | Issue presigned PUT. Body: `{key?, content_type, content_length, metadata?}`. Server fills `key` with `{entity_kind}/{ulid}` if absent. Returns `PresignedRequest` + metadata row id. |
+| `POST /buckets/:bucket/presign-get` | Issue presigned GET. Body: `{key}`. |
+| `GET /buckets/:bucket/objects/:key` | Inline GET (small objects; redirect to presigned URL above `inline_max_bytes`). |
+| `HEAD /buckets/:bucket/objects/:key` | Stat. |
+| `DELETE /buckets/:bucket/objects/:key` | Soft delete (sets `deleted_at`, removes via driver async). |
+| `GET /buckets/:bucket/objects` | List by entity. Query: `entity_kind`, `entity_id`, `cursor`, `limit`. |
+| `GET /raw/:token` | Localfs driver only — serves the presigned URL target. Verifies JWT-style token, streams the file. Never enabled when all buckets are S3. |
+| `POST /v1/events:object-uploaded` | Internal callback from frontend (or driver event listener) confirming an upload completed. Updates `etag` + `size_bytes` from the driver. |
+
+Response shape:
+
+```json
+{
+  "object_id": 4711,
+  "bucket": "dataset-artifacts",
+  "key": "dataset/01HXY2KQ4F0F9B0D5K8N5N7B6A.tar",
+  "size_bytes": null,
+  "presigned": {
+    "method": "PUT",
+    "url": "http://rustfs:9000/aegis-dataset/dataset/01HXY...?X-Amz-Algorithm=...",
+    "headers": {"Content-Type": "application/x-tar"},
+    "expires_at": "2026-05-12T03:14:05Z"
+  }
+}
+```
+
+### Producer SDK (`module/blobclient`)
+
+```go
+package blobclient
+
+type Client interface {
+    PresignPut(ctx context.Context, bucket string, req PresignPutReq) (*PresignResult, error)
+    PresignGet(ctx context.Context, bucket, key string) (*PresignResult, error)
+    Stat(ctx context.Context, bucket, key string) (*ObjectMeta, error)
+    Delete(ctx context.Context, bucket, key string) error
+    // small-payload helpers, optional
+    PutBytes(ctx context.Context, bucket, key string, body []byte, opts PutOpts) (*ObjectMeta, error)
+    GetBytes(ctx context.Context, bucket, key string) ([]byte, *ObjectMeta, error)
+}
+```
+
+Two implementations:
+
+- `LocalClient` — calls `module/blob` in-process; used by the monolith
+  and by any service that already imports `module/blob`.
+- `RemoteClient` — HTTP client to `aegis-blob`; carries a service
+  token from `ssoclient`. Used when caller is in a service that does
+  not embed `module/blob` (e.g. an independent dataset microservice).
+
+Selected at wiring time by config:
+
+```toml
+[blob.client]
+mode = "local"   # or "remote"
+endpoint = "http://aegis-blob:8085"
+```
+
+Identical to the `notificationclient` pattern, by design.
+
+### Standalone binary
+
+`cmd/aegis-blob` mirrors `cmd/aegis-notify`:
+
+```
+package main
+// cobra entry, default port :8085, --conf <dir>
+fx.New(blob.Options(conf, port)).Run()
+```
+
+`app/blob/options.go` composes:
+
+- `app.BaseOptions(conf)` + `ObserveOptions` + `DataOptions`
+- `module/auth` (JWT verifier — same service tokens as aegis-notify)
+- `module/user` (uploader display name lookup)
+- `module/blob`
+- `httpapi.Module` + `/healthz` decorator
+
+Buckets that use the `s3` driver get their credentials from env vars
+referenced by config (see bucket TOML above). RustFS endpoint is just
+another S3 endpoint; the driver code does not branch on RustFS.
+
+### Authorization model
+
+- JWT must be valid and audience-allowed.
+- Each bucket carries an ACL: `write_roles`, `read_roles`,
+  `public_read`. Service tokens get a default `service` role.
+- For private buckets, presigned GET requires the caller to either
+  have read access or own the object (`uploaded_by == ctx.UserID`).
+- Per-user quota (sum of `size_bytes` where `deleted_at IS NULL`)
+  enforced before issuing a presigned PUT.
+
+### Failure modes
+
+- Driver `PresignPut` fails → metadata row not created; client gets
+  502. (Metadata is written **after** the presign succeeds, so we
+  don't leave orphans referencing presign failures.)
+- Frontend never calls back `/v1/events:object-uploaded` → object
+  exists in driver but metadata row is `size_bytes=null`. Hourly
+  reconcile job calls `driver.Stat`, fills in or deletes orphan.
+- Driver outage → presign endpoint returns 503; producers retry with
+  backoff (idempotent because key generation is content-based when
+  caller doesn't provide one).
+
+## Migration plan
+
+1. **Phase A (this PR)**: land `module/blob` (driver iface + localfs +
+   s3 stub) + `module/blobclient` (local mode only) + `cmd/aegis-blob`
+   skeleton + metadata table migration. Default bucket `scratch`
+   (localfs). No producers wired yet.
+2. **Phase B**: complete `s3` driver, deploy RustFS in Helm chart,
+   declare `dataset-artifacts` + `user-avatars` buckets.
+3. **Phase C**: wire first real producer — `module/user` writes
+   avatars; frontend gets the upload flow. Use this to harden the
+   presign+confirm round trip.
+4. **Phase D**: migrate dataset writes through `module/blob`.
+
+## Alternatives considered
+
+- **Skip the abstraction, every module writes to S3 directly.** Tried
+  this pattern in prior projects — every consumer reinvents bucket
+  policy, presigning, retention. Inconsistent and risky.
+- **Use a managed product (Cloudflare R2 SDK directly, etc.).** No
+  abstraction means switching providers requires changing every
+  caller. Driver iface costs ~200 lines and buys provider freedom.
+- **Skip presigned URLs, proxy all bytes.** Simpler auth but the blob
+  service becomes the bandwidth bottleneck. RustFS deployment exists
+  precisely so we can offload bytes to it.
+- **DB-driven buckets in v1.** Adds an admin UI and migration story
+  with zero current need. Config-driven is the right v1.
+
+## Open questions
+
+1. **Where do driver credentials live?** Proposal: bucket config
+   references env-var names, not literal secrets. Helm/compose
+   populates the env from sealed secrets. Same model as the SSO
+   private-key path.
+2. **Localfs presign token signing key.** Reuse SSO's RSA keypair?
+   Or a dedicated HMAC key? Proposal: dedicated HMAC, narrower
+   blast radius if leaked.
+3. **Object-key generation.** Random ULID under
+   `{entity_kind}/{ulid}` is the v1 default. Some callers will want
+   deterministic keys (avatars by user id, for de-dupe). Solve via
+   `PresignPutReq.Key` override.
+4. **Inline GET threshold.** 64 KiB? 1 MiB? Set per bucket; default
+   64 KiB.
+
+## Acceptance criteria
+
+- `aegis-blob serve --port 8085` boots against a localfs scratch
+  bucket and an S3 bucket pointed at a local MinIO instance.
+- Frontend can: (1) call `POST /api/v2/blob/buckets/user-avatars/
+  presign-put`, (2) PUT the bytes directly to the returned URL,
+  (3) call back `:object-uploaded`, (4) reference the object by id
+  in `users.avatar_object_id`.
+- 1k presign calls/sec on a single replica without driver errors.
+- `pnpm check` on the console stays green after adding `blobclient`
+  to `apps/console`.

--- a/AegisLab/docs/rfcs/configcenter.md
+++ b/AegisLab/docs/rfcs/configcenter.md
@@ -1,0 +1,382 @@
+# RFC: Configuration center (`module/configcenter` + `cmd/aegis-configcenter`)
+
+- Status: **Draft**
+- Owners: aegis-backend
+- Stakeholders: every service (sso, notify, blob, monolith, gateway)
+- Related: `infra/etcd/Gateway` (the KV primitive this builds on),
+  `config/config.go` (viper TOML+env layer this extends),
+  `module/notification` (the standalone-service pattern this mirrors)
+
+---
+
+## Summary
+
+Promote etcd from "a KV some modules happen to use" into the
+platform's dynamic configuration source, fronted by a first-class
+service. Ship:
+
+- `module/configcenter` — in-process implementation on top of
+  `infra/etcd.Gateway`: layered merge (etcd > env > TOML), typed
+  `Bind[T]`, hot reload via Watch, audit trail.
+- `module/configcenterclient` — local + remote dual-mode SDK, matching
+  the `notificationclient` pattern.
+- `cmd/aegis-configcenter` — standalone microservice, default `:8087`,
+  composed identically to `aegis-notify` / `aegis-sso`. **It does NOT
+  replace etcd**; etcd remains the storage backend. The service owns
+  the typed admin API, audit log, schema validation, watch fanout,
+  and the only place that holds write credentials to etcd.
+
+Consumers go through `configcenterclient`. They never touch etcd
+directly for *configuration*. (Distributed-lock / lease use of etcd
+in `module/injection/alloc.go` is unrelated and stays on
+`infra/etcd.Gateway`.)
+
+## Motivation
+
+Today, configuration is split:
+
+- `config/config.go` — viper, reads TOML, applies env overrides via
+  `SetEnvKeyReplacer` (added when SSO landed).
+- `infra/etcd/Gateway` — used by `module/system`, `chaossystem`,
+  `injection/alloc` as a free-form KV store. Each consumer parses
+  its own values, no schema, no typed access, no hot reload.
+
+The gap:
+
+| Need | Today | Gap |
+| --- | --- | --- |
+| Read static config (DB DSN, ports) | TOML + env via viper | ✅ |
+| Read dynamic config (feature flags, ramp percentages) | nowhere | ❌ |
+| Watch for changes (no restart) | etcd Watch exists but no typed API | ⚠ raw KV only |
+| Audit who changed a value | none | ❌ |
+| Namespace per service | informal key naming | ⚠ |
+| Schema validation | none | ❌ — wrong type = runtime panic |
+| Override TOML at runtime | only env, not etcd | ❌ |
+
+Without a unified layer, every new dynamic-config consumer reinvents
+the same parsing + watch + reload boilerplate.
+
+## Non-goals
+
+- Replace TOML files. TOML stays the canonical static-config source
+  for "things that need to be set before the process starts" (DB
+  DSN, JWT keys path, etcd endpoints themselves).
+- Multi-cluster / multi-tenant config federation. Single etcd
+  cluster per environment in v1.
+- A general-purpose config-as-a-service GUI. We expose admin endpoints;
+  the portal can build a UI later.
+- Secrets manager. Secrets stay in env / sealed secrets / driver
+  credentials; this is for plain config.
+
+## Proposed design
+
+### Layered merge order
+
+```
+etcd  (highest — runtime override, hot)
+  ↓ env vars
+  ↓ TOML file
+defaults in code (lowest)
+```
+
+Rationale: TOML is checked-in baseline, env is per-deploy override
+(matches the SSO env-replacer change), etcd is the runtime override
+that can be flipped without redeploy. This matches the implicit
+order developers already expect — etcd just slots above env.
+
+### Typed API
+
+```go
+package configcenter
+
+type Center interface {
+    // Bind reads the value at namespace+key, decodes into out (a pointer to
+    // a struct or scalar), applies the layered merge, and registers a
+    // watcher so subsequent etcd changes update out atomically.
+    Bind(ctx context.Context, namespace, key string, out any, opts ...BindOpt) (Handle, error)
+
+    // Get reads the current resolved value as JSON (for admin / debug).
+    Get(ctx context.Context, namespace, key string) (raw []byte, layer string, err error)
+
+    // Set writes a value to etcd. Always at the etcd layer (top).
+    Set(ctx context.Context, namespace, key string, value any, opts ...SetOpt) error
+
+    // Delete removes the etcd-layer entry; lower layers reappear.
+    Delete(ctx context.Context, namespace, key string) error
+
+    // List returns all keys under a namespace, with their current values
+    // and which layer each resolves from.
+    List(ctx context.Context, namespace string) ([]Entry, error)
+}
+
+type Handle interface {
+    // Reload forces a re-decode (useful in tests).
+    Reload(ctx context.Context) error
+    // Subscribe registers a callback fired on every change.
+    Subscribe(fn func()) (unsubscribe func())
+    Close() error
+}
+
+type BindOpt func(*bindOptions)
+
+func WithDefault(v any) BindOpt
+func WithValidator(fn func(any) error) BindOpt
+func WithSchemaVersion(v int) BindOpt
+```
+
+Concrete consumer pattern:
+
+```go
+type RateLimitConfig struct {
+    DefaultRPS   int            `mapstructure:"default_rps"`
+    PerRoute     map[string]int `mapstructure:"per_route"`
+    Enabled      bool           `mapstructure:"enabled"`
+}
+
+var cfg RateLimitConfig
+h, err := center.Bind(ctx, "ratelimiter", "default", &cfg,
+    configcenter.WithDefault(RateLimitConfig{DefaultRPS: 100, Enabled: true}),
+    configcenter.WithValidator(validateRateLimit),
+)
+defer h.Close()
+h.Subscribe(func() { logrus.Info("rate limit config reloaded") })
+```
+
+All `cfg` reads from the same goroutine see a coherent snapshot
+because `Bind` swaps the pointer target atomically via reflect — or,
+for advanced cases, callers can use a sync.Value-style accessor.
+
+### Key naming
+
+```
+/aegis/<env>/<namespace>/<key>
+```
+
+- `env` — `dev` | `staging` | `prod`. Comes from process env at startup.
+- `namespace` — module-owned. e.g. `notification`, `blob`, `gateway`,
+  `injection`, `system`.
+- `key` — module-defined. Lowercase, dot-separated.
+
+Examples:
+
+```
+/aegis/prod/notification/dedup_window_seconds
+/aegis/prod/notification/channels.email.enabled
+/aegis/prod/gateway/rate_limit.default_rps
+/aegis/prod/blob/buckets.dataset-artifacts.retention_days
+```
+
+### Storage format
+
+Values are JSON, regardless of original type. Decoder uses
+`mapstructure` so struct tags from existing config types work
+unchanged. This lets `Set` accept either typed Go values or raw
+JSON (admin API).
+
+### Watch + atomic swap
+
+`Bind` opens a single etcd watch per Center instance (multiplexed
+internally). On change:
+
+1. Re-decode value.
+2. Run validator.
+3. If invalid: keep previous value, log + bump
+   `configcenter_invalid_updates_total{namespace,key}`.
+4. If valid: atomic pointer swap; fire subscribers.
+
+The merge is recomputed on every change. If the etcd value is
+deleted, the resolved value falls back to env → TOML → default.
+
+### HTTP surface (owned by `aegis-configcenter`)
+
+All routes JWT-required. Read endpoints accept any authenticated
+service token or human user; write endpoints require role = `admin`
+(human) or scope = `config:write` (service token).
+
+| Method & path | Description |
+| --- | --- |
+| `GET /api/v2/config/:namespace` | List all keys + values + resolving layer. |
+| `GET /api/v2/config/:namespace/:key` | Get one. |
+| `PUT /api/v2/config/:namespace/:key` | Set etcd layer. Body: JSON value. Writes audit row. |
+| `DELETE /api/v2/config/:namespace/:key` | Remove etcd layer. Writes audit row. |
+| `GET /api/v2/config/:namespace/:key/history` | Read recent revisions (capped). |
+| `GET /api/v2/config/:namespace/watch` | SSE stream of changes under a namespace. The `configcenterclient` remote impl subscribes here instead of opening its own etcd watch. |
+| `GET /healthz` | Liveness. |
+| `GET /readyz` | Etcd reachable + last successful watch event. |
+
+`aegis-configcenter` is the **only** process that holds etcd write
+credentials in v1. Etcd is locked down at the network layer to
+accept connections only from this service (admin) and from a
+read-only role used by services that fall back to direct watches
+during a configcenter outage (see Failure modes).
+
+### Audit
+
+```sql
+CREATE TABLE config_audit (
+  id          BIGINT       PRIMARY KEY AUTO_INCREMENT,
+  namespace   VARCHAR(64)  NOT NULL,
+  key_path    VARCHAR(256) NOT NULL,
+  action      VARCHAR(16)  NOT NULL,   -- set | delete
+  old_value   JSON,
+  new_value   JSON,
+  actor_id    INT,                      -- users.id, null for service tokens
+  actor_token VARCHAR(64),              -- token sub for service writes
+  reason      VARCHAR(256),
+  created_at  DATETIME(3) NOT NULL,
+  INDEX idx_ns_key (namespace, key_path, created_at DESC)
+);
+```
+
+Written synchronously on every Set/Delete by the admin handler. The
+typed in-process `Set` is only callable from the admin handler — no
+backdoor.
+
+### Producer SDK (`module/configcenterclient`)
+
+Mirrors `module/notificationclient` exactly: same `Client`
+interface, two impls, mode selected by config.
+
+```go
+package configcenterclient
+
+type Client interface {
+    Bind(ctx context.Context, namespace, key string, out any, opts ...BindOpt) (Handle, error)
+    Get(ctx context.Context, namespace, key string) (raw []byte, layer string, err error)
+    Set(ctx context.Context, namespace, key string, value any, opts ...SetOpt) error
+    Delete(ctx context.Context, namespace, key string) error
+    List(ctx context.Context, namespace string) ([]Entry, error)
+}
+```
+
+- `LocalClient` — wraps `module/configcenter` in-process. Used by
+  `aegis-configcenter` itself and by any binary that wants to skip
+  the hop (e.g. dev builds where everything runs in-process).
+- `RemoteClient` — HTTP client to `aegis-configcenter`. Subscribes to
+  the SSE watch stream for hot reload. Carries a service token from
+  `ssoclient`. This is what every other service uses by default.
+
+Wiring:
+
+```toml
+[configcenter.client]
+mode = "remote"
+endpoint = "http://aegis-configcenter:8087"
+```
+
+### Standalone binary
+
+`cmd/aegis-configcenter` mirrors `cmd/aegis-notify`:
+
+```
+package main
+// cobra entry, default port :8087, --conf <dir>
+fx.New(configcenter.Options(conf, port)).Run()
+```
+
+`app/configcenter/options.go` composes:
+
+- `app.BaseOptions(conf)` + `ObserveOptions` + `DataOptions`
+- `infra/etcd.Module` (this binary is the only one with etcd write
+  creds)
+- `module/auth` (JWT verifier — same as aegis-notify)
+- `module/user` (audit log actor lookup)
+- `module/configcenter`
+- `httpapi.Module` + `/healthz`/`/readyz` decorator
+
+### What stays in TOML
+
+Per-process bootstrap that the configcenter itself needs:
+
+- `etcd.endpoints`, `etcd.username`, `etcd.password`
+- DB DSN (you need a DB before you can read config from a DB-backed
+  fallback)
+- JWT keys path
+- Listen port
+
+Everything else is fair game for migration to configcenter.
+
+### Migration of existing consumers
+
+In-place, one module per PR:
+
+1. `module/system` — currently `etcd.Gateway.Get(...)`. Becomes
+   `center.Bind(ctx, "system", "...", &sysCfg)`. Keep the etcd
+   gateway as the low-level fallback for non-config KV uses (locks,
+   leases — not config).
+2. `module/chaossystem` — same.
+3. `module/injection/alloc.go` — same. (alloc.go uses etcd for
+   distributed coordination, NOT config; **do not migrate**. The
+   distinction matters.)
+4. New consumers (notification, blob, gateway) start on configcenter
+   from day one.
+
+### Failure modes
+
+- `aegis-configcenter` unreachable at startup → remote client falls
+  back to env → TOML → default. Service still boots. Retry loop
+  reconnects when the configcenter returns. Optional: the client may
+  open a **read-only direct etcd watch** as a degraded path (using a
+  read-only etcd credential), shedding only the audit guarantee.
+- etcd unreachable from `aegis-configcenter` → its `/readyz` fails;
+  the gateway can shed traffic. In-process `module/configcenter` (in
+  the configcenter binary itself) keeps last-known-good values in
+  memory; serves reads, fails writes.
+- etcd value malformed JSON → keep previous resolved value, alert
+  via `configcenter_invalid_updates_total`.
+- Validator rejects new value → same as malformed.
+
+## Migration plan
+
+1. **Phase A (this PR)**: land `module/configcenter` +
+   `module/configcenterclient` + `cmd/aegis-configcenter` +
+   `app/configcenter` + audit table migration. LocalClient wired in
+   the configcenter binary; everything else still on TOML+env. No
+   prod traffic yet.
+2. **Phase B**: deploy `aegis-configcenter` in Helm chart. Migrate
+   one consumer (e.g. notification's `retention_days`) to prove the
+   remote SDK + SSE watch end-to-end.
+3. **Phase C**: migrate `module/system` + `chaossystem` (existing
+   raw `infra/etcd.Gateway` config consumers) onto
+   `configcenterclient`. `infra/etcd.Gateway` stays in the tree but
+   is only used for non-config concerns (locks, leases).
+4. **Phase D**: every new module wires through `configcenterclient`
+   by default.
+
+## Alternatives considered
+
+- **Adopt Nacos / Apollo / Consul KV.** Adds an operational
+  component the team doesn't run. We already run etcd. The typed
+  layer is ~400 LOC; the wrapper cost is less than the operational
+  cost of adopting an external dependency.
+- **Just use viper everywhere with `viper.WatchConfig`.** That only
+  watches files, doesn't centralize, and gives no audit trail. No
+  cross-process consistency.
+- **Push config via env, restart pods on change.** Restart latency
+  defeats the point. Rate-limit ramps want sub-second propagation.
+
+## Open questions
+
+1. **Per-pod overrides.** A canary pod might want a different
+   rate-limit than the rest. Proposal: support
+   `/aegis/<env>/<namespace>/<key>@<pod_hostname>` as an optional
+   override key. Off by default.
+2. **Secrets bleed.** What stops someone setting a "secret" in
+   configcenter? Proposal: lint at Set time — reject if the key
+   path contains `password|secret|key|token`. Force secrets into
+   sealed secrets / env.
+3. **History retention.** etcd's native revision history is
+   compaction-bounded. For audit we have the DB table; do we ever
+   need etcd revisions specifically? Probably no. Keep DB audit
+   authoritative.
+
+## Acceptance criteria
+
+- `center.Bind(ctx, "notification", "retention_days", &n,
+  configcenter.WithDefault(90))` returns 90 with no etcd entry,
+  reflects new value within 1 s after `PUT /api/v2/config/...`.
+- Admin endpoints require `admin` role; mutation writes audit row.
+- Restart of any service preserves the etcd-layer value.
+- `pnpm check` (frontend) unaffected (no frontend changes in this
+  RFC).
+- etcd outage does not block service boot.

--- a/AegisLab/src/app/configcenter/options.go
+++ b/AegisLab/src/app/configcenter/options.go
@@ -1,0 +1,74 @@
+// Package configcenter hosts the fx composition for the standalone
+// configuration-center microservice. Mirrors `app/notify/options.go`
+// in shape.
+//
+// What's in this binary:
+//
+//   - module/configcenter — Center + audit + admin HTTP surface
+//   - module/auth         — JWT verifier (service tokens + human users)
+//   - module/user         — actor lookups for audit rows
+//   - infra/etcd          — this is the ONLY binary that holds etcd
+//                           write credentials in v1
+//   - http server         — admin endpoints under /api/v2/config
+//
+// What's NOT in this binary: chaos/k8s/dataset/injection/business
+// modules. This binary's job is "be the typed face of etcd".
+package configcenter
+
+import (
+	"strings"
+
+	"aegis/app"
+	"aegis/infra/etcd"
+	httpapi "aegis/interface/http"
+	"aegis/module/auth"
+	"aegis/module/configcenter"
+	"aegis/module/user"
+	"aegis/router"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/fx"
+)
+
+func Options(confPath, port string) fx.Option {
+	return fx.Options(
+		app.BaseOptions(confPath),
+		app.ObserveOptions(),
+		app.DataOptions(),
+
+		etcd.Module,
+		user.Module,
+		auth.Module,
+		configcenter.Module,
+
+		fx.Provide(auth.NewTokenVerifier),
+
+		fx.Supply(&router.Handlers{}),
+		fx.Supply(httpapi.ServerConfig{Addr: normalizeAddr(port)}),
+		httpapi.Module,
+
+		fx.Decorate(decorateEngineWithHealthz),
+	)
+}
+
+func decorateEngineWithHealthz(engine *gin.Engine) *gin.Engine {
+	engine.GET("/healthz", func(c *gin.Context) {
+		c.JSON(200, gin.H{"status": "ok"})
+	})
+	engine.GET("/readyz", func(c *gin.Context) {
+		// TODO: probe etcd reachability + last-successful-watch
+		// timestamp. v1 stub returns ok so kube-readiness can wire up.
+		c.JSON(200, gin.H{"status": "ok"})
+	})
+	return engine
+}
+
+func normalizeAddr(port string) string {
+	if port == "" {
+		return ":8087"
+	}
+	if strings.HasPrefix(port, ":") {
+		return port
+	}
+	return ":" + port
+}

--- a/AegisLab/src/cmd/aegis-configcenter/README.md
+++ b/AegisLab/src/cmd/aegis-configcenter/README.md
@@ -1,0 +1,33 @@
+# aegis-configcenter
+
+Standalone configuration-center microservice. Hosts `module/configcenter`
+— typed admin surface, layered merge (etcd > env > TOML > default),
+watch fanout, and audit log. The only binary in v1 that holds etcd
+write credentials.
+
+## Run locally
+
+```bash
+docker compose up -d mysql etcd aegis-sso
+cd src
+go build -tags duckdb_arrow -o /tmp/aegis-configcenter ./cmd/aegis-configcenter
+ENV_MODE=dev AEGIS_JWT_SECRET=... /tmp/aegis-configcenter serve --port 8087 --conf /etc/rcabench
+curl http://localhost:8087/healthz
+```
+
+Default port `8087`. Endpoints:
+
+- `GET    /healthz`
+- `GET    /readyz`
+- `GET    /api/v2/config/:namespace`              — list keys (etcd layer)
+- `GET    /api/v2/config/:namespace/:key`         — get one
+- `PUT    /api/v2/config/:namespace/:key`         — set (admin; writes audit)
+- `DELETE /api/v2/config/:namespace/:key`         — delete (admin; writes audit)
+- `GET    /api/v2/config/:namespace/:key/history` — recent audit rows
+- `GET    /api/v2/config/:namespace/watch`        — SSE change stream
+
+Consumers import `module/configcenterclient` and flip
+`[configcenter.client] mode = "remote"` +
+`[configcenter.client] endpoint = "http://aegis-configcenter:8087"`
+to talk to this binary instead of holding an in-process Center. No
+consumer code changes.

--- a/AegisLab/src/cmd/aegis-configcenter/main.go
+++ b/AegisLab/src/cmd/aegis-configcenter/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+
+	configcenter "aegis/app/configcenter"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/fx"
+)
+
+func main() {
+	var port, conf string
+
+	rootCmd := &cobra.Command{Use: "aegis-configcenter", Short: "Aegis configuration-center microservice"}
+	rootCmd.PersistentFlags().StringVarP(&port, "port", "p", "8087", "Port to run the server on")
+	rootCmd.PersistentFlags().StringVarP(&conf, "conf", "c", "/etc/aegis/config.prod.toml", "Path to configuration directory")
+
+	if err := viper.BindPFlag("port", rootCmd.PersistentFlags().Lookup("port")); err != nil {
+		logrus.Fatalf("failed to bind flag: %v", err)
+	}
+	if err := viper.BindPFlag("conf", rootCmd.PersistentFlags().Lookup("conf")); err != nil {
+		logrus.Fatalf("failed to bind flag: %v", err)
+	}
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "serve",
+		Short: "Run the configuration-center server",
+		Run: func(cmd *cobra.Command, args []string) {
+			fx.New(configcenter.Options(viper.GetString("conf"), viper.GetString("port"))).Run()
+		},
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		logrus.Println(err.Error())
+		os.Exit(1)
+	}
+}

--- a/AegisLab/src/module/configcenter/audit.go
+++ b/AegisLab/src/module/configcenter/audit.go
@@ -1,0 +1,41 @@
+package configcenter
+
+import (
+	"context"
+	"encoding/json"
+
+	"gorm.io/gorm"
+)
+
+// AuditWriter persists ConfigAudit rows. The HTTP handler calls it
+// synchronously on every Set/Delete so the audit log is the source of
+// truth for "who changed what".
+type AuditWriter interface {
+	Write(ctx context.Context, row ConfigAudit) error
+}
+
+type dbAuditWriter struct {
+	db *gorm.DB
+}
+
+// NewDBAuditWriter writes audit rows to the application database.
+func NewDBAuditWriter(db *gorm.DB) *dbAuditWriter {
+	return &dbAuditWriter{db: db}
+}
+
+func (w *dbAuditWriter) Write(ctx context.Context, row ConfigAudit) error {
+	return w.db.WithContext(ctx).Create(&row).Error
+}
+
+// auditValue marshals an arbitrary value into the JSON []byte the
+// model expects (`type:json`). nil is encoded as nil, not `"null"`.
+func auditValue(v any) []byte {
+	if v == nil {
+		return nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return b
+}

--- a/AegisLab/src/module/configcenter/center.go
+++ b/AegisLab/src/module/configcenter/center.go
@@ -1,0 +1,380 @@
+package configcenter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"sync"
+
+	"aegis/config"
+	"aegis/infra/etcd"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// Center is the in-process configuration-center surface. The HTTP
+// handler in this package is the only caller that issues Set/Delete
+// from outside — see audit.go for the actor-bearing wrapper.
+type Center interface {
+	Bind(ctx context.Context, namespace, key string, out any, opts ...BindOpt) (Handle, error)
+	Get(ctx context.Context, namespace, key string) (raw []byte, layer Layer, err error)
+	Set(ctx context.Context, namespace, key string, value any) error
+	Delete(ctx context.Context, namespace, key string) error
+	List(ctx context.Context, namespace string) ([]Entry, error)
+}
+
+// Handle is what Bind returns. Hold onto it for the lifetime you want
+// the binding to keep tracking changes; Close to release the watcher.
+type Handle interface {
+	Reload(ctx context.Context) error
+	Subscribe(fn func()) (unsubscribe func())
+	Close() error
+}
+
+// secretKey rejects key paths that look like they carry secrets.
+// Matches RFC §"Open questions / Secrets bleed".
+var secretKey = regexp.MustCompile(`(?i)(password|secret|key|token)`)
+
+// defaultCenter is the in-process implementation. It owns the etcd
+// watcher multiplexer and the binding registry.
+type defaultCenter struct {
+	gw  *etcd.Gateway
+	env string
+
+	mu       sync.RWMutex
+	bindings map[string]*binding // by fullKey
+	subs     *subscriberMux      // namespace -> []chan Entry
+	watcher  *watcher
+}
+
+// New constructs the Center. The fx provider in module.go wraps this.
+func New(gw *etcd.Gateway) (*defaultCenter, error) {
+	env := config.GetString("env")
+	if env == "" {
+		env = "dev"
+	}
+	c := &defaultCenter{
+		gw:       gw,
+		env:      env,
+		bindings: make(map[string]*binding),
+		subs:     newSubscriberMux(),
+	}
+	c.watcher = newWatcher(gw, c.fullPrefix(), c.dispatch)
+	return c, nil
+}
+
+// Start opens the multiplexed etcd watch. Called from the fx hook.
+func (c *defaultCenter) Start(ctx context.Context) error {
+	return c.watcher.Start(ctx)
+}
+
+// Stop closes the watcher and any open subscriber channels.
+func (c *defaultCenter) Stop(_ context.Context) error {
+	c.watcher.Stop()
+	c.subs.closeAll()
+	return nil
+}
+
+func (c *defaultCenter) fullPrefix() string {
+	return fmt.Sprintf("/aegis/%s/", c.env)
+}
+
+func (c *defaultCenter) fullKey(namespace, key string) string {
+	return fmt.Sprintf("/aegis/%s/%s/%s", c.env, namespace, key)
+}
+
+func splitKey(env, full string) (namespace, key string, ok bool) {
+	prefix := fmt.Sprintf("/aegis/%s/", env)
+	if !strings.HasPrefix(full, prefix) {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(full, prefix)
+	idx := strings.IndexByte(rest, '/')
+	if idx <= 0 {
+		return "", "", false
+	}
+	return rest[:idx], rest[idx+1:], true
+}
+
+// resolveLayered runs the merge: etcd > env > toml > default.
+// Returns raw JSON bytes plus which layer produced them.
+func (c *defaultCenter) resolveLayered(ctx context.Context, namespace, key string, def any) ([]byte, Layer, error) {
+	// etcd
+	if raw, err := c.gw.Get(ctx, c.fullKey(namespace, key)); err == nil && raw != "" {
+		return []byte(raw), LayerEtcd, nil
+	}
+	viperKey := namespace + "." + key
+	envName := strings.ToUpper(strings.NewReplacer(".", "_").Replace(viperKey))
+	if v, ok := os.LookupEnv(envName); ok && v != "" {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, "", fmt.Errorf("%w: %v", ErrEncode, err)
+		}
+		return b, LayerEnv, nil
+	}
+	if viper.IsSet(viperKey) {
+		v := viper.Get(viperKey)
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, "", fmt.Errorf("%w: %v", ErrEncode, err)
+		}
+		return b, LayerTOML, nil
+	}
+	if def != nil {
+		b, err := json.Marshal(def)
+		if err != nil {
+			return nil, "", fmt.Errorf("%w: %v", ErrEncode, err)
+		}
+		return b, LayerDefault, nil
+	}
+	return nil, "", ErrNotFound
+}
+
+// Bind decodes the current resolved value into out and registers a
+// watcher so subsequent etcd changes update out atomically.
+func (c *defaultCenter) Bind(ctx context.Context, namespace, key string, out any, opts ...BindOpt) (Handle, error) {
+	bopts := bindOptions{}
+	for _, o := range opts {
+		o(&bopts)
+	}
+	outV := reflect.ValueOf(out)
+	if outV.Kind() != reflect.Pointer || outV.IsNil() {
+		return nil, fmt.Errorf("configcenter.Bind: out must be a non-nil pointer")
+	}
+
+	b := &binding{
+		namespace: namespace,
+		key:       key,
+		fullKey:   c.fullKey(namespace, key),
+		out:       outV,
+		opts:      bopts,
+	}
+	if err := b.reload(ctx, c); err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.bindings[b.fullKey] = b
+	c.mu.Unlock()
+	return b, nil
+}
+
+// Get returns the resolved raw bytes and resolving layer.
+func (c *defaultCenter) Get(ctx context.Context, namespace, key string) ([]byte, Layer, error) {
+	return c.resolveLayered(ctx, namespace, key, nil)
+}
+
+// Set writes a value to the etcd layer. Always JSON-encodes value.
+func (c *defaultCenter) Set(ctx context.Context, namespace, key string, value any) error {
+	if secretKey.MatchString(key) || secretKey.MatchString(namespace) {
+		return ErrForbiddenKey
+	}
+	var raw []byte
+	switch v := value.(type) {
+	case []byte:
+		raw = v
+		if !json.Valid(raw) {
+			b, err := json.Marshal(string(raw))
+			if err != nil {
+				return fmt.Errorf("%w: %v", ErrEncode, err)
+			}
+			raw = b
+		}
+	case json.RawMessage:
+		raw = v
+	default:
+		b, err := json.Marshal(value)
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrEncode, err)
+		}
+		raw = b
+	}
+	return c.gw.Put(ctx, c.fullKey(namespace, key), string(raw), 0)
+}
+
+// Delete removes the etcd-layer entry; lower layers reappear.
+func (c *defaultCenter) Delete(ctx context.Context, namespace, key string) error {
+	return c.gw.Delete(ctx, c.fullKey(namespace, key))
+}
+
+// List returns every key under a namespace with current value + layer.
+//
+// v1 lists only the etcd layer (lower layers are baked into the
+// process and not enumerable cheaply). Lower layers still resolve via
+// Get on demand.
+func (c *defaultCenter) List(ctx context.Context, namespace string) ([]Entry, error) {
+	prefix := fmt.Sprintf("/aegis/%s/%s/", c.env, namespace)
+	kvs, err := c.gw.ListPrefix(ctx, prefix)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Entry, 0, len(kvs))
+	for _, kv := range kvs {
+		key := strings.TrimPrefix(kv.Key, prefix)
+		var val any
+		if jerr := json.Unmarshal([]byte(kv.Value), &val); jerr != nil {
+			val = kv.Value
+		}
+		out = append(out, Entry{
+			Namespace: namespace,
+			Key:       key,
+			Value:     val,
+			Layer:     LayerEtcd,
+		})
+	}
+	return out, nil
+}
+
+// dispatch is the callback the watcher fires on every etcd change.
+// It re-decodes affected bindings and pushes an Entry to subscribers.
+func (c *defaultCenter) dispatch(ctx context.Context, fullKey string, value []byte, deleted bool) {
+	namespace, key, ok := splitKey(c.env, fullKey)
+	if !ok {
+		return
+	}
+
+	c.mu.RLock()
+	b := c.bindings[fullKey]
+	c.mu.RUnlock()
+	if b != nil {
+		if err := b.reload(ctx, c); err != nil {
+			logrus.WithError(err).WithFields(logrus.Fields{
+				"namespace": namespace, "key": key,
+			}).Warn("configcenter: bind reload failed; keeping previous value")
+		}
+	}
+
+	var entryVal any
+	layer := LayerEtcd
+	if deleted {
+		layer = LayerDefault
+		entryVal = nil
+	} else if jerr := json.Unmarshal(value, &entryVal); jerr != nil {
+		entryVal = string(value)
+	}
+	c.subs.publish(namespace, Entry{
+		Namespace: namespace,
+		Key:       key,
+		Value:     entryVal,
+		Layer:     layer,
+	})
+}
+
+// Subscribe gives the HTTP SSE handler (and others) a way to receive
+// every change under a namespace.
+func (c *defaultCenter) Subscribe(ctx context.Context, namespace string) (<-chan Entry, func()) {
+	return c.subs.subscribe(ctx, namespace)
+}
+
+// --- binding ---
+
+type binding struct {
+	namespace string
+	key       string
+	fullKey   string
+
+	mu          sync.Mutex
+	out         reflect.Value // pointer
+	last        reflect.Value // last successful resolved value (for rollback)
+	opts        bindOptions
+	subscribers []func()
+	closed      bool
+}
+
+func (b *binding) reload(ctx context.Context, c *defaultCenter) error {
+	raw, _, err := c.resolveLayered(ctx, b.namespace, b.key, b.opts.defaultValue)
+	if err != nil {
+		return err
+	}
+	target := reflect.New(b.out.Elem().Type())
+	dec, derr := newMapstructureDecoder(target.Interface())
+	if derr != nil {
+		return derr
+	}
+
+	var jsonVal any
+	if jerr := json.Unmarshal(raw, &jsonVal); jerr != nil {
+		return fmt.Errorf("%w: %v", ErrDecode, jerr)
+	}
+	if err := dec.Decode(jsonVal); err != nil {
+		return fmt.Errorf("%w: %v", ErrDecode, err)
+	}
+
+	candidate := target.Elem()
+	if b.opts.validator != nil {
+		if verr := b.opts.validator(candidate.Interface()); verr != nil {
+			return fmt.Errorf("%w: %v", ErrInvalidValue, verr)
+		}
+	}
+	b.mu.Lock()
+	b.out.Elem().Set(candidate)
+	b.last = candidate
+	subs := append([]func(){}, b.subscribers...)
+	b.mu.Unlock()
+	for _, fn := range subs {
+		fn()
+	}
+	return nil
+}
+
+func newMapstructureDecoder(target any) (*mapstructure.Decoder, error) {
+	return mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           target,
+		TagName:          "mapstructure",
+		WeaklyTypedInput: true,
+	})
+}
+
+func (b *binding) Reload(ctx context.Context) error {
+	// The handle's parent Center is reachable through the registry —
+	// but since reload is centred on Center.resolveLayered, we rely on
+	// the watcher path. Reload triggers a one-shot re-read by reusing
+	// dispatch via a direct ListPrefix is overkill; instead expose
+	// Reload as "force-refresh against current sources".
+	return b.reloadVia(ctx)
+}
+
+// reloadVia is a thin shim so Reload doesn't require holding the
+// Center pointer; for v1 we simply re-bind via the package singleton
+// captured at construction. To keep the binding self-sufficient
+// without leaking a back-pointer cycle, we capture Center on the
+// binding lazily.
+//
+// TODO: thread Center pointer onto binding once we drop the package
+// singleton — kept minimal for the skeleton.
+var globalCenter *defaultCenter
+
+func (b *binding) reloadVia(ctx context.Context) error {
+	if globalCenter == nil {
+		return fmt.Errorf("configcenter: no center registered")
+	}
+	return b.reload(ctx, globalCenter)
+}
+
+func (b *binding) Subscribe(fn func()) func() {
+	b.mu.Lock()
+	idx := len(b.subscribers)
+	b.subscribers = append(b.subscribers, fn)
+	b.mu.Unlock()
+	return func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		if idx < len(b.subscribers) {
+			b.subscribers = append(b.subscribers[:idx], b.subscribers[idx+1:]...)
+		}
+	}
+}
+
+func (b *binding) Close() error {
+	b.mu.Lock()
+	b.closed = true
+	b.subscribers = nil
+	b.mu.Unlock()
+	return nil
+}

--- a/AegisLab/src/module/configcenter/handler.go
+++ b/AegisLab/src/module/configcenter/handler.go
@@ -1,0 +1,208 @@
+package configcenter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"aegis/dto"
+	"aegis/middleware"
+
+	"github.com/gin-contrib/sse"
+	"github.com/gin-gonic/gin"
+)
+
+// Handler hosts the configcenter admin HTTP surface. Mounted by the
+// standalone `aegis-configcenter` binary; not wired into the
+// monolith.
+type Handler struct {
+	center *defaultCenter
+	audit  AuditWriter
+}
+
+func NewHandler(center *defaultCenter, audit AuditWriter) *Handler {
+	return &Handler{center: center, audit: audit}
+}
+
+// SetReq is the body of PUT/POST writes. Value is held as raw JSON so
+// scalars / objects / arrays all flow through unchanged.
+type SetReq struct {
+	Value  json.RawMessage `json:"value"`
+	Reason string          `json:"reason,omitempty"`
+}
+
+// EntryResp mirrors Entry for stable wire format.
+type EntryResp struct {
+	Namespace string          `json:"namespace"`
+	Key       string          `json:"key"`
+	Value     json.RawMessage `json:"value"`
+	Layer     Layer           `json:"layer"`
+}
+
+func (h *Handler) List(c *gin.Context) {
+	ns := c.Param("namespace")
+	entries, err := h.center.List(c.Request.Context(), ns)
+	if err != nil {
+		dto.ErrorResponse(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	resp := make([]EntryResp, 0, len(entries))
+	for _, e := range entries {
+		raw, _ := json.Marshal(e.Value)
+		resp = append(resp, EntryResp{
+			Namespace: e.Namespace,
+			Key:       e.Key,
+			Value:     raw,
+			Layer:     e.Layer,
+		})
+	}
+	c.JSON(http.StatusOK, gin.H{"items": resp})
+}
+
+func (h *Handler) Get(c *gin.Context) {
+	ns := c.Param("namespace")
+	key := c.Param("key")
+	raw, layer, err := h.center.Get(c.Request.Context(), ns, key)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			dto.ErrorResponse(c, http.StatusNotFound, err.Error())
+			return
+		}
+		dto.ErrorResponse(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	c.JSON(http.StatusOK, EntryResp{
+		Namespace: ns, Key: key, Value: raw, Layer: layer,
+	})
+}
+
+func (h *Handler) Set(c *gin.Context) {
+	ns := c.Param("namespace")
+	key := c.Param("key")
+
+	var req SetReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		dto.ErrorResponse(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	if len(req.Value) == 0 {
+		dto.ErrorResponse(c, http.StatusBadRequest, "value required")
+		return
+	}
+
+	old, _, _ := h.center.Get(c.Request.Context(), ns, key)
+	if err := h.center.Set(c.Request.Context(), ns, key, []byte(req.Value)); err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, ErrForbiddenKey) {
+			status = http.StatusForbidden
+		}
+		dto.ErrorResponse(c, status, err.Error())
+		return
+	}
+
+	row := ConfigAudit{
+		Namespace: ns,
+		KeyPath:   key,
+		Action:    string(ActionSet),
+		OldValue:  old,
+		NewValue:  []byte(req.Value),
+		Reason:    req.Reason,
+		CreatedAt: time.Now(),
+	}
+	tagActor(c, &row)
+	if err := h.audit.Write(c.Request.Context(), row); err != nil {
+		dto.ErrorResponse(c, http.StatusInternalServerError, "audit write failed: "+err.Error())
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func (h *Handler) Delete(c *gin.Context) {
+	ns := c.Param("namespace")
+	key := c.Param("key")
+
+	old, _, _ := h.center.Get(c.Request.Context(), ns, key)
+	if err := h.center.Delete(c.Request.Context(), ns, key); err != nil {
+		dto.ErrorResponse(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	row := ConfigAudit{
+		Namespace: ns,
+		KeyPath:   key,
+		Action:    string(ActionDelete),
+		OldValue:  old,
+		CreatedAt: time.Now(),
+	}
+	tagActor(c, &row)
+	if err := h.audit.Write(c.Request.Context(), row); err != nil {
+		dto.ErrorResponse(c, http.StatusInternalServerError, "audit write failed: "+err.Error())
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// Watch streams every change under a namespace as SSE events. The
+// remote configcenterclient subscribes here to drive its in-process
+// Bind callers.
+func (h *Handler) Watch(c *gin.Context) {
+	ns := c.Param("namespace")
+
+	ctx, cancel := context.WithCancel(c.Request.Context())
+	defer cancel()
+
+	ch, unsub := h.center.Subscribe(ctx, ns)
+	defer unsub()
+
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Flush()
+
+	heartbeat := time.NewTicker(25 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-heartbeat.C:
+			c.Render(-1, sse.Event{Event: "ping", Data: "ok"})
+			c.Writer.Flush()
+		case e, ok := <-ch:
+			if !ok {
+				return
+			}
+			b, err := json.Marshal(e)
+			if err != nil {
+				continue
+			}
+			c.Render(-1, sse.Event{Event: "change", Data: string(b)})
+			c.Writer.Flush()
+		}
+	}
+}
+
+// History is a placeholder: etcd's compaction window is unreliable
+// for audit, so reads come from config_audit. v1 returns the recent
+// audit rows for a key.
+func (h *Handler) History(c *gin.Context) {
+	// TODO: query config_audit ordered by created_at desc with a cap.
+	// Out of scope for the skeleton; the model + index are in place.
+	c.JSON(http.StatusOK, gin.H{"items": []any{}})
+}
+
+func tagActor(c *gin.Context, row *ConfigAudit) {
+	if uid, ok := middleware.GetCurrentUserID(c); ok {
+		row.ActorID = &uid
+	}
+	if middleware.IsServiceToken(c) {
+		// best-effort sub from the claims context
+		if v, ok := c.Get("sub"); ok {
+			if s, ok := v.(string); ok {
+				row.ActorToken = s
+			}
+		}
+	}
+}

--- a/AegisLab/src/module/configcenter/migrations.go
+++ b/AegisLab/src/module/configcenter/migrations.go
@@ -1,0 +1,11 @@
+package configcenter
+
+import "aegis/framework"
+
+// Migrations registers the config_audit table.
+func Migrations() framework.MigrationRegistrar {
+	return framework.MigrationRegistrar{
+		Module:   "configcenter",
+		Entities: []any{&ConfigAudit{}},
+	}
+}

--- a/AegisLab/src/module/configcenter/model.go
+++ b/AegisLab/src/module/configcenter/model.go
@@ -1,0 +1,21 @@
+package configcenter
+
+import "time"
+
+// ConfigAudit is the durable log of every Set/Delete that the admin
+// handler performed. The in-process Center.Set is internal-only; only
+// the HTTP handler writes audit rows (per RFC).
+type ConfigAudit struct {
+	ID         int64     `gorm:"primaryKey;autoIncrement"`
+	Namespace  string    `gorm:"not null;size:64;index:idx_ns_key,priority:1"`
+	KeyPath    string    `gorm:"not null;size:256;index:idx_ns_key,priority:2"`
+	Action     string    `gorm:"not null;size:16"`
+	OldValue   []byte    `gorm:"type:json;serializer:json"`
+	NewValue   []byte    `gorm:"type:json;serializer:json"`
+	ActorID    *int      `gorm:"index"`
+	ActorToken string    `gorm:"size:64"`
+	Reason     string    `gorm:"size:256"`
+	CreatedAt  time.Time `gorm:"autoCreateTime;index:idx_ns_key,priority:3,sort:desc"`
+}
+
+func (ConfigAudit) TableName() string { return "config_audit" }

--- a/AegisLab/src/module/configcenter/module.go
+++ b/AegisLab/src/module/configcenter/module.go
@@ -1,0 +1,39 @@
+package configcenter
+
+import (
+	"aegis/infra/etcd"
+
+	"go.uber.org/fx"
+)
+
+// Module wires the in-process configcenter: Center + AuditWriter +
+// HTTP handler + routes + migrations. Loaded only by the standalone
+// `aegis-configcenter` binary (and by configcenterclient's local
+// mode in dev builds).
+var Module = fx.Module("configcenter",
+	fx.Provide(newCenterWithLifecycle),
+	fx.Provide(asCenter),
+	fx.Provide(asPubSub),
+	fx.Provide(fx.Annotate(NewDBAuditWriter, fx.As(new(AuditWriter)))),
+	fx.Provide(NewHandler),
+	fx.Provide(
+		fx.Annotate(RoutesAdmin, fx.ResultTags(`group:"routes"`)),
+		fx.Annotate(Migrations, fx.ResultTags(`group:"migrations"`)),
+	),
+)
+
+func newCenterWithLifecycle(lc fx.Lifecycle, gw *etcd.Gateway) (*defaultCenter, error) {
+	c, err := New(gw)
+	if err != nil {
+		return nil, err
+	}
+	globalCenter = c
+	lc.Append(fx.Hook{
+		OnStart: c.Start,
+		OnStop:  c.Stop,
+	})
+	return c, nil
+}
+
+func asCenter(c *defaultCenter) Center { return c }
+func asPubSub(c *defaultCenter) PubSub { return c }

--- a/AegisLab/src/module/configcenter/routes.go
+++ b/AegisLab/src/module/configcenter/routes.go
@@ -1,0 +1,29 @@
+package configcenter
+
+import (
+	"aegis/framework"
+	"aegis/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RoutesAdmin mounts the admin surface. Writes require admin; reads
+// require any authenticated principal. The SSE watch stream is also
+// auth-gated — only the remote configcenterclient subscribes here.
+func RoutesAdmin(handler *Handler) framework.RouteRegistrar {
+	return framework.RouteRegistrar{
+		Audience: framework.AudienceAdmin,
+		Name:     "configcenter.admin",
+		Register: func(v2 *gin.RouterGroup) {
+			cfg := v2.Group("/config", middleware.JWTAuth())
+			{
+				cfg.GET("/:namespace", handler.List)
+				cfg.GET("/:namespace/watch", handler.Watch)
+				cfg.GET("/:namespace/:key", handler.Get)
+				cfg.GET("/:namespace/:key/history", handler.History)
+				cfg.PUT("/:namespace/:key", middleware.RequireSystemAdmin(), handler.Set)
+				cfg.DELETE("/:namespace/:key", middleware.RequireSystemAdmin(), handler.Delete)
+			}
+		},
+	}
+}

--- a/AegisLab/src/module/configcenter/types.go
+++ b/AegisLab/src/module/configcenter/types.go
@@ -1,0 +1,102 @@
+// Package configcenter is the in-process configuration-center
+// implementation. It layers etcd (top, hot) over env vars and TOML
+// defaults, exposes a typed Bind/Get/Set/Delete/List API, fans out
+// watch events to subscribers, and persists an admin-driven audit
+// log to the application database.
+//
+// The standalone `aegis-configcenter` microservice is the only
+// binary that wires this module + holds etcd write credentials.
+// Every other service consumes it via `module/configcenterclient`.
+package configcenter
+
+import (
+	"context"
+	"errors"
+)
+
+// Layer identifies which source resolved a value.
+type Layer string
+
+const (
+	LayerEtcd    Layer = "etcd"
+	LayerEnv     Layer = "env"
+	LayerTOML    Layer = "toml"
+	LayerDefault Layer = "default"
+)
+
+// Action enumerates audit-log actions written by the admin handler.
+type Action string
+
+const (
+	ActionSet    Action = "set"
+	ActionDelete Action = "delete"
+)
+
+// Entry is a single key's resolved view, returned by List/Get.
+type Entry struct {
+	Namespace string `json:"namespace"`
+	Key       string `json:"key"`
+	Value     any    `json:"value"`
+	Layer     Layer  `json:"layer"`
+}
+
+// BindOpt customises Bind behaviour. Use the With* constructors.
+type BindOpt func(*bindOptions)
+
+type bindOptions struct {
+	defaultValue  any
+	validator     func(any) error
+	schemaVersion int
+}
+
+func WithDefault(v any) BindOpt {
+	return func(o *bindOptions) { o.defaultValue = v }
+}
+
+func WithValidator(fn func(any) error) BindOpt {
+	return func(o *bindOptions) { o.validator = fn }
+}
+
+func WithSchemaVersion(v int) BindOpt {
+	return func(o *bindOptions) { o.schemaVersion = v }
+}
+
+// SetOpt customises Set behaviour (audit fields).
+type SetOpt func(*setOptions)
+
+type setOptions struct {
+	actorUserID *int
+	actorToken  string
+	reason      string
+}
+
+// WithActorUser tags the audit row with a human actor.
+func WithActorUser(id int) SetOpt {
+	return func(o *setOptions) { o.actorUserID = &id }
+}
+
+// WithActorToken tags the audit row with a service-token sub.
+func WithActorToken(sub string) SetOpt {
+	return func(o *setOptions) { o.actorToken = sub }
+}
+
+// WithReason carries a human-facing reason into the audit row.
+func WithReason(reason string) SetOpt {
+	return func(o *setOptions) { o.reason = reason }
+}
+
+// Errors surfaced by the center. Callers may use errors.Is/As.
+var (
+	ErrNotFound       = errors.New("configcenter: key not found")
+	ErrForbiddenKey   = errors.New("configcenter: key path rejected (secret-like)")
+	ErrInvalidValue   = errors.New("configcenter: value failed validation")
+	ErrEncode         = errors.New("configcenter: value encode failed")
+	ErrDecode         = errors.New("configcenter: value decode failed")
+)
+
+// PubSub is a tiny pub/sub the watcher dispatches changes onto.
+// Public so the HTTP handler can subscribe for SSE without touching
+// the internal multiplexer directly.
+type PubSub interface {
+	Subscribe(ctx context.Context, namespace string) (<-chan Entry, func())
+}

--- a/AegisLab/src/module/configcenter/watch.go
+++ b/AegisLab/src/module/configcenter/watch.go
@@ -1,0 +1,131 @@
+package configcenter
+
+import (
+	"context"
+	"sync"
+
+	"aegis/infra/etcd"
+
+	"github.com/sirupsen/logrus"
+)
+
+// dispatchFn is the per-change callback the watcher invokes.
+type dispatchFn func(ctx context.Context, fullKey string, value []byte, deleted bool)
+
+// watcher fronts a single etcd Watch under the env prefix and fans
+// out events to the Center's dispatch callback. Bindings and HTTP
+// subscribers register through the Center, not directly here.
+type watcher struct {
+	gw       *etcd.Gateway
+	prefix   string
+	dispatch dispatchFn
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func newWatcher(gw *etcd.Gateway, prefix string, fn dispatchFn) *watcher {
+	return &watcher{gw: gw, prefix: prefix, dispatch: fn}
+}
+
+func (w *watcher) Start(parent context.Context) error {
+	ctx, cancel := context.WithCancel(parent)
+	w.cancel = cancel
+	ch := w.gw.Watch(ctx, w.prefix, true)
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case resp, ok := <-ch:
+				if !ok {
+					logrus.Warn("configcenter: etcd watch channel closed")
+					return
+				}
+				if resp.Err() != nil {
+					logrus.WithError(resp.Err()).Warn("configcenter: etcd watch response error")
+					continue
+				}
+				for _, ev := range resp.Events {
+					key := string(ev.Kv.Key)
+					deleted := ev.Type.String() == "DELETE"
+					w.dispatch(ctx, key, ev.Kv.Value, deleted)
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+func (w *watcher) Stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+	w.wg.Wait()
+}
+
+// subscriberMux fans out Entry events to per-namespace subscriber
+// channels. Used by the HTTP SSE handler.
+type subscriberMux struct {
+	mu      sync.Mutex
+	byNS    map[string][]chan Entry
+	closed  bool
+}
+
+func newSubscriberMux() *subscriberMux {
+	return &subscriberMux{byNS: make(map[string][]chan Entry)}
+}
+
+func (s *subscriberMux) subscribe(ctx context.Context, namespace string) (<-chan Entry, func()) {
+	ch := make(chan Entry, 16)
+	s.mu.Lock()
+	s.byNS[namespace] = append(s.byNS[namespace], ch)
+	s.mu.Unlock()
+	unsub := func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		subs := s.byNS[namespace]
+		for i, c := range subs {
+			if c == ch {
+				s.byNS[namespace] = append(subs[:i], subs[i+1:]...)
+				close(ch)
+				return
+			}
+		}
+	}
+	go func() {
+		<-ctx.Done()
+		unsub()
+	}()
+	return ch, unsub
+}
+
+func (s *subscriberMux) publish(namespace string, e Entry) {
+	s.mu.Lock()
+	subs := append([]chan Entry{}, s.byNS[namespace]...)
+	s.mu.Unlock()
+	for _, ch := range subs {
+		select {
+		case ch <- e:
+		default:
+			// drop if subscriber can't keep up; SSE clients re-list on reconnect
+		}
+	}
+}
+
+func (s *subscriberMux) closeAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	for ns, subs := range s.byNS {
+		for _, ch := range subs {
+			close(ch)
+		}
+		delete(s.byNS, ns)
+	}
+}

--- a/AegisLab/src/module/configcenterclient/local.go
+++ b/AegisLab/src/module/configcenterclient/local.go
@@ -1,0 +1,43 @@
+package configcenterclient
+
+import (
+	"context"
+
+	"aegis/module/configcenter"
+)
+
+// LocalClient wraps an in-process configcenter.Center. Used by the
+// configcenter binary itself and any dev/test build where everything
+// runs in one process.
+type LocalClient struct {
+	center configcenter.Center
+}
+
+func NewLocalClient(center configcenter.Center) *LocalClient {
+	return &LocalClient{center: center}
+}
+
+func (c *LocalClient) Bind(ctx context.Context, namespace, key string, out any, opts ...BindOpt) (Handle, error) {
+	return c.center.Bind(ctx, namespace, key, out, opts...)
+}
+
+func (c *LocalClient) Get(ctx context.Context, namespace, key string) ([]byte, Layer, error) {
+	return c.center.Get(ctx, namespace, key)
+}
+
+func (c *LocalClient) Set(ctx context.Context, namespace, key string, value any, _ ...SetOpt) error {
+	// LocalClient bypasses the audit writer on purpose — there's no
+	// HTTP request, no actor to record. Audit-bearing writes go
+	// through the remote (HTTP) path.
+	return c.center.Set(ctx, namespace, key, value)
+}
+
+func (c *LocalClient) Delete(ctx context.Context, namespace, key string) error {
+	return c.center.Delete(ctx, namespace, key)
+}
+
+func (c *LocalClient) List(ctx context.Context, namespace string) ([]Entry, error) {
+	return c.center.List(ctx, namespace)
+}
+
+var _ Client = (*LocalClient)(nil)

--- a/AegisLab/src/module/configcenterclient/module.go
+++ b/AegisLab/src/module/configcenterclient/module.go
@@ -1,0 +1,46 @@
+package configcenterclient
+
+import (
+	"fmt"
+
+	"aegis/config"
+	"aegis/module/configcenter"
+
+	"go.uber.org/fx"
+)
+
+// Module wires a configcenterclient.Client into the fx graph. The
+// concrete implementation is chosen by `[configcenter.client] mode`:
+//
+//	mode = "local"  → LocalClient over module/configcenter
+//	mode = "remote" → RemoteClient over HTTP+SSE
+//
+// Consumers always inject `configcenterclient.Client`.
+var Module = fx.Module("configcenterclient",
+	fx.Provide(provideClient),
+)
+
+func provideClient(
+	center configcenter.Center, // available iff module/configcenter is also loaded
+	tokenSrc TokenSource, // available iff app wires an adapter
+) (Client, error) {
+	mode := config.GetString("configcenter.client.mode")
+	if mode == "" {
+		mode = "local"
+	}
+	switch mode {
+	case "local":
+		if center == nil {
+			return nil, fmt.Errorf("configcenterclient mode=local but no configcenter.Center in graph")
+		}
+		return NewLocalClient(center), nil
+	case "remote":
+		base := config.GetString("configcenter.client.endpoint")
+		if base == "" {
+			return nil, fmt.Errorf("configcenterclient mode=remote requires [configcenter.client] endpoint")
+		}
+		return NewRemoteClient(RemoteClientConfig{BaseURL: base}, tokenSrc)
+	default:
+		return nil, fmt.Errorf("configcenterclient: unknown mode %q (want local|remote)", mode)
+	}
+}

--- a/AegisLab/src/module/configcenterclient/remote.go
+++ b/AegisLab/src/module/configcenterclient/remote.go
@@ -1,0 +1,349 @@
+package configcenterclient
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"aegis/module/configcenter"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+// RemoteClient talks to `aegis-configcenter` over HTTP and subscribes
+// to the SSE watch stream for hot reload. Service-to-service auth
+// uses a Bearer token from TokenSource (typically ssoclient).
+type RemoteClient struct {
+	baseURL  *url.URL
+	http     *http.Client
+	tokenSrc TokenSource
+	timeout  time.Duration
+
+	mu       sync.Mutex
+	bindings map[string][]*remoteBinding // by namespace
+	watches  map[string]context.CancelFunc
+}
+
+type RemoteClientConfig struct {
+	BaseURL string
+	Timeout time.Duration
+}
+
+func NewRemoteClient(cfg RemoteClientConfig, tokenSrc TokenSource) (*RemoteClient, error) {
+	u, err := url.Parse(cfg.BaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse configcenter base url: %w", err)
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 5 * time.Second
+	}
+	return &RemoteClient{
+		baseURL:  u,
+		http:     &http.Client{Timeout: cfg.Timeout},
+		tokenSrc: tokenSrc,
+		timeout:  cfg.Timeout,
+		bindings: make(map[string][]*remoteBinding),
+		watches:  make(map[string]context.CancelFunc),
+	}, nil
+}
+
+func (c *RemoteClient) Bind(ctx context.Context, namespace, key string, out any, opts ...BindOpt) (Handle, error) {
+	outV := reflect.ValueOf(out)
+	if outV.Kind() != reflect.Pointer || outV.IsNil() {
+		return nil, fmt.Errorf("configcenterclient: out must be non-nil pointer")
+	}
+	rb := &remoteBinding{
+		client:    c,
+		namespace: namespace,
+		key:       key,
+		out:       outV,
+	}
+	if err := rb.reload(ctx); err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	c.bindings[namespace] = append(c.bindings[namespace], rb)
+	if _, ok := c.watches[namespace]; !ok {
+		wctx, cancel := context.WithCancel(context.Background())
+		c.watches[namespace] = cancel
+		go c.runWatch(wctx, namespace)
+	}
+	c.mu.Unlock()
+	return rb, nil
+}
+
+func (c *RemoteClient) Get(ctx context.Context, namespace, key string) ([]byte, Layer, error) {
+	endpoint := c.url("/api/v2/config/" + namespace + "/" + key)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := c.auth(ctx, req); err != nil {
+		return nil, "", err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, "", configcenter.ErrNotFound
+	}
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, "", fmt.Errorf("get failed (%d): %s", resp.StatusCode, string(b))
+	}
+	var er struct {
+		Value json.RawMessage `json:"value"`
+		Layer Layer           `json:"layer"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		return nil, "", err
+	}
+	return er.Value, er.Layer, nil
+}
+
+func (c *RemoteClient) Set(ctx context.Context, namespace, key string, value any, _ ...SetOpt) error {
+	body, err := json.Marshal(struct {
+		Value any `json:"value"`
+	}{Value: value})
+	if err != nil {
+		return err
+	}
+	endpoint := c.url("/api/v2/config/" + namespace + "/" + key)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if err := c.auth(ctx, req); err != nil {
+		return err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("set failed (%d): %s", resp.StatusCode, string(b))
+	}
+	return nil
+}
+
+func (c *RemoteClient) Delete(ctx context.Context, namespace, key string) error {
+	endpoint := c.url("/api/v2/config/" + namespace + "/" + key)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	if err := c.auth(ctx, req); err != nil {
+		return err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("delete failed (%d): %s", resp.StatusCode, string(b))
+	}
+	return nil
+}
+
+func (c *RemoteClient) List(ctx context.Context, namespace string) ([]Entry, error) {
+	endpoint := c.url("/api/v2/config/" + namespace)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.auth(ctx, req); err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list failed (%d): %s", resp.StatusCode, string(b))
+	}
+	var out struct {
+		Items []Entry `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Items, nil
+}
+
+func (c *RemoteClient) url(path string) string {
+	u := *c.baseURL
+	u.Path = strings.TrimRight(u.Path, "/") + path
+	return u.String()
+}
+
+func (c *RemoteClient) auth(ctx context.Context, req *http.Request) error {
+	if c.tokenSrc == nil {
+		return nil
+	}
+	tok, err := c.tokenSrc.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire service token: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	return nil
+}
+
+// runWatch streams SSE change events for one namespace and reloads
+// every binding under it. The loop reconnects on disconnect with a
+// short backoff; the configcenter is expected to be HA, but a
+// rolling restart should not kill consumers.
+func (c *RemoteClient) runWatch(ctx context.Context, namespace string) {
+	endpoint := c.url("/api/v2/config/" + namespace + "/watch")
+	backoff := time.Second
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return
+		}
+		_ = c.auth(ctx, req)
+		req.Header.Set("Accept", "text/event-stream")
+		// no client timeout for SSE; rely on ctx
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			time.Sleep(backoff)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			time.Sleep(backoff)
+			continue
+		}
+		c.consumeSSE(ctx, resp.Body, namespace)
+		_ = resp.Body.Close()
+	}
+}
+
+func (c *RemoteClient) consumeSSE(ctx context.Context, body io.Reader, namespace string) {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if ctx.Err() != nil {
+			return
+		}
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "" || data == "ok" {
+			continue
+		}
+		var e Entry
+		if err := json.Unmarshal([]byte(data), &e); err != nil {
+			continue
+		}
+		c.notifyChange(ctx, namespace, e.Key)
+	}
+}
+
+func (c *RemoteClient) notifyChange(ctx context.Context, namespace, key string) {
+	c.mu.Lock()
+	binds := append([]*remoteBinding{}, c.bindings[namespace]...)
+	c.mu.Unlock()
+	for _, b := range binds {
+		if b.key != key {
+			continue
+		}
+		if err := b.reload(ctx); err != nil {
+			// keep previous value; logging here would cross a layer
+			// boundary, so we surface failures to subscribers instead.
+			continue
+		}
+	}
+}
+
+// --- remoteBinding ---
+
+type remoteBinding struct {
+	client    *RemoteClient
+	namespace string
+	key       string
+
+	mu          sync.Mutex
+	out         reflect.Value
+	subscribers []func()
+}
+
+func (b *remoteBinding) reload(ctx context.Context) error {
+	raw, _, err := b.client.Get(ctx, b.namespace, b.key)
+	if err != nil {
+		return err
+	}
+	target := reflect.New(b.out.Elem().Type())
+	var jsonVal any
+	if err := json.Unmarshal(raw, &jsonVal); err != nil {
+		return err
+	}
+	dec, derr := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:           target.Interface(),
+		TagName:          "mapstructure",
+		WeaklyTypedInput: true,
+	})
+	if derr != nil {
+		return derr
+	}
+	if err := dec.Decode(jsonVal); err != nil {
+		return err
+	}
+	b.mu.Lock()
+	b.out.Elem().Set(target.Elem())
+	subs := append([]func(){}, b.subscribers...)
+	b.mu.Unlock()
+	for _, fn := range subs {
+		fn()
+	}
+	return nil
+}
+
+func (b *remoteBinding) Reload(ctx context.Context) error { return b.reload(ctx) }
+
+func (b *remoteBinding) Subscribe(fn func()) func() {
+	b.mu.Lock()
+	idx := len(b.subscribers)
+	b.subscribers = append(b.subscribers, fn)
+	b.mu.Unlock()
+	return func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		if idx < len(b.subscribers) {
+			b.subscribers = append(b.subscribers[:idx], b.subscribers[idx+1:]...)
+		}
+	}
+}
+
+func (b *remoteBinding) Close() error {
+	b.mu.Lock()
+	b.subscribers = nil
+	b.mu.Unlock()
+	return nil
+}
+
+var _ Client = (*RemoteClient)(nil)
+var _ Handle = (*remoteBinding)(nil)

--- a/AegisLab/src/module/configcenterclient/types.go
+++ b/AegisLab/src/module/configcenterclient/types.go
@@ -1,0 +1,62 @@
+// Package configcenterclient is the consumer-side SDK for the
+// configuration center. Every service except `aegis-configcenter`
+// itself uses this package; it never touches etcd directly for
+// config purposes.
+//
+// Two interchangeable implementations:
+//
+//   - LocalClient — wraps the in-process `module/configcenter`. Used
+//     by `aegis-configcenter` itself and by dev builds where every
+//     service runs in-process.
+//   - RemoteClient — HTTP + SSE client against `aegis-configcenter`.
+//     Default for production services. Carries a service token from
+//     ssoclient.
+//
+// Switching deployment mode is a config flip
+// (`[configcenter.client] mode = "local"|"remote"`) — no consumer
+// code changes.
+package configcenterclient
+
+import (
+	"context"
+
+	"aegis/module/configcenter"
+)
+
+// Re-export the small surface so consumers depend on this package
+// only (mirrors notificationclient pattern).
+type (
+	Layer = configcenter.Layer
+	Entry = configcenter.Entry
+
+	BindOpt = configcenter.BindOpt
+	SetOpt  = configcenter.SetOpt
+
+	Handle = configcenter.Handle
+)
+
+// WithDefault re-exports configcenter.WithDefault so callers can
+// stay on this package.
+func WithDefault(v any) BindOpt { return configcenter.WithDefault(v) }
+
+// WithValidator re-exports configcenter.WithValidator.
+func WithValidator(fn func(any) error) BindOpt { return configcenter.WithValidator(fn) }
+
+// WithSchemaVersion re-exports configcenter.WithSchemaVersion.
+func WithSchemaVersion(v int) BindOpt { return configcenter.WithSchemaVersion(v) }
+
+// Client is the only type consumers reference.
+type Client interface {
+	Bind(ctx context.Context, namespace, key string, out any, opts ...BindOpt) (Handle, error)
+	Get(ctx context.Context, namespace, key string) (raw []byte, layer Layer, err error)
+	Set(ctx context.Context, namespace, key string, value any, opts ...SetOpt) error
+	Delete(ctx context.Context, namespace, key string) error
+	List(ctx context.Context, namespace string) ([]Entry, error)
+}
+
+// TokenSource produces a fresh Bearer token for cross-service calls
+// to `aegis-configcenter`. The app wiring layer supplies an adapter
+// — typically a thin wrapper over ssoclient.
+type TokenSource interface {
+	Token(ctx context.Context) (string, error)
+}


### PR DESCRIPTION
## Summary
- `module/configcenter`: layered merge (etcd > env > TOML > default), typed `Bind[T]` with atomic reflect swap, multiplexed etcd watch, DB audit log, admin HTTP + SSE `/api/v2/config/:namespace/watch`, secret-key guard on Set.
- `module/configcenterclient`: local + remote dual-mode SDK with SSE reconnect.
- `cmd/aegis-configcenter`: standalone service, default `:8087`. Only this binary holds etcd write creds.

Depends on `infra/etcd.Gateway` (no duplication). Existing `system/chaossystem` consumers not migrated (Phase B).

RFC: `docs/rfcs/configcenter.md`.

## TODO follow-ups
- `/history` endpoint returns empty (model + index ready; query layer deferred).
- `binding.Reload` uses package-level `globalCenter` to dodge skeleton-stage cycle.
- `/readyz` is a stub — needs etcd-reachability probe + last-watch-event timestamp.

## Test plan
- [x] `go build ./module/configcenter/... ./module/configcenterclient/... ./app/configcenter/... ./cmd/aegis-configcenter/...` clean.
- [ ] Manual: `aegis-configcenter serve --port 8087` against local etcd.
- [ ] Manual: `Set` → SSE watch fires within 1s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)