### PR TITLE
fix(injection): write Arrow IPC uncompressed (browser codec mismatch)

### DIFF
--- a/aegislab/src/core/domain/injection/query_datapack_arrow.go
+++ b/aegislab/src/core/domain/injection/query_datapack_arrow.go
@@ -84,7 +84,7 @@ func (s *Service) queryDatapackFileContent(ctx context.Context, id int, filePath
 		}
 		defer rdr.Release()
 
-		writer := ipc.NewWriter(pw, ipc.WithSchema(rdr.Schema()), ipc.WithZstd())
+		writer := ipc.NewWriter(pw, ipc.WithSchema(rdr.Schema()))
 		defer func() { _ = writer.Close() }()
 
 		for rdr.Next() {
@@ -418,7 +418,7 @@ func (s *Service) runDatapackQuery(ctx context.Context, id int, userSQL string) 
 		}
 		defer rdr.Release()
 
-		writer := ipc.NewWriter(pw, ipc.WithSchema(rdr.Schema()), ipc.WithZstd())
+		writer := ipc.NewWriter(pw, ipc.WithSchema(rdr.Schema()))
 		defer func() { _ = writer.Close() }()
 
 		for rdr.Next() {


### PR DESCRIPTION
Frontend console fails with "Record batch is compressed but codec not found" because apache-arrow JS doesn't ship the zstd codec. Drop `ipc.WithZstd()`; queries return single-parquet result sets so the wire-size gain isn't worth a JS codec dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)