### PR TITLE
chore(byte-cluster): bump rcabench to byte-20260517-datapack-query-r3

### DIFF
--- a/aegislab/manifests/byte-cluster/frontend.values.yaml
+++ b/aegislab/manifests/byte-cluster/frontend.values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: pair-cn-shanghai.cr.volces.com/opspai/rcabench-frontend
-  tag: byte-20260516-blob-detail-r14
+  tag: byte-20260517-datapack-query-r36
   pullPolicy: IfNotPresent
 
 # Frontend's own nginx /api proxy is unused on byte-cluster (edge-proxy

--- a/aegislab/manifests/byte-cluster/rcabench.values.yaml
+++ b/aegislab/manifests/byte-cluster/rcabench.values.yaml
@@ -12,7 +12,7 @@ global:
   images:
     rcabench:
       name: pair-cn-shanghai.cr.volces.com/opspai/rcabench
-      tag: byte-20260517-sdk-1.5.0-pages-r3
+      tag: byte-20260517-datapack-query-r3
       pullPolicy: IfNotPresent
 
 # Dev intercept anchors. Enabled on byte-cluster so developers can run


### PR DESCRIPTION
Bump byte-cluster manifests to the new images shipped by #414 + #415.

- backend r3: datapack-query/datapack-schema endpoints, observation removal, 404 mapping for not-ready datapacks
- frontend r36: console Data tab using the new endpoints

Already pushed to docker.io/opspai. After merge the next argocd/helm sync picks up the new tags; this PR meanwhile applied via local `helm upgrade` to roll out immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)