### PR TITLE
refactor(systemconfig): consolidate with chaossystem — single source of truth via live config manager

### DIFF
--- a/aegislab/src/crud/chaos/guided/main_test.go
+++ b/aegislab/src/crud/chaos/guided/main_test.go
@@ -1,0 +1,14 @@
+package guided
+
+import (
+	"os"
+	"testing"
+
+	"aegis/platform/systemconfig"
+	"aegis/platform/systemconfig/systemconfigtest"
+)
+
+func TestMain(m *testing.M) {
+	systemconfig.SetProvider(systemconfigtest.NewInMemoryProvider(systemconfigtest.BuiltinFixtures()...))
+	os.Exit(m.Run())
+}

--- a/aegislab/src/platform/k8s/resourcelookup/db_backed_test.go
+++ b/aegislab/src/platform/k8s/resourcelookup/db_backed_test.go
@@ -87,14 +87,14 @@ func withChaosStore(t *testing.T, s ChaosPointStore) {
 	prev := getChaosPointStore()
 	SetChaosPointStore(s)
 	t.Cleanup(func() { SetChaosPointStore(prev) })
-	ResetSystemCache(systemconfig.SystemTrainTicket)
-	ResetSystemCache(systemconfig.SystemOtelDemo)
+	ResetSystemCache(systemconfig.SystemType("ts"))
+	ResetSystemCache(systemconfig.SystemType("otel-demo"))
 }
 
 func TestDBBacked_HTTPEndpoints_PreservesGroundtruthMetadata(t *testing.T) {
 	withChaosStore(t, newStubStore())
 
-	got, err := GetSystemCache(systemconfig.SystemTrainTicket).GetAllHTTPEndpoints()
+	got, err := GetSystemCache(systemconfig.SystemType("ts")).GetAllHTTPEndpoints()
 	if err != nil {
 		t.Fatalf("GetAllHTTPEndpoints: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestDBBacked_HTTPEndpoints_PreservesGroundtruthMetadata(t *testing.T) {
 func TestDBBacked_NetworkPairs_CarriesSpanNames(t *testing.T) {
 	withChaosStore(t, newStubStore())
 
-	got, err := GetSystemCache(systemconfig.SystemTrainTicket).GetAllNetworkPairs()
+	got, err := GetSystemCache(systemconfig.SystemType("ts")).GetAllNetworkPairs()
 	if err != nil {
 		t.Fatalf("GetAllNetworkPairs: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestDBBacked_NetworkPairs_CarriesSpanNames(t *testing.T) {
 func TestDBBacked_DNSEndpoints_ExpandsDomainPatterns(t *testing.T) {
 	withChaosStore(t, newStubStore())
 
-	got, err := GetSystemCache(systemconfig.SystemTrainTicket).GetAllDNSEndpoints()
+	got, err := GetSystemCache(systemconfig.SystemType("ts")).GetAllDNSEndpoints()
 	if err != nil {
 		t.Fatalf("GetAllDNSEndpoints: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestDBBacked_DNSEndpoints_ExpandsDomainPatterns(t *testing.T) {
 func TestDBBacked_JVMMethods(t *testing.T) {
 	withChaosStore(t, newStubStore())
 
-	got, err := GetSystemCache(systemconfig.SystemTrainTicket).GetAllJVMMethods()
+	got, err := GetSystemCache(systemconfig.SystemType("ts")).GetAllJVMMethods()
 	if err != nil {
 		t.Fatalf("GetAllJVMMethods: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestDBBacked_JVMMethods(t *testing.T) {
 func TestDBBacked_DatabaseOperations_FromJVMMysqlFamily(t *testing.T) {
 	withChaosStore(t, newStubStore())
 
-	got, err := GetSystemCache(systemconfig.SystemTrainTicket).GetAllDatabaseOperations()
+	got, err := GetSystemCache(systemconfig.SystemType("ts")).GetAllDatabaseOperations()
 	if err != nil {
 		t.Fatalf("GetAllDatabaseOperations: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestDBBacked_DatabaseOperations_FromJVMMysqlFamily(t *testing.T) {
 func TestDBBacked_PerSystemScope(t *testing.T) {
 	withChaosStore(t, newStubStore())
 
-	got, err := GetSystemCache(systemconfig.SystemOtelDemo).GetAllHTTPEndpoints()
+	got, err := GetSystemCache(systemconfig.SystemType("otel-demo")).GetAllHTTPEndpoints()
 	if err != nil {
 		t.Fatalf("GetAllHTTPEndpoints: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestDBBacked_SharedSnapshot_OneQueryPerWarmup(t *testing.T) {
 	store := newStubStore()
 	withChaosStore(t, store)
 
-	cache := GetSystemCache(systemconfig.SystemTrainTicket)
+	cache := GetSystemCache(systemconfig.SystemType("ts"))
 	if _, err := cache.GetAllHTTPEndpoints(); err != nil {
 		t.Fatalf("http: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestDBBacked_CacheMetric_HitMiss(t *testing.T) {
 	missBefore := testutil.ToFloat64(miss)
 	hitBefore := testutil.ToFloat64(hit)
 
-	cache := GetSystemCache(systemconfig.SystemTrainTicket)
+	cache := GetSystemCache(systemconfig.SystemType("ts"))
 	if _, err := cache.GetAllHTTPEndpoints(); err != nil {
 		t.Fatalf("http: %v", err)
 	}
@@ -289,8 +289,8 @@ func TestDBBacked_CacheMetric_HitMiss(t *testing.T) {
 		t.Errorf("metric/QueryPoints disagree: want 1 SELECT, got %d", n)
 	}
 
-	ResetSystemCache(systemconfig.SystemTrainTicket)
-	if _, err := GetSystemCache(systemconfig.SystemTrainTicket).GetAllHTTPEndpoints(); err != nil {
+	ResetSystemCache(systemconfig.SystemType("ts"))
+	if _, err := GetSystemCache(systemconfig.SystemType("ts")).GetAllHTTPEndpoints(); err != nil {
 		t.Fatalf("http (post-reset): %v", err)
 	}
 	if got := testutil.ToFloat64(miss) - missBefore; got != 2 {

--- a/aegislab/src/platform/systemconfig/registry_test.go
+++ b/aegislab/src/platform/systemconfig/registry_test.go
@@ -74,9 +74,10 @@ func (m *MockJavaClassMethodProvider) GetClassMethodsByService(serviceName strin
 
 func TestMetadataRegistry(t *testing.T) {
 	// Reset the registry and system for testing
+	withBuiltins(t)
 	registry := GetRegistry()
 	registry.Clear()
-	_ = SetCurrentSystem(SystemTrainTicket)
+	_ = SetCurrentSystem(SystemType("ts"))
 
 	// Create mock providers
 	tsEndpointProvider := &MockServiceEndpointProvider{
@@ -98,11 +99,11 @@ func TestMetadataRegistry(t *testing.T) {
 	}
 
 	// Register providers
-	registry.RegisterServiceEndpointProvider(SystemTrainTicket, tsEndpointProvider)
-	registry.RegisterServiceEndpointProvider(SystemOtelDemo, otelEndpointProvider)
+	registry.RegisterServiceEndpointProvider(SystemType("ts"), tsEndpointProvider)
+	registry.RegisterServiceEndpointProvider(SystemType("otel-demo"), otelEndpointProvider)
 
 	// Test getting provider for TrainTicket system
-	_ = SetCurrentSystem(SystemTrainTicket)
+	_ = SetCurrentSystem(SystemType("ts"))
 	provider, err := registry.GetServiceEndpointProvider()
 	if err != nil {
 		t.Fatalf("GetServiceEndpointProvider() error = %v", err)
@@ -117,7 +118,7 @@ func TestMetadataRegistry(t *testing.T) {
 	}
 
 	// Test getting provider for OtelDemo system
-	_ = SetCurrentSystem(SystemOtelDemo)
+	_ = SetCurrentSystem(SystemType("otel-demo"))
 	provider, err = registry.GetServiceEndpointProvider()
 	if err != nil {
 		t.Fatalf("GetServiceEndpointProvider() error = %v", err)
@@ -133,9 +134,10 @@ func TestMetadataRegistry(t *testing.T) {
 }
 
 func TestRegistryHasProviders(t *testing.T) {
+	withBuiltins(t)
 	registry := GetRegistry()
 	registry.Clear()
-	_ = SetCurrentSystem(SystemTrainTicket)
+	_ = SetCurrentSystem(SystemType("ts"))
 
 	// Initially no providers
 	if registry.HasServiceEndpointProvider() {
@@ -143,7 +145,7 @@ func TestRegistryHasProviders(t *testing.T) {
 	}
 
 	// Register a provider
-	registry.RegisterServiceEndpointProvider(SystemTrainTicket, &MockServiceEndpointProvider{})
+	registry.RegisterServiceEndpointProvider(SystemType("ts"), &MockServiceEndpointProvider{})
 
 	// Now it should exist
 	if !registry.HasServiceEndpointProvider() {
@@ -151,16 +153,17 @@ func TestRegistryHasProviders(t *testing.T) {
 	}
 
 	// Switch to OtelDemo - should not have provider
-	_ = SetCurrentSystem(SystemOtelDemo)
+	_ = SetCurrentSystem(SystemType("otel-demo"))
 	if registry.HasServiceEndpointProvider() {
 		t.Error("HasServiceEndpointProvider() should return false for OtelDemo system")
 	}
 }
 
 func TestRegistryGetProviderNotRegistered(t *testing.T) {
+	withBuiltins(t)
 	registry := GetRegistry()
 	registry.Clear()
-	_ = SetCurrentSystem(SystemTrainTicket)
+	_ = SetCurrentSystem(SystemType("ts"))
 
 	_, err := registry.GetServiceEndpointProvider()
 	if err == nil {
@@ -179,9 +182,10 @@ func TestRegistryGetProviderNotRegistered(t *testing.T) {
 }
 
 func TestDatabaseOperationProviderRegistry(t *testing.T) {
+	withBuiltins(t)
 	registry := GetRegistry()
 	registry.Clear()
-	_ = SetCurrentSystem(SystemTrainTicket)
+	_ = SetCurrentSystem(SystemType("ts"))
 
 	mockProvider := &MockDatabaseOperationProvider{
 		services: []string{"ts-order-service"},
@@ -192,7 +196,7 @@ func TestDatabaseOperationProviderRegistry(t *testing.T) {
 		},
 	}
 
-	registry.RegisterDatabaseOperationProvider(SystemTrainTicket, mockProvider)
+	registry.RegisterDatabaseOperationProvider(SystemType("ts"), mockProvider)
 
 	if !registry.HasDatabaseOperationProvider() {
 		t.Error("HasDatabaseOperationProvider() should return true after registration")
@@ -210,9 +214,10 @@ func TestDatabaseOperationProviderRegistry(t *testing.T) {
 }
 
 func TestGRPCOperationProviderRegistry(t *testing.T) {
+	withBuiltins(t)
 	registry := GetRegistry()
 	registry.Clear()
-	_ = SetCurrentSystem(SystemOtelDemo)
+	_ = SetCurrentSystem(SystemType("otel-demo"))
 
 	mockProvider := &MockGRPCOperationProvider{
 		services: []string{"checkout"},
@@ -223,7 +228,7 @@ func TestGRPCOperationProviderRegistry(t *testing.T) {
 		},
 	}
 
-	registry.RegisterGRPCOperationProvider(SystemOtelDemo, mockProvider)
+	registry.RegisterGRPCOperationProvider(SystemType("otel-demo"), mockProvider)
 
 	if !registry.HasGRPCOperationProvider() {
 		t.Error("HasGRPCOperationProvider() should return true after registration")
@@ -244,9 +249,10 @@ func TestGRPCOperationProviderRegistry(t *testing.T) {
 }
 
 func TestJavaClassMethodProviderRegistry(t *testing.T) {
+	withBuiltins(t)
 	registry := GetRegistry()
 	registry.Clear()
-	_ = SetCurrentSystem(SystemTrainTicket)
+	_ = SetCurrentSystem(SystemType("ts"))
 
 	mockProvider := &MockJavaClassMethodProvider{
 		services: []string{"ts-order-service"},
@@ -257,7 +263,7 @@ func TestJavaClassMethodProviderRegistry(t *testing.T) {
 		},
 	}
 
-	registry.RegisterJavaClassMethodProvider(SystemTrainTicket, mockProvider)
+	registry.RegisterJavaClassMethodProvider(SystemType("ts"), mockProvider)
 
 	if !registry.HasJavaClassMethodProvider() {
 		t.Error("HasJavaClassMethodProvider() should return true after registration")

--- a/aegislab/src/platform/systemconfig/systemconfig.go
+++ b/aegislab/src/platform/systemconfig/systemconfig.go
@@ -1,6 +1,7 @@
-// Package systemconfig provides a global configuration for the target system type.
-// This package allows different systems (TrainTicket, OtelDemo, etc.) to coexist
-// with their own metadata and configurations.
+// Package systemconfig exposes the live chaos-system configuration as a small
+// set of accessors. There is no static registration table — every read goes
+// through Provider, which is wired to the etcd/Viper-backed
+// chaosSystemConfigManager in production.
 package systemconfig
 
 import (
@@ -8,197 +9,134 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"aegis/platform/chaos"
+	"aegis/platform/config"
 )
 
-// SystemType represents the type of system being analyzed/targeted.
+// SystemType is the short code that identifies a target microservice system
+// (e.g. "ts", "otel-demo"). Live registrations live in etcd; this stays a
+// string alias to keep the chaos-service HTTP boundary trivial.
 type SystemType string
 
-const (
-	// SystemTrainTicket represents the TrainTicket microservice system.
-	SystemTrainTicket SystemType = "ts"
-	// SystemOtelDemo represents the OpenTelemetry Demo system.
-	SystemOtelDemo SystemType = "otel-demo"
-	// SystemMediaMicroservices represents the Media Microservices system.
-	SystemMediaMicroservices SystemType = "media"
-	// SystemHotelReservation represents the Hotel Reservation system.
-	SystemHotelReservation SystemType = "hs"
-	// SystemSocialNetwork represents the Social Network system.
-	SystemSocialNetwork SystemType = "sn"
-	// SystemOnlineBoutique represents the Online Boutique system.
-	SystemOnlineBoutique SystemType = "ob"
-	// SystemSockShop represents the Sock Shop system.
-	SystemSockShop SystemType = "sockshop"
-	// SystemTeaStore represents the Tea Store system.
-	SystemTeaStore SystemType = "teastore"
-)
+// String returns the string representation of the SystemType.
+func (s SystemType) String() string { return string(s) }
 
-// SystemRegistration holds registration data for a system.
-type SystemRegistration struct {
+// Registration is the read-only view of a chaos-system that callers need from
+// systemconfig. It is decoded from the live config manager every time it is
+// requested; there is no in-package cache.
+type Registration struct {
 	Name        SystemType
 	NsPattern   string
 	DisplayName string
-	// AppLabelKey is the pod label key used to select application workloads
-	// (e.g. "app", "app.kubernetes.io/name"). An empty value defaults to "app".
 	AppLabelKey string
 }
 
-var (
-	currentSystem   = SystemTrainTicket
-	currentSystemMu sync.RWMutex
-
-	registeredSystems   map[SystemType]SystemRegistration
-	registeredSystemsMu sync.RWMutex
-)
-
-func init() {
-	registeredSystems = make(map[SystemType]SystemRegistration)
-	for _, reg := range builtinSystemRegistrations() {
-		registeredSystems[reg.Name] = reg
-	}
+// Provider abstracts the source of system registrations so tests can swap in
+// an in-memory map without booting Viper / etcd.
+type Provider interface {
+	Get(SystemType) (Registration, bool)
+	All() []Registration
 }
 
-func builtinSystemRegistrations() []SystemRegistration {
-	return []SystemRegistration{
-		{Name: SystemTrainTicket, NsPattern: "^ts\\d+$", DisplayName: "TrainTicket", AppLabelKey: "app"},
-		{Name: SystemOtelDemo, NsPattern: "^otel-demo\\d+$", DisplayName: "OtelDemo", AppLabelKey: "app.kubernetes.io/name"},
-		{Name: SystemMediaMicroservices, NsPattern: "^media\\d+$", DisplayName: "MediaMicroservices", AppLabelKey: "app"},
-		{Name: SystemHotelReservation, NsPattern: "^hs\\d+$", DisplayName: "HotelReservation", AppLabelKey: "app"},
-		{Name: SystemSocialNetwork, NsPattern: "^sn\\d+$", DisplayName: "SocialNetwork", AppLabelKey: "app"},
-		{Name: SystemOnlineBoutique, NsPattern: "^ob\\d+$", DisplayName: "OnlineBoutique", AppLabelKey: "app"},
-		{Name: SystemSockShop, NsPattern: "^sockshop\\d+$", DisplayName: "SockShop", AppLabelKey: "app"},
-		{Name: SystemTeaStore, NsPattern: "^teastore\\d+$", DisplayName: "TeaStore", AppLabelKey: "app"},
+var (
+	providerMu sync.RWMutex
+	provider   Provider = configManagerProvider{}
+
+	currentSystem   SystemType = "ts"
+	currentSystemMu sync.RWMutex
+)
+
+// SetProvider swaps the active Provider. Returns the previously installed
+// provider so callers (typically test fixtures) can restore it.
+func SetProvider(p Provider) Provider {
+	providerMu.Lock()
+	defer providerMu.Unlock()
+	prev := provider
+	provider = p
+	return prev
+}
+
+func getProvider() Provider {
+	providerMu.RLock()
+	defer providerMu.RUnlock()
+	return provider
+}
+
+// configManagerProvider is the production Provider. It is stateless; the
+// chaosSystemConfigManager façade reads Viper on each call.
+type configManagerProvider struct{}
+
+func (configManagerProvider) Get(system SystemType) (Registration, bool) {
+	cfg, ok := config.GetChaosSystemConfigManager().Get(chaos.SystemType(system))
+	if !ok {
+		return Registration{}, false
 	}
+	return Registration{
+		Name:        system,
+		NsPattern:   cfg.NsPattern,
+		DisplayName: cfg.DisplayName,
+		AppLabelKey: cfg.AppLabelKey,
+	}, true
+}
+
+func (configManagerProvider) All() []Registration {
+	all := config.GetChaosSystemConfigManager().GetAll()
+	out := make([]Registration, 0, len(all))
+	for name, cfg := range all {
+		out = append(out, Registration{
+			Name:        SystemType(name),
+			NsPattern:   cfg.NsPattern,
+			DisplayName: cfg.DisplayName,
+			AppLabelKey: cfg.AppLabelKey,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return string(out[i].Name) < string(out[j].Name)
+	})
+	return out
+}
+
+// GetRegistration returns the live registration for a system, or nil if the
+// system is not configured.
+func GetRegistration(system SystemType) *Registration {
+	reg, ok := getProvider().Get(system)
+	if !ok {
+		return nil
+	}
+	return &reg
+}
+
+// IsRegistered reports whether the system is currently configured.
+func IsRegistered(system SystemType) bool {
+	_, ok := getProvider().Get(system)
+	return ok
 }
 
 // GetAppLabelKey returns the pod selector label key for the given system.
-// Defaults to "app" if the system is unregistered or the registration has an empty AppLabelKey.
+// Defaults to "app" if the system is unregistered or the field is empty.
 func GetAppLabelKey(system SystemType) string {
-	reg := GetRegistration(system)
-	if reg == nil || reg.AppLabelKey == "" {
+	reg, ok := getProvider().Get(system)
+	if !ok || reg.AppLabelKey == "" {
 		return "app"
 	}
 	return reg.AppLabelKey
 }
 
-// GetCurrentAppLabelKey returns the pod selector label key for the current system.
+// GetCurrentAppLabelKey returns the pod selector label key for the current
+// system.
 func GetCurrentAppLabelKey() string {
 	return GetAppLabelKey(GetCurrentSystem())
 }
 
-// RegisterSystem registers a new system type.
-func RegisterSystem(reg SystemRegistration) error {
-	if reg.Name == "" {
-		return fmt.Errorf("system name must not be empty")
-	}
-
-	registeredSystemsMu.Lock()
-	defer registeredSystemsMu.Unlock()
-
-	if _, exists := registeredSystems[reg.Name]; exists {
-		return fmt.Errorf("system %s is already registered", reg.Name)
-	}
-
-	registeredSystems[reg.Name] = reg
-	return nil
-}
-
-// UpdateSystem updates the registration fields (NsPattern/DisplayName/AppLabelKey)
-// of an already-registered system in place. Unlike UnregisterSystem + RegisterSystem,
-// this does NOT touch any metadata providers attached to the system, so the
-// compile-time static service-endpoint / database / JVM-method providers stay
-// wired up for callers that rely on internal-data fallback.
-func UpdateSystem(reg SystemRegistration) error {
-	if reg.Name == "" {
-		return fmt.Errorf("system name must not be empty")
-	}
-
-	registeredSystemsMu.Lock()
-	defer registeredSystemsMu.Unlock()
-
-	if _, exists := registeredSystems[reg.Name]; !exists {
-		return fmt.Errorf("system %s is not registered", reg.Name)
-	}
-
-	registeredSystems[reg.Name] = reg
-	return nil
-}
-
-// UnregisterSystem removes a previously registered system.
-func UnregisterSystem(name SystemType) error {
-	registeredSystemsMu.Lock()
-	defer registeredSystemsMu.Unlock()
-
-	if _, exists := registeredSystems[name]; !exists {
-		return fmt.Errorf("system %s is not registered", name)
-	}
-
-	delete(registeredSystems, name)
-
-	currentSystemMu.Lock()
-	defer currentSystemMu.Unlock()
-	if currentSystem != name {
-		return nil
-	}
-
-	if _, exists := registeredSystems[SystemTrainTicket]; exists {
-		currentSystem = SystemTrainTicket
-		return nil
-	}
-
-	currentSystem = ""
-	return nil
-}
-
-// IsRegistered returns true if the given system type is registered.
-func IsRegistered(system SystemType) bool {
-	registeredSystemsMu.RLock()
-	defer registeredSystemsMu.RUnlock()
-
-	_, exists := registeredSystems[system]
-	return exists
-}
-
-// GetRegistration returns the registration for a system, or nil if not found.
-func GetRegistration(system SystemType) *SystemRegistration {
-	registeredSystemsMu.RLock()
-	defer registeredSystemsMu.RUnlock()
-
-	reg, exists := registeredSystems[system]
-	if !exists {
-		return nil
-	}
-
-	copied := reg
-	return &copied
-}
-
-// GetAllRegisteredSystems returns all registered system type names in a stable order.
-func GetAllRegisteredSystems() []SystemType {
-	registeredSystemsMu.RLock()
-	defer registeredSystemsMu.RUnlock()
-
-	systems := make([]SystemType, 0, len(registeredSystems))
-	for system := range registeredSystems {
-		systems = append(systems, system)
-	}
-
-	sort.Slice(systems, func(i, j int) bool {
-		return string(systems[i]) < string(systems[j])
-	})
-
-	return systems
-}
-
-// SetCurrentSystem sets the global system type for the current process.
-// This should be called at initialization time before any metadata is accessed.
+// SetCurrentSystem sets the process-wide system type. It validates the value
+// against the live Provider.
 func SetCurrentSystem(system SystemType) error {
 	if !IsRegistered(system) {
 		return fmt.Errorf("invalid system type: %s, valid types are: %s", system, strings.Join(registeredSystemNames(), ", "))
 	}
-
 	currentSystemMu.Lock()
 	defer currentSystemMu.Unlock()
-
 	currentSystem = system
 	return nil
 }
@@ -210,75 +148,30 @@ func GetCurrentSystem() SystemType {
 	return currentSystem
 }
 
-// IsTrainTicket returns true if the current system is TrainTicket.
-func IsTrainTicket() bool {
-	return GetCurrentSystem() == SystemTrainTicket
-}
-
-// IsOtelDemo returns true if the current system is OpenTelemetry Demo.
-func IsOtelDemo() bool {
-	return GetCurrentSystem() == SystemOtelDemo
-}
-
-// IsMediaMicroservices returns true if the current system is Media Microservices.
-func IsMediaMicroservices() bool {
-	return GetCurrentSystem() == SystemMediaMicroservices
-}
-
-// IsHotelReservation returns true if the current system is Hotel Reservation.
-func IsHotelReservation() bool {
-	return GetCurrentSystem() == SystemHotelReservation
-}
-
-// IsSocialNetwork returns true if the current system is Social Network.
-func IsSocialNetwork() bool {
-	return GetCurrentSystem() == SystemSocialNetwork
-}
-
-// IsOnlineBoutique returns true if the current system is Online Boutique.
-func IsOnlineBoutique() bool {
-	return GetCurrentSystem() == SystemOnlineBoutique
-}
-
-// IsSockShop returns true if the current system is Sock Shop.
-func IsSockShop() bool {
-	return GetCurrentSystem() == SystemSockShop
-}
-
-// IsTeaStore returns true if the current system is Tea Store.
-func IsTeaStore() bool {
-	return GetCurrentSystem() == SystemTeaStore
-}
-
-// String returns the string representation of the SystemType.
-func (s SystemType) String() string {
-	return string(s)
-}
-
-// IsValid returns true if this SystemType is registered.
-func (s SystemType) IsValid() bool {
-	return IsRegistered(s)
-}
-
-// GetAllSystemTypes returns all registered system types.
+// GetAllSystemTypes returns every system currently configured, sorted by name.
 func GetAllSystemTypes() []SystemType {
-	return GetAllRegisteredSystems()
+	regs := getProvider().All()
+	out := make([]SystemType, len(regs))
+	for i, reg := range regs {
+		out[i] = reg.Name
+	}
+	return out
 }
 
-// GetNamespaceByIndex generates a namespace name based on the system type and index.
+// GetNamespaceByIndex expands the system's ns_pattern with the given index.
 func GetNamespaceByIndex(system SystemType, index int) (string, error) {
-	reg := GetRegistration(system)
-	if reg == nil {
+	reg, ok := getProvider().Get(system)
+	if !ok {
 		return "", fmt.Errorf("system type not found: %s", system)
 	}
-
 	name := strings.TrimPrefix(reg.NsPattern, "^")
 	name = strings.TrimSuffix(name, "$")
-	name = strings.Replace(name, "\\d+", fmt.Sprintf("%d", index), 1)
+	name = strings.Replace(name, `\d+`, fmt.Sprintf("%d", index), 1)
 	return name, nil
 }
 
-// ParseSystemType parses a string into a SystemType.
+// ParseSystemType parses a string into a SystemType, validating against the
+// live Provider.
 func ParseSystemType(s string) (SystemType, error) {
 	system := SystemType(s)
 	if !IsRegistered(system) {
@@ -288,7 +181,7 @@ func ParseSystemType(s string) (SystemType, error) {
 }
 
 func registeredSystemNames() []string {
-	systems := GetAllRegisteredSystems()
+	systems := GetAllSystemTypes()
 	names := make([]string, len(systems))
 	for i, system := range systems {
 		names[i] = system.String()

--- a/aegislab/src/platform/systemconfig/systemconfig_test.go
+++ b/aegislab/src/platform/systemconfig/systemconfig_test.go
@@ -1,515 +1,224 @@
 package systemconfig
 
 import (
+	"sort"
+	"sync"
 	"testing"
 )
 
+type mapProvider struct {
+	mu      sync.RWMutex
+	systems map[SystemType]Registration
+}
+
+func newMapProvider(regs ...Registration) *mapProvider {
+	p := &mapProvider{systems: make(map[SystemType]Registration, len(regs))}
+	for _, reg := range regs {
+		p.systems[reg.Name] = reg
+	}
+	return p
+}
+
+func (p *mapProvider) Get(s SystemType) (Registration, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	reg, ok := p.systems[s]
+	return reg, ok
+}
+
+func (p *mapProvider) All() []Registration {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]Registration, 0, len(p.systems))
+	for _, reg := range p.systems {
+		out = append(out, reg)
+	}
+	sort.Slice(out, func(i, j int) bool { return string(out[i].Name) < string(out[j].Name) })
+	return out
+}
+
+func (p *mapProvider) set(reg Registration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.systems[reg.Name] = reg
+}
+
+func builtinTestRegs() []Registration {
+	return []Registration{
+		{Name: "ts", NsPattern: `^ts\d+$`, DisplayName: "TrainTicket", AppLabelKey: "app"},
+		{Name: "otel-demo", NsPattern: `^otel-demo\d+$`, DisplayName: "OtelDemo", AppLabelKey: "app.kubernetes.io/name"},
+		{Name: "media", NsPattern: `^media\d+$`, DisplayName: "MediaMicroservices", AppLabelKey: "app"},
+		{Name: "hs", NsPattern: `^hs\d+$`, DisplayName: "HotelReservation", AppLabelKey: "app"},
+		{Name: "sn", NsPattern: `^sn\d+$`, DisplayName: "SocialNetwork", AppLabelKey: "app"},
+		{Name: "ob", NsPattern: `^ob\d+$`, DisplayName: "OnlineBoutique", AppLabelKey: "app"},
+		{Name: "sockshop", NsPattern: `^sockshop\d+$`, DisplayName: "SockShop", AppLabelKey: "app"},
+		{Name: "teastore", NsPattern: `^teastore\d+$`, DisplayName: "TeaStore", AppLabelKey: "app"},
+	}
+}
+
+func withBuiltins(t *testing.T) *mapProvider {
+	t.Helper()
+	p := newMapProvider(builtinTestRegs()...)
+	prev := SetProvider(p)
+	t.Cleanup(func() { SetProvider(prev) })
+	return p
+}
+
 func TestSetCurrentSystem(t *testing.T) {
-	// Reset to default before tests
-	_ = SetCurrentSystem(SystemTrainTicket)
+	withBuiltins(t)
+	_ = SetCurrentSystem("ts")
 
 	tests := []struct {
-		name        string
-		system      SystemType
-		wantErr     bool
-		expectedSys SystemType
+		name    string
+		system  SystemType
+		wantErr bool
 	}{
-		{
-			name:        "set TrainTicket system",
-			system:      SystemTrainTicket,
-			wantErr:     false,
-			expectedSys: SystemTrainTicket,
-		},
-		{
-			name:        "set OtelDemo system",
-			system:      SystemOtelDemo,
-			wantErr:     false,
-			expectedSys: SystemOtelDemo,
-		},
-		{
-			name:        "set MediaMicroservices system",
-			system:      SystemMediaMicroservices,
-			wantErr:     false,
-			expectedSys: SystemMediaMicroservices,
-		},
-		{
-			name:        "set HotelReservation system",
-			system:      SystemHotelReservation,
-			wantErr:     false,
-			expectedSys: SystemHotelReservation,
-		},
-		{
-			name:        "set SocialNetwork system",
-			system:      SystemSocialNetwork,
-			wantErr:     false,
-			expectedSys: SystemSocialNetwork,
-		},
-		{
-			name:        "set OnlineBoutique system",
-			system:      SystemOnlineBoutique,
-			wantErr:     false,
-			expectedSys: SystemOnlineBoutique,
-		},
-		{
-			name:        "set SockShop system",
-			system:      SystemSockShop,
-			wantErr:     false,
-			expectedSys: SystemSockShop,
-		},
-		{
-			name:        "set TeaStore system",
-			system:      SystemTeaStore,
-			wantErr:     false,
-			expectedSys: SystemTeaStore,
-		},
-		{
-			name:        "set invalid system",
-			system:      "invalid-system",
-			wantErr:     true,
-			expectedSys: SystemTeaStore, // Should remain unchanged from previous test
-		},
+		{"ts", "ts", false},
+		{"otel-demo", "otel-demo", false},
+		{"media", "media", false},
+		{"hs", "hs", false},
+		{"sn", "sn", false},
+		{"ob", "ob", false},
+		{"sockshop", "sockshop", false},
+		{"teastore", "teastore", false},
+		{"invalid", "invalid-system", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := SetCurrentSystem(tt.system)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("SetCurrentSystem() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("SetCurrentSystem(%q) error = %v, wantErr %v", tt.system, err, tt.wantErr)
 			}
-			if !tt.wantErr && GetCurrentSystem() != tt.expectedSys {
-				t.Errorf("GetCurrentSystem() = %v, want %v", GetCurrentSystem(), tt.expectedSys)
+			if !tt.wantErr && GetCurrentSystem() != tt.system {
+				t.Fatalf("GetCurrentSystem() = %v, want %v", GetCurrentSystem(), tt.system)
 			}
 		})
 	}
 }
 
 func TestGetCurrentSystem(t *testing.T) {
-	// Reset to default
-	_ = SetCurrentSystem(SystemTrainTicket)
-
-	if got := GetCurrentSystem(); got != SystemTrainTicket {
-		t.Errorf("GetCurrentSystem() = %v, want %v", got, SystemTrainTicket)
+	withBuiltins(t)
+	_ = SetCurrentSystem("ts")
+	if got := GetCurrentSystem(); got != "ts" {
+		t.Errorf("GetCurrentSystem() = %v, want ts", got)
 	}
-
-	_ = SetCurrentSystem(SystemOtelDemo)
-	if got := GetCurrentSystem(); got != SystemOtelDemo {
-		t.Errorf("GetCurrentSystem() = %v, want %v", got, SystemOtelDemo)
-	}
-}
-
-func TestIsTrainTicket(t *testing.T) {
-	// Reset to TrainTicket
-	_ = SetCurrentSystem(SystemTrainTicket)
-
-	if !IsTrainTicket() {
-		t.Error("IsTrainTicket() should return true when system is TrainTicket")
-	}
-
-	_ = SetCurrentSystem(SystemOtelDemo)
-	if IsTrainTicket() {
-		t.Error("IsTrainTicket() should return false when system is OtelDemo")
-	}
-}
-
-func TestIsOtelDemo(t *testing.T) {
-	// Reset to TrainTicket
-	_ = SetCurrentSystem(SystemTrainTicket)
-
-	if IsOtelDemo() {
-		t.Error("IsOtelDemo() should return false when system is TrainTicket")
-	}
-
-	_ = SetCurrentSystem(SystemOtelDemo)
-	if !IsOtelDemo() {
-		t.Error("IsOtelDemo() should return true when system is OtelDemo")
-	}
-}
-
-func TestIsMediaMicroservices(t *testing.T) {
-	_ = SetCurrentSystem(SystemTrainTicket)
-
-	if IsMediaMicroservices() {
-		t.Error("IsMediaMicroservices() should return false when system is TrainTicket")
-	}
-
-	_ = SetCurrentSystem(SystemMediaMicroservices)
-	if !IsMediaMicroservices() {
-		t.Error("IsMediaMicroservices() should return true when system is MediaMicroservices")
-	}
-}
-
-func TestIsHotelReservation(t *testing.T) {
-	_ = SetCurrentSystem(SystemTrainTicket)
-
-	if IsHotelReservation() {
-		t.Error("IsHotelReservation() should return false when system is TrainTicket")
-	}
-
-	_ = SetCurrentSystem(SystemHotelReservation)
-	if !IsHotelReservation() {
-		t.Error("IsHotelReservation() should return true when system is HotelReservation")
-	}
-}
-
-func TestIsSocialNetwork(t *testing.T) {
-	_ = SetCurrentSystem(SystemTrainTicket)
-
-	if IsSocialNetwork() {
-		t.Error("IsSocialNetwork() should return false when system is TrainTicket")
-	}
-
-	_ = SetCurrentSystem(SystemSocialNetwork)
-	if !IsSocialNetwork() {
-		t.Error("IsSocialNetwork() should return true when system is SocialNetwork")
-	}
-}
-
-func TestIsOnlineBoutique(t *testing.T) {
-	_ = SetCurrentSystem(SystemTrainTicket)
-
-	if IsOnlineBoutique() {
-		t.Error("IsOnlineBoutique() should return false when system is TrainTicket")
-	}
-
-	_ = SetCurrentSystem(SystemOnlineBoutique)
-	if !IsOnlineBoutique() {
-		t.Error("IsOnlineBoutique() should return true when system is OnlineBoutique")
-	}
-}
-
-func TestIsSockShop(t *testing.T) {
-	_ = SetCurrentSystem(SystemTrainTicket)
-
-	if IsSockShop() {
-		t.Error("IsSockShop() should return false when system is TrainTicket")
-	}
-
-	_ = SetCurrentSystem(SystemSockShop)
-	if !IsSockShop() {
-		t.Error("IsSockShop() should return true when system is SockShop")
-	}
-}
-
-func TestIsTeaStore(t *testing.T) {
-	_ = SetCurrentSystem(SystemTrainTicket)
-
-	if IsTeaStore() {
-		t.Error("IsTeaStore() should return false when system is TrainTicket")
-	}
-
-	_ = SetCurrentSystem(SystemTeaStore)
-	if !IsTeaStore() {
-		t.Error("IsTeaStore() should return true when system is TeaStore")
-	}
-}
-
-func TestSystemTypeString(t *testing.T) {
-	if SystemTrainTicket.String() != "ts" {
-		t.Errorf("SystemTrainTicket.String() = %v, want %v", SystemTrainTicket.String(), "ts")
-	}
-
-	if SystemOtelDemo.String() != "otel-demo" {
-		t.Errorf("SystemOtelDemo.String() = %v, want %v", SystemOtelDemo.String(), "otel-demo")
-	}
-
-	if SystemMediaMicroservices.String() != "media" {
-		t.Errorf("SystemMediaMicroservices.String() = %v, want %v", SystemMediaMicroservices.String(), "media")
-	}
-
-	if SystemHotelReservation.String() != "hs" {
-		t.Errorf("SystemHotelReservation.String() = %v, want %v", SystemHotelReservation.String(), "hs")
-	}
-
-	if SystemSocialNetwork.String() != "sn" {
-		t.Errorf("SystemSocialNetwork.String() = %v, want %v", SystemSocialNetwork.String(), "sn")
-	}
-
-	if SystemOnlineBoutique.String() != "ob" {
-		t.Errorf("SystemOnlineBoutique.String() = %v, want %v", SystemOnlineBoutique.String(), "ob")
-	}
-
-	if SystemSockShop.String() != "sockshop" {
-		t.Errorf("SystemSockShop.String() = %v, want %v", SystemSockShop.String(), "sockshop")
-	}
-
-	if SystemTeaStore.String() != "teastore" {
-		t.Errorf("SystemTeaStore.String() = %v, want %v", SystemTeaStore.String(), "teastore")
+	_ = SetCurrentSystem("otel-demo")
+	if got := GetCurrentSystem(); got != "otel-demo" {
+		t.Errorf("GetCurrentSystem() = %v, want otel-demo", got)
 	}
 }
 
 func TestGetAllSystemTypes(t *testing.T) {
+	withBuiltins(t)
 	types := GetAllSystemTypes()
 	if len(types) != 8 {
-		t.Errorf("GetAllSystemTypes() returned %d types, want 8", len(types))
+		t.Fatalf("GetAllSystemTypes() returned %d types, want 8", len(types))
 	}
-
-	found := make(map[SystemType]bool)
+	want := map[SystemType]bool{
+		"ts": true, "otel-demo": true, "media": true, "hs": true,
+		"sn": true, "ob": true, "sockshop": true, "teastore": true,
+	}
 	for _, st := range types {
-		found[st] = true
-	}
-
-	if !found[SystemTrainTicket] {
-		t.Error("GetAllSystemTypes() should include SystemTrainTicket")
-	}
-	if !found[SystemOtelDemo] {
-		t.Error("GetAllSystemTypes() should include SystemOtelDemo")
-	}
-	if !found[SystemMediaMicroservices] {
-		t.Error("GetAllSystemTypes() should include SystemMediaMicroservices")
-	}
-	if !found[SystemHotelReservation] {
-		t.Error("GetAllSystemTypes() should include SystemHotelReservation")
-	}
-	if !found[SystemSocialNetwork] {
-		t.Error("GetAllSystemTypes() should include SystemSocialNetwork")
-	}
-	if !found[SystemOnlineBoutique] {
-		t.Error("GetAllSystemTypes() should include SystemOnlineBoutique")
-	}
-	if !found[SystemSockShop] {
-		t.Error("GetAllSystemTypes() should include SystemSockShop")
-	}
-	if !found[SystemTeaStore] {
-		t.Error("GetAllSystemTypes() should include SystemTeaStore")
+		if !want[st] {
+			t.Errorf("unexpected system in GetAllSystemTypes(): %v", st)
+		}
 	}
 }
 
 func TestParseSystemType(t *testing.T) {
+	withBuiltins(t)
 	tests := []struct {
-		name    string
-		input   string
+		in      string
 		want    SystemType
 		wantErr bool
 	}{
-		{
-			name:    "parse ts",
-			input:   "ts",
-			want:    SystemTrainTicket,
-			wantErr: false,
-		},
-		{
-			name:    "parse otel-demo",
-			input:   "otel-demo",
-			want:    SystemOtelDemo,
-			wantErr: false,
-		},
-		{
-			name:    "parse media",
-			input:   "media",
-			want:    SystemMediaMicroservices,
-			wantErr: false,
-		},
-		{
-			name:    "parse hs",
-			input:   "hs",
-			want:    SystemHotelReservation,
-			wantErr: false,
-		},
-		{
-			name:    "parse sn",
-			input:   "sn",
-			want:    SystemSocialNetwork,
-			wantErr: false,
-		},
-		{
-			name:    "parse ob",
-			input:   "ob",
-			want:    SystemOnlineBoutique,
-			wantErr: false,
-		},
-		{
-			name:    "parse sockshop",
-			input:   "sockshop",
-			want:    SystemSockShop,
-			wantErr: false,
-		},
-		{
-			name:    "parse teastore",
-			input:   "teastore",
-			want:    SystemTeaStore,
-			wantErr: false,
-		},
-		{
-			name:    "parse invalid",
-			input:   "invalid",
-			want:    "",
-			wantErr: true,
-		},
+		{"ts", "ts", false},
+		{"otel-demo", "otel-demo", false},
+		{"sockshop", "sockshop", false},
+		{"invalid", "", true},
 	}
-
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseSystemType(tt.input)
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := ParseSystemType(tt.in)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseSystemType() error = %v, wantErr %v", err, tt.wantErr)
-				return
+				t.Fatalf("ParseSystemType(%q) error = %v, wantErr %v", tt.in, err, tt.wantErr)
 			}
 			if got != tt.want {
-				t.Errorf("ParseSystemType() = %v, want %v", got, tt.want)
+				t.Errorf("ParseSystemType(%q) = %v, want %v", tt.in, got, tt.want)
 			}
 		})
 	}
 }
 
 func TestGetAppLabelKey_DefaultsToApp(t *testing.T) {
-	// An unregistered system should fall back to "app".
-	got := GetAppLabelKey(SystemType("does-not-exist"))
-	if got != "app" {
-		t.Errorf("GetAppLabelKey(unregistered) = %q, want %q", got, "app")
+	withBuiltins(t)
+	if got := GetAppLabelKey("does-not-exist"); got != "app" {
+		t.Errorf("GetAppLabelKey(unregistered) = %q, want app", got)
 	}
 }
 
 func TestGetAppLabelKey_OtelDemoUsesKubernetesName(t *testing.T) {
-	got := GetAppLabelKey(SystemOtelDemo)
-	if got != "app.kubernetes.io/name" {
-		t.Errorf("GetAppLabelKey(SystemOtelDemo) = %q, want %q", got, "app.kubernetes.io/name")
+	withBuiltins(t)
+	if got := GetAppLabelKey("otel-demo"); got != "app.kubernetes.io/name" {
+		t.Errorf("GetAppLabelKey(otel-demo) = %q, want app.kubernetes.io/name", got)
 	}
 }
 
 func TestGetAppLabelKey_FallbackOnEmptyField(t *testing.T) {
-	const testSystem = SystemType("empty-label-key-system")
+	p := newMapProvider(Registration{Name: "ts", NsPattern: `^ts\d+$`, DisplayName: "TrainTicket", AppLabelKey: "app"})
+	p.set(Registration{Name: "empty-label", NsPattern: `^empty\d+$`, DisplayName: "Empty"})
+	prev := SetProvider(p)
+	t.Cleanup(func() { SetProvider(prev) })
 
-	t.Cleanup(func() {
-		_ = SetCurrentSystem(SystemTrainTicket)
-		_ = UnregisterSystem(testSystem)
-	})
-
-	reg := SystemRegistration{
-		Name:        testSystem,
-		NsPattern:   "^empty-label-key-system\\d+$",
-		DisplayName: "EmptyLabelKeySystem",
-		// AppLabelKey intentionally left empty.
+	if got := GetAppLabelKey("empty-label"); got != "app" {
+		t.Errorf("GetAppLabelKey(empty field) = %q, want app", got)
 	}
-	if err := RegisterSystem(reg); err != nil {
-		t.Fatalf("RegisterSystem() error = %v", err)
-	}
-
-	if got := GetAppLabelKey(testSystem); got != "app" {
-		t.Errorf("GetAppLabelKey(empty field) = %q, want %q", got, "app")
-	}
-
-	if err := SetCurrentSystem(testSystem); err != nil {
+	if err := SetCurrentSystem("empty-label"); err != nil {
 		t.Fatalf("SetCurrentSystem() error = %v", err)
 	}
 	if got := GetCurrentAppLabelKey(); got != "app" {
-		t.Errorf("GetCurrentAppLabelKey() = %q, want %q", got, "app")
+		t.Errorf("GetCurrentAppLabelKey() = %q, want app", got)
 	}
 }
 
-func TestRegisterSystemLifecycle(t *testing.T) {
-	const testSystem = SystemType("dynamic-test-system")
+// TestGetAppLabelKey_LiveUpdate proves there is no static map: updating the
+// provider mid-test must be observed by the next GetAppLabelKey call.
+func TestGetAppLabelKey_LiveUpdate(t *testing.T) {
+	p := withBuiltins(t)
 
-	t.Cleanup(func() {
-		_ = SetCurrentSystem(SystemTrainTicket)
-		_ = UnregisterSystem(testSystem)
+	if got := GetAppLabelKey("ts"); got != "app" {
+		t.Fatalf("baseline GetAppLabelKey(ts) = %q, want app", got)
+	}
+
+	p.set(Registration{
+		Name:        "ts",
+		NsPattern:   `^ts\d+$`,
+		DisplayName: "TrainTicket",
+		AppLabelKey: "x-test-label",
 	})
 
-	if IsRegistered(testSystem) {
-		t.Fatalf("test system %q should not be pre-registered", testSystem)
+	if got := GetAppLabelKey("ts"); got != "x-test-label" {
+		t.Fatalf("after update GetAppLabelKey(ts) = %q, want x-test-label", got)
 	}
+}
 
-	reg := SystemRegistration{
-		Name:        testSystem,
-		NsPattern:   "^dynamic-test-system\\d+$",
-		DisplayName: "DynamicTestSystem",
-	}
-
-	if err := RegisterSystem(reg); err != nil {
-		t.Fatalf("RegisterSystem() error = %v", err)
-	}
-
-	if !IsRegistered(testSystem) {
-		t.Fatalf("IsRegistered() = false, want true")
-	}
-
-	gotReg := GetRegistration(testSystem)
-	if gotReg == nil {
-		t.Fatalf("GetRegistration() returned nil")
-	}
-	if gotReg.DisplayName != reg.DisplayName {
-		t.Fatalf("GetRegistration().DisplayName = %q, want %q", gotReg.DisplayName, reg.DisplayName)
-	}
-
-	parsed, err := ParseSystemType(string(testSystem))
-	if err != nil {
-		t.Fatalf("ParseSystemType() error = %v", err)
-	}
-	if parsed != testSystem {
-		t.Fatalf("ParseSystemType() = %q, want %q", parsed, testSystem)
-	}
-
-	if err := SetCurrentSystem(testSystem); err != nil {
-		t.Fatalf("SetCurrentSystem() error = %v", err)
-	}
-	if GetCurrentSystem() != testSystem {
-		t.Fatalf("GetCurrentSystem() = %q, want %q", GetCurrentSystem(), testSystem)
-	}
-
-	namespace, err := GetNamespaceByIndex(testSystem, 7)
+func TestGetNamespaceByIndex(t *testing.T) {
+	withBuiltins(t)
+	got, err := GetNamespaceByIndex("ts", 7)
 	if err != nil {
 		t.Fatalf("GetNamespaceByIndex() error = %v", err)
 	}
-	if namespace != "dynamic-test-system7" {
-		t.Fatalf("GetNamespaceByIndex() = %q, want %q", namespace, "dynamic-test-system7")
+	if got != "ts7" {
+		t.Errorf("GetNamespaceByIndex(ts,7) = %q, want ts7", got)
 	}
-
-	if err := RegisterSystem(reg); err == nil {
-		t.Fatal("RegisterSystem() should reject duplicate registrations")
-	}
-
-	if err := UnregisterSystem(testSystem); err != nil {
-		t.Fatalf("UnregisterSystem() error = %v", err)
-	}
-	if IsRegistered(testSystem) {
-		t.Fatal("IsRegistered() = true after unregister")
-	}
-	if GetCurrentSystem() != SystemTrainTicket {
-		t.Fatalf("GetCurrentSystem() = %q after unregister, want %q", GetCurrentSystem(), SystemTrainTicket)
+	if _, err := GetNamespaceByIndex("not-registered", 0); err == nil {
+		t.Error("GetNamespaceByIndex(not-registered) should error")
 	}
 }
 
-func TestUpdateSystem(t *testing.T) {
-	const testSystem = SystemType("update-test-system")
-
-	t.Cleanup(func() {
-		_ = UnregisterSystem(testSystem)
-	})
-
-	// UpdateSystem on an unregistered system must error.
-	if err := UpdateSystem(SystemRegistration{Name: testSystem, NsPattern: "x", DisplayName: "X"}); err == nil {
-		t.Fatal("UpdateSystem() on unregistered system should return an error")
-	}
-
-	orig := SystemRegistration{
-		Name:        testSystem,
-		NsPattern:   "^update-test-system\\d+$",
-		DisplayName: "Original",
-		AppLabelKey: "app",
-	}
-	if err := RegisterSystem(orig); err != nil {
-		t.Fatalf("RegisterSystem() error = %v", err)
-	}
-
-	updated := SystemRegistration{
-		Name:        testSystem,
-		NsPattern:   "^uts\\d+$",
-		DisplayName: "Renamed",
-		AppLabelKey: "app.kubernetes.io/name",
-	}
-	if err := UpdateSystem(updated); err != nil {
-		t.Fatalf("UpdateSystem() error = %v", err)
-	}
-
-	got := GetRegistration(testSystem)
-	if got == nil {
-		t.Fatal("GetRegistration() returned nil after update")
-	}
-	if got.NsPattern != updated.NsPattern || got.DisplayName != updated.DisplayName || got.AppLabelKey != updated.AppLabelKey {
-		t.Fatalf("GetRegistration() = %+v, want %+v", got, updated)
-	}
-
-	// Empty name must be rejected.
-	if err := UpdateSystem(SystemRegistration{}); err == nil {
-		t.Fatal("UpdateSystem() with empty name should return an error")
+func TestSystemTypeString(t *testing.T) {
+	if SystemType("ts").String() != "ts" {
+		t.Fail()
 	}
 }

--- a/aegislab/src/platform/systemconfig/systemconfigtest/fixture.go
+++ b/aegislab/src/platform/systemconfig/systemconfigtest/fixture.go
@@ -1,0 +1,84 @@
+// Package systemconfigtest provides test-only fixtures that swap the
+// systemconfig Provider for an in-memory map so unit tests don't have to
+// boot Viper / etcd.
+package systemconfigtest
+
+import (
+	"sort"
+	"sync"
+	"testing"
+
+	"aegis/platform/systemconfig"
+)
+
+// InMemoryProvider implements systemconfig.Provider backed by a map.
+type InMemoryProvider struct {
+	mu      sync.RWMutex
+	systems map[systemconfig.SystemType]systemconfig.Registration
+}
+
+// NewInMemoryProvider seeds an InMemoryProvider with the given registrations.
+func NewInMemoryProvider(regs ...systemconfig.Registration) *InMemoryProvider {
+	p := &InMemoryProvider{systems: make(map[systemconfig.SystemType]systemconfig.Registration, len(regs))}
+	for _, reg := range regs {
+		p.systems[reg.Name] = reg
+	}
+	return p
+}
+
+// Set inserts or replaces a registration. Safe for use after the provider
+// has been installed.
+func (p *InMemoryProvider) Set(reg systemconfig.Registration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.systems[reg.Name] = reg
+}
+
+// Get implements systemconfig.Provider.
+func (p *InMemoryProvider) Get(system systemconfig.SystemType) (systemconfig.Registration, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	reg, ok := p.systems[system]
+	return reg, ok
+}
+
+// All implements systemconfig.Provider.
+func (p *InMemoryProvider) All() []systemconfig.Registration {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]systemconfig.Registration, 0, len(p.systems))
+	for _, reg := range p.systems {
+		out = append(out, reg)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return string(out[i].Name) < string(out[j].Name)
+	})
+	return out
+}
+
+// WithSystems installs an InMemoryProvider seeded with regs for the duration
+// of the test. The previous provider is restored via t.Cleanup.
+func WithSystems(t *testing.T, regs ...systemconfig.Registration) *InMemoryProvider {
+	t.Helper()
+	p := NewInMemoryProvider(regs...)
+	prev := systemconfig.SetProvider(p)
+	t.Cleanup(func() {
+		systemconfig.SetProvider(prev)
+	})
+	return p
+}
+
+// BuiltinFixtures returns the 8 historical builtin systems as Registration
+// values. Useful for tests that previously relied on the hardcoded map.
+func BuiltinFixtures() []systemconfig.Registration {
+	return []systemconfig.Registration{
+		{Name: "ts", NsPattern: `^ts\d+$`, DisplayName: "TrainTicket", AppLabelKey: "app"},
+		{Name: "otel-demo", NsPattern: `^otel-demo\d+$`, DisplayName: "OtelDemo", AppLabelKey: "app.kubernetes.io/name"},
+		{Name: "media", NsPattern: `^media\d+$`, DisplayName: "MediaMicroservices", AppLabelKey: "app"},
+		{Name: "hs", NsPattern: `^hs\d+$`, DisplayName: "HotelReservation", AppLabelKey: "app"},
+		{Name: "sn", NsPattern: `^sn\d+$`, DisplayName: "SocialNetwork", AppLabelKey: "app"},
+		{Name: "ob", NsPattern: `^ob\d+$`, DisplayName: "OnlineBoutique", AppLabelKey: "app"},
+		{Name: "sockshop", NsPattern: `^sockshop\d+$`, DisplayName: "SockShop", AppLabelKey: "app"},
+		{Name: "teastore", NsPattern: `^teastore\d+$`, DisplayName: "TeaStore", AppLabelKey: "app"},
+	}
+}


### PR DESCRIPTION
## Investigation

The chaos stack had a dual source of truth for "what systems exist":

- `platform/systemconfig/` built a `registeredSystems` map at `init()` from a
  hardcoded `builtinSystemRegistrations()` table (8 entries).
- The same 8 systems were already seeded declaratively into etcd via
  `data/initial_data/prod/data.yaml` (the `injection.system.<name>.<field>`
  keyspace, mirrored into Viper, accessed through
  `config.GetChaosSystemConfigManager()`).

The hot bug: `systemconfig.GetAppLabelKey(system)` read the static
in-process map. Ops changes to `injection.system.ts.app_label_key` were
silently ignored at runtime. Same shape for `GetNamespaceByIndex`,
`ParseSystemType`, `GetAllSystemTypes`, and `IsRegistered` — every one
of them disagreed with the etcd source of truth as soon as ops touched a
system.

## What changed

- Every `systemconfig` getter (`GetAppLabelKey`,
  `GetCurrentAppLabelKey`, `GetNamespaceByIndex`, `ParseSystemType`,
  `GetAllSystemTypes`, `IsRegistered`, `GetRegistration`) now reads
  through a `Provider` indirection. The default provider is a stateless
  façade over `config.GetChaosSystemConfigManager()` — every call
  decodes fresh from Viper, no cache.
- Deleted `registeredSystems`, `builtinSystemRegistrations()`, the
  `init()` that populated them, the 8 named constants
  (`SystemTrainTicket`, `SystemOtelDemo`, …), the 8 unused `Is*()`
  helpers, the `SystemType.IsValid()` method, and the
  `RegisterSystem` / `UpdateSystem` / `UnregisterSystem` mutators (no
  production callers; their job belongs to the chaossystem domain that
  writes to etcd).
- `MetadataRegistry` / `metadataStoreRouter` are untouched —
  orthogonal provider plumbing, not a system list.
- New `platform/systemconfig/systemconfigtest/` subpackage with
  `InMemoryProvider`, `WithSystems(t, …)` and `BuiltinFixtures()` so
  test code outside the package can pin a system table without booting
  Viper.

## Test plan

- `go build -tags duckdb_arrow ./...` clean.
- `go vet -tags duckdb_arrow ./...` clean.
- `go test -tags duckdb_arrow ./platform/systemconfig/... ./crud/chaos/guided/... ./platform/k8s/resourcelookup/...` clean.
- `golangci-lint run` on the changed packages — 0 issues.
- Full `go test ./...` failures are pre-existing on main (rbac SQL
  regex drift, boot smoke tests, blob List_* tests, docs gen tests) —
  re-verified by stashing my changes and re-running.
- New test `TestGetAppLabelKey_LiveUpdate` exercises the regression
  directly: install a provider, observe `GetAppLabelKey("ts") == "app"`,
  mutate the provider in place, observe the next call returns
  `"x-test-label"`. Would have failed against the old static-map
  implementation.

## Acceptance grep

```
$ cd aegislab/src
$ git grep -nE 'registeredSystems|builtinSystemRegistrations'
$ git grep -nE 'System(TrainTicket|OtelDemo|SockShop|HotelReservation|SocialNetwork|OnlineBoutique|Media|MediaMicroservices|TeaStore)\b'
```

Both return zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)