### PR TITLE
perf(chaos/reconciler): replace per-row dynamic.Get with chaos-mesh CR informer

### DIFF
--- a/aegislab/src/crud/chaos/executor_chaosmesh.go
+++ b/aegislab/src/crud/chaos/executor_chaosmesh.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
 )
 
 const (
@@ -63,8 +67,21 @@ func ChaosMeshGroupVersionResourceForNetworkChaos() schema.GroupVersionResource 
 	return networkChaosGVR
 }
 
+// chaosMeshInformerResync controls how often the shared informer relists
+// each watched GVR. 5m matches client-go's typical defaults and is long
+// enough that the relist storm at boot doesn't dominate apiserver load,
+// short enough that any missed-event drift heals within a single
+// reconciler tick window.
+const chaosMeshInformerResync = 5 * time.Minute
+
 type ChaosMeshExecutor struct {
 	Dyn dynamic.Interface
+
+	informerMu sync.RWMutex
+	// factory + listers are populated by WatchStatus. When listers is empty
+	// (test / pre-boot path), Status falls back to a per-call dynamic.Get.
+	factory dynamicinformer.DynamicSharedInformerFactory
+	listers map[schema.GroupVersionResource]cache.GenericLister
 }
 
 var _ Executor = (*ChaosMeshExecutor)(nil)
@@ -164,17 +181,80 @@ func (e *ChaosMeshExecutor) Status(ctx context.Context, handle string) (ExecStat
 	if err != nil {
 		return ExecStateFailed, nil, err
 	}
+
+	if got, ok := e.lookupFromInformer(h); ok {
+		return interpretChaosMeshStatus(got), readStatusDiagnostics(got), nil
+	}
+
+	// Cache miss (informer not started, GVR not watched, or just-after-Apply
+	// before the watch has observed the new CR). One dynamic.Get keeps the
+	// pre-informer semantics — including the cr_absent → Orphaned branch
+	// that the reconciler depends on.
 	got, err := e.Dyn.Resource(h.GVR).Namespace(h.Namespace).Get(ctx, h.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			// CR absent. Caller (reconciler) reconciles against the row's
-			// prior status to distinguish post-Destroy steady state from a
-			// mid-flight vanish.
 			return ExecStateOrphaned, map[string]any{"reason": "cr_absent"}, nil
 		}
 		return ExecStateFailed, nil, fmt.Errorf("chaos-mesh status: %w", err)
 	}
 	return interpretChaosMeshStatus(got), readStatusDiagnostics(got), nil
+}
+
+// lookupFromInformer returns (CR, true) if the shared informer for h.GVR
+// is started and its cache currently holds the named CR. Any other
+// outcome — informer not started, GVR not watched, cache miss, type
+// mismatch — returns (_, false) so Status falls back to dynamic.Get.
+// Treating cache-miss as "fall back" (rather than as cr_absent) is
+// deliberate: informers are eventually consistent, and a just-applied CR
+// can legitimately be absent from the cache for a tick.
+func (e *ChaosMeshExecutor) lookupFromInformer(h ChaosMeshHandle) (*unstructured.Unstructured, bool) {
+	e.informerMu.RLock()
+	lister, ok := e.listers[h.GVR]
+	e.informerMu.RUnlock()
+	if !ok || lister == nil {
+		return nil, false
+	}
+	obj, err := lister.ByNamespace(h.Namespace).Get(h.Name)
+	if err != nil {
+		return nil, false
+	}
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, false
+	}
+	return u, true
+}
+
+// WatchStatus starts a chaos-mesh CR informer for every GVR currently
+// known to the renderer registry and blocks until ctx is done. Status
+// reads from the informer cache instead of issuing one GET per row per
+// tick once this returns from WaitForCacheSync.
+//
+// The watch is single-flight: a second concurrent WatchStatus call
+// returns immediately. client-go's shared informer factory handles
+// apiserver disconnects and resyncs internally, so no manual restart
+// logic is needed.
+func (e *ChaosMeshExecutor) WatchStatus(ctx context.Context) error {
+	e.informerMu.Lock()
+	if e.factory != nil {
+		e.informerMu.Unlock()
+		<-ctx.Done()
+		return nil
+	}
+	factory := dynamicinformer.NewDynamicSharedInformerFactory(e.Dyn, chaosMeshInformerResync)
+	gvrs := registeredGVRs()
+	listers := make(map[schema.GroupVersionResource]cache.GenericLister, len(gvrs))
+	for _, gvr := range gvrs {
+		listers[gvr] = factory.ForResource(gvr).Lister()
+	}
+	e.factory = factory
+	e.listers = listers
+	e.informerMu.Unlock()
+
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+	<-ctx.Done()
+	return nil
 }
 
 // interpretChaosMeshStatus reads AllInjected / AllRecovered conditions,

--- a/aegislab/src/crud/chaos/executor_chaosmesh_informer_test.go
+++ b/aegislab/src/crud/chaos/executor_chaosmesh_informer_test.go
@@ -1,0 +1,181 @@
+package chaos
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// newAllChaosSchemeForTest registers every chaos-mesh GVR the renderer
+// registry produces. The informer factory watches all of them at boot;
+// the fake dynamic client panics if its scheme doesn't know how to LIST a
+// watched resource. Mirror the registry here so adding a new renderer
+// can't silently break this test.
+func newAllChaosSchemeForTest() (*runtime.Scheme, map[schema.GroupVersionResource]string) {
+	scheme := runtime.NewScheme()
+	kindByResource := map[string]string{
+		"podchaos":     "PodChaos",
+		"networkchaos": "NetworkChaos",
+		"stresschaos":  "StressChaos",
+		"timechaos":    "TimeChaos",
+		"dnschaos":     "DNSChaos",
+		"jvmchaos":     "JVMChaos",
+		"httpchaos":    "HTTPChaos",
+	}
+	listKinds := make(map[schema.GroupVersionResource]string, len(kindByResource))
+	for resource, kind := range kindByResource {
+		gvk := schema.GroupVersionKind{Group: ChaosMeshGroup, Version: ChaosMeshVersion, Kind: kind}
+		scheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		listGVK := gvk
+		listGVK.Kind += "List"
+		scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+		gvr := schema.GroupVersionResource{Group: ChaosMeshGroup, Version: ChaosMeshVersion, Resource: resource}
+		listKinds[gvr] = kind + "List"
+	}
+	return scheme, listKinds
+}
+
+// TestChaosMeshExecutor_StatusServedFromInformerCache verifies that once
+// WatchStatus has synced the informer cache, Status reads the CR from the
+// cache and does NOT call the dynamic client's GET. This is the whole
+// point of the informer wiring — it caps apiserver QPS at one watch per
+// GVR regardless of how many rows the reconciler scans.
+func TestChaosMeshExecutor_StatusServedFromInformerCache(t *testing.T) {
+	scheme, listKinds := newAllChaosSchemeForTest()
+	podChaosGVK := schema.GroupVersionKind{Group: ChaosMeshGroup, Version: ChaosMeshVersion, Kind: "PodChaos"}
+
+	cr := &unstructured.Unstructured{}
+	cr.SetGroupVersionKind(podChaosGVK)
+	cr.SetNamespace("ns0")
+	cr.SetName("podkill-xyz")
+	_ = unstructured.SetNestedSlice(cr.Object, []any{
+		map[string]any{"type": "AllRecovered", "status": "True"},
+	}, "status", "conditions")
+
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	if _, err := dyn.Resource(podChaosGVR).Namespace("ns0").Create(context.Background(), cr, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed CR: %v", err)
+	}
+
+	var getCalls int64
+	dyn.PrependReactor("get", "podchaos", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		atomic.AddInt64(&getCalls, 1)
+		return false, nil, nil // let the default tracker handle it
+	})
+
+	exec := NewChaosMeshExecutor(dyn)
+
+	watchCtx, watchCancel := context.WithCancel(context.Background())
+	defer watchCancel()
+	watchDone := make(chan struct{})
+	go func() {
+		_ = exec.WatchStatus(watchCtx)
+		close(watchDone)
+	}()
+
+	// Poll until the informer cache has seen our seeded CR. WaitForCacheSync
+	// returns once the initial LIST completes; ByNamespace.Get then succeeds.
+	handle, err := exec.DeriveHandle("pod_kill", "k", "ns0", map[string]any{"namespace": "sys", "app": "x"})
+	if err != nil {
+		t.Fatalf("DeriveHandle: %v", err)
+	}
+	h, _ := decodeHandle(handle)
+	h.Name = "podkill-xyz"
+	rehandle, _ := encodeHandle(h)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if u, ok := exec.lookupFromInformer(h); ok && u != nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, ok := exec.lookupFromInformer(h); !ok {
+		t.Fatal("informer cache never observed the seeded CR")
+	}
+
+	// Reset the get counter — the dynamicfake's initial LIST does not
+	// flow through the "get" reactor, but be defensive.
+	atomic.StoreInt64(&getCalls, 0)
+
+	state, _, err := exec.Status(context.Background(), rehandle)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if state != ExecStateSucceeded {
+		t.Fatalf("state: got %v, want %v (AllRecovered)", state, ExecStateSucceeded)
+	}
+	if n := atomic.LoadInt64(&getCalls); n != 0 {
+		t.Fatalf("Status issued %d dynamic GET calls; expected 0 (informer cache hit)", n)
+	}
+}
+
+// TestChaosMeshExecutor_StatusFallsBackOnCacheMiss exercises the
+// just-after-Apply path: the informer is running but hasn't observed a
+// freshly-created CR yet (we simulate this by NOT seeding the CR before
+// starting the informer, then creating it AFTER cache sync but querying
+// immediately so the cache may still be empty). The fallback dynamic.Get
+// must succeed regardless.
+func TestChaosMeshExecutor_StatusFallsBackOnCacheMiss(t *testing.T) {
+	scheme, listKinds := newAllChaosSchemeForTest()
+	gvk := schema.GroupVersionKind{Group: ChaosMeshGroup, Version: ChaosMeshVersion, Kind: "PodChaos"}
+
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+	exec := NewChaosMeshExecutor(dyn)
+
+	// Start informer with no objects.
+	watchCtx, watchCancel := context.WithCancel(context.Background())
+	defer watchCancel()
+	go func() { _ = exec.WatchStatus(watchCtx) }()
+
+	// Wait briefly so the informer is registered.
+	time.Sleep(50 * time.Millisecond)
+
+	// Apply a CR.
+	cr := &unstructured.Unstructured{}
+	cr.SetGroupVersionKind(gvk)
+	cr.SetNamespace("ns0")
+	cr.SetName("late-cr")
+	_ = unstructured.SetNestedSlice(cr.Object, []any{
+		map[string]any{"type": "AllInjected", "status": "True"},
+	}, "status", "conditions")
+	if _, err := dyn.Resource(podChaosGVR).Namespace("ns0").Create(context.Background(), cr, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create CR: %v", err)
+	}
+
+	// Build the handle the executor expects.
+	h := ChaosMeshHandle{GVR: podChaosGVR, Namespace: "ns0", Name: "late-cr"}
+	handle, _ := encodeHandle(h)
+
+	// Immediately query Status. The informer cache may not have observed
+	// the CR yet — Status must fall back to dynamic.Get and still return
+	// the right state (Running, since AllInjected=True without AllRecovered
+	// for non-destructive PodChaos defaults to Running, but our CR has no
+	// spec.action so isDestructivePodChaos returns false → Running).
+	state, _, err := exec.Status(context.Background(), handle)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if state != ExecStateRunning && state != ExecStateSucceeded {
+		// Succeeded acceptable if the cache happened to observe in time
+		// and the renderer treated it as destructive (it doesn't here);
+		// Running is the expected non-destructive AllInjected state.
+		t.Fatalf("state: got %v, want Running (AllInjected, non-destructive)", state)
+	}
+}
+
+// Compile-time guard: the type-assertion in module.go expects this
+// signature. If WatchStatus's signature drifts, the fx wiring will
+// silently stop starting the informer — keep the contract pinned.
+var _ interface {
+	WatchStatus(context.Context) error
+} = (*ChaosMeshExecutor)(nil)
+

--- a/aegislab/src/crud/chaos/module.go
+++ b/aegislab/src/crud/chaos/module.go
@@ -53,10 +53,22 @@ func NewReconcilerDefault(db *gorm.DB, exec Executor, webhook *WebhookSender) *R
 	return NewReconciler(db, exec, webhook, 5*time.Second, logrus.StandardLogger())
 }
 
-func runReconciler(lc fx.Lifecycle, r *Reconciler) {
+func runReconciler(lc fx.Lifecycle, r *Reconciler, exec Executor) {
 	ctx, cancel := context.WithCancel(context.Background())
 	lc.Append(fx.Hook{
 		OnStart: func(_ context.Context) error {
+			// Best-effort: only the chaos-mesh executor exposes WatchStatus;
+			// any other Executor (test fakes, future executors) keeps the
+			// pre-informer per-call Status path.
+			if w, ok := exec.(interface {
+				WatchStatus(context.Context) error
+			}); ok {
+				go func() {
+					if err := w.WatchStatus(ctx); err != nil {
+						logrus.WithError(err).Warn("chaos: informer watch exited")
+					}
+				}()
+			}
 			go r.Run(ctx)
 			return nil
 		},

--- a/aegislab/src/crud/chaos/renderer.go
+++ b/aegislab/src/crud/chaos/renderer.go
@@ -86,3 +86,31 @@ func registeredCapabilities() []CapabilitySupport {
 	sort.Slice(out, func(i, j int) bool { return out[i].Capability < out[j].Capability })
 	return out
 }
+
+// registeredGVRs returns the deduplicated set of GVRs that registered
+// renderers can produce CRs for. Used by the informer factory wiring to
+// decide which chaos-mesh resources to watch.
+func registeredGVRs() []schema.GroupVersionResource {
+	rendererMu.RLock()
+	defer rendererMu.RUnlock()
+	seen := make(map[schema.GroupVersionResource]struct{}, len(rendererRegistry))
+	out := make([]schema.GroupVersionResource, 0, len(rendererRegistry))
+	for _, r := range rendererRegistry {
+		g := r.GVR()
+		if _, dup := seen[g]; dup {
+			continue
+		}
+		seen[g] = struct{}{}
+		out = append(out, g)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Group != out[j].Group {
+			return out[i].Group < out[j].Group
+		}
+		if out[i].Version != out[j].Version {
+			return out[i].Version < out[j].Version
+		}
+		return out[i].Resource < out[j].Resource
+	})
+	return out
+}


### PR DESCRIPTION
## Motivation

The chaos reconciler scans pending/running injection rows every 5s and calls `Executor.Status(handle)` per row, which today is one `dynamic.Get` against the apiserver. At 200 concurrent injections that's 40 sustained QPS just for status polling — a per-row read pattern that scales linearly with in-flight work.

## Design

- `ChaosMeshExecutor.WatchStatus(ctx)` starts a `dynamicinformer.DynamicSharedInformerFactory` on all chaos-mesh GVRs the renderer registry knows about (PodChaos / NetworkChaos / StressChaos / TimeChaos / DNSChaos / JVMChaos / HTTPChaos — discovered via a new `registeredGVRs()` helper so adding a renderer auto-extends the watch set), watches them cluster-wide, and blocks until ctx is done.
- `Status(handle)` first asks the GVR's lister cache. On cache miss (informer not started, just-after-Apply before the watch observed the new CR, or any cast/type oddity) it falls back to a single `dynamic.Get` — which preserves the `cr_absent → ExecStateOrphaned` branch the reconciler depends on for mid-flight CR vanish detection.
- `module.go::runReconciler` type-asserts the `Executor` for `WatchStatus` and runs it alongside the reconciler loop under the same fx lifecycle context. Test fakes that don't implement `WatchStatus` keep their pre-informer behaviour.

Reconciler loop interval (5s) and batch size (200) are unchanged — the cost reduction is entirely inside the executor. Watch reconnect after apiserver disruptions is handled by client-go's shared informer; no manual restart logic.

## Test plan

- [x] `go build -tags duckdb_arrow ./...` green
- [x] `go vet -tags duckdb_arrow ./...` green
- [x] `go test ./crud/chaos/... ./platform/k8s/...` green (existing reconciler / orphaned-CR / request-namespace tests untouched)
- [x] New `TestChaosMeshExecutor_StatusServedFromInformerCache` — seeds a CR with `AllRecovered=True` via the fake dynamic client, starts `WatchStatus`, waits for cache sync, then asserts `Status` returns `ExecStateSucceeded` and issued zero dynamic GET calls (informer hit, not fallback).
- [x] New `TestChaosMeshExecutor_StatusFallsBackOnCacheMiss` — starts the informer with no objects, creates a CR after sync, immediately queries `Status` — exercises the just-after-Apply fallback path.

## Out of scope

- Reconciler loop interval / batch size (kept at 5s / 200 per project memory).
- DB schema / row state transitions.
- Webhook firing logic.
- Path A / Path B writing logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)