### PR TITLE
feat(portal): SDK 1.5.0 backend gaps (umbrella for #408)

### DIFF
--- a/aegislab/src/boot/http_modules.go
+++ b/aegislab/src/boot/http_modules.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"context"
+
 	blobclient "aegis/clients/blob"
 	configcenterclient "aegis/clients/configcenter"
 	gateway "aegis/clients/gateway"
@@ -115,6 +117,33 @@ func apiHTTPModuleNames() []string {
 
 //go:generate echo "no generator: edit apiHTTPModules above by hand"
 
+// taskCancellerAdapter bridges *task.Service into the narrow
+// injection.TaskCanceller seam so injection cancel can cascade-cancel the
+// task that backs the injection without injection.Service importing the
+// task package (and risking the reverse import cycle).
+type taskCancellerAdapter struct{ svc *task.Service }
+
+func (a taskCancellerAdapter) CancelTask(ctx context.Context, taskID string) (*injection.CancelInjectionTaskResult, error) {
+	r, err := a.svc.CancelTask(ctx, taskID)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		return nil, nil
+	}
+	return &injection.CancelInjectionTaskResult{
+		TaskID:            r.TaskID,
+		State:             r.State,
+		Message:           r.Message,
+		DeletedPodChaos:   r.DeletedPodChaos,
+		RemovedRedisTasks: r.RemovedRedisTasks,
+	}, nil
+}
+
+func newTaskCanceller(svc *task.Service) injection.TaskCanceller {
+	return taskCancellerAdapter{svc: svc}
+}
+
 // chaosSystemWriterAdapter bridges chaossystem.Writer (admin-scoped, broad)
 // to the narrow injection.ChaosSystemWriter the injection module needs for
 // the #156 namespace-count bump. Defined at the app level so the injection
@@ -139,6 +168,7 @@ func ExecutionInjectionOwnerModules() fx.Option {
 		blob.Module,
 		blobclient.Module,
 		fx.Provide(chaosSystemWriterAdapter),
+		fx.Provide(newTaskCanceller),
 	)
 }
 
@@ -146,5 +176,6 @@ func ProducerHTTPModules() fx.Option {
 	return fx.Options(
 		fx.Options(apiHTTPModules()...),
 		fx.Provide(chaosSystemWriterAdapter),
+		fx.Provide(newTaskCanceller),
 	)
 }

--- a/aegislab/src/boot/http_modules.go
+++ b/aegislab/src/boot/http_modules.go
@@ -7,6 +7,7 @@ import (
 	notificationclient "aegis/clients/notification"
 	chaossystem "aegis/core/domain/chaossystem"
 	container "aegis/core/domain/container"
+	dashboard "aegis/core/domain/dashboard"
 	dataset "aegis/core/domain/dataset"
 	execution "aegis/core/domain/execution"
 	group "aegis/core/domain/group"
@@ -54,6 +55,7 @@ func apiHTTPModules() []fx.Option {
 		// core/domain
 		chaossystem.Module,
 		container.Module,
+		dashboard.Module,
 		dataset.Module,
 		execution.Module,
 		group.Module,
@@ -101,7 +103,7 @@ func apiHTTPModules() []fx.Option {
 // by smoke / registry tests. Kept in sync with apiHTTPModules above.
 func apiHTTPModuleNames() []string {
 	return []string{
-		"chaossystem", "container", "dataset", "execution", "group",
+		"chaossystem", "container", "dashboard", "dataset", "execution", "group",
 		"injection", "pedestal", "task",
 		"label", "project", "team",
 		"evaluation", "metric", "observation", "sdk", "system",

--- a/aegislab/src/core/domain/dashboard/api_types.go
+++ b/aegislab/src/core/domain/dashboard/api_types.go
@@ -1,0 +1,32 @@
+package dashboard
+
+import (
+	"time"
+
+	execution "aegis/core/domain/execution"
+	injection "aegis/core/domain/injection"
+	project "aegis/crud/iam/project"
+	trace "aegis/crud/observability/trace"
+)
+
+// DashboardCounts is the KPI-tile payload for a single project. All counts
+// are point-in-time totals; "tasks_running" is the count of tasks currently
+// in the Running state.
+type DashboardCounts struct {
+	InjectionsTotal int64 `json:"injections_total"`
+	ExecutionsTotal int64 `json:"executions_total"`
+	TasksRunning    int64 `json:"tasks_running"`
+	TracesTotal     int64 `json:"traces_total"`
+}
+
+// DashboardResp is the fan-in payload returned by
+// GET /api/v2/projects/{project_id}/dashboard. It composes existing
+// per-resource DTOs rather than inventing new shapes.
+type DashboardResp struct {
+	Project          project.ProjectDetailResp `json:"project"`
+	Counts           DashboardCounts           `json:"counts"`
+	RecentInjections []injection.InjectionResp `json:"recent_injections"`
+	RecentExecutions []execution.ExecutionResp `json:"recent_executions"`
+	RecentTraces     []trace.TraceResp         `json:"recent_traces"`
+	UpdatedAt        time.Time                 `json:"updated_at"`
+}

--- a/aegislab/src/core/domain/dashboard/handler.go
+++ b/aegislab/src/core/domain/dashboard/handler.go
@@ -1,0 +1,53 @@
+package dashboard
+
+import (
+	"net/http"
+	"strconv"
+
+	"aegis/platform/consts"
+	"aegis/platform/dto"
+	"aegis/platform/httpx"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Handler struct {
+	service HandlerService
+}
+
+func NewHandler(service HandlerService) *Handler {
+	return &Handler{service: service}
+}
+
+// GetProjectDashboard returns a fan-in aggregate for the portal dashboard page.
+//
+//	@Summary		Get project dashboard aggregate
+//	@Description	Returns the KPI tiles and recent-activity panels for a project in a single round-trip. Combines project metadata, point-in-time totals (injections, executions, running tasks, traces), and the 10 most recent injections, executions, and traces — ordered most-recent-first.
+//	@Tags			Projects
+//	@ID				get_project_dashboard
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			project_id	path		int									true	"Project ID"
+//	@Success		200			{object}	dto.GenericResponse[DashboardResp]	"Dashboard aggregate retrieved successfully"
+//	@Failure		400			{object}	dto.GenericResponse[any]			"Invalid project ID"
+//	@Failure		401			{object}	dto.GenericResponse[any]			"Authentication required"
+//	@Failure		403			{object}	dto.GenericResponse[any]			"Permission denied"
+//	@Failure		404			{object}	dto.GenericResponse[any]			"Project not found"
+//	@Failure		500			{object}	dto.GenericResponse[any]			"Internal server error"
+//	@Router			/api/v2/projects/{project_id}/dashboard [get]
+//	@x-api-type		{"portal":"true"}
+func (h *Handler) GetProjectDashboard(c *gin.Context) {
+	projectIDStr := c.Param(consts.URLPathProjectID)
+	projectID, err := strconv.Atoi(projectIDStr)
+	if err != nil || projectID <= 0 {
+		dto.ErrorResponse(c, http.StatusBadRequest, "Invalid project ID")
+		return
+	}
+
+	resp, err := h.service.GetProjectDashboard(c.Request.Context(), projectID)
+	if httpx.HandleServiceError(c, err) {
+		return
+	}
+
+	dto.SuccessResponse(c, resp)
+}

--- a/aegislab/src/core/domain/dashboard/handler_service.go
+++ b/aegislab/src/core/domain/dashboard/handler_service.go
@@ -1,0 +1,13 @@
+package dashboard
+
+import "context"
+
+// HandlerService captures the dashboard aggregator operation consumed by the
+// HTTP handler.
+type HandlerService interface {
+	GetProjectDashboard(context.Context, int) (*DashboardResp, error)
+}
+
+func AsHandlerService(service *Service) HandlerService {
+	return service
+}

--- a/aegislab/src/core/domain/dashboard/module.go
+++ b/aegislab/src/core/domain/dashboard/module.go
@@ -1,0 +1,14 @@
+package dashboard
+
+import "go.uber.org/fx"
+
+var Module = fx.Module("dashboard",
+	fx.Provide(
+		NewService,
+		AsHandlerService,
+		NewHandler,
+	),
+	fx.Provide(
+		fx.Annotate(RoutesPortal, fx.ResultTags(`group:"routes"`)),
+	),
+)

--- a/aegislab/src/core/domain/dashboard/routes.go
+++ b/aegislab/src/core/domain/dashboard/routes.go
@@ -1,0 +1,22 @@
+package dashboard
+
+import (
+	"aegis/platform/framework"
+	"aegis/platform/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RoutesPortal contributes the dashboard aggregator's portal HTTP route.
+// The underlying per-resource list services already enforce read-side RBAC,
+// so project_read is the necessary and sufficient gate here.
+func RoutesPortal(handler *Handler) framework.RouteRegistrar {
+	return framework.RouteRegistrar{
+		Audience: framework.AudiencePortal,
+		Name:     "dashboard",
+		Register: func(v2 *gin.RouterGroup) {
+			projects := v2.Group("/projects", middleware.TrustedHeaderAuth(), middleware.RequireProjectRead)
+			projects.GET("/:project_id/dashboard", handler.GetProjectDashboard)
+		},
+	}
+}

--- a/aegislab/src/core/domain/dashboard/service.go
+++ b/aegislab/src/core/domain/dashboard/service.go
@@ -1,0 +1,162 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	execution "aegis/core/domain/execution"
+	injection "aegis/core/domain/injection"
+	task "aegis/core/domain/task"
+	project "aegis/crud/iam/project"
+	trace "aegis/crud/observability/trace"
+	"aegis/platform/consts"
+	"aegis/platform/dto"
+)
+
+const recentLimit = consts.PageSizeSmall
+
+// Narrow collaborator surfaces — we only need the list endpoints from the
+// per-resource services. Defining them locally keeps the dashboard module
+// out of the import-cycle danger zone and makes test doubles trivial.
+
+type projectReader interface {
+	GetProjectDetail(context.Context, int) (*project.ProjectDetailResp, error)
+}
+
+type injectionLister interface {
+	ListProjectInjections(context.Context, *injection.ListInjectionReq, int) (*dto.ListResp[injection.InjectionResp], error)
+}
+
+type executionLister interface {
+	ListProjectExecutions(context.Context, *execution.ListExecutionReq, int) (*dto.ListResp[execution.ExecutionResp], error)
+}
+
+type traceLister interface {
+	ListTraces(context.Context, *trace.ListTraceReq) (*dto.ListResp[trace.TraceResp], error)
+}
+
+type taskLister interface {
+	List(context.Context, *task.ListTaskReq) (*dto.ListResp[dto.TaskResp], error)
+}
+
+type Service struct {
+	projects   projectReader
+	injections injectionLister
+	executions executionLister
+	traces     traceLister
+	tasks      taskLister
+}
+
+func NewService(
+	projects project.HandlerService,
+	injections injection.HandlerService,
+	executions execution.HandlerService,
+	traces trace.HandlerService,
+	tasks task.HandlerService,
+) *Service {
+	return &Service{
+		projects:   projects,
+		injections: injections,
+		executions: executions,
+		traces:     traces,
+		tasks:      tasks,
+	}
+}
+
+func (s *Service) GetProjectDashboard(ctx context.Context, projectID int) (*DashboardResp, error) {
+	proj, err := s.projects.GetProjectDetail(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	injectionPage, err := s.injections.ListProjectInjections(ctx, newPaginatedInjectionReq(), projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list project injections: %w", err)
+	}
+
+	executionPage, err := s.executions.ListProjectExecutions(ctx, newPaginatedExecutionReq(), projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list project executions: %w", err)
+	}
+
+	tracePage, err := s.traces.ListTraces(ctx, newPaginatedTraceReq(projectID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list project traces: %w", err)
+	}
+
+	tasksRunningTotal, err := s.countRunningTasks(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count running tasks: %w", err)
+	}
+
+	return &DashboardResp{
+		Project: *proj,
+		Counts: DashboardCounts{
+			InjectionsTotal: paginationTotal(injectionPage),
+			ExecutionsTotal: paginationTotal(executionPage),
+			TasksRunning:    tasksRunningTotal,
+			TracesTotal:     paginationTotal(tracePage),
+		},
+		RecentInjections: itemsOrEmpty(injectionPage),
+		RecentExecutions: itemsOrEmpty(executionPage),
+		RecentTraces:     itemsOrEmpty(tracePage),
+		UpdatedAt:        time.Now().UTC(),
+	}, nil
+}
+
+func (s *Service) countRunningTasks(ctx context.Context, projectID int) (int64, error) {
+	running := consts.TaskRunning
+	req := &task.ListTaskReq{
+		PaginationReq: dto.PaginationReq{Page: 1, Size: consts.PageSizeTiny},
+		ProjectID:     projectID,
+		State:         consts.GetTaskStateName(running),
+	}
+	if err := req.Validate(); err != nil {
+		return 0, err
+	}
+	page, err := s.tasks.List(ctx, req)
+	if err != nil {
+		return 0, err
+	}
+	return paginationTotal(page), nil
+}
+
+func newPaginatedInjectionReq() *injection.ListInjectionReq {
+	req := &injection.ListInjectionReq{
+		PaginationReq: dto.PaginationReq{Page: 1, Size: recentLimit},
+	}
+	_ = req.Validate()
+	return req
+}
+
+func newPaginatedExecutionReq() *execution.ListExecutionReq {
+	req := &execution.ListExecutionReq{
+		PaginationReq: dto.PaginationReq{Page: 1, Size: recentLimit},
+	}
+	_ = req.Validate()
+	return req
+}
+
+func newPaginatedTraceReq(projectID int) *trace.ListTraceReq {
+	req := &trace.ListTraceReq{
+		PaginationReq: dto.PaginationReq{Page: 1, Size: recentLimit},
+		ProjectID:     projectID,
+	}
+	_ = req.Validate()
+	return req
+}
+
+func paginationTotal[T any](page *dto.ListResp[T]) int64 {
+	if page == nil || page.Pagination == nil {
+		return 0
+	}
+	return page.Pagination.Total
+}
+
+func itemsOrEmpty[T any](page *dto.ListResp[T]) []T {
+	if page == nil || page.Items == nil {
+		return []T{}
+	}
+	return page.Items
+}

--- a/aegislab/src/core/domain/execution/api_types.go
+++ b/aegislab/src/core/domain/execution/api_types.go
@@ -123,6 +123,7 @@ type ListExecutionReq struct {
 	Status     *consts.StatusType     `form:"status" binding:"omitempty"`
 	Labels     []string               `form:"labels" binding:"omitempty"`
 	DatapackID *int                   `form:"datapack_id" binding:"omitempty"`
+	ProjectID  *int                   `form:"project_id" binding:"omitempty"`
 }
 
 func (req *ListExecutionReq) Validate() error {
@@ -137,6 +138,9 @@ func (req *ListExecutionReq) Validate() error {
 	}
 	if err := validateExecutionLabels(req.Labels); err != nil {
 		return err
+	}
+	if req.ProjectID != nil && *req.ProjectID <= 0 {
+		return fmt.Errorf("project_id must be positive")
 	}
 	return nil
 }

--- a/aegislab/src/core/domain/execution/handler.go
+++ b/aegislab/src/core/domain/execution/handler.go
@@ -68,6 +68,44 @@ func (h *Handler) ListProjectExecutions(c *gin.Context) {
 	dto.SuccessResponse(c, resp)
 }
 
+// ListExecutions lists algorithm executions across projects (portal).
+//
+//	@Summary		List executions
+//	@Description	Get paginated list of algorithm executions across projects the caller can read. Use the project_id query param to scope results to a single project.
+//	@Tags			Executions
+//	@ID				list_executions
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			page		query		int													false	"Page number"	default(1)
+//	@Param			size		query		int													false	"Page size"		default(20)
+//	@Param			project_id	query		int													false	"Filter by project ID"
+//	@Param			state		query		consts.ExecutionState								false	"Filter by execution state"
+//	@Param			status		query		consts.StatusType									false	"Filter by status"
+//	@Param			labels		query		[]string											false	"Filter by labels (key:value, repeatable)"
+//	@Success		200			{object}	dto.GenericResponse[dto.ListResp[ExecutionResp]]	"Executions retrieved successfully"
+//	@Failure		400			{object}	dto.GenericResponse[any]							"Invalid query parameters"
+//	@Failure		401			{object}	dto.GenericResponse[any]							"Authentication required"
+//	@Failure		403			{object}	dto.GenericResponse[any]							"Permission denied"
+//	@Failure		500			{object}	dto.GenericResponse[any]							"Internal server error"
+//	@Router			/api/v2/executions [get]
+//	@x-api-type		{"portal":"true"}
+func (h *Handler) ListExecutions(c *gin.Context) {
+	var req ListExecutionReq
+	if err := c.ShouldBindQuery(&req); err != nil {
+		dto.ErrorResponse(c, http.StatusBadRequest, "Invalid request format: "+err.Error())
+		return
+	}
+	if err := req.Validate(); err != nil {
+		dto.ErrorResponse(c, http.StatusBadRequest, "Validation failed: "+err.Error())
+		return
+	}
+	resp, err := h.service.ListExecutions(c.Request.Context(), &req)
+	if httpx.HandleServiceError(c, err) {
+		return
+	}
+	dto.SuccessResponse(c, resp)
+}
+
 // SubmitAlgorithmExecution submits batch algorithm execution for multiple datapacks or datasets
 //
 //	@Summary		Submit batch algorithm execution

--- a/aegislab/src/core/domain/execution/repository.go
+++ b/aegislab/src/core/domain/execution/repository.go
@@ -85,6 +85,12 @@ func (r *Repository) listExecutionsView(limit, offset int, req *ListExecutionReq
 	if req.Status != nil {
 		query = query.Where("status = ?", *req.Status)
 	}
+	if req.ProjectID != nil {
+		query = query.
+			Joins("JOIN tasks ON tasks.id = executions.task_id").
+			Joins("JOIN traces ON traces.id = tasks.trace_id").
+			Where("traces.project_id = ?", *req.ProjectID)
+	}
 	for _, condition := range labelConditions {
 		subQuery := r.db.Table("execution_injection_labels eil").
 			Select("eil.execution_id").

--- a/aegislab/src/core/domain/execution/routes.go
+++ b/aegislab/src/core/domain/execution/routes.go
@@ -15,6 +15,7 @@ func RoutesPortal(handler *Handler) framework.RouteRegistrar {
 		Register: func(v2 *gin.RouterGroup) {
 			executions := v2.Group("/executions", middleware.TrustedHeaderAuth())
 			{
+				executions.GET("", handler.ListExecutions)
 				executions.GET("/labels", middleware.RequireAPIKeyScopesAny(consts.ScopeSDKAll, consts.ScopeSDKExecutionsAll, consts.ScopeSDKExecutionsRead), handler.ListAvailableExecutionLabels)
 				executions.POST("/batch-delete", handler.BatchDeleteExecutions)
 				executions.POST("/compare", handler.CompareExecutions)

--- a/aegislab/src/core/domain/injection/api_types.go
+++ b/aegislab/src/core/domain/injection/api_types.go
@@ -668,6 +668,18 @@ type InjectionWarnings struct {
 	BatchesExistInDatabase    []int    `json:"batches_exist_in_database,omitempty"`    // Batch indices that already exist in database
 }
 
+// CancelInjectionResp describes the outcome of best-effort cancellation of
+// an injection — cascades through to the underlying task's redis queue
+// entries and chaos CRDs.
+type CancelInjectionResp struct {
+	InjectionID       int      `json:"injection_id"`
+	TaskID            string   `json:"task_id,omitempty"`
+	State             string   `json:"state,omitempty"`
+	Message           string   `json:"message,omitempty"`
+	DeletedPodChaos   []string `json:"deleted_podchaos,omitempty"`
+	RemovedRedisTasks []string `json:"removed_redis_tasks,omitempty"`
+}
+
 type SubmitInjectionResp struct {
 	GroupID       string                `json:"group_id"`
 	Items         []SubmitInjectionItem `json:"items"`

--- a/aegislab/src/core/domain/injection/handler.go
+++ b/aegislab/src/core/domain/injection/handler.go
@@ -848,6 +848,35 @@ func spanFromGin(c *gin.Context, operation string) (context.Context, trace.Span,
 	return spanCtx, trace.SpanFromContext(spanCtx), true
 }
 
+// CancelInjection handles best-effort cancellation of a fault injection.
+//
+//	@Summary		Cancel a fault injection (best-effort)
+//	@Description	Cascade-cancels the task that backs the injection — marks the task row as Cancelled, evicts redis queue entries, and best-effort deletes chaos CRDs labelled with task_id=<id>. Returns 200 with the terminal state when the injection's task is already terminal.
+//	@Tags			Injections
+//	@ID				cancel_injection
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id	path		int										true	"Injection ID"
+//	@Success		200	{object}	dto.GenericResponse[CancelInjectionResp]	"Injection cancelled (or task already terminal)"
+//	@Failure		400	{object}	dto.GenericResponse[any]				"Invalid injection ID or injection has no associated task"
+//	@Failure		401	{object}	dto.GenericResponse[any]				"Authentication required"
+//	@Failure		403	{object}	dto.GenericResponse[any]				"Permission denied"
+//	@Failure		404	{object}	dto.GenericResponse[any]				"Injection not found"
+//	@Failure		500	{object}	dto.GenericResponse[any]				"Internal server error"
+//	@Router			/api/v2/injections/{id}/cancel [post]
+//	@x-api-type		{"portal":"true"}
+func (h *Handler) CancelInjection(c *gin.Context) {
+	id, ok := parsePositiveID(c, "id", "injection ID")
+	if !ok {
+		return
+	}
+	resp, err := h.service.CancelInjection(c.Request.Context(), id)
+	if httpx.HandleServiceError(c, err) {
+		return
+	}
+	dto.SuccessResponse(c, resp)
+}
+
 func parsePositiveID(c *gin.Context, key, label string) (int, bool) {
 	id, ok := httpx.ParsePositiveID(c, c.Param(key), label)
 	return id, ok

--- a/aegislab/src/core/domain/injection/handler_service.go
+++ b/aegislab/src/core/domain/injection/handler_service.go
@@ -34,6 +34,7 @@ type HandlerService interface {
 	QueryDatapackFile(context.Context, int, string) (string, int64, io.ReadCloser, error)
 	UpdateGroundtruth(context.Context, int, *UpdateGroundtruthReq) error
 	UploadDatapack(context.Context, *UploadDatapackReq, io.Reader, int64) (*UploadDatapackResp, error)
+	CancelInjection(context.Context, int) (*CancelInjectionResp, error)
 }
 
 func AsHandlerService(service *Service) HandlerService {

--- a/aegislab/src/core/domain/injection/routes.go
+++ b/aegislab/src/core/domain/injection/routes.go
@@ -65,6 +65,7 @@ func RoutesPortal(handler *Handler) framework.RouteRegistrar {
 				injections.PATCH("/labels/batch", handler.BatchManageInjectionLabels)
 				injections.POST("/batch-delete", handler.BatchDeleteInjections)
 				injections.POST("/upload", handler.UploadDatapack)
+				injections.POST("/:id/cancel", middleware.RequireTaskStop, handler.CancelInjection)
 				injections.PUT("/:id/groundtruth", handler.UpdateGroundtruth)
 
 				observation := injections.Group("", middleware.RequireProjectRead)

--- a/aegislab/src/core/domain/injection/service.go
+++ b/aegislab/src/core/domain/injection/service.go
@@ -74,27 +74,47 @@ type ChaosSystemWriter interface {
 	EnsureCountForNamespace(ctx context.Context, systemName, namespace string) (bool, error)
 }
 
-type Service struct {
-	repo         *Repository
-	store        DatapackStorage
-	lokiClient   *loki.Client
-	containers   container.Reader
-	datasets     dataset.Reader
-	labels       label.Writer
-	redis        *redis.Gateway
-	chaosSystems ChaosSystemWriter
+// TaskCanceller is the narrow contract injection.Service needs to cancel
+// the task backing an injection. Implemented by *task.Service via an
+// app-level adapter so this package owns its own DTO shape and avoids
+// pulling task into the injection import graph.
+type TaskCanceller interface {
+	CancelTask(ctx context.Context, taskID string) (*CancelInjectionTaskResult, error)
 }
 
-func NewService(repo *Repository, store DatapackStorage, lokiClient *loki.Client, containers container.Reader, datasets dataset.Reader, labels label.Writer, redis *redis.Gateway, chaosSystems ChaosSystemWriter) *Service {
+// CancelInjectionTaskResult is the structural projection of the underlying
+// task cancel response consumed by injection.Service.
+type CancelInjectionTaskResult struct {
+	TaskID            string
+	State             string
+	Message           string
+	DeletedPodChaos   []string
+	RemovedRedisTasks []string
+}
+
+type Service struct {
+	repo          *Repository
+	store         DatapackStorage
+	lokiClient    *loki.Client
+	containers    container.Reader
+	datasets      dataset.Reader
+	labels        label.Writer
+	redis         *redis.Gateway
+	chaosSystems  ChaosSystemWriter
+	taskCanceller TaskCanceller
+}
+
+func NewService(repo *Repository, store DatapackStorage, lokiClient *loki.Client, containers container.Reader, datasets dataset.Reader, labels label.Writer, redis *redis.Gateway, chaosSystems ChaosSystemWriter, taskCanceller TaskCanceller) *Service {
 	return &Service{
-		repo:         repo,
-		store:        store,
-		lokiClient:   lokiClient,
-		containers:   containers,
-		datasets:     datasets,
-		labels:       labels,
-		redis:        redis,
-		chaosSystems: chaosSystems,
+		repo:          repo,
+		store:         store,
+		lokiClient:    lokiClient,
+		containers:    containers,
+		datasets:      datasets,
+		labels:        labels,
+		redis:         redis,
+		chaosSystems:  chaosSystems,
+		taskCanceller: taskCanceller,
 	}
 }
 
@@ -1236,6 +1256,45 @@ func (s *Service) batchDeleteByLabels(labelItems []dto.LabelItem) error {
 		return fmt.Errorf("failed to list injection ids by labels: %w", err)
 	}
 	return s.batchDeleteByIDs(injectionIDs)
+}
+
+// CancelInjection cascades cancellation through to the task that backs the
+// injection. The DB write + redis eviction + chaos CRD delete all happen
+// inside task.Service.CancelTask; this method just resolves injection_id →
+// task_id and surfaces the underlying outcome.
+//
+// Contract:
+//   - injection not found → wrapped consts.ErrNotFound
+//   - injection has no associated task (already detached / never submitted) →
+//     wrapped consts.ErrBadRequest
+//   - task already terminal → response carries the terminal state with no error
+func (s *Service) CancelInjection(ctx context.Context, injectionID int) (*CancelInjectionResp, error) {
+	injection, err := s.repo.loadInjection(injectionID)
+	if err != nil {
+		if errors.Is(err, consts.ErrNotFound) {
+			return nil, fmt.Errorf("%w: injection id: %d", consts.ErrNotFound, injectionID)
+		}
+		return nil, fmt.Errorf("failed to load injection: %w", err)
+	}
+	if injection.TaskID == nil || *injection.TaskID == "" {
+		return nil, fmt.Errorf("%w: injection %d has no associated task to cancel", consts.ErrBadRequest, injectionID)
+	}
+	if s.taskCanceller == nil {
+		return nil, fmt.Errorf("task canceller is not wired")
+	}
+
+	result, err := s.taskCanceller.CancelTask(ctx, *injection.TaskID)
+	if err != nil {
+		return nil, err
+	}
+	return &CancelInjectionResp{
+		InjectionID:       injectionID,
+		TaskID:            result.TaskID,
+		State:             result.State,
+		Message:           result.Message,
+		DeletedPodChaos:   result.DeletedPodChaos,
+		RemovedRedisTasks: result.RemovedRedisTasks,
+	}, nil
 }
 
 func splitLabelCondition(item string) [2]string {

--- a/aegislab/src/core/domain/injection/service_test.go
+++ b/aegislab/src/core/domain/injection/service_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestServiceSearchNilRequest(t *testing.T) {
-	service := NewService(nil, nil, nil, nil, nil, nil, nil, nil)
+	service := NewService(nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	_, err := service.Search(t.Context(), nil, nil)
 
@@ -16,7 +16,7 @@ func TestServiceSearchNilRequest(t *testing.T) {
 }
 
 func TestServiceListNoIssuesEmptyLabelsSucceeds(t *testing.T) {
-	service := NewService(nil, nil, nil, nil, nil, nil, nil, nil)
+	service := NewService(nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	resp, err := service.ListNoIssues(t.Context(), &ListInjectionNoIssuesReq{}, nil)
 

--- a/aegislab/src/core/domain/task/api_types.go
+++ b/aegislab/src/core/domain/task/api_types.go
@@ -10,6 +10,17 @@ import (
 	"aegis/platform/utils"
 )
 
+// CancelTaskResp describes the outcome of a best-effort task cancellation.
+// All slice fields are optional so partial success renders cleanly. Mirrors
+// the trace-level CancelTraceResp but scoped to a single task_id.
+type CancelTaskResp struct {
+	TaskID            string   `json:"task_id,omitempty"`
+	State             string   `json:"state,omitempty"`
+	Message           string   `json:"message,omitempty"`
+	DeletedPodChaos   []string `json:"deleted_podchaos,omitempty"`
+	RemovedRedisTasks []string `json:"removed_redis_tasks,omitempty"`
+}
+
 // BatchDeleteTaskReq represents the request to batch delete tasks.
 type BatchDeleteTaskReq struct {
 	IDs []string `json:"ids" binding:"required"`

--- a/aegislab/src/core/domain/task/handler.go
+++ b/aegislab/src/core/domain/task/handler.go
@@ -137,6 +137,38 @@ func (h *Handler) ExpediteTask(c *gin.Context) {
 	dto.SuccessResponse(c, resp)
 }
 
+// CancelTask handles best-effort cancellation of a single task.
+//
+//	@Summary		Cancel a task (best-effort)
+//	@Description	Marks the task as Cancelled if it is currently Pending/Rescheduled/Running, evicts its entry from the redis queues, and best-effort deletes any chaos CRDs labelled with task_id=<id>. Returns 200 with a no-op response when the task is already terminal.
+//	@Tags			Tasks
+//	@ID				cancel_task
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			task_id	path		string									true	"Task ID"
+//	@Success		200		{object}	dto.GenericResponse[CancelTaskResp]		"Task cancelled (or already terminal)"
+//	@Failure		400		{object}	dto.GenericResponse[any]				"Invalid task ID"
+//	@Failure		401		{object}	dto.GenericResponse[any]				"Authentication required"
+//	@Failure		403		{object}	dto.GenericResponse[any]				"Permission denied"
+//	@Failure		404		{object}	dto.GenericResponse[any]				"Task not found"
+//	@Failure		500		{object}	dto.GenericResponse[any]				"Internal server error"
+//	@Router			/api/v2/tasks/{task_id}/cancel [post]
+//	@x-api-type		{"portal":"true"}
+func (h *Handler) CancelTask(c *gin.Context) {
+	taskID := c.Param(consts.URLPathTaskID)
+	if !utils.IsValidUUID(taskID) {
+		dto.ErrorResponse(c, http.StatusBadRequest, "Invalid task ID")
+		return
+	}
+
+	resp, err := h.service.CancelTask(c.Request.Context(), taskID)
+	if httpx.HandleServiceError(c, err) {
+		return
+	}
+
+	dto.SuccessResponse(c, resp)
+}
+
 // ListTasks handles simple task listing
 //
 //	@Summary		List tasks

--- a/aegislab/src/core/domain/task/handler_service.go
+++ b/aegislab/src/core/domain/task/handler_service.go
@@ -17,6 +17,7 @@ type HandlerService interface {
 	GetForLogStream(context.Context, string) (*model.Task, error)
 	StreamLogs(context.Context, *websocket.Conn, *model.Task)
 	Expedite(context.Context, string) (*dto.TaskResp, error)
+	CancelTask(context.Context, string) (*CancelTaskResp, error)
 }
 
 func AsHandlerService(service *Service) HandlerService {

--- a/aegislab/src/core/domain/task/repository.go
+++ b/aegislab/src/core/domain/task/repository.go
@@ -51,6 +51,17 @@ func (r *Repository) UpdateExecuteTime(taskID string, executeTime int64) error {
 		Update("execute_time", executeTime).Error
 }
 
+// MarkCancelled transitions a single non-terminal task to the Cancelled
+// terminal state. No-op if the row is already terminal — caller decides
+// whether to surface that as 200 or 409.
+func (r *Repository) MarkCancelled(taskID string) error {
+	return r.db.Model(&model.Task{}).
+		Where("id = ? AND status != ? AND state IN ?",
+			taskID, consts.CommonDeleted,
+			[]consts.TaskState{consts.TaskPending, consts.TaskRescheduled, consts.TaskRunning}).
+		Update("state", consts.TaskCancelled).Error
+}
+
 func (r *Repository) List(limit, offset int, filters *ListTaskFilters) ([]model.Task, int64, error) {
 	var (
 		tasks []model.Task

--- a/aegislab/src/core/domain/task/routes.go
+++ b/aegislab/src/core/domain/task/routes.go
@@ -25,6 +25,7 @@ func RoutesPortal(handler *Handler) framework.RouteRegistrar {
 
 				tasks.POST("/batch-delete", middleware.RequireTaskDelete, handler.BatchDelete)
 				tasks.POST("/:task_id/expedite", middleware.RequireTaskExecute, handler.ExpediteTask)
+				tasks.POST("/:task_id/cancel", middleware.RequireTaskStop, handler.CancelTask)
 			}
 		},
 	}

--- a/aegislab/src/core/domain/task/service.go
+++ b/aegislab/src/core/domain/task/service.go
@@ -8,8 +8,9 @@ import (
 
 	"aegis/platform/consts"
 	"aegis/platform/dto"
-	redisinfra "aegis/platform/redis"
+	k8sinfra "aegis/platform/k8s"
 	"aegis/platform/model"
+	redisinfra "aegis/platform/redis"
 
 	"github.com/gorilla/websocket"
 	"github.com/sirupsen/logrus"
@@ -21,14 +22,16 @@ type Service struct {
 	logService *TaskLogService
 	loki       *LokiGateway
 	redis      *redisinfra.Gateway
+	k8s        *k8sinfra.Gateway
 }
 
-func NewService(repository *Repository, logService *TaskLogService, loki *LokiGateway, redis *redisinfra.Gateway) *Service {
+func NewService(repository *Repository, logService *TaskLogService, loki *LokiGateway, redis *redisinfra.Gateway, k8s *k8sinfra.Gateway) *Service {
 	return &Service{
 		repository: repository,
 		logService: logService,
 		loki:       loki,
 		redis:      redis,
+		k8s:        k8s,
 	}
 }
 
@@ -139,6 +142,83 @@ func (s *Service) emitExpediteScheduledEvent(ctx context.Context, task *model.Ta
 		logrus.WithField("task_id", task.ID).
 			Warnf("failed to emit expedite task.scheduled event: %v", err)
 	}
+}
+
+// CancelTask marks a non-terminal task as Cancelled and best-effort evicts
+// its redis queue entries + cluster-side PodChaos CRDs labelled with
+// task_id=<id>. Mirrors trace.Service.CancelTrace but scoped to a single
+// task — used by the UI when only one execution/injection needs to stop.
+//
+// Contract:
+//   - task not found → wrapped consts.ErrNotFound
+//   - task already terminal (Completed/Error/Cancelled) → no-op response
+//     with state set to the current terminal state, no error
+//   - otherwise: DB state → Cancelled, redis queue entries best-effort
+//     evicted, PodChaos with label task_id=<id> best-effort deleted
+func (s *Service) CancelTask(ctx context.Context, taskID string) (*CancelTaskResp, error) {
+	task, err := s.repository.GetByID(taskID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("%w: task id: %s", consts.ErrNotFound, taskID)
+		}
+		return nil, fmt.Errorf("failed to load task: %w", err)
+	}
+
+	logEntry := logrus.WithField("task_id", taskID)
+
+	switch task.State {
+	case consts.TaskCompleted, consts.TaskError, consts.TaskCancelled:
+		return &CancelTaskResp{
+			TaskID: taskID,
+			State:  consts.GetTaskStateName(task.State),
+			Message: fmt.Sprintf("task already terminal (%s); nothing to cancel",
+				consts.GetTaskStateName(task.State)),
+		}, nil
+	}
+
+	if err := s.repository.MarkCancelled(taskID); err != nil {
+		return nil, fmt.Errorf("failed to mark task cancelled: %w", err)
+	}
+
+	resp := &CancelTaskResp{
+		TaskID: taskID,
+		State:  consts.GetTaskStateName(consts.TaskCancelled),
+	}
+
+	if s.redis != nil {
+		removed := false
+		if ok := s.redis.RemoveFromZSet(ctx, redisinfra.DelayedQueueKey, taskID); ok {
+			removed = true
+		}
+		if ok, err := s.redis.RemoveFromList(ctx, redisinfra.ReadyQueueKey, taskID); err == nil && ok {
+			removed = true
+		} else if err != nil {
+			logEntry.Warnf("failed to remove task from ready queue: %v", err)
+		}
+		if ok := s.redis.RemoveFromZSet(ctx, redisinfra.DeadLetterKey, taskID); ok {
+			removed = true
+		}
+		if err := s.redis.DeleteTaskIndex(ctx, taskID); err != nil {
+			logEntry.Warnf("failed to clear task index: %v", err)
+		}
+		if removed {
+			resp.RemovedRedisTasks = append(resp.RemovedRedisTasks, taskID)
+		}
+	}
+
+	if s.k8s != nil {
+		deleted, warnings := s.k8s.DeleteChaosCRDsByLabel(ctx, consts.JobLabelTaskID, taskID)
+		for _, d := range deleted {
+			resp.DeletedPodChaos = append(resp.DeletedPodChaos, d.Name)
+		}
+		for _, w := range warnings {
+			logEntry.Warnf("chaos CRD cleanup warning: %v", w)
+		}
+	}
+
+	resp.Message = fmt.Sprintf("cancelled task %s (podchaos=%d, redis_evicted=%d)",
+		taskID, len(resp.DeletedPodChaos), len(resp.RemovedRedisTasks))
+	return resp, nil
 }
 
 func (s *Service) GetForLogStream(ctx context.Context, taskID string) (*model.Task, error) {

--- a/aegislab/src/core/domain/task/service_test.go
+++ b/aegislab/src/core/domain/task/service_test.go
@@ -36,7 +36,7 @@ func newTaskService(t *testing.T, gateway *LokiGateway) (*Service, sqlmock.Sqlmo
 		gateway = NewLokiGateway(&lokiinfra.Client{})
 	}
 
-	service := NewService(NewRepository(db), NewTaskLogService(NewRepository(db), nil, gateway), gateway, nil)
+	service := NewService(NewRepository(db), NewTaskLogService(NewRepository(db), nil, gateway), gateway, nil, nil)
 	return service, mock, func() {
 		_ = sqlDB.Close()
 	}

--- a/aegislab/src/crud/iam/project/api_types.go
+++ b/aegislab/src/crud/iam/project/api_types.go
@@ -117,12 +117,13 @@ func (req *ManageProjectLabelReq) Validate() error {
 
 // ProjectResp represents basic project response.
 type ProjectResp struct {
-	ID        int       `json:"id"`
-	Name      string    `json:"name"`
-	IsPublic  bool      `json:"is_public"`
-	Status    string    `json:"status"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID          int       `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	IsPublic    bool      `json:"is_public"`
+	Status      string    `json:"status"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
 
 	LastInjectionAt *time.Time      `json:"last_injection_at,omitempty"`
 	LastExecutionAt *time.Time      `json:"last_execution_at,omitempty"`
@@ -133,12 +134,13 @@ type ProjectResp struct {
 
 func NewProjectResp(project *model.Project, stats *dto.ProjectStatistics) *ProjectResp {
 	resp := &ProjectResp{
-		ID:        project.ID,
-		Name:      project.Name,
-		IsPublic:  project.IsPublic,
-		Status:    consts.GetStatusTypeName(project.Status),
-		CreatedAt: project.CreatedAt,
-		UpdatedAt: project.UpdatedAt,
+		ID:          project.ID,
+		Name:        project.Name,
+		Description: project.Description,
+		IsPublic:    project.IsPublic,
+		Status:      consts.GetStatusTypeName(project.Status),
+		CreatedAt:   project.CreatedAt,
+		UpdatedAt:   project.UpdatedAt,
 	}
 
 	if stats != nil {

--- a/aegislab/src/crud/observability/evaluation/handler.go
+++ b/aegislab/src/crud/observability/evaluation/handler.go
@@ -35,7 +35,7 @@ func NewHandler(service HandlerService) *Handler {
 //	@Failure		403		{object}	dto.GenericResponse[any]						"Permission denied"
 //	@Failure		500		{object}	dto.GenericResponse[any]						"Internal server error"
 //	@Router			/api/v2/evaluations/datapacks [post]
-//	@x-api-type		{"sdk":"true"}
+//	@x-api-type		{"portal":"true","sdk":"true"}
 func (h *Handler) ListDatapackEvaluationResults(c *gin.Context) {
 	userID, exists := middleware.GetCurrentUserID(c)
 	if !exists || userID <= 0 {
@@ -78,7 +78,7 @@ func (h *Handler) ListDatapackEvaluationResults(c *gin.Context) {
 //	@Failure		403		{object}	dto.GenericResponse[any]						"Permission denied"
 //	@Failure		500		{object}	dto.GenericResponse[any]						"Internal server error"
 //	@Router			/api/v2/evaluations/datasets [post]
-//	@x-api-type		{"sdk":"true"}
+//	@x-api-type		{"portal":"true","sdk":"true"}
 func (h *Handler) ListDatasetEvaluationResults(c *gin.Context) {
 	userID, exists := middleware.GetCurrentUserID(c)
 	if !exists || userID <= 0 {
@@ -120,7 +120,7 @@ func (h *Handler) ListDatasetEvaluationResults(c *gin.Context) {
 //	@Failure		401		{object}	dto.GenericResponse[any]							"Authentication required"
 //	@Failure		500		{object}	dto.GenericResponse[any]							"Internal server error"
 //	@Router			/api/v2/evaluations [get]
-//	@x-api-type		{"sdk":"true"}
+//	@x-api-type		{"portal":"true","sdk":"true"}
 func (h *Handler) ListEvaluations(c *gin.Context) {
 	var req ListEvaluationReq
 	if err := c.ShouldBindQuery(&req); err != nil {
@@ -155,7 +155,7 @@ func (h *Handler) ListEvaluations(c *gin.Context) {
 //	@Failure		404	{object}	dto.GenericResponse[any]			"Evaluation not found"
 //	@Failure		500	{object}	dto.GenericResponse[any]			"Internal server error"
 //	@Router			/api/v2/evaluations/{id} [get]
-//	@x-api-type		{"sdk":"true"}
+//	@x-api-type		{"portal":"true","sdk":"true"}
 func (h *Handler) GetEvaluation(c *gin.Context) {
 	id, ok := httpx.ParsePositiveID(c, c.Param(consts.URLPathID), "evaluation ID")
 	if !ok {


### PR DESCRIPTION
## Summary

Rolls up three independent backend branches that close the portal-SDK gaps surfaced during the aegis-ui wiring pass. Each gap is a small, targeted commit kept in this branch's history for review; the rollup will be squash-merged.

### 1. Evaluations swagger audience (`f6fd11ed`)
Four evaluation handlers were emitting the wrong `@x-api-type` tag (`{"sdk":"true"}` instead of `{"portal":"true","sdk":"true"}`), so they never landed in `@lincyaw/portal`. Fixes annotations only — no behavior change.

### 2. Dashboard aggregate (`233cf560`)
New `GET /api/v2/projects/:id/dashboard` returning `{project, counts, recent_injections, recent_executions, recent_traces, updated_at}`. Each count reuses the existing per-domain list service's `pagination.Total` (one `COUNT(*)` + `LIMIT 10` per resource), so the recent rows and totals share a query path. Replaces a 4-query fan-out from the portal dashboard page.

Deviation from sketch: `datasets_total` dropped (datasets aren't project-scoped, would cross a domain boundary); `traces_total` added since traces are already project-scoped and the recent_traces panel needs it.

### 3. List executions + cancel endpoints (`d779b3a8`)
- `GET /api/v2/executions` — exposes the previously-orphan `service.ListExecutions` to the portal, with `project_id` filtering joined through `tasks→traces`.
- `POST /api/v2/tasks/:task_id/cancel` — DB state flip + redis queue cleanup + chaos-CRD delete by `task_id` label, mirroring existing `trace.CancelTrace`.
- `POST /api/v2/injections/:id/cancel` — resolves `injection.task_id` then delegates to the new task cancel; bridged via a narrow `injection.TaskCanceller` seam in `boot/http_modules.go` to avoid an injection→task import cycle.
- `ProjectResp.description` populated from the existing DB column.

## Why one PR, not three

These three branches collectively unblock the portal pages currently falling back to ClickHouse / `apiFetch` / per-resource fan-out. Shipping them together lets the consumer (`aegis-ui` PR #1) bump SDK + rewire pages in a single pass instead of three.

Umbrella issue: OperationsPAI/aegis#408 (covers the contracts/inject-points design that's *not* in this PR — pure backend wiring gaps only).

## Test plan
- [ ] `go build -tags duckdb_arrow ./...` from `aegislab/src`
- [ ] `go test ./core/domain/{execution,task,injection,dashboard}/...`
- [ ] `just swagger-init` regenerates `docs/openapi2/swagger.json` cleanly with all 3 new operations + the 4 evaluation operations now flagged for portal
- [ ] After merge: `just generate-portal 1.5.0` + npm publish, then bump consumer to `^1.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)