### PR TITLE
fix(injection): map not-ready / missing-datapack to 404

### DIFF
--- a/aegislab/src/core/domain/injection/datapack_store.go
+++ b/aegislab/src/core/domain/injection/datapack_store.go
@@ -80,7 +80,7 @@ func (s *FilesystemDatapackStore) BuildFileTree(datapackName, baseURL string, da
 		return nil, fmt.Errorf("invalid path access to %s", workDir)
 	}
 	if _, err := os.Stat(workDir); os.IsNotExist(err) {
-		return nil, fmt.Errorf("datapack directory not found for datapack id %d", datapackID)
+		return nil, fmt.Errorf("%w: datapack directory not found for datapack id %d", consts.ErrNotFound, datapackID)
 	}
 
 	resp := &DatapackFilesResp{

--- a/aegislab/src/core/domain/injection/datapack_store_s3.go
+++ b/aegislab/src/core/domain/injection/datapack_store_s3.go
@@ -119,7 +119,7 @@ func (s *S3DatapackStore) BuildFileTree(datapackName, baseURL string, datapackID
 		return nil, fmt.Errorf("failed to probe datapack %s: %w", datapackName, err)
 	}
 	if len(probe.Objects) == 0 && len(probe.CommonPrefixes) == 0 {
-		return nil, fmt.Errorf("datapack directory not found for datapack id %d", datapackID)
+		return nil, fmt.Errorf("%w: datapack directory not found for datapack id %d", consts.ErrNotFound, datapackID)
 	}
 
 	resp := &DatapackFilesResp{Files: []DatapackFileItem{}}

--- a/aegislab/src/core/domain/injection/query_datapack_arrow.go
+++ b/aegislab/src/core/domain/injection/query_datapack_arrow.go
@@ -5,6 +5,7 @@ package injection
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -196,10 +197,19 @@ func sanitizeViewName(raw string) string {
 func (s *Service) getDatapackSchema(ctx context.Context, id int) (*DatapackSchemaResp, error) {
 	injection, err := s.getReadyDatapack(id)
 	if err != nil {
+		// Not-ready datapack is a normal pre-data state for the SQL editor;
+		// return an empty schema instead of bubbling 404 so the page can
+		// show "no tables yet" rather than an error.
+		if errors.Is(err, consts.ErrNotFound) {
+			return &DatapackSchemaResp{Tables: []DatapackTableSchema{}}, nil
+		}
 		return nil, err
 	}
 	parquets, err := s.listDatapackParquets(injection.Name)
 	if err != nil {
+		if errors.Is(err, consts.ErrNotFound) {
+			return &DatapackSchemaResp{Tables: []DatapackTableSchema{}}, nil
+		}
 		return nil, err
 	}
 	if len(parquets) == 0 {

--- a/aegislab/src/core/domain/injection/service.go
+++ b/aegislab/src/core/domain/injection/service.go
@@ -1228,7 +1228,7 @@ func (s *Service) getReadyDatapack(id int) (*model.FaultInjection, error) {
 		return nil, fmt.Errorf("failed to get injection: %w", err)
 	}
 	if injection.State < consts.DatapackBuildSuccess {
-		return nil, fmt.Errorf("datapack %d is not ready", id)
+		return nil, fmt.Errorf("%w: datapack %d is not ready", consts.ErrNotFound, id)
 	}
 	return injection, nil
 }


### PR DESCRIPTION
Follow-up to #414. After deploy, smoke test of /api/v2/injections/:id/datapack-schema returned 500 because:

- \`getReadyDatapack\` wrapped the raw \"datapack N is not ready\" string with neither sentinel nor format verb — \`HandleServiceError\` default-cased it to 500.
- \`S3DatapackStore.BuildFileTree\` and \`FilesystemDatapackStore.BuildFileTree\` did the same with \"datapack directory not found\".

Both should be 404 (Swagger already documents 404 for these cases).

Also: in \`GetDatapackSchema\`, when the datapack isn't ready OR the blob is empty, return \`{tables:[]}\` 200 instead of 404. The SQL-editor empty state can then render \"no tables yet\" cleanly without distinguishing 404 from genuine errors in the frontend.

Adjacent benefit: existing /files, /files/download, /files/query handlers also stop 500ing on not-ready datapacks — they now 404 correctly through the same \`getReadyDatapack\` shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)