### PR TITLE
fix(injection): keep DuckDB in-memory db alive across setup+query

### DIFF
--- a/aegislab/src/core/domain/injection/query_datapack_arrow.go
+++ b/aegislab/src/core/domain/injection/query_datapack_arrow.go
@@ -374,6 +374,16 @@ func (s *Service) runDatapackQuery(ctx context.Context, id int, userSQL string) 
 		return nil, err
 	}
 
+	// Reserve one connection up front. The in-memory DuckDB database lives
+	// only as long as at least one connection from this connector is open;
+	// without a keeper, closing setupDB below would destroy the database
+	// before the goroutine's query connection can open, surfacing as
+	// "could not connect to database".
+	keeperConn, err := connector.Connect(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("duckdb keeper connect: %w", err)
+	}
+
 	// Register VIEWs (httpfs is loaded by the connector init for every conn).
 	setupDB := sql.OpenDB(connector)
 	for _, p := range parquets {
@@ -383,6 +393,7 @@ func (s *Service) runDatapackQuery(ctx context.Context, id int, userSQL string) 
 		)
 		if _, err := setupDB.ExecContext(ctx, stmt); err != nil {
 			_ = setupDB.Close()
+			_ = keeperConn.Close()
 			return nil, fmt.Errorf("failed to register view %s: %w", p.view, err)
 		}
 	}
@@ -391,6 +402,7 @@ func (s *Service) runDatapackQuery(ctx context.Context, id int, userSQL string) 
 	pr, pw := io.Pipe()
 	go func() {
 		defer func() { _ = pw.Close() }()
+		defer func() { _ = keeperConn.Close() }()
 
 		conn, err := connector.Connect(ctx)
 		if err != nil {


### PR DESCRIPTION
Follow-up to #418/#419/#420. After all those landed, /datapack-query was reaching 200 but with empty Arrow stream; backend log showed:

```
failed to stream query result: connect failed:
database/sql/driver: could not connect to database
```

`runDatapackQuery` created VIEWs via a sql.DB pool, closed it, then opened a fresh connection for the actual Arrow query. The in-memory DuckDB database is reference-counted by the connector — closing setupDB released the last connection, destroying the DB, so the next `Connect()` returned the error above. Reserve a keeper connection before the setup pool and only close it after the goroutine finishes streaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)