### PR TITLE
fix(app): split BaseOptions; standalone services boot cleanly

### DIFF
--- a/AegisLab/src/app/app.go
+++ b/AegisLab/src/app/app.go
@@ -16,13 +16,34 @@ import (
 	"go.uber.org/fx"
 )
 
+// BaseOptions provides only config + logger. JWT key material is no
+// longer baked in — each binary picks WithSigner (it owns a private
+// key, like aegis-sso / the monolith) or WithRemoteVerifier (verifies
+// JWKS from another process, like aegis-notify / aegis-blob /
+// aegis-configcenter / aegis-gateway). Producers that go through
+// `module/ssoclient` already get a remote Verifier transitively and
+// must NOT also pull WithRemoteVerifier (fx would see a duplicate
+// `*jwtkeys.Verifier` provider).
 func BaseOptions(confPath string) fx.Option {
 	return fx.Options(
 		fx.Supply(config.Params{Path: confPath}),
 		config.Module,
 		logger.Module,
-		jwtkeys.SignerModule,
 	)
+}
+
+// WithSigner registers the JWT signer + a Verifier that trusts the
+// signer's own public key. Use in any binary that mints tokens.
+func WithSigner() fx.Option {
+	return jwtkeys.SignerModule
+}
+
+// WithRemoteVerifier registers a Verifier backed by a remote JWKS
+// endpoint (sso.jwks_url). Use in verify-only binaries that DO NOT
+// import `module/ssoclient` (which already brings the same module
+// in transitively).
+func WithRemoteVerifier() fx.Option {
+	return jwtkeys.VerifierModule
 }
 
 func ObserveOptions() fx.Option {

--- a/AegisLab/src/app/blob/options.go
+++ b/AegisLab/src/app/blob/options.go
@@ -18,8 +18,8 @@ import (
 
 	"aegis/app"
 	httpapi "aegis/interface/http"
-	"aegis/module/auth"
 	"aegis/module/blob"
+	"aegis/module/ssoclient"
 	"aegis/router"
 
 	"github.com/gin-gonic/gin"
@@ -32,10 +32,10 @@ func Options(confPath, port string) fx.Option {
 		app.ObserveOptions(),
 		app.DataOptions(),
 
-		auth.Module,
+		// ssoclient brings remote JWKS Verifier, TokenVerifier, and
+		// PermissionChecker. Verify-only binary — no WithSigner.
+		ssoclient.Module,
 		blob.Module,
-
-		fx.Provide(auth.NewTokenVerifier),
 
 		fx.Supply(&router.Handlers{}),
 		fx.Supply(httpapi.ServerConfig{Addr: normalizeAddr(port)}),

--- a/AegisLab/src/app/configcenter/options.go
+++ b/AegisLab/src/app/configcenter/options.go
@@ -21,8 +21,8 @@ import (
 	"aegis/app"
 	"aegis/infra/etcd"
 	httpapi "aegis/interface/http"
-	"aegis/module/auth"
 	"aegis/module/configcenter"
+	"aegis/module/ssoclient"
 	"aegis/module/user"
 	"aegis/router"
 
@@ -38,10 +38,10 @@ func Options(confPath, port string) fx.Option {
 
 		etcd.Module,
 		user.Module,
-		auth.Module,
+		// ssoclient brings remote JWKS Verifier, TokenVerifier, and
+		// PermissionChecker. Verify-only binary — no WithSigner.
+		ssoclient.Module,
 		configcenter.Module,
-
-		fx.Provide(auth.NewTokenVerifier),
 
 		fx.Supply(&router.Handlers{}),
 		fx.Supply(httpapi.ServerConfig{Addr: normalizeAddr(port)}),

--- a/AegisLab/src/app/monolith/options.go
+++ b/AegisLab/src/app/monolith/options.go
@@ -23,6 +23,7 @@ import (
 func Options(confPath, port string) fx.Option {
 	return fx.Options(
 		app.BaseOptions(confPath),
+		app.WithSigner(),
 		app.ObserveOptions(),
 		app.DataOptions(),
 		app.CoordinationOptions(),

--- a/AegisLab/src/app/notify/options.go
+++ b/AegisLab/src/app/notify/options.go
@@ -21,8 +21,8 @@ import (
 
 	"aegis/app"
 	httpapi "aegis/interface/http"
-	"aegis/module/auth"
 	"aegis/module/notification"
+	"aegis/module/ssoclient"
 	"aegis/module/user"
 	"aegis/router"
 
@@ -37,13 +37,12 @@ func Options(confPath, port string) fx.Option {
 		app.DataOptions(),
 
 		user.Module,
-		auth.Module,
+		// ssoclient brings: jwtkeys.VerifierModule (remote JWKS),
+		// middleware.TokenVerifier, middleware.PermissionChecker.
+		// This binary verifies tokens minted by aegis-sso; it does not
+		// mint its own, so no WithSigner.
+		ssoclient.Module,
 		notification.Module,
-
-		// auth in this binary owns the JWT verifier so it can validate
-		// service tokens issued by SSO and human-user tokens issued by
-		// the same SSO. Matches the sso binary's pattern.
-		fx.Provide(auth.NewTokenVerifier),
 
 		fx.Supply(&router.Handlers{}),
 		fx.Supply(httpapi.ServerConfig{Addr: normalizeAddr(port)}),

--- a/AegisLab/src/app/runtime/options.go
+++ b/AegisLab/src/app/runtime/options.go
@@ -19,6 +19,7 @@ import (
 func Options(confPath string) fx.Option {
 	return fx.Options(
 		app.BaseOptions(confPath),
+		app.WithSigner(),
 		app.ObserveOptions(),
 		app.DataOptions(),
 		app.CoordinationOptions(),

--- a/AegisLab/src/app/sso/options.go
+++ b/AegisLab/src/app/sso/options.go
@@ -20,6 +20,7 @@ import (
 func Options(confPath, port string) fx.Option {
 	return fx.Options(
 		app.BaseOptions(confPath),
+		app.WithSigner(),
 		app.ObserveOptions(),
 		app.DataOptions(),
 		user.Module,

--- a/AegisLab/src/infra/jwtkeys/module.go
+++ b/AegisLab/src/infra/jwtkeys/module.go
@@ -106,7 +106,10 @@ func newRemoteVerifier(lc fx.Lifecycle) (*Verifier, error) {
 		OnStart: func(ctx context.Context) error {
 			fetchCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			defer cancel()
-			return v.Refresh(fetchCtx)
+			if err := v.Refresh(fetchCtx); err != nil {
+				logrus.WithError(err).Warn("jwks initial fetch failed; refresh loop will retry")
+			}
+			return nil
 		},
 	})
 	startRefreshLoop(lc, v)

--- a/AegisLab/src/module/blob/module.go
+++ b/AegisLab/src/module/blob/module.go
@@ -32,7 +32,6 @@ var Module = fx.Module("blob",
 
 	fx.Provide(
 		fx.Annotate(RoutesPortal, fx.ResultTags(`group:"routes"`)),
-		fx.Annotate(RoutesSDK, fx.ResultTags(`group:"routes"`)),
 		fx.Annotate(Migrations, fx.ResultTags(`group:"migrations"`)),
 	),
 )

--- a/AegisLab/src/module/blob/routes.go
+++ b/AegisLab/src/module/blob/routes.go
@@ -34,22 +34,6 @@ func RoutesPortal(handler *Handler) framework.RouteRegistrar {
 	}
 }
 
-// RoutesSDK mounts the cross-service blob endpoints (same handlers,
-// service-token auth). Producers calling the standalone aegis-blob
-// binary land here.
-func RoutesSDK(handler *Handler) framework.RouteRegistrar {
-	return framework.RouteRegistrar{
-		Audience: framework.AudienceSDK,
-		Name:     "blob.sdk",
-		Register: func(v2 *gin.RouterGroup) {
-			g := v2.Group("/blob", middleware.JWTAuth())
-			{
-				g.POST("/buckets/:bucket/presign-put", handler.PresignPut)
-				g.POST("/buckets/:bucket/presign-get", handler.PresignGet)
-				g.HEAD("/buckets/:bucket/objects/:key", handler.Stat)
-				g.DELETE("/buckets/:bucket/objects/:key", handler.Delete)
-				g.GET("/buckets/:bucket/objects", handler.List)
-			}
-		},
-	}
-}
+// RoutesPortal already accepts both human and service tokens (JWTAuth
+// without RequireHumanUserAuth), so producers calling the standalone
+// aegis-blob binary use the same routes.


### PR DESCRIPTION
## Summary
Validates the just-landed standalone services (#398 / #399 / #400) end-to-end by docker-infra smoke. All five binaries (sso/notify/blob/gateway/configcenter) now boot and answer \`/healthz\`.

## Root causes

1. **\`app.BaseOptions\` hardcoded \`jwtkeys.SignerModule\`** — every standalone service inherited a signer it didn't own AND collided with \`ssoclient.Module\`'s \`jwtkeys.VerifierModule\`. Split into \`BaseOptions\` (config + logger only) + \`WithSigner()\` + \`WithRemoteVerifier()\`. SSO + monolith + runtime explicitly take \`WithSigner()\`; everyone else gets a Verifier transitively from \`ssoclient\`.

2. **notify/blob/configcenter never provided \`middleware.PermissionChecker\`** — they pulled \`module/auth\` (SSO-local apikey/user/role) for a TokenVerifier but \`router.New\` also needs PermissionChecker. Switched to \`ssoclient.Module\` which brings Verifier + TokenVerifier + PermissionChecker.

3. **\`jwtkeys.newRemoteVerifier\` hard-failed on first JWKS fetch** — defeated \`ssoclient\`'s own warn-but-continue boot semantic. Demoted to a warn; refresh loop retries.

4. **\`module/blob\` registered Portal + SDK groups under the same \`/blob\` prefix** — gin panicked. Portal already accepts service tokens, so SDK was redundant. Dropped.

## Validation

Locally with mysql/redis/etcd via \`docker compose up -d\`:

\`\`\`
:8083 sso=alive          /healthz={"status":"ok"}
:8084 notify=alive       /healthz={"status":"ok"}
:8085 blob=alive         /healthz={"status":"ok"}
:8086 gateway=alive      /healthz={"status":"ok"}
:8087 configcenter=alive /healthz={"status":"ok"}
\`\`\`

- \`GET /api/v2/inbox\` through gateway with no JWT → \`401\` (pre-auth correct, upstream never hit)
- \`GET /api/v2/config/notification\` direct configcenter, no JWT → \`401\`
- \`GET /api/v2/inbox\` direct notify, no JWT → \`401\`
- SSO direct \`/.well-known/openid-configuration\` → \`200\`
- Gateway → SSO via configured route → 502 with \`aegis-sso:8083\` because k8s service-name DNS isn't on the host. Deployment concern, not code; confirmed by hitting SSO directly.

## Test plan
- [x] \`go build ./...\` clean
- [x] All 5 binaries boot, \`/healthz\` returns ok
- [x] Pre-auth 401 on protected paths (gateway never reaches upstream)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)