### PR TITLE
fix(regression): preflight label tolerance + helm upsert + dedup-on-terminal + --app override + drop dead duration field

### DIFF
--- a/aegislab/regression/README.md
+++ b/aegislab/regression/README.md
@@ -31,7 +31,6 @@ submit:
         namespace: otel-demo
         app: frontend
         chaos_type: PodKill
-        duration: 1
 validation:
   timeout_seconds: 3000
   min_events: 6
@@ -69,6 +68,10 @@ validation:
   observed trace events.
 - `validation.required_task_chain`: Ordered subsequence of task types that must
   be present on the fetched trace detail.
+
+`submit.specs[][].duration` is **not accepted** — the abnormal window is pinned
+server-side to `consts.FixedAbnormalWindowMinutes`. The case loader rejects any
+file that carries a `duration:` field inside a spec entry.
 
 ## Running a case
 

--- a/aegislab/regression/hotelreservation-guided.yaml
+++ b/aegislab/regression/hotelreservation-guided.yaml
@@ -26,7 +26,6 @@ submit:
         namespace: hs0
         app: profile
         chaos_type: PodFailure
-        duration: 5
 validation:
   timeout_seconds: 3000
   min_events: 6

--- a/aegislab/regression/mediamicroservices-guided.yaml
+++ b/aegislab/regression/mediamicroservices-guided.yaml
@@ -26,7 +26,6 @@ submit:
         namespace: mm0
         app: user-service
         chaos_type: PodKill
-        duration: 5
 validation:
   timeout_seconds: 3000
   min_events: 6

--- a/aegislab/regression/ob-guided.yaml
+++ b/aegislab/regression/ob-guided.yaml
@@ -24,7 +24,6 @@ submit:
         namespace: ob0
         app: checkoutservice
         chaos_type: PodKill
-        duration: 1
 validation:
   timeout_seconds: 3000
   min_events: 6

--- a/aegislab/regression/otel-demo-guided.yaml
+++ b/aegislab/regression/otel-demo-guided.yaml
@@ -24,7 +24,6 @@ submit:
         namespace: otel-demo0
         app: quote
         chaos_type: PodFailure
-        duration: 1
 validation:
   timeout_seconds: 3000
   min_events: 6

--- a/aegislab/regression/socialnetwork-guided.yaml
+++ b/aegislab/regression/socialnetwork-guided.yaml
@@ -26,7 +26,6 @@ submit:
         namespace: sn0
         app: user-service
         chaos_type: PodKill
-        duration: 5
 validation:
   timeout_seconds: 3000
   min_events: 6

--- a/aegislab/regression/sockshop-guided.yaml
+++ b/aegislab/regression/sockshop-guided.yaml
@@ -24,7 +24,6 @@ submit:
         namespace: sockshop0
         app: carts
         chaos_type: PodKill
-        duration: 5
 validation:
   timeout_seconds: 3000
   min_events: 6

--- a/aegislab/regression/teastore-guided.yaml
+++ b/aegislab/regression/teastore-guided.yaml
@@ -26,7 +26,6 @@ submit:
         namespace: tea0
         app: auth
         chaos_type: PodKill
-        duration: 5
 validation:
   timeout_seconds: 3000
   min_events: 6

--- a/aegislab/src/cli/apiclient/model_injection_submit_injection_req.go
+++ b/aegislab/src/cli/apiclient/model_injection_submit_injection_req.go
@@ -29,6 +29,8 @@ type InjectionSubmitInjectionReq struct {
 	AutoAllocate *bool `json:"auto_allocate,omitempty"`
 	// Benchmark (detector) configuration
 	Benchmark DtoContainerSpec `json:"benchmark"`
+	// ForceResubmit, when true, suppresses the engine-config dedup check even if a previous batch with the same engine_config is still in a non-terminal task state. Terminal-state previous batches (Completed / Error / Cancelled) no longer block resubmission — this flag exists for the narrower case where the operator wants to override an in- flight run as well.
+	ForceResubmit *bool `json:"force_resubmit,omitempty"`
 	// Labels to attach to the injection
 	Labels []DtoLabelItem `json:"labels,omitempty"`
 	// Pedestal (workload) configuration
@@ -182,6 +184,38 @@ func (o *InjectionSubmitInjectionReq) GetBenchmarkOk() (*DtoContainerSpec, bool)
 // SetBenchmark sets field value
 func (o *InjectionSubmitInjectionReq) SetBenchmark(v DtoContainerSpec) {
 	o.Benchmark = v
+}
+
+// GetForceResubmit returns the ForceResubmit field value if set, zero value otherwise.
+func (o *InjectionSubmitInjectionReq) GetForceResubmit() bool {
+	if o == nil || IsNil(o.ForceResubmit) {
+		var ret bool
+		return ret
+	}
+	return *o.ForceResubmit
+}
+
+// GetForceResubmitOk returns a tuple with the ForceResubmit field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *InjectionSubmitInjectionReq) GetForceResubmitOk() (*bool, bool) {
+	if o == nil || IsNil(o.ForceResubmit) {
+		return nil, false
+	}
+	return o.ForceResubmit, true
+}
+
+// HasForceResubmit returns a boolean if a field has been set.
+func (o *InjectionSubmitInjectionReq) HasForceResubmit() bool {
+	if o != nil && !IsNil(o.ForceResubmit) {
+		return true
+	}
+
+	return false
+}
+
+// SetForceResubmit gets a reference to the given bool and assigns it to the ForceResubmit field.
+func (o *InjectionSubmitInjectionReq) SetForceResubmit(v bool) {
+	o.ForceResubmit = &v
 }
 
 // GetLabels returns the Labels field value if set, zero value otherwise.
@@ -348,6 +382,9 @@ func (o InjectionSubmitInjectionReq) ToMap() (map[string]interface{}, error) {
 		toSerialize["auto_allocate"] = o.AutoAllocate
 	}
 	toSerialize["benchmark"] = o.Benchmark
+	if !IsNil(o.ForceResubmit) {
+		toSerialize["force_resubmit"] = o.ForceResubmit
+	}
 	if !IsNil(o.Labels) {
 		toSerialize["labels"] = o.Labels
 	}
@@ -408,6 +445,7 @@ func (o *InjectionSubmitInjectionReq) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "allow_bootstrap")
 		delete(additionalProperties, "auto_allocate")
 		delete(additionalProperties, "benchmark")
+		delete(additionalProperties, "force_resubmit")
 		delete(additionalProperties, "labels")
 		delete(additionalProperties, "pedestal")
 		delete(additionalProperties, "project_name")

--- a/aegislab/src/cli/cmd/pedestal_chart.go
+++ b/aegislab/src/cli/cmd/pedestal_chart.go
@@ -279,7 +279,12 @@ func runPedestalChartInstall(systemCode, namespace, tgz, repo, chartName, versio
 		output.PrintInfo(fmt.Sprintf("merged %d helm_config_values overrides for %s@%s", len(src.values), systemCode, tag))
 	}
 
-	helmArgs := []string{"install", namespace, src.positional, "-n", namespace, "--create-namespace"}
+	// "upgrade --install" is the upsert idiom — works whether the release
+	// exists or not. Previously this was bare `install`, which crashed on
+	// re-runs with "cannot re-use a name that is still in use" when the
+	// release was already deployed (hit by `regression run --auto-install`
+	// today after a prior preflight install).
+	helmArgs := []string{"upgrade", "--install", namespace, src.positional, "-n", namespace, "--create-namespace"}
 	cleanup := func() {}
 	if valuesFile, fileCleanup, err := materializeChartValuesFile(src); err != nil {
 		return err

--- a/aegislab/src/cli/cmd/pedestal_chart_test.go
+++ b/aegislab/src/cli/cmd/pedestal_chart_test.go
@@ -255,7 +255,7 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 			t.Fatalf("want 1 helm call, got %d: %v", len(f.calls), f.calls)
 		}
 		call := f.calls[0]
-		if call[0] != "helm" || call[1] != "install" || call[2] != "ts0" {
+		if call[0] != "helm" || call[1] != "upgrade" || call[2] != "--install" || call[3] != "ts0" {
 			t.Fatalf("bad helm args: %v", call)
 		}
 		joined := strings.Join(call, " ")

--- a/aegislab/src/cli/cmd/regression.go
+++ b/aegislab/src/cli/cmd/regression.go
@@ -63,6 +63,8 @@ var (
 	regressionSkipRestartPedestal bool
 	regressionReadyTimeoutSeconds int
 	regressionAppLabelKey       string
+	regressionAppOverride       string
+	regressionForceResubmit     bool
 	regressionPodListerHook     PodLister // test injection seam; nil => real k8s client
 	regressionInstallerHook     chartInstaller
 	regressionSystemsHook       SystemsFetcher // test injection seam; nil => real HTTP client
@@ -133,6 +135,19 @@ var regressionRunCmd = &cobra.Command{
 		}
 		if err != nil {
 			return err
+		}
+
+		if regressionAppOverride != "" {
+			if err := overrideFirstSpecApp(&rc, regressionAppOverride); err != nil {
+				return err
+			}
+		}
+
+		if regressionForceResubmit {
+			if rc.Submit == nil {
+				rc.Submit = map[string]any{}
+			}
+			rc.Submit["force_resubmit"] = true
 		}
 
 		if err := resolveRegressionNamespaces(cmd.Context(), &rc, regressionSystemsHook); err != nil {
@@ -284,6 +299,59 @@ func validateRegressionCase(rc regressionCase, path string) error {
 	if rc.Validation.MinEvents < 0 {
 		return fmt.Errorf("validate regression case %q: validation.min_events must be >= 0", path)
 	}
+	if err := rejectSpecDurationField(rc, path); err != nil {
+		return err
+	}
+	return nil
+}
+
+// rejectSpecDurationField fails the case load when any inject spec carries a
+// `duration:` key. The server pins per-spec duration to
+// consts.FixedAbnormalWindowMinutes via SubmitInjectionReq.Validate, so the
+// YAML field has been load-bearing only as a footgun — operators edit it
+// expecting an effect that never lands.
+func rejectSpecDurationField(rc regressionCase, path string) error {
+	groups, ok := rc.Submit["specs"].([]any)
+	if !ok {
+		return nil
+	}
+	for i, g := range groups {
+		inner, ok := g.([]any)
+		if !ok {
+			continue
+		}
+		for j, s := range inner {
+			spec, ok := s.(map[string]any)
+			if !ok {
+				continue
+			}
+			if _, has := spec["duration"]; has {
+				return fmt.Errorf("validate regression case %q: submit.specs[%d][%d].duration is no longer accepted; duration is fixed by the server (FixedAbnormalWindowMinutes) — remove the field", path, i, j)
+			}
+		}
+	}
+	return nil
+}
+
+// overrideFirstSpecApp rewrites the `app` field of the first spec in the first
+// batch. Callers use this to retarget a regression case without touching the
+// YAML on disk (typical use: dedup workaround after a previous run completed).
+// Multi-batch / multi-spec cases are untouched beyond the first entry; that's
+// the contract documented on the --app flag.
+func overrideFirstSpecApp(rc *regressionCase, app string) error {
+	groups, ok := rc.Submit["specs"].([]any)
+	if !ok || len(groups) == 0 {
+		return fmt.Errorf("--app: regression case has no submit.specs to override")
+	}
+	inner, ok := groups[0].([]any)
+	if !ok || len(inner) == 0 {
+		return fmt.Errorf("--app: regression case first batch is empty")
+	}
+	spec, ok := inner[0].(map[string]any)
+	if !ok {
+		return fmt.Errorf("--app: first spec is not a map")
+	}
+	spec["app"] = app
 	return nil
 }
 
@@ -695,20 +763,39 @@ func preflightRegressionCase(ctx context.Context, rc regressionCase, lister PodL
 		}
 		lister = l
 	}
-	labelKey := strings.TrimSpace(regressionAppLabelKey)
-	if labelKey == "" {
-		labelKey = "app"
+	primaryLabelKey := strings.TrimSpace(regressionAppLabelKey)
+	if primaryLabelKey == "" {
+		primaryLabelKey = "app"
+	}
+	// Fallback covers modern charts (otel-demo, etc.) that label pods with
+	// app.kubernetes.io/name=<svc> instead of the legacy app=<svc> key. Keep
+	// the primary first so operators who explicitly set --app-label-key still
+	// see their selector tried before the fallback.
+	labelKeysToTry := []string{primaryLabelKey}
+	if primaryLabelKey == "app" {
+		labelKeysToTry = append(labelKeysToTry, "app.kubernetes.io/name")
 	}
 
 	var misses []regressionTarget
+	var missAttempts [][]string // parallel to misses; selectors that returned 0
 	for _, t := range targets {
-		selector := labelKey + "=" + t.App
-		n, err := lister.ListPods(ctx, t.Namespace, selector)
-		if err != nil {
-			return fmt.Errorf("preflight: list pods in ns=%s selector=%s: %w (use --skip-preflight to bypass)", t.Namespace, selector, err)
+		var triedSelectors []string
+		matched := false
+		for _, key := range labelKeysToTry {
+			selector := key + "=" + t.App
+			triedSelectors = append(triedSelectors, selector)
+			n, err := lister.ListPods(ctx, t.Namespace, selector)
+			if err != nil {
+				return fmt.Errorf("preflight: list pods in ns=%s selector=%s: %w (use --skip-preflight to bypass)", t.Namespace, selector, err)
+			}
+			if n > 0 {
+				matched = true
+				break
+			}
 		}
-		if n == 0 {
+		if !matched {
 			misses = append(misses, t)
+			missAttempts = append(missAttempts, triedSelectors)
 		}
 	}
 	if len(misses) == 0 {
@@ -716,12 +803,12 @@ func preflightRegressionCase(ctx context.Context, rc regressionCase, lister PodL
 	}
 
 	var b strings.Builder
-	for _, m := range misses {
+	for idx, m := range misses {
 		sys := m.System
 		if sys == "" {
 			sys = "<system>"
 		}
-		fmt.Fprintf(&b, "preflight: namespace %s has no pods matching %s=%s\n", m.Namespace, labelKey, m.App)
+		fmt.Fprintf(&b, "preflight: namespace %s has no pods matching any of: %s\n", m.Namespace, strings.Join(missAttempts[idx], ", "))
 		fmt.Fprintf(&b, "  fix: aegisctl pedestal chart install %s --namespace %s\n", sys, m.Namespace)
 	}
 
@@ -757,19 +844,36 @@ func preflightRegressionCase(ctx context.Context, rc regressionCase, lister PodL
 		}
 		deadline := time.Now().Add(time.Duration(timeoutSec) * time.Second)
 		for _, m := range misses {
-			selector := labelKey + "=" + m.App
 			for {
-				total, ready, err := lister.CountReadyPods(ctx, m.Namespace, selector)
-				if err != nil {
-					return fmt.Errorf("preflight: wait-for-ready ns=%s selector=%s: %w", m.Namespace, selector, err)
+				// Match the same pair of selectors used during the initial
+				// preflight scan so a chart that labels pods with the modern
+				// app.kubernetes.io/name key is still counted as Ready.
+				var total, ready int
+				var lastSelector string
+				var listErr error
+				for _, key := range labelKeysToTry {
+					sel := key + "=" + m.App
+					lastSelector = sel
+					t, r, err := lister.CountReadyPods(ctx, m.Namespace, sel)
+					if err != nil {
+						listErr = err
+						break
+					}
+					if t > 0 {
+						total, ready = t, r
+						break
+					}
+				}
+				if listErr != nil {
+					return fmt.Errorf("preflight: wait-for-ready ns=%s selector=%s: %w", m.Namespace, lastSelector, listErr)
 				}
 				if total > 0 && ready == total {
-					fmt.Fprintf(os.Stderr, "preflight: ready ns=%s %s (%d/%d)\n", m.Namespace, selector, ready, total)
+					fmt.Fprintf(os.Stderr, "preflight: ready ns=%s %s (%d/%d)\n", m.Namespace, lastSelector, ready, total)
 					break
 				}
 				if time.Now().After(deadline) {
 					return fmt.Errorf("preflight: timed out after %ds waiting for pods ns=%s selector=%s (ready %d/%d); bump --ready-timeout or inspect with `kubectl -n %s get pods -l %s`",
-						timeoutSec, m.Namespace, selector, ready, total, m.Namespace, selector)
+						timeoutSec, m.Namespace, lastSelector, ready, total, m.Namespace, lastSelector)
 				}
 				select {
 				case <-ctx.Done():
@@ -856,7 +960,9 @@ func init() {
 	regressionRunCmd.Flags().BoolVar(&regressionAutoInstall, "auto-install", false, "If preflight finds missing charts, shell out to `aegisctl pedestal chart install <system> --namespace <ns>` to fix them before submit")
 	regressionRunCmd.Flags().BoolVar(&regressionSkipRestartPedestal, "skip-restart-pedestal", false, "Hint the backend to skip the RestartPedestal helm install when the chart is already deployed (useful after --auto-install + wait-for-ready)")
 	regressionRunCmd.Flags().IntVar(&regressionReadyTimeoutSeconds, "ready-timeout", 600, "Seconds --auto-install waits for all preflight targets to become Ready before submit")
-	regressionRunCmd.Flags().StringVar(&regressionAppLabelKey, "app-label-key", "app", "Label key used to match pods against each spec's `app` value during preflight")
+	regressionRunCmd.Flags().StringVar(&regressionAppLabelKey, "app-label-key", "app", "Label key used to match pods against each spec's `app` value during preflight (always falls back to app.kubernetes.io/name when unset)")
+	regressionRunCmd.Flags().StringVar(&regressionAppOverride, "app", "", "Override the FIRST spec's `app` value without editing the YAML on disk (multi-spec cases: only spec[0] is changed)")
+	regressionRunCmd.Flags().BoolVar(&regressionForceResubmit, "force", false, "Bypass the server-side dedup check even when the previous batch is still Running. \"I know what I'm doing\" cases only — normal terminal-state retries no longer require this.")
 
 	regressionCmd.AddCommand(regressionRunCmd)
 }

--- a/aegislab/src/cli/cmd/regression_test.go
+++ b/aegislab/src/cli/cmd/regression_test.go
@@ -225,7 +225,7 @@ func TestRegressionPreflight_MissingReportsFixHint(t *testing.T) {
 		t.Fatal("expected preflight error")
 	}
 	msg := err.Error()
-	wantLine := "preflight: namespace mm0 has no pods matching app=user-service"
+	wantLine := "preflight: namespace mm0 has no pods matching any of: app=user-service, app.kubernetes.io/name=user-service"
 	if !strings.Contains(msg, wantLine) {
 		t.Fatalf("missing preflight line; got: %s", msg)
 	}
@@ -308,7 +308,6 @@ project_name: pair_diagnosis
 submit:
   specs:
     - - chaos_type: PodKill
-        duration: 1
 validation:
   expected_final_event: datapack.result.collection
   required_task_chain:
@@ -355,7 +354,6 @@ project_name: pair_diagnosis
 submit:
   specs:
     - - chaos_type: PodKill
-        duration: 1
 validation:
   expected_final_event: datapack.result.collection
   required_task_chain:
@@ -585,7 +583,6 @@ project_name: pair_diagnosis
 submit:
   specs:
     - - chaos_type: PodKill
-        duration: 1
 validation:
   expected_final_event: datapack.no_anomaly
   required_task_chain:
@@ -719,7 +716,6 @@ submit:
         namespace: otel-demo
         app: frontend
         chaos_type: PodKill
-        duration: 1
 validation:
   timeout_seconds: 5
   min_events: 6
@@ -781,3 +777,188 @@ validation:
 	}
 }
 
+// TestRegressionPreflight_ModernAppLabelKeyFallback verifies that a chart
+// labeling its pods with app.kubernetes.io/name=<svc> (otel-demo and friends)
+// passes preflight even when the operator did not override --app-label-key.
+func TestRegressionPreflight_ModernAppLabelKeyFallback(t *testing.T) {
+	rc := makePreflightCase()
+	lister := &fakePodLister{byNSApp: map[string]int{
+		// Legacy `app=` selector returns zero pods.
+		"mm0|app=user-service":         0,
+		"mm0|app=compose-post-service": 0,
+		// Modern selector matches.
+		"mm0|app.kubernetes.io/name=user-service":         2,
+		"mm0|app.kubernetes.io/name=compose-post-service": 1,
+	}}
+	if err := preflightRegressionCase(context.Background(), rc, lister, nil); err != nil {
+		t.Fatalf("expected preflight to pass via modern label key, got %v", err)
+	}
+}
+
+// TestRegressionPreflight_MissingErrorListsBothSelectors confirms the failure
+// path reports both selectors that were tried so operators see why the
+// fallback also missed.
+func TestRegressionPreflight_MissingErrorListsBothSelectors(t *testing.T) {
+	rc := makePreflightCase()
+	lister := &fakePodLister{byNSApp: map[string]int{}} // every lookup returns 0
+	err := preflightRegressionCase(context.Background(), rc, lister, nil)
+	if err == nil {
+		t.Fatal("expected preflight error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "app=user-service") || !strings.Contains(msg, "app.kubernetes.io/name=user-service") {
+		t.Fatalf("expected both selectors in error, got: %s", msg)
+	}
+}
+
+func TestOverrideFirstSpecApp(t *testing.T) {
+	rc := makePreflightCase()
+	if err := overrideFirstSpecApp(&rc, "shipping"); err != nil {
+		t.Fatalf("override: %v", err)
+	}
+	groups := rc.Submit["specs"].([]any)
+	first := groups[0].([]any)[0].(map[string]any)
+	if first["app"] != "shipping" {
+		t.Fatalf("expected app=shipping, got %v", first["app"])
+	}
+	// Second spec untouched.
+	second := groups[0].([]any)[1].(map[string]any)
+	if second["app"] != "compose-post-service" {
+		t.Fatalf("expected second spec unchanged, got %v", second["app"])
+	}
+}
+
+func TestRegressionRunWithAppOverride(t *testing.T) {
+	oldServer := flagServer
+	oldToken := flagToken
+	oldProject := flagProject
+	oldOutput := flagOutput
+	oldCasesDir := regressionCasesDir
+	oldCaseFile := regressionCaseFile
+	oldApp := regressionAppOverride
+	oldSkip := regressionSkipPreflight
+	defer func() {
+		flagServer = oldServer
+		flagToken = oldToken
+		flagProject = oldProject
+		flagOutput = oldOutput
+		regressionCasesDir = oldCasesDir
+		regressionCaseFile = oldCaseFile
+		regressionAppOverride = oldApp
+		regressionSkipPreflight = oldSkip
+	}()
+
+	var capturedApp string
+	traceID := "trace-app-override"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v2/projects":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"code": 200, "message": "success",
+				"data": map[string]any{
+					"items":      []map[string]any{{"id": 7, "name": "pair_diagnosis"}},
+					"pagination": map[string]any{"page": 1, "size": 100, "total": 1, "total_pages": 1},
+				},
+			})
+		case r.URL.Path == "/api/v2/projects/7/injections/inject":
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if specs, ok := body["specs"].([]any); ok && len(specs) > 0 {
+				if inner, ok := specs[0].([]any); ok && len(inner) > 0 {
+					if spec, ok := inner[0].(map[string]any); ok {
+						capturedApp, _ = spec["app"].(string)
+					}
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"code": 200, "message": "success",
+				"data": map[string]any{
+					"group_id": "g",
+					"items":    []map[string]any{{"index": 0, "trace_id": traceID, "task_id": "t"}},
+				},
+			})
+		case r.URL.Path == "/api/v2/traces/"+traceID+"/stream":
+			w.Header().Set("Content-Type", "text/event-stream")
+			f, _ := w.(http.Flusher)
+			_, _ = fmt.Fprintf(w, "event: update\ndata: {\"event_name\":\"datapack.no_anomaly\"}\n\n")
+			f.Flush()
+			_, _ = fmt.Fprint(w, "event: end\ndata: done\n\n")
+			f.Flush()
+		case r.URL.Path == "/api/v2/traces/"+traceID:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"code": 200, "message": "success",
+				"data": map[string]any{"trace_id": traceID, "tasks": []map[string]any{{"type": "RestartPedestal"}}},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	casesDir := t.TempDir()
+	casePath := filepath.Join(casesDir, "appx.yaml")
+	if err := os.WriteFile(casePath, []byte(`name: appx
+project_name: pair_diagnosis
+submit:
+  specs:
+    - - chaos_type: PodKill
+        app: quote
+validation:
+  expected_final_event: datapack.no_anomaly
+  required_task_chain:
+    - RestartPedestal
+`), 0o644); err != nil {
+		t.Fatalf("write case: %v", err)
+	}
+
+	flagServer = ts.URL
+	flagToken = ""
+	flagProject = ""
+	flagOutput = "json"
+	regressionCasesDir = casesDir
+	regressionCaseFile = ""
+	regressionAppOverride = "shipping"
+	regressionSkipPreflight = true
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := regressionRunCmd.RunE(regressionRunCmd, []string{"appx"})
+	w.Close()
+	os.Stdout = oldStdout
+	_, _ = io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("RunE: %v", err)
+	}
+	if capturedApp != "shipping" {
+		t.Fatalf("expected server to see app=shipping, got %q", capturedApp)
+	}
+}
+
+func TestLoadRegressionCaseRejectsSpecDuration(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dur.yaml")
+	if err := os.WriteFile(path, []byte(`name: dur
+project_name: pair_diagnosis
+submit:
+  specs:
+    - - chaos_type: PodKill
+        duration: 5
+validation:
+  expected_final_event: datapack.no_anomaly
+  required_task_chain:
+    - RestartPedestal
+`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, _, err := loadRegressionCaseFile(path)
+	if err == nil {
+		t.Fatal("expected duration field to be rejected")
+	}
+	if !strings.Contains(err.Error(), "duration") || !strings.Contains(err.Error(), "FixedAbnormalWindowMinutes") {
+		t.Fatalf("error should mention duration + server pin, got: %v", err)
+	}
+}

--- a/aegislab/src/core/domain/injection/api_types.go
+++ b/aegislab/src/core/domain/injection/api_types.go
@@ -429,6 +429,14 @@ type SubmitInjectionReq struct {
 	// submit-time BuildInjection's pod listing is skipped for fresh
 	// slots since pods don't exist yet. See PR-C of #166.
 	AllowBootstrap bool `json:"allow_bootstrap" binding:"omitempty"`
+
+	// ForceResubmit, when true, suppresses the engine-config dedup check
+	// even if a previous batch with the same engine_config is still in a
+	// non-terminal task state. Terminal-state previous batches (Completed /
+	// Error / Cancelled) no longer block resubmission — this flag exists
+	// for the narrower case where the operator wants to override an in-
+	// flight run as well.
+	ForceResubmit bool `json:"force_resubmit" binding:"omitempty"`
 }
 
 func (req *SubmitInjectionReq) GuidedSpecs() [][]chaos.GuidedConfig {

--- a/aegislab/src/core/domain/injection/repository.go
+++ b/aegislab/src/core/domain/injection/repository.go
@@ -161,11 +161,26 @@ func (r *Repository) listExistingEngineConfigs(configs []string) ([]string, erro
 		Joins("JOIN labels ON labels.id = fil.label_id").
 		Where("labels.label_key = ? AND labels.label_value = ?", consts.LabelKeyTag, "invalid")
 
+	// Only count a previous injection as a "still in flight" duplicate when
+	// its owning task hasn't reached a terminal state. A regression case
+	// rerun after its previous batch completed / failed / was cancelled
+	// must not be silently suppressed — the operator's intent is clearly to
+	// re-run the same scenario. Tasks in pending/rescheduled/running keep
+	// the suppression active so a second submit during an in-flight run
+	// still fails fast.
+	terminalTaskStates := []consts.TaskState{
+		consts.TaskCompleted,
+		consts.TaskError,
+		consts.TaskCancelled,
+	}
+
 	var existing []string
 	if err := r.db.Model(&model.FaultInjection{}).
 		Select("engine_config").
-		Where("engine_config IN (?) AND state >= ? AND status = ?", configs, consts.DatapackInjectSuccess, consts.CommonEnabled).
+		Joins("LEFT JOIN tasks ON tasks.id = fault_injections.task_id").
+		Where("engine_config IN (?) AND fault_injections.state >= ? AND fault_injections.status = ?", configs, consts.DatapackInjectSuccess, consts.CommonEnabled).
 		Where("fault_injections.id NOT IN (?)", invalidLabelSubQuery).
+		Where("tasks.id IS NULL OR tasks.state NOT IN (?)", terminalTaskStates).
 		Pluck("engine_config", &existing).Error; err != nil {
 		return nil, err
 	}

--- a/aegislab/src/core/domain/injection/repository_dedup_test.go
+++ b/aegislab/src/core/domain/injection/repository_dedup_test.go
@@ -1,0 +1,96 @@
+package injection
+
+import (
+	"testing"
+	"time"
+
+	"aegis/platform/consts"
+	"aegis/platform/model"
+	"aegis/platform/testutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestListExistingEngineConfigs_TerminalTaskStateAllowsResubmit pins the R3
+// behavior change: a previous FaultInjection whose owning Task has reached a
+// terminal state (Completed / Error / Cancelled) must NOT count as a
+// duplicate, so an operator can rerun the same regression case after it
+// finishes. Tasks still in flight (Pending / Running / Rescheduled) keep
+// the suppression active so concurrent submits of the same scenario still
+// fail fast.
+func TestListExistingEngineConfigs_TerminalTaskStateAllowsResubmit(t *testing.T) {
+	db := testutil.NewSQLiteGormDB(t)
+	require.NoError(t, db.AutoMigrate(
+		&model.Task{},
+		&model.FaultInjection{},
+		&model.Label{},
+	))
+
+	repo := NewRepository(db)
+	engineCfg := `[{"chaos_type":"PodKill","app":"frontend"}]`
+
+	mkTask := func(id string, state consts.TaskState) *model.Task {
+		return &model.Task{
+			ID:        id,
+			Type:      consts.TaskTypeRestartPedestal,
+			Status:    consts.CommonEnabled,
+			State:     state,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+	}
+	mkInjection := func(taskID string) *model.FaultInjection {
+		return &model.FaultInjection{
+			Name:         "n",
+			Source:       consts.DatapackSourceInjection,
+			EngineConfig: engineCfg,
+			TaskID:       &taskID,
+			State:        consts.DatapackInjectSuccess,
+			Status:       consts.CommonEnabled,
+		}
+	}
+
+	t.Run("in_flight_task_blocks", func(t *testing.T) {
+		require.NoError(t, db.Exec("DELETE FROM fault_injections").Error)
+		require.NoError(t, db.Exec("DELETE FROM tasks").Error)
+		require.NoError(t, db.Create(mkTask("t-running", consts.TaskRunning)).Error)
+		require.NoError(t, db.Create(mkInjection("t-running")).Error)
+
+		existing, err := repo.listExistingEngineConfigs([]string{engineCfg})
+		require.NoError(t, err)
+		require.Equal(t, []string{engineCfg}, existing, "running task must still block resubmit")
+	})
+
+	t.Run("completed_task_allows_resubmit", func(t *testing.T) {
+		require.NoError(t, db.Exec("DELETE FROM fault_injections").Error)
+		require.NoError(t, db.Exec("DELETE FROM tasks").Error)
+		require.NoError(t, db.Create(mkTask("t-done", consts.TaskCompleted)).Error)
+		require.NoError(t, db.Create(mkInjection("t-done")).Error)
+
+		existing, err := repo.listExistingEngineConfigs([]string{engineCfg})
+		require.NoError(t, err)
+		require.Empty(t, existing, "completed task must not block resubmit")
+	})
+
+	t.Run("error_task_allows_resubmit", func(t *testing.T) {
+		require.NoError(t, db.Exec("DELETE FROM fault_injections").Error)
+		require.NoError(t, db.Exec("DELETE FROM tasks").Error)
+		require.NoError(t, db.Create(mkTask("t-err", consts.TaskError)).Error)
+		require.NoError(t, db.Create(mkInjection("t-err")).Error)
+
+		existing, err := repo.listExistingEngineConfigs([]string{engineCfg})
+		require.NoError(t, err)
+		require.Empty(t, existing, "failed task must not block resubmit")
+	})
+
+	t.Run("cancelled_task_allows_resubmit", func(t *testing.T) {
+		require.NoError(t, db.Exec("DELETE FROM fault_injections").Error)
+		require.NoError(t, db.Exec("DELETE FROM tasks").Error)
+		require.NoError(t, db.Create(mkTask("t-canc", consts.TaskCancelled)).Error)
+		require.NoError(t, db.Create(mkInjection("t-canc")).Error)
+
+		existing, err := repo.listExistingEngineConfigs([]string{engineCfg})
+		require.NoError(t, err)
+		require.Empty(t, existing, "cancelled task must not block resubmit")
+	})
+}

--- a/aegislab/src/core/domain/injection/service.go
+++ b/aegislab/src/core/domain/injection/service.go
@@ -420,7 +420,7 @@ func (s *Service) SubmitFaultInjection(ctx context.Context, req *SubmitInjection
 		}
 	}
 
-	uniqueItems, duplicatedInRequest, alreadyExisted, err := s.removeDuplicated(processedItems)
+	uniqueItems, duplicatedInRequest, alreadyExisted, err := s.removeDuplicated(processedItems, req.ForceResubmit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to remove duplicated batches: %w", err)
 	}

--- a/aegislab/src/core/domain/injection/submit.go
+++ b/aegislab/src/core/domain/injection/submit.go
@@ -193,7 +193,7 @@ func flattenYAMLToParameters(data map[string]any, prefix string) []dto.Parameter
 	return params
 }
 
-func (s *Service) removeDuplicated(items []injectionProcessItem) ([]injectionProcessItem, []int, []int, error) {
+func (s *Service) removeDuplicated(items []injectionProcessItem, forceResubmit bool) ([]injectionProcessItem, []int, []int, error) {
 	engineConfigStrs := make([]string, len(items))
 	for i, item := range items {
 		if len(item.guidedConfigs) == 0 {
@@ -229,14 +229,16 @@ func (s *Service) removeDuplicated(items []injectionProcessItem) ([]injectionPro
 	}
 
 	existed := make(map[string]struct{})
-	for start := 0; start < len(keys); start += 100 {
-		end := min(start+100, len(keys))
-		existing, err := s.repo.listExistingEngineConfigs(keys[start:end])
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		for _, v := range existing {
-			existed[v] = struct{}{}
+	if !forceResubmit {
+		for start := 0; start < len(keys); start += 100 {
+			end := min(start+100, len(keys))
+			existing, err := s.repo.listExistingEngineConfigs(keys[start:end])
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			for _, v := range existing {
+				existed[v] = struct{}{}
+			}
 		}
 	}
 

--- a/aegislab/src/docs/openapi2/docs.go
+++ b/aegislab/src/docs/openapi2/docs.go
@@ -30340,6 +30340,10 @@ const docTemplate = `{
                         }
                     ]
                 },
+                "force_resubmit": {
+                    "description": "ForceResubmit, when true, suppresses the engine-config dedup check\neven if a previous batch with the same engine_config is still in a\nnon-terminal task state. Terminal-state previous batches (Completed /\nError / Cancelled) no longer block resubmission — this flag exists\nfor the narrower case where the operator wants to override an in-\nflight run as well.",
+                    "type": "boolean"
+                },
                 "labels": {
                     "description": "Labels to attach to the injection",
                     "type": "array",

--- a/aegislab/src/docs/openapi2/swagger.json
+++ b/aegislab/src/docs/openapi2/swagger.json
@@ -30333,6 +30333,10 @@
                         }
                     ]
                 },
+                "force_resubmit": {
+                    "description": "ForceResubmit, when true, suppresses the engine-config dedup check\neven if a previous batch with the same engine_config is still in a\nnon-terminal task state. Terminal-state previous batches (Completed /\nError / Cancelled) no longer block resubmission — this flag exists\nfor the narrower case where the operator wants to override an in-\nflight run as well.",
+                    "type": "boolean"
+                },
                 "labels": {
                     "description": "Labels to attach to the injection",
                     "type": "array",

--- a/aegislab/src/docs/openapi2/swagger.yaml
+++ b/aegislab/src/docs/openapi2/swagger.yaml
@@ -7097,6 +7097,15 @@ definitions:
         allOf:
         - $ref: '#/definitions/dto.ContainerSpec'
         description: Benchmark (detector) configuration
+      force_resubmit:
+        description: |-
+          ForceResubmit, when true, suppresses the engine-config dedup check
+          even if a previous batch with the same engine_config is still in a
+          non-terminal task state. Terminal-state previous batches (Completed /
+          Error / Cancelled) no longer block resubmission — this flag exists
+          for the narrower case where the operator wants to override an in-
+          flight run as well.
+        type: boolean
       labels:
         description: Labels to attach to the injection
         items:


### PR DESCRIPTION
## Summary

Five regression-flow ergonomic fixes that surfaced today during otel-demo validation.

- **R1 preflight tolerates both label keys** — modern charts use \`app.kubernetes.io/name=<name>\` instead of legacy \`app=<name>\`. Preflight now tries both; error message lists both selectors when neither matches.
- **R2 \`helm upgrade --install\`** — \`--auto-install\` no longer crashes on "cannot re-use a name that is still in use" when a release already exists.
- **R3 dedup honours terminal task state** — \`listExistingEngineConfigs\` LEFT JOIN tasks; injections owned by Completed/Error/Cancelled tasks don't block resubmission. New \`--force\` flag + \`force_resubmit\` JSON field bypass the check entirely.
- **R4 \`--app <name>\` override** — rewrites \`submit.specs[0][0].app\` so operators can re-run a case after dedup without editing yaml. (Stretch goal — suggest apps from chaos_points on dedup miss — deferred.)
- **R5 dead \`duration:\` field rejected at load time** — \`rejectSpecDurationField\` surfaces the field as a validation error pointing operators at \`FixedAbnormalWindowMinutes\`; swept from all 7 \`aegislab/regression/*.yaml\`; README updated.

## Test plan

- [x] \`go build -tags duckdb_arrow -o /dev/null ./main.go\`
- [x] \`go build -o /dev/null ./cli\`
- [x] \`go test ./crud/chaos/... ./core/domain/... ./cli/cmd/...\` green (pre-existing \`TestSubmitGuidedApplyDryRunJSON\` + flaky \`TestEtcdRoundTrip\` unrelated)
- [x] SDK regenerated (\`just generate-go-sdk\`) for the new \`force_resubmit\` field

schema-changes-acknowledged: true

🤖 Generated with [Claude Code](https://claude.com/claude-code)