### PR TITLE
chore(byte-cluster): bump rcabench to byte-20260517-datapack-query-r4

### DIFF
--- a/aegislab/manifests/byte-cluster/rcabench.values.yaml
+++ b/aegislab/manifests/byte-cluster/rcabench.values.yaml
@@ -12,7 +12,7 @@ global:
   images:
     rcabench:
       name: pair-cn-shanghai.cr.volces.com/opspai/rcabench
-      tag: byte-20260517-datapack-query-r3
+      tag: byte-20260517-datapack-query-r4
       pullPolicy: IfNotPresent
 
 # Dev intercept anchors. Enabled on byte-cluster so developers can run


### PR DESCRIPTION
Rebuild on top of #416 to reconcile against the parallel pages-perms-r2 rollout that overwrote r2 on the cluster. Identical code (main HEAD 2188758b), new tag, already pushed + helm-upgraded locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)