### PR TITLE
feat(trace): expose orchestrator OTel spans via /api/v2/traces/{id}/spans

### DIFF
--- a/aegislab/scripts/command/src/swagger/init.py
+++ b/aegislab/scripts/command/src/swagger/init.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -456,6 +457,31 @@ class SDKPostProcesser:
 
         for old_name in list(schemas.keys()):
             new_name = old_name
+
+            # Collapse multi-segment directory prefixes swag synthesises from
+            # a model's full Go package path down to just the leaf package
+            # segment. Keeps the published SDK type names stable across
+            # internal package moves — e.g. when `src/trace` became
+            # `src/crud/observability/trace`, swag started emitting
+            # 'crud_observability_trace.TraceDetailResp' instead of
+            # 'trace.TraceDetailResp'. Without this normalisation every such
+            # move is a breaking rename for every SDK consumer. The regex
+            # collapses any lowercase-underscored chain that ends in `.` to
+            # just the last segment, in place — so it also handles wrapped
+            # forms like 'GenericResponse-crud_storage_pages.PageSiteResponse'.
+            new_name = re.sub(
+                r"(?:[a-z][a-z0-9]*_)+([a-z][a-z0-9]*)\.",
+                r"\1.",
+                new_name,
+            )
+            # And the wrapped form 'GenericResponse-pkg_subpkg_leaf_Model'
+            # (no '.' between leaf and Model — swag emits this for
+            # generic-typed responses). Collapse to 'leaf_Model'.
+            new_name = re.sub(
+                r"(?:[a-z][a-z0-9]*_)+([a-z][a-z0-9]*_)([A-Z])",
+                r"\1\2",
+                new_name,
+            )
 
             # Remove 'consts.' prefix
             if new_name.startswith("consts."):

--- a/aegislab/src/crud/observability/trace/api_types.go
+++ b/aegislab/src/crud/observability/trace/api_types.go
@@ -174,6 +174,30 @@ type TraceDetailResp struct {
 	Tasks []dto.TaskResp `json:"tasks"`
 }
 
+// SpanNode is one OTel span emitted by the aegislab orchestrator while a
+// trace was running, projected from otel.otel_traces. The shape intentionally
+// mirrors a flat span list: parent_id points to span_id (within the same
+// otel_trace_id), and the frontend rebuilds the tree client-side. Multiple
+// OTel TraceIds can appear under a single aegis trace UUID (one per task
+// dispatch); they're returned interleaved and the frontend groups by
+// otel_trace_id when rendering.
+type SpanNode struct {
+	OTelTraceID  string            `json:"otel_trace_id"`
+	SpanID       string            `json:"span_id"`
+	ParentSpanID string            `json:"parent_id,omitempty"`
+	Service      string            `json:"service,omitempty"`
+	Op           string            `json:"op,omitempty"`
+	StartTS      time.Time         `json:"start_ts"`
+	EndTS        time.Time         `json:"end_ts"`
+	Status       string            `json:"status,omitempty"`
+	Attrs        map[string]string `json:"attrs,omitempty"`
+}
+
+// SpansResp wraps the flat span list. Ordered by start_ts ASC.
+type SpansResp struct {
+	Spans []SpanNode `json:"spans"`
+}
+
 func NewTraceDetailResp(trace *model.Trace) *TraceDetailResp {
 	resp := &TraceDetailResp{
 		TraceResp: *NewTraceResp(trace),

--- a/aegislab/src/crud/observability/trace/cancel_test.go
+++ b/aegislab/src/crud/observability/trace/cancel_test.go
@@ -27,7 +27,7 @@ func newCancelService(t *testing.T) (*Service, sqlmock.Sqlmock, func()) {
 
 	// nil redis + nil k8s — CancelTrace tolerates both, so the unit test
 	// exercises only the DB/state-machine logic.
-	svc := NewService(NewRepository(db), nil, nil)
+	svc := NewService(NewRepository(db), nil, nil, nil)
 	return svc, mock, func() { _ = sqlDB.Close() }
 }
 

--- a/aegislab/src/crud/observability/trace/handler.go
+++ b/aegislab/src/crud/observability/trace/handler.go
@@ -58,6 +58,42 @@ func (h *Handler) GetTrace(c *gin.Context) {
 	dto.SuccessResponse(c, resp)
 }
 
+// GetTraceSpans returns every OTel span the orchestrator emitted while the
+// trace was running, queried from ClickHouse otel.otel_traces filtered by
+// the aegis trace_id SpanAttribute. Returns 200 with an empty list when the
+// trace exists but no spans have been ingested yet (e.g. the collector is
+// behind or tracing was disabled).
+//
+//	@Summary		Get orchestrator OTel spans for a trace
+//	@Description	Returns the full flat list of OTel spans emitted by aegislab while this trace was running. The frontend rebuilds the parent/child tree client-side. Multiple OTel TraceIds may be returned interleaved (one per task dispatch); group by otel_trace_id when rendering.
+//	@Tags			Traces
+//	@ID				get_trace_spans
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			trace_id	path		string								true	"Trace ID"
+//	@Success		200			{object}	dto.GenericResponse[SpansResp]		"Spans retrieved successfully"
+//	@Failure		400			{object}	dto.GenericResponse[any]			"Invalid trace ID"
+//	@Failure		401			{object}	dto.GenericResponse[any]			"Authentication required"
+//	@Failure		403			{object}	dto.GenericResponse[any]			"Permission denied"
+//	@Failure		404			{object}	dto.GenericResponse[any]			"Trace not found"
+//	@Failure		500			{object}	dto.GenericResponse[any]			"Internal server error"
+//	@Router			/api/v2/traces/{trace_id}/spans [get]
+//	@x-api-type		{"portal":"true"}
+func (h *Handler) GetTraceSpans(c *gin.Context) {
+	traceID := c.Param(consts.URLPathTraceID)
+	if !utils.IsValidUUID(traceID) {
+		dto.ErrorResponse(c, http.StatusBadRequest, "Invalid trace ID")
+		return
+	}
+
+	resp, err := h.service.GetTraceSpans(c.Request.Context(), traceID)
+	if httpx.HandleServiceError(c, err) {
+		return
+	}
+
+	dto.SuccessResponse(c, resp)
+}
+
 // CancelTrace handles best-effort cancellation of a running trace.
 //
 //	@Summary		Cancel a running trace (best-effort)

--- a/aegislab/src/crud/observability/trace/handler_service.go
+++ b/aegislab/src/crud/observability/trace/handler_service.go
@@ -12,6 +12,7 @@ import (
 // HandlerService captures trace operations consumed by HTTP handlers and gateway adapters.
 type HandlerService interface {
 	GetTrace(context.Context, string) (*TraceDetailResp, error)
+	GetTraceSpans(context.Context, string) (*SpansResp, error)
 	ListTraces(context.Context, *ListTraceReq) (*dto.ListResp[TraceResp], error)
 	GetTraceStreamProcessor(context.Context, string) (*StreamProcessor, error)
 	ReadTraceStreamMessages(context.Context, string, string, int64, time.Duration) ([]redis.XStream, error)

--- a/aegislab/src/crud/observability/trace/module.go
+++ b/aegislab/src/crud/observability/trace/module.go
@@ -4,6 +4,7 @@ import "go.uber.org/fx"
 
 var Module = fx.Module("trace",
 	fx.Provide(NewRepository),
+	fx.Provide(NewClickHouseSpanReader),
 	fx.Provide(NewService),
 	fx.Provide(AsHandlerService),
 	fx.Provide(NewHandler),

--- a/aegislab/src/crud/observability/trace/routes.go
+++ b/aegislab/src/crud/observability/trace/routes.go
@@ -16,6 +16,7 @@ func RoutesPortal(handler *Handler) framework.RouteRegistrar {
 			{
 				traces.GET("", handler.ListTraces)
 				traces.GET("/:trace_id", handler.GetTrace)
+				traces.GET("/:trace_id/spans", handler.GetTraceSpans)
 				traces.GET("/:trace_id/stream", handler.GetTraceStream)
 			}
 			tracesWrite := v2.Group("/traces", middleware.TrustedHeaderAuth(), middleware.RequireTraceWrite)

--- a/aegislab/src/crud/observability/trace/service.go
+++ b/aegislab/src/crud/observability/trace/service.go
@@ -21,10 +21,11 @@ type Service struct {
 	repo  *Repository
 	redis *redisinfra.Gateway
 	k8s   *k8sinfra.Gateway
+	spans SpanReader
 }
 
-func NewService(repo *Repository, redis *redisinfra.Gateway, k8s *k8sinfra.Gateway) *Service {
-	return &Service{repo: repo, redis: redis, k8s: k8s}
+func NewService(repo *Repository, redis *redisinfra.Gateway, k8s *k8sinfra.Gateway, spans SpanReader) *Service {
+	return &Service{repo: repo, redis: redis, k8s: k8s, spans: spans}
 }
 
 // CancelTrace marks a trace as Cancelled and performs best-effort cleanup of
@@ -199,6 +200,47 @@ func (s *Service) GetTraceStreamAlgorithms(ctx context.Context, traceID string) 
 		}
 	}
 	return filtered, nil
+}
+
+// GetTraceSpans returns every OTel span the aegislab orchestrator emitted
+// for traceID, fanned out from otel.otel_traces via the aegis trace_id
+// SpanAttribute. The trace's existence in PostgreSQL is verified first so a
+// 404 still distinguishes "no such aegis trace" from "trace exists but the
+// OTel collector hasn't ingested anything yet". An empty list is a valid
+// 200 response in the latter case.
+func (s *Service) GetTraceSpans(ctx context.Context, traceID string) (*SpansResp, error) {
+	if _, err := s.repo.GetTraceByID(traceID); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("%w: trace id: %s", consts.ErrNotFound, traceID)
+		}
+		return nil, fmt.Errorf("failed to load trace: %w", err)
+	}
+	if s.spans == nil {
+		return nil, fmt.Errorf("clickhouse span reader not configured")
+	}
+	rows, err := s.spans.ReadSpansByTraceID(ctx, traceID)
+	if err != nil {
+		return nil, fmt.Errorf("read spans: %w", err)
+	}
+	out := &SpansResp{Spans: make([]SpanNode, 0, len(rows))}
+	for _, r := range rows {
+		endTS := r.Timestamp
+		if r.DurationNanos > 0 {
+			endTS = r.Timestamp.Add(time.Duration(r.DurationNanos))
+		}
+		out.Spans = append(out.Spans, SpanNode{
+			OTelTraceID:  r.TraceID,
+			SpanID:       r.SpanID,
+			ParentSpanID: r.ParentSpanID,
+			Service:      r.ServiceName,
+			Op:           r.SpanName,
+			StartTS:      r.Timestamp,
+			EndTS:        endTS,
+			Status:       r.StatusCode,
+			Attrs:        r.SpanAttributes,
+		})
+	}
+	return out, nil
 }
 
 func (s *Service) ReadTraceStreamMessages(ctx context.Context, streamKey, lastID string, count int64, block time.Duration) ([]goredis.XStream, error) {

--- a/aegislab/src/crud/observability/trace/spans_clickhouse.go
+++ b/aegislab/src/crud/observability/trace/spans_clickhouse.go
@@ -1,0 +1,156 @@
+package trace
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	chdriver "github.com/ClickHouse/clickhouse-go/v2"
+
+	db "aegis/platform/db"
+)
+
+// orchestratorServiceName is the ServiceName attribute the aegislab runtime
+// stamps on every span it exports via OTLP (see platform/tracing/provider.go).
+// Filtering on this keeps the span tree scoped to aegislab's own activity and
+// excludes spans the OTel collector ingests from the SUT.
+const orchestratorServiceName = "rcabench"
+
+// orchestratorTraceAttr is the SpanAttribute carrying the aegislab trace UUID
+// (consts.TraceCarrier propagates it through the orchestrator). Each OTel
+// TraceId emitted under a single aegis trace gets this attribute on at least
+// the root span, so the two-stage IN query below can fan from one aegis
+// trace_id to N OTel traces and pull every descendant span.
+const orchestratorTraceAttr = "trace_id"
+
+// SpanReader is the seam the trace service uses to fetch orchestrator OTel
+// spans from ClickHouse. Mirrors the FreshnessProbe pattern in
+// core/orchestrator/freshness.go so tests can fake the storage layer without
+// opening a TCP connection.
+type SpanReader interface {
+	ReadSpansByTraceID(ctx context.Context, traceID string) ([]OTelSpanRow, error)
+}
+
+// OTelSpanRow is the raw shape of one otel.otel_traces row that we project
+// into a SpanNode for the API response. Kept separate so service-layer code
+// can defer the conversion until it sees the rowset (e.g. to compute relative
+// startNs against the earliest span in the trace).
+type OTelSpanRow struct {
+	TraceID         string
+	SpanID          string
+	ParentSpanID    string
+	ServiceName     string
+	SpanName        string
+	Timestamp       time.Time
+	DurationNanos   int64
+	StatusCode      string
+	SpanAttributes  map[string]string
+	ResourceService string
+}
+
+type clickHouseSpanReader struct {
+	cfg *db.DatabaseConfig
+}
+
+// NewClickHouseSpanReader builds the production reader from the same
+// [database.clickhouse] config block that the FreshnessProbe uses.
+func NewClickHouseSpanReader() SpanReader {
+	return &clickHouseSpanReader{cfg: db.NewDatabaseConfig("clickhouse")}
+}
+
+func (r *clickHouseSpanReader) ReadSpansByTraceID(ctx context.Context, traceID string) ([]OTelSpanRow, error) {
+	if r.cfg == nil || r.cfg.Host == "" {
+		return nil, fmt.Errorf("clickhouse host not configured")
+	}
+
+	conn, err := chdriver.Open(&chdriver.Options{
+		Addr: []string{net.JoinHostPort(r.cfg.Host, strconv.Itoa(r.cfg.Port))},
+		Auth: chdriver.Auth{
+			Database: "otel",
+			Username: r.cfg.User,
+			Password: r.cfg.Password,
+		},
+		Protocol:    chdriver.HTTP,
+		DialTimeout: 3 * time.Second,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("clickhouse open: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Two-stage fan-out:
+	//   1. inner SELECT discovers every OTel TraceId tagged with this aegis
+	//      trace UUID on at least one span. The attribute lives on the root
+	//      span of each task; child DB/HTTP spans inherit context but not
+	//      attributes, so we need this hop to find them.
+	//   2. outer SELECT pulls every span whose OTel TraceId is in that set.
+	//
+	// We pin a 7-day lookback so the inner partition prune actually fires —
+	// the table is `PARTITION BY toDate(Timestamp)` and a full-table scan
+	// for one rarely-used attribute would be expensive. 7 days lines up with
+	// the retention window we keep for orchestration traces in PostgreSQL,
+	// so anything still visible in /traces should also resolve here.
+	const stmt = `
+		SELECT
+			TraceId,
+			SpanId,
+			ParentSpanId,
+			ServiceName,
+			SpanName,
+			Timestamp,
+			Duration,
+			StatusCode,
+			SpanAttributes,
+			ResourceAttributes['service.name'] AS resource_service
+		FROM otel.otel_traces
+		WHERE TraceId IN (
+			SELECT DISTINCT TraceId FROM otel.otel_traces
+			WHERE ServiceName = ?
+			  AND SpanAttributes[?] = ?
+			  AND Timestamp > now() - INTERVAL 7 DAY
+		)
+		  AND Timestamp > now() - INTERVAL 7 DAY
+		ORDER BY Timestamp ASC
+	`
+	rows, err := conn.Query(ctx, stmt, orchestratorServiceName, orchestratorTraceAttr, traceID)
+	if err != nil {
+		return nil, fmt.Errorf("clickhouse query spans: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []OTelSpanRow
+	for rows.Next() {
+		var (
+			row     OTelSpanRow
+			attrs   map[string]string
+			ts      time.Time
+			dur     int64
+			statusC string
+		)
+		if err := rows.Scan(
+			&row.TraceID,
+			&row.SpanID,
+			&row.ParentSpanID,
+			&row.ServiceName,
+			&row.SpanName,
+			&ts,
+			&dur,
+			&statusC,
+			&attrs,
+			&row.ResourceService,
+		); err != nil {
+			return nil, fmt.Errorf("clickhouse scan span row: %w", err)
+		}
+		row.Timestamp = ts
+		row.DurationNanos = dur
+		row.StatusCode = statusC
+		row.SpanAttributes = attrs
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("clickhouse iter span rows: %w", err)
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary

- New endpoint `GET /api/v2/traces/{trace_id}/spans` returning the orchestrator's OTel spans for an aegis trace UUID
- Backed by a two-stage ClickHouse query against `otel.otel_traces`: fan from `SpanAttributes['trace_id']=<aegis_uuid>` to OTel TraceIds, then pull every descendant span
- Powers the frontend Process tab's span tree (per-service/per-op durations, real start_ts/end_ts, no created→now estimates)
- Bonus: extended the swagger model-name post-processor so multi-segment Go package paths (`crud_observability_trace.*`, `GenericResponse-crud_iam_auth_*`) collapse to v2.0.0-compatible names — preserves SDK ABI across internal package moves

## Why a new endpoint and not /datapack-query

`/datapack-query` (recently added in #414) exposes the **SUT's** traces via DuckDB over parquet. Those are the workload-under-test spans, not aegislab's own orchestration. The orchestrator's spans land in ClickHouse via the otel-collector pipeline, separate plumbing.

## Test plan

- [x] `go build -tags duckdb_arrow ./main.go` green
- [x] `go test ./crud/observability/trace/...` green  
- [x] `just swagger-init v=2.1.0` regenerates spec with the new endpoint
- [x] `just release-portal v=2.1.0` generates the SDK with the new types; verified existing v2.0.0-published type names (`TraceTraceDetailResp`, `GenericResponseAuthAPIKeyInfo`, etc.) are preserved by the post-processor change
- [ ] Manual: `aegisctl inject` a fault, hit the new endpoint, confirm spans return
- [ ] CI: after merge, `git tag release-ts-portal/v2.1.0 && git push --tags` to publish the SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)