### PR TITLE
fix(edge-proxy): support multiple site addresses for one backend

### DIFF
--- a/aegislab/helm/templates/edge-proxy-config.yaml
+++ b/aegislab/helm/templates/edge-proxy-config.yaml
@@ -50,8 +50,12 @@ data:
       {{- if $host -}}
         {{- $siteAddr = printf "%s:%d" $host $port -}}
       {{- end -}}
+    {{- end -}}
+    {{- $addrs := list $siteAddr -}}
+    {{- range .Values.global.additionalSiteAddresses | default list -}}
+      {{- $addrs = append $addrs . -}}
     {{- end }}
-    {{ $siteAddr }} {
+    {{ join ", " $addrs }} {
         tracing {
             span aegis-edge-proxy
         }

--- a/aegislab/helm/values.yaml
+++ b/aegislab/helm/values.yaml
@@ -16,6 +16,16 @@ global:
   # other "where does the browser reach us" value from it. Leave empty for
   # in-cluster / dev installs (subcharts fall back to localhost defaults).
   publicBaseURL: ""
+  # Extra `host:port` site addresses to attach to the edge-proxy Caddy
+  # site block alongside the one derived from publicBaseURL. Use when a
+  # second EIP / NAT CLB fronts the same backend (clients reach edge-proxy
+  # with a different Host header). NB: the `port` here is the in-pod
+  # LISTENER port Caddy binds — when an external CLB does port translation
+  # (e.g. 38082 → 8082), put the in-pod port (`8082`), not the external
+  # one. Caddy ignores the port in the Host header when matching, so the
+  # hostname is what does the routing. `tls internal` will also issue a
+  # local-CA cert covering every listed hostname. Each entry: `host:port`.
+  additionalSiteAddresses: []
   # Shared backend image (re-used by parent + notify/blob/gateway subcharts).
   images:
     rcabench:

--- a/aegislab/manifests/byte-cluster/rcabench.values.yaml
+++ b/aegislab/manifests/byte-cluster/rcabench.values.yaml
@@ -6,6 +6,17 @@ global:
   # cert (see `edgeProxy.tls.enabled` below). The SPA needs a Secure
   # Context for `crypto.subtle.digest` (PKCE code_challenge).
   publicBaseURL: "https://118.196.98.178:8082"
+  # Second public ingress: a NAT proxy CLB that forwards external
+  # 23.189.248.55:38082 to the same edge-proxy backend. The CLB does port
+  # translation, so traffic reaches the pod on listener :8082 (not :38082).
+  # The site-address port here is the LISTENER port, while Caddy ignores
+  # the port in the Host header when matching site blocks — so we list
+  # the host on the existing :8082 listener, NOT on a fake :38082
+  # listener (lost a debug session 2026-05-17 trying the latter).
+  # Caddy will also issue the internal cert with `23.189.248.55` in the
+  # SAN list.
+  additionalSiteAddresses:
+    - "23.189.248.55:8082"
   # Single source of truth for the shared backend image — consumed by
   # parent-chart deployments and every extracted subchart (notify, future
   # sso/blob).


### PR DESCRIPTION
## Summary
- byte-cluster has two public ingresses fronting the same edge-proxy: the direct EIP `118.196.98.178:8082` and a NAT CLB at `23.189.248.55:38082`. The Caddyfile template only emitted one site address (from `global.publicBaseURL`), so requests via the second EIP fell through to Caddy's default empty handler — every path returned HTTP 200 + empty body, and `aegisctl share upload` then nil-panicked on the empty response.
- Add `global.additionalSiteAddresses` (list of `host:port`) joined into the same site block. `tls internal` covers each listed hostname.
- Pin `23.189.248.55:8082` in byte-cluster values. The port is the **in-pod listener port** — the external CLB does `38082 → 8082` translation, and Caddy ignores the port in the Host header when matching site blocks, so we list the hostname on the existing `:8082` listener, not a fake `:38082` one.

## Test plan
- [x] `helm template` renders site block as `118.196.98.178:8082, 23.189.248.55:8082`
- [x] `kubectl apply` of the rendered ConfigMap + `rollout restart` on byte-cluster
- [x] Caddy startup logs: `domains:["23.189.248.55","118.196.98.178"]` (cert SAN includes both)
- [x] `curl -skI https://118.196.98.178:8082/healthz` → `via: 1.1 Caddy`, `{"status":"ok"}`
- [x] `curl -skI https://23.189.248.55:38082/healthz` → `via: 1.1 Caddy`, `{"status":"ok"}` (previously empty 200)
- [x] `aegisctl share upload / list / download / revoke` round-trip end-to-end against the proxy host

🤖 Generated with [Claude Code](https://claude.com/claude-code)