### PR TITLE
feat(chaos-points): prometheus metrics on DB read path

### DIFF
--- a/aegislab/src/crud/chaos/metadata_provider.go
+++ b/aegislab/src/crud/chaos/metadata_provider.go
@@ -4,9 +4,29 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"gorm.io/gorm"
 
 	"aegis/internal/chaosengine/chaosmeta"
+)
+
+// chaos_points DB-read instrumentation. Histogram buckets cover the 1ms-1s
+// log range; the byte-cluster `ts` system returns ~thousands of rows per
+// SELECT and lands well under 100ms when MySQL is healthy. The rows
+// histogram is sized to spot data drift (sudden drop after a bad supersede).
+var (
+	chaosPointsSelectSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "aegis_chaos_points_select_seconds",
+		Help:    "MySQL roundtrip latency for chaos_points SELECT by system.",
+		Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0},
+	}, []string{"system"})
+
+	chaosPointsRowsReturned = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "aegis_chaos_points_rows_returned",
+		Help:    "Row count returned by chaos_points SELECT by system.",
+		Buckets: []float64{1, 10, 100, 500, 1000, 5000, 10000},
+	}, []string{"system"})
 )
 
 type chaosPointStore struct {
@@ -18,12 +38,16 @@ func NewChaosPointStore(db *gorm.DB) chaosmeta.ChaosPointStore {
 }
 
 func (s *chaosPointStore) QueryPoints(ctx context.Context, system string) ([]chaosmeta.ChaosPointRow, error) {
+	timer := prometheus.NewTimer(chaosPointsSelectSeconds.WithLabelValues(system))
 	var rows []Point
-	if err := s.db.WithContext(ctx).
+	err := s.db.WithContext(ctx).
 		Where("system_name = ? AND status = ?", system, PointActive).
-		Find(&rows).Error; err != nil {
+		Find(&rows).Error
+	timer.ObserveDuration()
+	if err != nil {
 		return nil, fmt.Errorf("chaosPointStore: query chaos_points for system %q: %w", system, err)
 	}
+	chaosPointsRowsReturned.WithLabelValues(system).Observe(float64(len(rows)))
 	out := make([]chaosmeta.ChaosPointRow, 0, len(rows))
 	for _, r := range rows {
 		out = append(out, chaosmeta.ChaosPointRow{

--- a/aegislab/src/go.mod
+++ b/aegislab/src/go.mod
@@ -213,6 +213,7 @@ require (
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/aegislab/src/internal/chaosengine/resourcelookup/db_backed_test.go
+++ b/aegislab/src/internal/chaosengine/resourcelookup/db_backed_test.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	"aegis/internal/chaosengine/systemconfig"
 )
 
@@ -245,5 +247,53 @@ func TestDBBacked_SharedSnapshot_OneQueryPerWarmup(t *testing.T) {
 
 	if n := atomic.LoadInt64(&store.queryCount); n != 1 {
 		t.Errorf("want exactly 1 QueryPoints call across 5 GetAllX, got %d", n)
+	}
+}
+
+// TestDBBacked_CacheMetric_HitMiss proves the per-system snapshot counter
+// classifies the first GetAllX as a miss and every subsequent reuse within
+// the same warm-up as a hit. ResetSystemCache forces a new warm-up.
+func TestDBBacked_CacheMetric_HitMiss(t *testing.T) {
+	store := newStubStore()
+	withChaosStore(t, store)
+
+	miss := chaosPointsCacheTotal.WithLabelValues("ts", "miss")
+	hit := chaosPointsCacheTotal.WithLabelValues("ts", "hit")
+	missBefore := testutil.ToFloat64(miss)
+	hitBefore := testutil.ToFloat64(hit)
+
+	cache := GetSystemCache(systemconfig.SystemTrainTicket)
+	if _, err := cache.GetAllHTTPEndpoints(); err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	if _, err := cache.GetAllNetworkPairs(); err != nil {
+		t.Fatalf("network: %v", err)
+	}
+	if _, err := cache.GetAllDNSEndpoints(); err != nil {
+		t.Fatalf("dns: %v", err)
+	}
+	if _, err := cache.GetAllJVMMethods(); err != nil {
+		t.Fatalf("jvm: %v", err)
+	}
+	if _, err := cache.GetAllDatabaseOperations(); err != nil {
+		t.Fatalf("db: %v", err)
+	}
+
+	if got := testutil.ToFloat64(miss) - missBefore; got != 1 {
+		t.Errorf("want 1 miss across 5 GetAllX in one warm-up, got %v", got)
+	}
+	if got := testutil.ToFloat64(hit) - hitBefore; got != 4 {
+		t.Errorf("want 4 hits across 5 GetAllX in one warm-up, got %v", got)
+	}
+	if n := atomic.LoadInt64(&store.queryCount); n != 1 {
+		t.Errorf("metric/QueryPoints disagree: want 1 SELECT, got %d", n)
+	}
+
+	ResetSystemCache(systemconfig.SystemTrainTicket)
+	if _, err := GetSystemCache(systemconfig.SystemTrainTicket).GetAllHTTPEndpoints(); err != nil {
+		t.Fatalf("http (post-reset): %v", err)
+	}
+	if got := testutil.ToFloat64(miss) - missBefore; got != 2 {
+		t.Errorf("post-reset: want 2 cumulative misses, got %v", got)
 	}
 }

--- a/aegislab/src/internal/chaosengine/resourcelookup/lookup.go
+++ b/aegislab/src/internal/chaosengine/resourcelookup/lookup.go
@@ -12,9 +12,21 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"aegis/internal/chaosengine/client"
 	"aegis/internal/chaosengine/systemconfig"
 )
+
+// chaosPointsCacheTotal counts hit/miss against the per-system chaos_points
+// snapshot shared by all DB-backed GetAllX methods. A miss is one whose
+// chaosPointSnapshot() call triggered a fresh ChaosPointStore.QueryPoints;
+// every subsequent reuse within the same warm-up is a hit.
+var chaosPointsCacheTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "aegis_chaos_points_cache_total",
+	Help: "chaos_points per-system snapshot cache lookups by result (hit|miss).",
+}, []string{"system", "result"})
 
 // GetAllAppLabels returns app labels for the current system.
 func GetAllAppLabels(namespace, key string) ([]string, error) {
@@ -109,10 +121,13 @@ func GetSystemCache(system systemconfig.SystemType) *systemCache {
 func (s *systemCache) chaosPointSnapshot(ctx context.Context, store ChaosPointStore) ([]ChaosPointRow, error) {
 	s.dbSnapshotMu.Lock()
 	defer s.dbSnapshotMu.Unlock()
+	system := string(s.system)
 	if s.dbSnapshotOK {
+		chaosPointsCacheTotal.WithLabelValues(system, "hit").Inc()
 		return s.dbSnapshotRows, s.dbSnapshotErr
 	}
-	s.dbSnapshotRows, s.dbSnapshotErr = store.QueryPoints(ctx, string(s.system))
+	chaosPointsCacheTotal.WithLabelValues(system, "miss").Inc()
+	s.dbSnapshotRows, s.dbSnapshotErr = store.QueryPoints(ctx, system)
 	s.dbSnapshotOK = true
 	return s.dbSnapshotRows, s.dbSnapshotErr
 }


### PR DESCRIPTION
## Summary

Three Prometheus metrics surface the previously black-box DB-backed chaos_points read path:

- \`aegis_chaos_points_select_seconds{system}\` — histogram, MySQL roundtrip latency for chaos_points SELECT. Buckets 1ms–1s, sized for byte-cluster \`ts\` (thousands of rows, healthy <100ms).
- \`aegis_chaos_points_rows_returned{system}\` — histogram, row count per SELECT. Catches data drift after a bad supersede (sudden drop).
- \`aegis_chaos_points_cache_total{system,result=hit|miss}\` — counter on the shared per-system snapshot; under the shared-snapshot flow (#431), each warm-up is 1 miss + N hits across the 5 \`GetAllX\` methods.

Registered via \`promauto\` in two locations — one for the SQL roundtrip (\`crud/chaos/metadata_provider.go\`), one for the snapshot cache (\`internal/chaosengine/resourcelookup/lookup.go\`) — to avoid \`AlreadyRegisteredError\` on the default registry.

## Test plan

- [x] \`go test ./internal/chaosengine/resourcelookup/\` — new \`TestDBBacked_CacheMetric_HitMiss\` pins 1-miss-then-4-hits per warm-up + re-miss after \`ResetSystemCache\`
- [x] \`go build -tags duckdb_arrow -o /dev/null ./main.go\`
- [x] \`go build -o /dev/null ./cli\`
- [x] \`go mod tidy\` (\`prometheus/client_golang\` promoted to direct dep)
- [ ] Post-merge: confirm metrics scrape on byte-cluster after ops loads chaos_points data

## Out of scope

- Grafana panel JSON — no \`helm/charts/grafana/\` tree exists in the repo. Metrics alone; ops team can add the panel.
- Centralized metrics catalog — repo has zero such convention; metrics live next to the code that emits them (mirrors \`core/orchestrator/*\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)