### PR TITLE
fix(injection): read parquets via presigned URL + DuckDB httpfs

### DIFF
--- a/aegislab/src/core/domain/injection/datapack_storage.go
+++ b/aegislab/src/core/domain/injection/datapack_storage.go
@@ -2,8 +2,10 @@ package injection
 
 import (
 	"archive/zip"
+	"context"
 	"io"
 	"os"
+	"time"
 
 	"aegis/platform/model"
 	"aegis/platform/utils"
@@ -19,6 +21,11 @@ type DatapackStorage interface {
 	BuildFileTree(datapackName, baseURL string, datapackID int) (*DatapackFilesResp, error)
 	OpenFile(datapackName, filePath string) (string, string, int64, io.ReadSeekCloser, error)
 	ResolveFilePath(datapackName, filePath string) (string, error)
+	// ParquetReaderPath returns a path/URL usable inside DuckDB's
+	// read_parquet(). Filesystem backends return an absolute local path;
+	// S3-backed backends return a short-lived presigned HTTPS URL ready
+	// for the `httpfs` extension. TTL must outlive the query.
+	ParquetReaderPath(ctx context.Context, datapackName, filePath string, ttl time.Duration) (string, error)
 	CreateUploadTempFile() (*os.File, error)
 	ValidateArchive(zipPath string) error
 	EnsureDatapackDirAvailable(datapackName string) (string, error)

--- a/aegislab/src/core/domain/injection/datapack_store.go
+++ b/aegislab/src/core/domain/injection/datapack_store.go
@@ -2,6 +2,7 @@ package injection
 
 import (
 	"archive/zip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	blobclient "aegis/clients/blob"
 	"aegis/platform/config"
@@ -141,6 +143,10 @@ func (s *FilesystemDatapackStore) OpenFile(datapackName, filePath string) (strin
 }
 
 func (s *FilesystemDatapackStore) ResolveFilePath(datapackName, filePath string) (string, error) {
+	return s.resolveFilePath(datapackName, filePath)
+}
+
+func (s *FilesystemDatapackStore) ParquetReaderPath(_ context.Context, datapackName, filePath string, _ time.Duration) (string, error) {
 	return s.resolveFilePath(datapackName, filePath)
 }
 

--- a/aegislab/src/core/domain/injection/datapack_store_s3.go
+++ b/aegislab/src/core/domain/injection/datapack_store_s3.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	blobclient "aegis/clients/blob"
 	"aegis/platform/consts"
@@ -268,6 +269,28 @@ func guessContentTypeByExt(name string) string {
 
 func (s *S3DatapackStore) ResolveFilePath(datapackName, filePath string) (string, error) {
 	return s.resolveKey(datapackName, filePath)
+}
+
+// ParquetReaderPath returns a presigned HTTPS URL pointing at the object.
+// DuckDB's httpfs extension can `read_parquet()` it directly. TTL must
+// outlast the query — 10 minutes is a sensible default for one-shot
+// schema-and-query usage; for connections that run multiple sequential
+// queries against the same VIEW, set a longer TTL.
+func (s *S3DatapackStore) ParquetReaderPath(ctx context.Context, datapackName, filePath string, ttl time.Duration) (string, error) {
+	key, err := s.resolveKey(datapackName, filePath)
+	if err != nil {
+		return "", err
+	}
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+	presigned, err := s.client.PresignGet(ctx, s.bucket, key, blobclient.PresignGetReq{
+		TTLSeconds: int(ttl.Seconds()),
+	})
+	if err != nil {
+		return "", fmt.Errorf("%w: presign %s/%s: %v", consts.ErrNotFound, datapackName, filePath, err)
+	}
+	return presigned.URL, nil
 }
 
 func (s *S3DatapackStore) resolveKey(datapackName, filePath string) (string, error) {

--- a/aegislab/src/core/domain/injection/query_datapack_arrow.go
+++ b/aegislab/src/core/domain/injection/query_datapack_arrow.go
@@ -5,12 +5,14 @@ package injection
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"aegis/platform/consts"
 
@@ -25,15 +27,15 @@ func (s *Service) queryDatapackFileContent(ctx context.Context, id int, filePath
 		return "", 0, nil, err
 	}
 
-	fullPath, err := s.store.ResolveFilePath(injection.Name, filePath)
-	if err != nil {
-		return "", 0, nil, fmt.Errorf("invalid file path: %w", err)
-	}
-	if filepath.Ext(fullPath) != ".parquet" {
+	if filepath.Ext(filePath) != ".parquet" {
 		return "", 0, nil, fmt.Errorf("file is not a parquet file: %s", filePath)
 	}
+	fullPath, err := s.store.ParquetReaderPath(ctx, injection.Name, filePath, 15*time.Minute)
+	if err != nil {
+		return "", 0, nil, fmt.Errorf("resolve parquet: %w", err)
+	}
 
-	connector, err := duckdb.NewConnector("", nil)
+	connector, err := newDuckDBConnector()
 	if err != nil {
 		return "", 0, nil, err
 	}
@@ -149,8 +151,10 @@ type datapackParquet struct {
 }
 
 // listDatapackParquets enumerates parquet files that actually exist in the
-// datapack root. Missing files are silently skipped — that is data, not error.
-func (s *Service) listDatapackParquets(injectionName string) ([]datapackParquet, error) {
+// datapack root and resolves each to a DuckDB-readable path (filesystem
+// path for local stores, presigned HTTPS URL for S3-backed stores).
+// Missing files are silently skipped — that is data, not error.
+func (s *Service) listDatapackParquets(ctx context.Context, injectionName string) ([]datapackParquet, error) {
 	tree, err := s.store.BuildFileTree(injectionName, "", 0)
 	if err != nil {
 		return nil, err
@@ -168,7 +172,9 @@ func (s *Service) listDatapackParquets(injectionName string) ([]datapackParquet,
 		if view == "" {
 			continue
 		}
-		resolved, err := s.store.ResolveFilePath(injectionName, item.Path)
+		// 15-minute TTL covers schema describe + count(*) + several
+		// follow-up user queries against the same VIEW in this connection.
+		resolved, err := s.store.ParquetReaderPath(ctx, injectionName, item.Path, 15*time.Minute)
 		if err != nil {
 			// Existence was just confirmed by BuildFileTree; a resolve failure
 			// here is genuinely abnormal and worth surfacing.
@@ -178,6 +184,24 @@ func (s *Service) listDatapackParquets(injectionName string) ([]datapackParquet,
 		out = append(out, datapackParquet{view: view, file: item.Path, path: resolved})
 	}
 	return out, nil
+}
+
+// newDuckDBConnector returns a duckdb connector whose init callback
+// loads the httpfs extension on every new connection. DuckDB extensions
+// are per-connection, so this must run before any read_parquet() against
+// an HTTPS URL (the S3-backed presigned URLs we hand out).
+func newDuckDBConnector() (*duckdb.Connector, error) {
+	return duckdb.NewConnector("", func(execer driver.ExecerContext) error {
+		for _, stmt := range []string{
+			"INSTALL httpfs",
+			"LOAD httpfs",
+		} {
+			if _, err := execer.ExecContext(context.Background(), stmt, nil); err != nil {
+				return fmt.Errorf("duckdb init %s: %w", stmt, err)
+			}
+		}
+		return nil
+	})
 }
 
 var viewNameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
@@ -205,7 +229,7 @@ func (s *Service) getDatapackSchema(ctx context.Context, id int) (*DatapackSchem
 		}
 		return nil, err
 	}
-	parquets, err := s.listDatapackParquets(injection.Name)
+	parquets, err := s.listDatapackParquets(ctx, injection.Name)
 	if err != nil {
 		if errors.Is(err, consts.ErrNotFound) {
 			return &DatapackSchemaResp{Tables: []DatapackTableSchema{}}, nil
@@ -216,7 +240,7 @@ func (s *Service) getDatapackSchema(ctx context.Context, id int) (*DatapackSchem
 		return &DatapackSchemaResp{Tables: []DatapackTableSchema{}}, nil
 	}
 
-	connector, err := duckdb.NewConnector("", nil)
+	connector, err := newDuckDBConnector()
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +355,7 @@ func (s *Service) runDatapackQuery(ctx context.Context, id int, userSQL string) 
 	if err != nil {
 		return nil, err
 	}
-	parquets, err := s.listDatapackParquets(injection.Name)
+	parquets, err := s.listDatapackParquets(ctx, injection.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -339,17 +363,12 @@ func (s *Service) runDatapackQuery(ctx context.Context, id int, userSQL string) 
 		return nil, fmt.Errorf("%w: datapack has no parquet files", consts.ErrNotFound)
 	}
 
-	connector, err := duckdb.NewConnector("", nil)
+	connector, err := newDuckDBConnector()
 	if err != nil {
 		return nil, err
 	}
 
-	// Prepare an isolated connection: register VIEWs, then disable external
-	// access so the user SQL can only see what we exposed.
-	setupConn, err := connector.Connect(ctx)
-	if err != nil {
-		return nil, err
-	}
+	// Register VIEWs (httpfs is loaded by the connector init for every conn).
 	setupDB := sql.OpenDB(connector)
 	for _, p := range parquets {
 		stmt := fmt.Sprintf(
@@ -357,12 +376,10 @@ func (s *Service) runDatapackQuery(ctx context.Context, id int, userSQL string) 
 			quoteIdent(p.view), p.path,
 		)
 		if _, err := setupDB.ExecContext(ctx, stmt); err != nil {
-			_ = setupConn.Close()
 			_ = setupDB.Close()
 			return nil, fmt.Errorf("failed to register view %s: %w", p.view, err)
 		}
 	}
-	_ = setupConn.Close()
 	_ = setupDB.Close()
 
 	pr, pw := io.Pipe()


### PR DESCRIPTION
Follow-up to #414 and #415. After deploying r3, smoke testing /datapack-schema against injections that DO have parquets in blob (e.g. id 20) returned empty tables. Backend logs showed DuckDB failing:

\`\`\`
DESCRIBE SELECT * FROM read_parquet('otel-demo3-cart-pod-kill-8lbwrf/abnormal_traces.parquet')
→ IO Error: No files found that match the pattern
\`\`\`

\`S3DatapackStore.ResolveFilePath\` returns a bare S3 key, which DuckDB has no way to dereference — no \`httpfs\` extension loaded, no S3 credentials configured. The whole parquet-querying surface (\`/files/query\`, \`/datapack-schema\`, \`/datapack-query\`) was broken on S3-backed clusters, predating #414.

### Approach: presigned URL + httpfs

- New \`DatapackStorage.ParquetReaderPath(ctx, name, file, ttl)\` returns
  - filesystem backend: absolute local path
  - S3 backend: a short-lived presigned HTTPS URL via \`blobclient.PresignGet\`
- \`newDuckDBConnector()\` installs+loads the \`httpfs\` extension on every new connection (via duckdb-go's init callback) so \`read_parquet('https://...')\` works.
- All three query paths (\`queryDatapackFileContent\`, \`getDatapackSchema\`, \`runDatapackQuery\`) now go through \`ParquetReaderPath\` + \`newDuckDBConnector()\`.

### Why presigned URL, not DuckDB S3 secret

- Doesn't require DuckDB to learn rustfs endpoint / creds — respects the existing blob client abstraction
- Works identically for any S3-compatible backend (rustfs / MinIO / AWS S3 / volces TOS)
- TTL-bounded access
- One small downside: presigned URL must outlive the query. 15 min default covers schema-describe + count + several follow-up VIEW queries on the same connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)