### PR TITLE
refactor(seed): retire producerSeedRequired gate, make all declarative seeds idempotent

### DIFF
--- a/aegislab/src/boot/seed/consumer.go
+++ b/aegislab/src/boot/seed/consumer.go
@@ -3,6 +3,7 @@ package initialization
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -37,27 +38,16 @@ func InitializeConsumer(
 	buildDatapackLimiter *consumer.TokenBucketRateLimiter,
 	algoLimiter *consumer.TokenBucketRateLimiter,
 ) error {
+	// Declarative seeds run unconditionally and are idempotent: see
+	// initializeDynamicConfigs and initializeSystemPrerequisites for the
+	// per-row upsert semantics.
+	if err := initializeConsumer(ctx, db, etcdGw); err != nil {
+		return fmt.Errorf("failed to initialize system data for consumer: %w", err)
+	}
+
 	consumerData, err := newConfigDataWithDB(db, consts.ConfigScopeConsumer)
 	if err != nil {
 		return fmt.Errorf("failed to load consumer config metadata: %w", err)
-	}
-
-	if len(consumerData.configs) == 0 {
-		logrus.Info("Seeding initial system data for consumer...")
-		if err := initializeConsumer(ctx, db, etcdGw); err != nil {
-			return fmt.Errorf("failed to initialize system data for consumer: %w", err)
-		}
-		logrus.Info("Successfully seeded initial system data for consumer")
-	} else {
-		logrus.Info("Initial system data for consumer already seeded, skipping initialization")
-		// Prerequisites (issue #115) are additive metadata, not the big
-		// first-boot bootstrap. Reconcile them on every boot so a data.yaml
-		// prereq addition (e.g. new sockshop chart) lands without requiring
-		// a full reseed. ReconcileSystemPrerequisites is idempotent and does
-		// not stomp a reconciled status for unchanged specs.
-		if err := reconcilePrerequisitesFromDataFile(db); err != nil {
-			logrus.WithError(err).Warn("Failed to reconcile system prerequisites from data.yaml")
-		}
 	}
 
 	common.RegisterGlobalHandlers(publisher)
@@ -155,6 +145,19 @@ func initializeDynamicConfigs(tx *gorm.DB, data *InitialData) ([]model.DynamicCo
 		cfg := configData.ConvertToDBDynamicConfig()
 		if err := common.ValidateConfigMetadataConstraints(cfg); err != nil {
 			return nil, fmt.Errorf("invalid config value for key %s: %w", configData.Key, err)
+		}
+
+		// Idempotency: skip rows whose key already exists. default_value
+		// drift between data.yaml and DB is reconciled by the explicit
+		// ReseedFromDataFile path, never silently on boot.
+		var existing model.DynamicConfig
+		err := tx.Where("config_key = ?", configData.Key).First(&existing).Error
+		if err == nil {
+			configs = append(configs, existing)
+			continue
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("lookup dynamic config %s: %w", configData.Key, err)
 		}
 
 		if err := common.CreateConfig(tx, cfg); err != nil {

--- a/aegislab/src/boot/seed/producer.go
+++ b/aegislab/src/boot/seed/producer.go
@@ -40,35 +40,20 @@ func InitializeProducer(db *gorm.DB, publisher *redis.Gateway, etcdGw *etcd.Gate
 		return fmt.Errorf("failed to load producer initial data: %w", err)
 	}
 
-	shouldSeed, err := producerSeedRequired(db, initialData)
-	if err != nil {
-		return fmt.Errorf("failed to determine producer bootstrap state: %w", err)
+	// Every declarative seed runs on every boot and is idempotent: rows added
+	// to data.yaml after first boot land on the next restart without operator
+	// intervention, and re-running over an already-seeded DB is a no-op. The
+	// old `producerSeedRequired` gate (which used a non-empty `containers`
+	// table as proxy for "have we ever bootstrapped") is gone — it silently
+	// dropped new declarative rows past the first boot.
+	if err := initializeProducer(db, initialData); err != nil {
+		return fmt.Errorf("failed to initialize system data for producer: %w", err)
 	}
 
-	if shouldSeed {
-		logrus.Info("Seeding initial system data for producer...")
-		if err := initializeProducer(db, initialData); err != nil {
-			return fmt.Errorf("failed to initialize system data for producer: %w", err)
-		}
-		logrus.Info("Successfully seeded initial system data for producer")
-	} else {
-		logrus.Info("Initial system data for producer already seeded, skipping initialization")
-	}
-
-	// Issue #104: even after first-boot seeding, a new permission added to
-	// consts.SystemRolePermissions (or contributed via a module's RoleGrants
-	// registrar and merged by rbac.AggregatePermissions) must reach the
-	// permissions + role_permissions tables. Running ReconcileSystemPermissions
-	// unconditionally is the canonical place — it is idempotent and only
-	// writes rows that are missing.
 	if err := ReconcileSystemPermissions(db); err != nil {
 		return fmt.Errorf("failed to reconcile system permissions: %w", err)
 	}
 
-	// service_accounts is a declarative table — every boot upserts by name so
-	// rows added to data.yaml after the once-only seed (gated on `containers`
-	// being empty) still land. Manual revocations are preserved because the
-	// upsert never touches `revoked_at`.
 	if err := seedServiceAccounts(db, initialData.ServiceAccounts); err != nil {
 		return fmt.Errorf("failed to seed service accounts: %w", err)
 	}
@@ -114,29 +99,6 @@ func loadInitialDataFromConfiguredPath() (*InitialData, error) {
 	dataPath := config.GetString("initialization.data_path")
 	filePath := filepath.Join(dataPath, consts.InitialFilename)
 	return loadInitialDataFromFile(filePath)
-}
-
-func producerSeedRequired(db *gorm.DB, initialData *InitialData) (bool, error) {
-	if initialData == nil {
-		return false, fmt.Errorf("initial data is nil")
-	}
-	adminUsername := initialData.AdminUser.Username
-	if adminUsername == "" {
-		return false, fmt.Errorf("initial data admin user username is empty")
-	}
-
-	// SSO bootstraps its own admin user, so admin-existence alone is not a
-	// reliable gate for "producer already seeded". Require that containers
-	// have been seeded too — they're producer-owned and won't appear by
-	// accident.
-	var containerCount int64
-	if err := db.Table("containers").Count(&containerCount).Error; err != nil {
-		return false, fmt.Errorf("failed to count containers: %w", err)
-	}
-	if containerCount > 0 {
-		return false, nil
-	}
-	return true, nil
 }
 
 func initializeProducer(db *gorm.DB, initialData *InitialData) error {
@@ -270,6 +232,20 @@ func initializeContainers(tx *gorm.DB, data *InitialData, userID int) error {
 	dataPath := config.GetString("initialization.data_path")
 
 	for _, containerData := range data.Containers {
+		// Idempotency: if a container with this name already exists, the
+		// nested CreateContainerCore path would error with ErrDuplicatedKey
+		// on the unique active_name index. Containers are declarative, so
+		// skip the row — additive changes (new versions / values) are
+		// reconciled via the ReseedFromDataFile path, not the boot seed.
+		var existing model.Container
+		err := tx.Where("name = ? AND type = ?", containerData.Name, containerData.Type).First(&existing).Error
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("lookup container %s: %w", containerData.Name, err)
+		}
+
 		containerModel := containerData.ConvertToDBContainer()
 		if containerModel.Type == consts.ContainerTypePedestal {
 			system := chaos.SystemType(containerModel.Name)
@@ -337,6 +313,15 @@ func initializeContainers(tx *gorm.DB, data *InitialData, userID int) error {
 
 func initializeDatasets(tx *gorm.DB, data *InitialData, userID int) error {
 	for _, datasetData := range data.Datasets {
+		var existing model.Dataset
+		err := tx.Where("name = ?", datasetData.Name).First(&existing).Error
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return fmt.Errorf("lookup dataset %s: %w", datasetData.Name, err)
+		}
+
 		datasetModel := datasetData.ConvertToDBDataset()
 
 		versions := make([]model.DatasetVersion, 0, len(datasetData.Versions))
@@ -345,8 +330,7 @@ func initializeDatasets(tx *gorm.DB, data *InitialData, userID int) error {
 			versions = append(versions, *version)
 		}
 
-		_, err := dataset.NewRepository(tx).CreateDatasetCore(datasetModel, versions, userID)
-		if err != nil {
+		if _, err := dataset.NewRepository(tx).CreateDatasetCore(datasetModel, versions, userID); err != nil {
 			return fmt.Errorf("failed to create dataset %s: %w", datasetData.Name, err)
 		}
 	}

--- a/aegislab/src/boot/seed/producer_test.go
+++ b/aegislab/src/boot/seed/producer_test.go
@@ -2,6 +2,7 @@ package initialization
 
 import (
 	"testing"
+	"time"
 
 	"aegis/platform/consts"
 	"aegis/platform/model"
@@ -10,65 +11,102 @@ import (
 	"gorm.io/gorm"
 )
 
-func newProducerTestDB(t *testing.T) *gorm.DB {
+func newDynamicConfigTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	if err := db.AutoMigrate(&model.DynamicConfig{}, &model.User{}); err != nil {
+	if err := db.AutoMigrate(&model.DynamicConfig{}, &model.ConfigHistory{}); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
 	return db
 }
 
-func TestProducerSeedRequired_IgnoresDynamicConfigsWithoutAdminUser(t *testing.T) {
-	db := newProducerTestDB(t)
-
-	if err := db.Create(&model.DynamicConfig{
-		Key:          "database.clickhouse.host",
-		DefaultValue: "clickhouse.monitoring.svc.cluster.local",
-		ValueType:    consts.ConfigValueTypeString,
-		Scope:        consts.ConfigScopeConsumer,
-		Category:     "database.clickhouse",
-		Description:  "ClickHouse database host",
-	}).Error; err != nil {
-		t.Fatalf("seed dynamic config: %v", err)
+// TestInitializeDynamicConfigs_IdempotentOnSecondBoot pins that re-running the
+// declarative seed over an already-populated DB is observationally a no-op:
+// no duplicate rows, no spurious UpdatedAt bumps. Replaces the producerSeedRequired
+// gate that previously hid this seed behind a `containers`-table check.
+func TestInitializeDynamicConfigs_IdempotentOnSecondBoot(t *testing.T) {
+	db := newDynamicConfigTestDB(t)
+	data := &InitialData{
+		DynamicConfigs: []InitialDynamicConfig{
+			{
+				Key:          "database.clickhouse.host",
+				DefaultValue: "clickhouse.monitoring.svc.cluster.local",
+				ValueType:    consts.ConfigValueTypeString,
+				Scope:        consts.ConfigScopeConsumer,
+				Category:     "database.clickhouse",
+				Description:  "ClickHouse database host",
+			},
+		},
 	}
 
-	required, err := producerSeedRequired(db, &InitialData{
-		AdminUser: InitialDataUser{Username: "admin"},
-	})
+	first, err := initializeDynamicConfigs(db, data)
 	if err != nil {
-		t.Fatalf("producerSeedRequired: %v", err)
+		t.Fatalf("first seed: %v", err)
 	}
-	if !required {
-		t.Fatalf("producer seed should still be required when only dynamic configs exist")
+	if len(first) != 1 {
+		t.Fatalf("first seed: want 1 row, got %d", len(first))
+	}
+
+	var beforeRow model.DynamicConfig
+	if err := db.Where("config_key = ?", data.DynamicConfigs[0].Key).First(&beforeRow).Error; err != nil {
+		t.Fatalf("lookup pre-second-seed: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	second, err := initializeDynamicConfigs(db, data)
+	if err != nil {
+		t.Fatalf("second seed: %v", err)
+	}
+	if len(second) != 1 {
+		t.Fatalf("second seed: want 1 row returned, got %d", len(second))
+	}
+
+	var afterRows []model.DynamicConfig
+	if err := db.Where("config_key = ?", data.DynamicConfigs[0].Key).Find(&afterRows).Error; err != nil {
+		t.Fatalf("lookup post-second-seed: %v", err)
+	}
+	if len(afterRows) != 1 {
+		t.Fatalf("second seed inserted duplicates: %d rows", len(afterRows))
+	}
+	if !afterRows[0].UpdatedAt.Equal(beforeRow.UpdatedAt) {
+		t.Fatalf("idempotent seed must not touch UpdatedAt: before=%v after=%v", beforeRow.UpdatedAt, afterRows[0].UpdatedAt)
 	}
 }
 
-func TestProducerSeedRequired_SkipsWhenAdminUserExists(t *testing.T) {
-	db := newProducerTestDB(t)
-
-	if err := db.Omit("active_username").Create(&model.User{
-		Username: "admin",
-		Email:    "admin@rcabench.local",
-		Password: "admin123",
-		FullName: "System Admin",
-		IsActive: true,
-		Status:   consts.CommonEnabled,
-	}).Error; err != nil {
-		t.Fatalf("seed admin user: %v", err)
+// TestInitializeDynamicConfigs_AddsNewRowOnSubsequentBoot pins the additive
+// behavior the dropped gate previously blocked: a fresh row in data.yaml lands
+// in the DB on the next boot.
+func TestInitializeDynamicConfigs_AddsNewRowOnSubsequentBoot(t *testing.T) {
+	db := newDynamicConfigTestDB(t)
+	first := &InitialData{
+		DynamicConfigs: []InitialDynamicConfig{
+			{Key: "k1", DefaultValue: "v1", ValueType: consts.ConfigValueTypeString,
+				Scope: consts.ConfigScopeConsumer, Category: "test"},
+		},
+	}
+	if _, err := initializeDynamicConfigs(db, first); err != nil {
+		t.Fatalf("first seed: %v", err)
 	}
 
-	required, err := producerSeedRequired(db, &InitialData{
-		AdminUser: InitialDataUser{Username: "admin"},
-	})
-	if err != nil {
-		t.Fatalf("producerSeedRequired: %v", err)
+	second := &InitialData{
+		DynamicConfigs: append(first.DynamicConfigs, InitialDynamicConfig{
+			Key: "k2", DefaultValue: "v2", ValueType: consts.ConfigValueTypeString,
+			Scope: consts.ConfigScopeConsumer, Category: "test",
+		}),
 	}
-	if required {
-		t.Fatalf("producer seed should be skipped after the admin user exists")
+	if _, err := initializeDynamicConfigs(db, second); err != nil {
+		t.Fatalf("second seed: %v", err)
+	}
+
+	var k2 model.DynamicConfig
+	if err := db.Where("config_key = ?", "k2").First(&k2).Error; err != nil {
+		t.Fatalf("new row k2 not seeded on second boot: %v", err)
+	}
+	if k2.DefaultValue != "v2" {
+		t.Fatalf("k2 default_value: want v2 got %q", k2.DefaultValue)
 	}
 }

--- a/aegislab/src/boot/seed/service_accounts_test.go
+++ b/aegislab/src/boot/seed/service_accounts_test.go
@@ -22,10 +22,9 @@ func newServiceAccountTestDB(t *testing.T) *gorm.DB {
 	return db
 }
 
-// TestSeedServiceAccounts_AddsRowOnSubsequentBoot pins the bug the unconditional
-// seed call exists to fix: producerSeedRequired returns false once `containers`
-// is non-empty, so without an unconditional upsert path, a fresh SA row added
-// to data.yaml after first boot would never reach the DB.
+// TestSeedServiceAccounts_AddsRowOnSubsequentBoot pins the unconditional
+// upsert path: an SA row added to data.yaml after first boot reaches the DB
+// on the next restart without manual intervention.
 func TestSeedServiceAccounts_AddsRowOnSubsequentBoot(t *testing.T) {
 	db := newServiceAccountTestDB(t)
 


### PR DESCRIPTION
## Summary

Retire the \`producerSeedRequired\` gate by making every declarative seed idempotent — same pattern Phase 2e-cleanup (#fbac8aac) established for service_accounts. Removes a real footgun: the gate's catch-all "containers table is non-empty" signal was wrong for any other declarative table; the next person to add a declarative table would have re-hit the same bug.

context.md debt #6.

## Sites converted

- \`InitializeProducer\` / \`InitializeConsumer\` — gates removed; seeds run unconditionally
- \`initializeContainers\` / \`initializeDatasets\` / \`initializeDynamicConfigs\` — early-skip on existing row (find-then-create rather than UPSERT because some tables lack unique index; behavior identical, semantics clearer)
- \`seedServiceAccounts\` — already SA-style UPSERT, kept; obsolete gate-reference in comment cleaned up
- Already-idempotent paths untouched: \`initializeAdminUser\`, \`initializeProjectsAndTeams\`, \`initializeUsers\`, \`initializeExecutionLabels\`, \`initializeSystemPrerequisites\`, \`ReconcileSystemPermissions\`

## Tests

- \`TestInitializeDynamicConfigs_IdempotentOnSecondBoot\` — second run produces no duplicate row, no UpdatedAt bump
- \`TestInitializeDynamicConfigs_AddsNewRowOnSubsequentBoot\` — pins the additive behavior the gate previously blocked
- Existing SA idempotency tests retained

## Test plan

- [x] \`go build -tags duckdb_arrow -o /dev/null ./main.go\` clean
- [x] \`go test ./boot/seed/...\` green
- [x] \`go test ./crud/chaos/...\` green
- [x] \`grep -rn 'producerSeedRequired' .\` finds only two inline comments explaining the removal; function and callers gone

## Open

\`model.DynamicConfig.config_key\` lacks a unique index — used find-then-create instead of OnConflict UPSERT. If we want a true UPSERT, that's a separate \`uniqueIndex\` migration. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)