### PR TITLE
feat(gateway): aegis-gateway L7 service + rename monolith

### DIFF
--- a/AegisLab/docker-compose.microservices.yaml
+++ b/AegisLab/docker-compose.microservices.yaml
@@ -3,7 +3,7 @@ services:
   api-gateway:
     image: golang:1.24-bookworm
     working_dir: /workspace/src
-    command: ["go", "run", "./cmd/api-gateway", "-conf", "/workspace/src/config.dev.toml", "-port", "8082"]
+    command: ["go", "run", "./cmd/aegis-api", "-conf", "/workspace/src/config.dev.toml", "-port", "8082"]
     volumes:
       - ./:/workspace
     environment:

--- a/AegisLab/src/app/gateway/options.go
+++ b/AegisLab/src/app/gateway/options.go
@@ -1,31 +1,83 @@
+// Package gateway hosts the fx composition for the L7 application
+// gateway binary (cmd/aegis-gateway). Mirrors app/notify/options.go in
+// shape.
+//
+// What's in this binary:
+//
+//   - module/gateway       — route matching, proxy, middleware chain
+//   - module/ssoclient     — JWT verifier for pre-auth
+//   - infra (config, logger, tracing, loki, jwtkeys)
+//   - http server          — root handler is the gateway dispatcher
+//
+// What's NOT in this binary: DB, redis, k8s, chaos, any business
+// module. The gateway is a transport-layer policy point; everything
+// stateful lives downstream.
 package gateway
 
 import (
-	"aegis/app"
-	chaos "aegis/infra/chaos"
-	k8s "aegis/infra/k8s"
-	grpcruntimeintake "aegis/interface/grpc/runtimeintake"
+	"context"
+	"errors"
+	"net/http"
+	"strings"
 
+	"aegis/app"
+	gatewaymod "aegis/module/gateway"
+	"aegis/module/ssoclient"
+
+	"github.com/sirupsen/logrus"
 	"go.uber.org/fx"
 )
 
-// Options builds the dedicated api-gateway runtime.
-//
-// Post phase-2, api-gateway is the single API binary: it owns every
-// module and wires them via plain local provides (no fx.Decorate
-// remote-shim layer). The only gRPC surface it exposes is the
-// RuntimeIntakeService, which runtime-worker uses to write execution
-// and injection state back into the shared DB.
+// Options builds the aegis-gateway runtime.
 func Options(confPath, port string) fx.Option {
 	return fx.Options(
 		app.BaseOptions(confPath),
 		app.ObserveOptions(),
-		app.DataOptions(),
-		app.CoordinationOptions(),
-		app.BuildInfraOptions(),
-		chaos.Module,
-		k8s.Module,
-		app.ProducerHTTPOptions(port),
-		grpcruntimeintake.Module,
+
+		ssoclient.Module,
+		gatewaymod.Module,
+
+		fx.Supply(serverConfig{Addr: normalizeAddr(port)}),
+		fx.Provide(newServer),
+		fx.Invoke(registerServerLifecycle),
 	)
+}
+
+type serverConfig struct {
+	Addr string
+}
+
+func newServer(cfg serverConfig, h *gatewaymod.Handler) *http.Server {
+	return &http.Server{
+		Addr:    cfg.Addr,
+		Handler: h,
+	}
+}
+
+func registerServerLifecycle(lc fx.Lifecycle, server *http.Server) {
+	lc.Append(fx.Hook{
+		OnStart: func(_ context.Context) error {
+			go func() {
+				logrus.Infof("aegis-gateway: listening on %s", server.Addr)
+				if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+					logrus.Errorf("aegis-gateway: server error: %v", err)
+				}
+			}()
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			logrus.Info("aegis-gateway: shutting down")
+			return server.Shutdown(ctx)
+		},
+	})
+}
+
+func normalizeAddr(port string) string {
+	if port == "" {
+		return ":8086"
+	}
+	if strings.HasPrefix(port, ":") {
+		return port
+	}
+	return ":" + port
 }

--- a/AegisLab/src/app/monolith/options.go
+++ b/AegisLab/src/app/monolith/options.go
@@ -1,0 +1,35 @@
+package monolith
+
+import (
+	"aegis/app"
+	chaos "aegis/infra/chaos"
+	k8s "aegis/infra/k8s"
+	grpcruntimeintake "aegis/interface/grpc/runtimeintake"
+
+	"go.uber.org/fx"
+)
+
+// Options builds the monolith API runtime (cmd/aegis-api).
+//
+// This is the single API binary: it owns every module and wires them
+// via plain local provides (no fx.Decorate remote-shim layer). The only
+// gRPC surface it exposes is the RuntimeIntakeService, which
+// runtime-worker uses to write execution and injection state back into
+// the shared DB.
+//
+// Note: this used to live at app/gateway / cmd/api-gateway. Despite the
+// historical name it was always the monolith; the real L7 gateway lives
+// at app/gateway + cmd/aegis-gateway (see docs/rfcs/api-gateway.md).
+func Options(confPath, port string) fx.Option {
+	return fx.Options(
+		app.BaseOptions(confPath),
+		app.ObserveOptions(),
+		app.DataOptions(),
+		app.CoordinationOptions(),
+		app.BuildInfraOptions(),
+		chaos.Module,
+		k8s.Module,
+		app.ProducerHTTPOptions(port),
+		grpcruntimeintake.Module,
+	)
+}

--- a/AegisLab/src/app/service_entrypoints_test.go
+++ b/AegisLab/src/app/service_entrypoints_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"aegis/app"
-	gateway "aegis/app/gateway"
+	monolith "aegis/app/monolith"
 	runtimeapp "aegis/app/runtime"
 	buildkit "aegis/infra/buildkit"
 	etcd "aegis/infra/etcd"
@@ -186,7 +186,7 @@ func TestDedicatedServiceOptionsValidate(t *testing.T) {
 		name   string
 		option fx.Option
 	}{
-		{name: "gateway", option: gateway.Options("..", "0")},
+		{name: "gateway", option: monolith.Options("..", "0")},
 		{name: "runtime", option: runtimeapp.Options("..")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -207,7 +207,7 @@ func TestAPIGatewayStandaloneHTTPIntegrationSmoke(t *testing.T) {
 
 	addr := reserveLoopbackAddr(t)
 	appInstance := fx.New(
-		gateway.Options("..", "0"),
+		monolith.Options("..", "0"),
 		replacements,
 		fx.Replace(httpapi.ServerConfig{Addr: addr}),
 	)

--- a/AegisLab/src/cmd/aegis-api/main.go
+++ b/AegisLab/src/cmd/aegis-api/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 
-	gateway "aegis/app/gateway"
+	monolith "aegis/app/monolith"
 
 	"go.uber.org/fx"
 )
@@ -13,5 +13,5 @@ func main() {
 	port := flag.String("port", "8080", "port to run the API gateway on")
 	flag.Parse()
 
-	fx.New(gateway.Options(*conf, *port)).Run()
+	fx.New(monolith.Options(*conf, *port)).Run()
 }

--- a/AegisLab/src/cmd/aegis-gateway/README.md
+++ b/AegisLab/src/cmd/aegis-gateway/README.md
@@ -1,0 +1,19 @@
+# `aegis-gateway`
+
+L7 application gateway. Default port `:8086`.
+
+Owns route → upstream mapping, JWT pre-auth via `module/ssoclient`,
+trusted-header injection (HMAC-signed), global + per-route rate limit,
+CORS, and access logging with trace propagation.
+
+This binary has **no database** and **no business logic**. See
+`docs/rfcs/api-gateway.md` for the full design.
+
+## Run
+
+```bash
+go run ./cmd/aegis-gateway serve --conf ./config.dev.toml --port 8086
+```
+
+Route table is loaded from the `[gateway]` section of the config file;
+see `config.dev.toml` for the default microservice topology.

--- a/AegisLab/src/cmd/aegis-gateway/main.go
+++ b/AegisLab/src/cmd/aegis-gateway/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+
+	gateway "aegis/app/gateway"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.uber.org/fx"
+)
+
+func main() {
+	var port, conf string
+
+	rootCmd := &cobra.Command{Use: "aegis-gateway", Short: "Aegis L7 API gateway"}
+	rootCmd.PersistentFlags().StringVarP(&port, "port", "p", "8086", "Port to run the gateway on")
+	rootCmd.PersistentFlags().StringVarP(&conf, "conf", "c", "/etc/aegis/config.prod.toml", "Path to configuration directory")
+
+	if err := viper.BindPFlag("port", rootCmd.PersistentFlags().Lookup("port")); err != nil {
+		logrus.Fatalf("failed to bind flag: %v", err)
+	}
+	if err := viper.BindPFlag("conf", rootCmd.PersistentFlags().Lookup("conf")); err != nil {
+		logrus.Fatalf("failed to bind flag: %v", err)
+	}
+
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "serve",
+		Short: "Run the gateway server",
+		Run: func(cmd *cobra.Command, args []string) {
+			fx.New(gateway.Options(viper.GetString("conf"), viper.GetString("port"))).Run()
+		},
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		logrus.Println(err.Error())
+		os.Exit(1)
+	}
+}

--- a/AegisLab/src/config.dev.toml
+++ b/AegisLab/src/config.dev.toml
@@ -126,3 +126,61 @@ root = "/tmp/aegis-blob/scratch"
 max_object_bytes = 5_368_709_120
 retention_days = 7
 inline_max_bytes = 65_536
+
+# ---------------------------------------------------------------------
+# [gateway] — aegis-gateway (cmd/aegis-gateway, default :8086).
+# See docs/rfcs/api-gateway.md. Routes are matched first-by-prefix
+# (longer prefixes win, ties broken by config order).
+# ---------------------------------------------------------------------
+[gateway]
+# HMAC key used to sign trusted headers (X-Aegis-User-Id, …) so
+# Phase-C upstreams can detect forgery. Override per deploy with env
+# GATEWAY_TRUSTED_HEADER_KEY. Empty → dev fallback (logged at warn).
+trusted_header_key = ""
+
+[gateway.rate_limit]
+rps   = 200
+burst = 400
+
+[gateway.cors]
+allowed_origins   = ["http://localhost:3101", "http://127.0.0.1:3101"]
+allowed_methods   = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"]
+allowed_headers   = ["Authorization", "Content-Type", "X-Aegis-Request-Id"]
+allow_credentials = true
+max_age_seconds   = 86400
+
+[[gateway.routes]]
+prefix   = "/v1/"
+upstream = "aegis-sso:8083"
+auth     = "none"
+
+[[gateway.routes]]
+prefix   = "/.well-known/"
+upstream = "aegis-sso:8083"
+auth     = "none"
+
+[[gateway.routes]]
+prefix    = "/api/v2/inbox/"
+upstream  = "aegis-notify:8084"
+auth      = "jwt"
+audiences = ["portal"]
+
+[[gateway.routes]]
+prefix   = "/api/v2/notifications/"
+upstream = "aegis-notify:8084"
+auth     = "jwt"
+
+[[gateway.routes]]
+prefix   = "/api/v2/blob/"
+upstream = "aegis-blob:8085"
+auth     = "jwt"
+
+[[gateway.routes]]
+prefix   = "/api/v2/auth/"
+upstream = "aegis-api:8080"
+auth     = "none"
+
+[[gateway.routes]]
+prefix   = "/"
+upstream = "aegis-api:8080"
+auth     = "jwt"

--- a/AegisLab/src/main.go
+++ b/AegisLab/src/main.go
@@ -21,7 +21,7 @@ import (
 	"os"
 
 	"aegis/app"
-	gateway "aegis/app/gateway"
+	monolith "aegis/app/monolith"
 	runtimeapp "aegis/app/runtime"
 	sso "aegis/app/sso"
 
@@ -72,7 +72,7 @@ func main() {
 		fx.New(app.BothOptions(viper.GetString("conf"), viper.GetString("port"))).Run()
 	})
 	apiGatewayCmd := newModeCommand("api-gateway", "Run as the API gateway", func() {
-		fx.New(gateway.Options(viper.GetString("conf"), viper.GetString("port"))).Run()
+		fx.New(monolith.Options(viper.GetString("conf"), viper.GetString("port"))).Run()
 	})
 	runtimeWorkerServiceCmd := newModeCommand("runtime-worker-service", "Run as the runtime worker service", func() {
 		fx.New(runtimeapp.Options(viper.GetString("conf"))).Run()

--- a/AegisLab/src/module/gateway/handler.go
+++ b/AegisLab/src/module/gateway/handler.go
@@ -1,0 +1,70 @@
+package gateway
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Handler is the root http.Handler for the gateway. It matches the
+// route, builds the middleware chain (logging → cors → rate-limit →
+// auth → proxy), and dispatches.
+type Handler struct {
+	routes  *RouteTable
+	proxies *ProxyPool
+	auth    *Authenticator
+	rl      *RateLimiter
+	cors    CORSConfig
+}
+
+// NewHandler wires the matched-route dispatch pipeline. It is the
+// single object the http.Server hangs off.
+func NewHandler(routes *RouteTable, proxies *ProxyPool, auth *Authenticator, rl *RateLimiter, cfg Config) *Handler {
+	return &Handler{
+		routes:  routes,
+		proxies: proxies,
+		auth:    auth,
+		rl:      rl,
+		cors:    cfg.CORS,
+	}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/healthz" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+		return
+	}
+	// TODO(phase-A): /readyz probes a configurable subset of upstreams.
+	if r.URL.Path == "/readyz" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ready"}`))
+		return
+	}
+
+	route := h.routes.Match(r.URL.Path)
+	if route == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	if route.StripPrefix {
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, route.Prefix)
+		if !strings.HasPrefix(r.URL.Path, "/") {
+			r.URL.Path = "/" + r.URL.Path
+		}
+	}
+
+	proxy, err := h.proxies.For(route.Upstream, route.Timeout())
+	if err != nil {
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+		return
+	}
+
+	chain := h.auth.Middleware(route, proxy)
+	chain = h.rl.Middleware(route, chain)
+	chain = CORSMiddleware(h.cors, chain)
+	chain = LoggingMiddleware(route, chain)
+	chain.ServeHTTP(w, r)
+}

--- a/AegisLab/src/module/gateway/middleware_auth.go
+++ b/AegisLab/src/module/gateway/middleware_auth.go
@@ -1,0 +1,184 @@
+package gateway
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"aegis/module/ssoclient"
+	"aegis/utils"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Authenticator pre-authenticates requests at the edge and injects
+// trusted headers signed with a shared HMAC key. Upstreams that opt
+// into trusted-header short-circuit (Phase C of the RFC) verify the
+// signature instead of re-running the JWT pipeline.
+type Authenticator struct {
+	client *ssoclient.Client
+	key    []byte
+}
+
+// NewAuthenticator wires the SSO client + the gateway-wide HMAC signing
+// key. An empty key triggers a dev-only fallback so the gateway still
+// boots in local dev; production deployments MUST configure
+// `gateway.trusted_header_key`.
+func NewAuthenticator(client *ssoclient.Client, key string) *Authenticator {
+	k := strings.TrimSpace(key)
+	if k == "" {
+		logrus.Warn("gateway: trusted_header_key is empty; using dev fallback. Set [gateway].trusted_header_key in production.")
+		k = "aegis-dev-trusted-header-key-do-not-use-in-prod"
+	}
+	return &Authenticator{client: client, key: []byte(k)}
+}
+
+// Middleware returns an http middleware that enforces the route's
+// AuthPolicy. On success it injects trusted headers + signature.
+func (a *Authenticator) Middleware(route *Route, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch route.Auth {
+		case AuthNone:
+			next.ServeHTTP(w, r)
+			return
+		case AuthJWT, AuthJWTOrService, AuthServiceToken:
+			if err := a.enforce(r, route); err != nil {
+				logrus.WithError(err).WithField("path", r.URL.Path).Debug("gateway: auth rejected")
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+		default:
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		}
+	})
+}
+
+func (a *Authenticator) enforce(r *http.Request, route *Route) error {
+	raw := bearer(r)
+	if raw == "" {
+		return errMissingToken
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	switch route.Auth {
+	case AuthServiceToken:
+		sc, err := a.client.VerifyServiceToken(ctx, raw)
+		if err != nil {
+			return err
+		}
+		a.injectServiceHeaders(r, sc)
+	case AuthJWT:
+		uc, err := a.client.VerifyToken(ctx, raw)
+		if err != nil {
+			return err
+		}
+		if err := checkAudience(uc, route.Audiences); err != nil {
+			return err
+		}
+		a.injectUserHeaders(r, uc)
+	case AuthJWTOrService:
+		if uc, err := a.client.VerifyToken(ctx, raw); err == nil {
+			if err := checkAudience(uc, route.Audiences); err != nil {
+				return err
+			}
+			a.injectUserHeaders(r, uc)
+			return nil
+		}
+		sc, err := a.client.VerifyServiceToken(ctx, raw)
+		if err != nil {
+			return err
+		}
+		a.injectServiceHeaders(r, sc)
+	}
+	return nil
+}
+
+func (a *Authenticator) injectUserHeaders(r *http.Request, c *utils.Claims) {
+	aud := ""
+	if c.Audience != nil && len(c.Audience) > 0 {
+		aud = c.Audience[0]
+	}
+	headers := map[string]string{
+		HeaderUserID:    strconv.Itoa(c.UserID),
+		HeaderUserEmail: c.Email,
+		HeaderRoles:     strings.Join(c.Roles, ","),
+		HeaderTokenAud:  aud,
+		HeaderTokenJti:  c.ID,
+	}
+	a.applyAndSign(r, headers)
+}
+
+func (a *Authenticator) injectServiceHeaders(r *http.Request, c *utils.ServiceClaims) {
+	aud := ""
+	if c.Audience != nil && len(c.Audience) > 0 {
+		aud = c.Audience[0]
+	}
+	headers := map[string]string{
+		HeaderUserID:    "0",
+		HeaderUserEmail: "",
+		HeaderRoles:     "service:" + c.Service,
+		HeaderTokenAud:  aud,
+		HeaderTokenJti:  c.ID,
+	}
+	a.applyAndSign(r, headers)
+}
+
+// applyAndSign writes the canonical header set and an HMAC-SHA256 over
+// "<user_id>|<email>|<roles>|<aud>|<jti>" so an upstream can detect a
+// caller forging headers from outside the gateway. v1 spec: simple
+// canonicalization, no replay protection (jti carries that).
+func (a *Authenticator) applyAndSign(r *http.Request, h map[string]string) {
+	canonical := strings.Join([]string{
+		h[HeaderUserID], h[HeaderUserEmail], h[HeaderRoles], h[HeaderTokenAud], h[HeaderTokenJti],
+	}, "|")
+	mac := hmac.New(sha256.New, a.key)
+	_, _ = mac.Write([]byte(canonical))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	for k, v := range h {
+		r.Header.Set(k, v)
+	}
+	r.Header.Set(HeaderSignature, sig)
+}
+
+func bearer(r *http.Request) string {
+	h := r.Header.Get("Authorization")
+	if h == "" {
+		return ""
+	}
+	if !strings.HasPrefix(strings.ToLower(h), "bearer ") {
+		return ""
+	}
+	return strings.TrimSpace(h[len("Bearer "):])
+}
+
+func checkAudience(c *utils.Claims, want []string) error {
+	if len(want) == 0 {
+		return nil
+	}
+	have := c.Audience
+	for _, w := range want {
+		for _, h := range have {
+			if h == w {
+				return nil
+			}
+		}
+	}
+	return errAudienceMismatch
+}
+
+type authError string
+
+func (e authError) Error() string { return string(e) }
+
+const (
+	errMissingToken     authError = "missing bearer token"
+	errAudienceMismatch authError = "audience mismatch"
+)

--- a/AegisLab/src/module/gateway/middleware_cors.go
+++ b/AegisLab/src/module/gateway/middleware_cors.go
@@ -1,0 +1,60 @@
+package gateway
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// CORSMiddleware applies the gateway-wide CORS policy to every response
+// and short-circuits OPTIONS preflight requests with 204.
+func CORSMiddleware(cfg CORSConfig, next http.Handler) http.Handler {
+	allowedOrigins := index(cfg.AllowedOrigins)
+	allowAll := allowedOrigins["*"]
+	methods := joinNonEmpty(cfg.AllowedMethods, ",")
+	headers := joinNonEmpty(cfg.AllowedHeaders, ",")
+	maxAge := strconv.Itoa(cfg.MaxAgeSeconds)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if origin != "" && (allowAll || allowedOrigins[origin]) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			if cfg.AllowCredentials {
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+			}
+			if methods != "" {
+				w.Header().Set("Access-Control-Allow-Methods", methods)
+			}
+			if headers != "" {
+				w.Header().Set("Access-Control-Allow-Headers", headers)
+			}
+			if cfg.MaxAgeSeconds > 0 {
+				w.Header().Set("Access-Control-Max-Age", maxAge)
+			}
+			w.Header().Add("Vary", "Origin")
+		}
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func index(ss []string) map[string]bool {
+	out := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		out[s] = true
+	}
+	return out
+}
+
+func joinNonEmpty(ss []string, sep string) string {
+	clean := ss[:0:0]
+	for _, s := range ss {
+		if strings.TrimSpace(s) != "" {
+			clean = append(clean, s)
+		}
+	}
+	return strings.Join(clean, sep)
+}

--- a/AegisLab/src/module/gateway/middleware_logging.go
+++ b/AegisLab/src/module/gateway/middleware_logging.go
@@ -1,0 +1,61 @@
+package gateway
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// statusRecorder captures the response status code so the access log
+// can include it without buffering the body.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}
+
+// LoggingMiddleware emits one access-log line per request and
+// propagates `traceparent` to the upstream via OTel propagators. It is
+// the outermost middleware in the gateway chain.
+func LoggingMiddleware(route *Route, next http.Handler) http.Handler {
+	prop := otel.GetTextMapPropagator()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		reqID := r.Header.Get(HeaderRequestID)
+		if reqID == "" {
+			reqID = uuid.New().String()
+			r.Header.Set(HeaderRequestID, reqID)
+		}
+		w.Header().Set(HeaderRequestID, reqID)
+
+		// OTel context extraction so the upstream proxy carries
+		// `traceparent` forward. The downstream ReverseProxy preserves
+		// req.Header so this propagator hand-off is enough.
+		ctx := prop.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+		prop.Inject(ctx, propagation.HeaderCarrier(r.Header))
+		r = r.WithContext(ctx)
+
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+
+		logrus.WithFields(logrus.Fields{
+			"route":      route.Prefix,
+			"upstream":   route.Upstream,
+			"method":     r.Method,
+			"path":       r.URL.Path,
+			"status":     rec.status,
+			"latency_ms": time.Since(start).Milliseconds(),
+			"user_id":    r.Header.Get(HeaderUserID),
+			"request_id": reqID,
+		}).Info("gateway: access")
+	})
+}

--- a/AegisLab/src/module/gateway/middleware_ratelimit.go
+++ b/AegisLab/src/module/gateway/middleware_ratelimit.go
@@ -1,0 +1,100 @@
+package gateway
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// TODO(phase-D): when module/ratelimiter exposes an in-process,
+// DB-free limiter (or a Redis-backed mode wired separately from the
+// admin token-bucket Service), swap this minimal token bucket for
+// that implementation so operators can introspect/reset gateway
+// buckets through the same admin API.
+
+// tokenBucket is a tiny lock-protected token bucket used per route.
+// rps is steady-state, burst is max bucket size; refill is continuous.
+type tokenBucket struct {
+	mu     sync.Mutex
+	rps    float64
+	burst  float64
+	tokens float64
+	last   time.Time
+}
+
+func newBucket(rps float64, burst int) *tokenBucket {
+	if burst <= 0 {
+		burst = int(rps)
+	}
+	if burst <= 0 {
+		burst = 1
+	}
+	return &tokenBucket{rps: rps, burst: float64(burst), tokens: float64(burst), last: time.Now()}
+}
+
+func (b *tokenBucket) Allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	now := time.Now()
+	delta := now.Sub(b.last).Seconds()
+	b.last = now
+	b.tokens += delta * b.rps
+	if b.tokens > b.burst {
+		b.tokens = b.burst
+	}
+	if b.tokens >= 1 {
+		b.tokens -= 1
+		return true
+	}
+	return false
+}
+
+// RateLimiter holds a global default + per-route overrides.
+type RateLimiter struct {
+	global *tokenBucket
+	routes map[string]*tokenBucket
+}
+
+// NewRateLimiter pre-builds buckets for each route's override (keyed by
+// route prefix). The global bucket is used when no per-route override
+// is set. A zero RPS disables that bucket (Allow always returns true).
+func NewRateLimiter(global RateLimitPolicy, routes []Route) *RateLimiter {
+	rl := &RateLimiter{
+		routes: make(map[string]*tokenBucket, len(routes)),
+	}
+	if global.RPS > 0 {
+		rl.global = newBucket(global.RPS, global.Burst)
+	}
+	for _, r := range routes {
+		if r.RateLimit.RPS > 0 {
+			rl.routes[r.Prefix] = newBucket(r.RateLimit.RPS, r.RateLimit.Burst)
+		}
+	}
+	return rl
+}
+
+// Middleware enforces the per-route bucket (falling back to the global
+// bucket) and writes RFC-style RateLimit headers.
+func (rl *RateLimiter) Middleware(route *Route, next http.Handler) http.Handler {
+	bucket := rl.routes[route.Prefix]
+	if bucket == nil {
+		bucket = rl.global
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if bucket == nil {
+			w.Header().Set("X-RateLimit-Limit", "unlimited")
+			next.ServeHTTP(w, r)
+			return
+		}
+		w.Header().Set("X-RateLimit-Limit", strconv.FormatFloat(bucket.rps, 'f', -1, 64))
+		w.Header().Set("X-RateLimit-Burst", strconv.Itoa(int(bucket.burst)))
+		if !bucket.Allow() {
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, fmt.Sprintf("rate limit exceeded: %g rps", bucket.rps), http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/AegisLab/src/module/gateway/module.go
+++ b/AegisLab/src/module/gateway/module.go
@@ -1,0 +1,41 @@
+package gateway
+
+import (
+	"aegis/module/ssoclient"
+
+	"go.uber.org/fx"
+)
+
+// Module wires the gateway primitives. It depends on ssoclient.Module
+// from the caller (wired in app/gateway/options.go) for the JWT
+// verifier.
+//
+// Provides:
+//   - Config         (loaded from viper's [gateway] section)
+//   - *RouteTable    (sorted, normalized)
+//   - *ProxyPool     (one reverse proxy per upstream, lazily built)
+//   - *RateLimiter   (in-process token buckets, see middleware_ratelimit.go TODO)
+//   - *Authenticator (HMAC-signed trusted-header injection)
+//   - *Handler       (root http.Handler)
+var Module = fx.Module("gateway",
+	fx.Provide(
+		LoadConfig,
+		newRouteTable,
+		NewProxyPool,
+		newRateLimiter,
+		newAuthenticator,
+		NewHandler,
+	),
+)
+
+func newRouteTable(cfg Config) *RouteTable {
+	return NewRouteTable(cfg.Routes)
+}
+
+func newRateLimiter(cfg Config) *RateLimiter {
+	return NewRateLimiter(cfg.RateLimit, cfg.Routes)
+}
+
+func newAuthenticator(cfg Config, client *ssoclient.Client) *Authenticator {
+	return NewAuthenticator(client, cfg.TrustedHeaderKey)
+}

--- a/AegisLab/src/module/gateway/proxy.go
+++ b/AegisLab/src/module/gateway/proxy.go
@@ -1,0 +1,81 @@
+package gateway
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ProxyPool memoizes one httputil.ReverseProxy per upstream so each
+// route reuses a connection pool. Built lazily on first match.
+type ProxyPool struct {
+	mu      sync.RWMutex
+	proxies map[string]*httputil.ReverseProxy
+}
+
+// NewProxyPool returns an empty pool.
+func NewProxyPool() *ProxyPool {
+	return &ProxyPool{proxies: make(map[string]*httputil.ReverseProxy)}
+}
+
+// For returns (and lazily creates) the proxy bound to the given
+// upstream host. The upstream string may be `host:port` or a full URL;
+// missing scheme defaults to http.
+func (p *ProxyPool) For(upstream string, timeout time.Duration) (*httputil.ReverseProxy, error) {
+	p.mu.RLock()
+	if rp, ok := p.proxies[upstream]; ok {
+		p.mu.RUnlock()
+		return rp, nil
+	}
+	p.mu.RUnlock()
+
+	target := upstream
+	if !strings.Contains(target, "://") {
+		target = "http://" + target
+	}
+	u, err := url.Parse(target)
+	if err != nil {
+		return nil, err
+	}
+
+	rp := httputil.NewSingleHostReverseProxy(u)
+	// Override Director so we control header rewrites that
+	// httputil.NewSingleHostReverseProxy would otherwise stomp on.
+	defaultDirector := rp.Director
+	rp.Director = func(req *http.Request) {
+		defaultDirector(req)
+		req.Host = u.Host
+		req.Header.Set("X-Forwarded-Host", req.Header.Get("Host"))
+		if req.Header.Get("X-Forwarded-Proto") == "" {
+			req.Header.Set("X-Forwarded-Proto", u.Scheme)
+		}
+	}
+	rp.Transport = &http.Transport{
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
+		IdleConnTimeout:       90 * time.Second,
+		ResponseHeaderTimeout: timeout,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	rp.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		logrus.WithError(err).WithFields(logrus.Fields{
+			"path":     r.URL.Path,
+			"upstream": upstream,
+		}).Warn("gateway: upstream error")
+		http.Error(w, "bad gateway", http.StatusBadGateway)
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if existing, ok := p.proxies[upstream]; ok {
+		return existing, nil
+	}
+	p.proxies[upstream] = rp
+	return rp, nil
+}

--- a/AegisLab/src/module/gateway/router.go
+++ b/AegisLab/src/module/gateway/router.go
@@ -1,0 +1,70 @@
+package gateway
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// RouteTable is an ordered set of routes; Match returns the first
+// route whose prefix is a prefix of the request path. Routes are
+// sorted by descending prefix length at load time so longer-prefix
+// rules win even when the config order is sloppy.
+type RouteTable struct {
+	routes []Route
+}
+
+// NewRouteTable normalizes routes and sorts them by descending prefix
+// length for first-match semantics consistent with the RFC.
+func NewRouteTable(routes []Route) *RouteTable {
+	cp := make([]Route, 0, len(routes))
+	for _, r := range routes {
+		if r.Prefix == "" || r.Upstream == "" {
+			logrus.WithFields(logrus.Fields{
+				"prefix":   r.Prefix,
+				"upstream": r.Upstream,
+			}).Warn("gateway: skipping incomplete route")
+			continue
+		}
+		if r.Auth == "" {
+			r.Auth = AuthJWT
+		}
+		cp = append(cp, r)
+	}
+	sort.SliceStable(cp, func(i, j int) bool {
+		return len(cp[i].Prefix) > len(cp[j].Prefix)
+	})
+	return &RouteTable{routes: cp}
+}
+
+// Match returns the first route whose prefix is a path-prefix of p, or
+// nil if nothing matches.
+func (t *RouteTable) Match(p string) *Route {
+	for i := range t.routes {
+		if strings.HasPrefix(p, t.routes[i].Prefix) {
+			return &t.routes[i]
+		}
+	}
+	return nil
+}
+
+// Routes returns a snapshot copy of the underlying route slice. Useful
+// for /admin/routes introspection (not wired in v1).
+func (t *RouteTable) Routes() []Route {
+	out := make([]Route, len(t.routes))
+	copy(out, t.routes)
+	return out
+}
+
+// LoadConfig reads the [gateway] section from viper. Returns a Config
+// with safe defaults if the section is missing — the gateway can still
+// boot, the route table will just be empty and every request will 404.
+func LoadConfig() Config {
+	var cfg Config
+	if err := viper.UnmarshalKey("gateway", &cfg); err != nil {
+		logrus.WithError(err).Error("gateway: failed to unmarshal [gateway] config; continuing with defaults")
+	}
+	return cfg
+}

--- a/AegisLab/src/module/gateway/types.go
+++ b/AegisLab/src/module/gateway/types.go
@@ -1,0 +1,97 @@
+// Package gateway implements the aegis L7 application gateway.
+//
+// Responsibilities (see docs/rfcs/api-gateway.md):
+//   - Route → upstream mapping (config-driven).
+//   - JWT pre-auth via module/ssoclient + trusted-header injection.
+//   - Per-route + global rate limit.
+//   - CORS, access logging, trace propagation.
+//
+// This module has NO database and NO business logic. It is the
+// transport-layer policy point.
+package gateway
+
+import "time"
+
+// AuthPolicy controls how the gateway authenticates a request before
+// proxying it to the upstream.
+type AuthPolicy string
+
+const (
+	// AuthNone disables auth on the route — request is proxied as-is.
+	AuthNone AuthPolicy = "none"
+	// AuthJWT requires a valid user JWT (Bearer token).
+	AuthJWT AuthPolicy = "jwt"
+	// AuthServiceToken requires a valid service token (client_credentials).
+	AuthServiceToken AuthPolicy = "service-token"
+	// AuthJWTOrService accepts either a user JWT or a service token.
+	AuthJWTOrService AuthPolicy = "jwt-or-service"
+)
+
+// RateLimitPolicy is a per-route override of the global limiter.
+type RateLimitPolicy struct {
+	// RPS is the steady-state requests-per-second.
+	RPS float64 `mapstructure:"rps"`
+	// Burst is the bucket size.
+	Burst int `mapstructure:"burst"`
+}
+
+// RetryPolicy describes how the proxy retries upstream failures.
+type RetryPolicy struct {
+	// Attempts is the number of additional attempts after the first.
+	Attempts int `mapstructure:"attempts"`
+	// OnStatus is the set of HTTP status codes that trigger a retry.
+	OnStatus []int `mapstructure:"on_status"`
+}
+
+// Route is one entry in the gateway's route table. Matching is by
+// longest-prefix, first-match against the request path.
+type Route struct {
+	Prefix         string          `mapstructure:"prefix"`
+	Upstream       string          `mapstructure:"upstream"`
+	Auth           AuthPolicy      `mapstructure:"auth"`
+	Audiences      []string        `mapstructure:"audiences"`
+	RateLimit      RateLimitPolicy `mapstructure:"rate_limit"`
+	StripPrefix    bool            `mapstructure:"strip_prefix"`
+	TimeoutSeconds int             `mapstructure:"timeout_seconds"`
+	Retry          RetryPolicy     `mapstructure:"retry"`
+}
+
+// Timeout returns the configured per-route upstream timeout, falling
+// back to a 30s default.
+func (r Route) Timeout() time.Duration {
+	if r.TimeoutSeconds <= 0 {
+		return 30 * time.Second
+	}
+	return time.Duration(r.TimeoutSeconds) * time.Second
+}
+
+// CORSConfig is the gateway-wide CORS policy.
+type CORSConfig struct {
+	AllowedOrigins   []string `mapstructure:"allowed_origins"`
+	AllowedMethods   []string `mapstructure:"allowed_methods"`
+	AllowedHeaders   []string `mapstructure:"allowed_headers"`
+	AllowCredentials bool     `mapstructure:"allow_credentials"`
+	MaxAgeSeconds    int      `mapstructure:"max_age_seconds"`
+}
+
+// Config is the [gateway] section of config.<env>.toml.
+type Config struct {
+	Routes            []Route         `mapstructure:"routes"`
+	CORS              CORSConfig      `mapstructure:"cors"`
+	RateLimit         RateLimitPolicy `mapstructure:"rate_limit"`
+	TrustedHeaderKey  string          `mapstructure:"trusted_header_key"`
+}
+
+// Trusted-header names injected by the gateway after JWT pre-auth.
+// Upstreams that opt in (Phase C) can trust these instead of
+// re-verifying the JWT. Always sent together with X-Aegis-Signature
+// (HMAC of the canonical header set keyed by gateway.trusted_header_key).
+const (
+	HeaderUserID    = "X-Aegis-User-Id"
+	HeaderUserEmail = "X-Aegis-User-Email"
+	HeaderRoles     = "X-Aegis-Roles"
+	HeaderTokenAud  = "X-Aegis-Token-Aud"
+	HeaderTokenJti  = "X-Aegis-Token-Jti"
+	HeaderSignature = "X-Aegis-Signature"
+	HeaderRequestID = "X-Aegis-Request-Id"
+)


### PR DESCRIPTION
## Summary
Phase A of the api-gateway RFC.

**Renames** (the old `api-gateway` was the monolith API binary, misnamed):
- `cmd/api-gateway` → `cmd/aegis-api`
- `app/gateway` → `app/monolith`

**New**:
- `module/gateway`: route table, ReverseProxy, JWT pre-auth via `ssoclient` with HMAC-signed trusted-header injection, CORS, in-process token-bucket rate limit, access log + tracing propagation.
- `app/gateway` (now means the gateway, not the monolith).
- `cmd/aegis-gateway`: standalone service, default `:8086`.
- `config.dev.toml`: `[gateway]` section with initial routes for sso/notify/blob/monolith.

Helm chart + k8s manifest service names kept as `api-gateway` to minimize deploy diff. RFC: `docs/rfcs/api-gateway.md`.

## TODO follow-ups
- Backend `module/auth` trusted-header short-circuit is Phase C (not touched here).
- Ratelimiter integration deferred — `module/ratelimiter` is hard-coupled to gorm.DB+Redis. Need to extract a DB-free `Limiter` interface before wiring through. **Open a follow-up issue.**
- `/readyz` always 200 — needs per-upstream TCP probes.
- Per-pod gateway: rate limit is per-pod; multi-replica needs Redis-backed limiter.

## Test plan
- [x] `go build ./...` clean across whole workspace (rename ripple verified).
- [ ] Manual: `aegis-gateway serve --port 8086` boots, route table loaded.
- [ ] Manual: hit `http://gateway/api/v2/inbox` with valid JWT → reaches `aegis-notify` with `X-Aegis-User-Id` injected.
- [ ] Manual: hit same without JWT → 401 from gateway, never reaches notify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)