### PR TITLE
fix(seed): initializeAdminUser idempotent — skip Create when admin row already exists

### DIFF
--- a/aegislab/src/boot/seed/producer.go
+++ b/aegislab/src/boot/seed/producer.go
@@ -384,12 +384,20 @@ func initializeUsers(store *bootstrapStore, data *InitialData) error {
 	for _, userData := range data.Users {
 		user := userData.ConvertToDBUser()
 
-		if err := store.createUser(user); err != nil {
-			if errors.Is(err, consts.ErrAlreadyExists) {
-				logrus.Warnf("User %s already exists, skipping", user.Username)
-				continue
+		// Same race as initializeAdminUser: ConvertToDBUser yields Password=""
+		// which User.BeforeCreate rejects before INSERT, so the dup-key path
+		// never fires on re-boot. Look up by username first and reuse the
+		// existing row when present.
+		existing, getErr := store.getUserByUsername(user.Username)
+		switch {
+		case getErr == nil:
+			user = existing
+		case errors.Is(getErr, consts.ErrNotFound):
+			if err := store.createUser(user); err != nil {
+				return fmt.Errorf("failed to create user %s: %w", user.Username, err)
 			}
-			return fmt.Errorf("failed to create user %s: %w", user.Username, err)
+		default:
+			return fmt.Errorf("user %s lookup failed: %w", user.Username, getErr)
 		}
 
 		if err := store.createUserRole(&model.UserRole{

--- a/aegislab/src/boot/seed/producer.go
+++ b/aegislab/src/boot/seed/producer.go
@@ -177,17 +177,23 @@ func seedServiceAccounts(db *gorm.DB, accounts []InitialDataServiceAccount) erro
 
 func initializeAdminUser(store *bootstrapStore, data *InitialData) (*model.User, error) {
 	adminUser := data.AdminUser.ConvertToDBUser()
-	if err := store.createUser(adminUser); err != nil {
-		if !errors.Is(err, consts.ErrAlreadyExists) {
+
+	// Look up the existing admin BEFORE attempting Create. SSO bootstrap
+	// (boot/sso/initialization.go) may have already created this row with a
+	// real password. ConvertToDBUser produces Password="" which the
+	// User.BeforeCreate GORM hook rejects (HashPassword refuses <8 chars)
+	// before the INSERT runs — so gorm.ErrDuplicatedKey never surfaces and
+	// the old ErrAlreadyExists recovery branch is unreachable on re-boot.
+	existing, getErr := store.getUserByUsername(adminUser.Username)
+	switch {
+	case getErr == nil:
+		adminUser = existing
+	case errors.Is(getErr, consts.ErrNotFound):
+		if err := store.createUser(adminUser); err != nil {
 			return nil, fmt.Errorf("failed to create admin user: %w", err)
 		}
-		// SSO may have bootstrapped this admin already; fetch the existing row
-		// so we can still link the super_admin role.
-		existing, getErr := store.getUserByUsername(adminUser.Username)
-		if getErr != nil {
-			return nil, fmt.Errorf("admin user reportedly exists but lookup failed: %w", getErr)
-		}
-		adminUser = existing
+	default:
+		return nil, fmt.Errorf("admin user lookup failed: %w", getErr)
 	}
 
 	superAdminRole, err := store.getRoleByName("super_admin")

--- a/aegislab/src/boot/seed/producer_test.go
+++ b/aegislab/src/boot/seed/producer_test.go
@@ -11,6 +11,69 @@ import (
 	"gorm.io/gorm"
 )
 
+// TestInitializeAdminUser_SkipsCreateWhenAdminAlreadyExists pins the SSO
+// re-boot path: an admin row with a real (non-empty) password is already in
+// the DB. ConvertToDBUser builds a Password="" model.User; if Create runs,
+// User.BeforeCreate calls crypto.HashPassword("") which rejects strings <8
+// chars and fails the boot before the dup-key path is reachable. So the
+// re-boot path MUST look the user up first, not rely on ErrAlreadyExists.
+func TestInitializeAdminUser_SkipsCreateWhenAdminAlreadyExists(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&model.User{}, &model.Role{}, &model.UserRole{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// SSO bootstrap path: real password, real row, predates the seed run.
+	preExisting := &model.User{
+		Username: AdminUsername,
+		Email:    "admin@aegis.local",
+		Password: "a-real-bcrypt-hash-from-sso-bootstrap",
+		FullName: "Admin",
+		IsActive: true,
+		Status:   consts.CommonEnabled,
+	}
+	if err := db.Omit("active_username").Create(preExisting).Error; err != nil {
+		t.Fatalf("seed pre-existing admin: %v", err)
+	}
+
+	if err := db.Omit("active_name").Create(&model.Role{Name: string(consts.RoleSuperAdmin), Status: consts.CommonEnabled}).Error; err != nil {
+		t.Fatalf("seed super_admin role: %v", err)
+	}
+
+	store := newBootstrapStore(db)
+	data := &InitialData{
+		AdminUser: InitialDataUser{
+			Username: AdminUsername,
+			Email:    "admin@aegis.local",
+			FullName: "Admin",
+			IsActive: true,
+			Status:   consts.CommonEnabled,
+		},
+	}
+
+	got, err := initializeAdminUser(store, data)
+	if err != nil {
+		t.Fatalf("initializeAdminUser on re-boot: %v", err)
+	}
+	if got.ID != preExisting.ID {
+		t.Fatalf("returned user ID: want pre-existing %d, got %d (Create ran?)", preExisting.ID, got.ID)
+	}
+	if got.Password != preExisting.Password {
+		t.Fatalf("admin password was clobbered: want %q, got %q", preExisting.Password, got.Password)
+	}
+
+	var count int64
+	if err := db.Model(&model.User{}).Where("username = ?", AdminUsername).Count(&count).Error; err != nil {
+		t.Fatalf("count admin rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 admin row, got %d", count)
+	}
+}
+
 func newDynamicConfigTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})

--- a/aegislab/src/boot/seed/producer_test.go
+++ b/aegislab/src/boot/seed/producer_test.go
@@ -74,6 +74,80 @@ func TestInitializeAdminUser_SkipsCreateWhenAdminAlreadyExists(t *testing.T) {
 	}
 }
 
+// TestInitializeUsers_IdempotentOnSecondBoot pins the same re-boot path for
+// the non-admin user loop fed from data.yaml#users. ConvertToDBUser returns
+// Password="" — without the lookup-first fix, BeforeCreate fails for every
+// already-existing user the second time around. This guards against the
+// data.yaml-driven blast radius (rainysteven1/2/3 in prod).
+func TestInitializeUsers_IdempotentOnSecondBoot(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&model.User{},
+		&model.Role{},
+		&model.UserRole{},
+		&model.Team{},
+		&model.Project{},
+		&model.UserScopedRole{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	if err := db.Omit("active_name").Create(&model.Role{Name: string(consts.RoleUser), Status: consts.CommonEnabled}).Error; err != nil {
+		t.Fatalf("seed user role: %v", err)
+	}
+
+	preExisting := &model.User{
+		Username: "rainysteven1",
+		Email:    "rainysteven1@aegis.local",
+		Password: "a-real-bcrypt-hash-from-sso-bootstrap",
+		FullName: "Rainy Steven 1",
+		IsActive: true,
+		Status:   consts.CommonEnabled,
+	}
+	if err := db.Omit("active_username").Create(preExisting).Error; err != nil {
+		t.Fatalf("seed pre-existing user: %v", err)
+	}
+
+	store := newBootstrapStore(db)
+	data := &InitialData{
+		Users: []InitialDataUser{
+			{
+				Username: "rainysteven1",
+				Email:    "rainysteven1@aegis.local",
+				FullName: "Rainy Steven 1",
+				IsActive: true,
+				Status:   consts.CommonEnabled,
+			},
+		},
+	}
+
+	if err := initializeUsers(store, data); err != nil {
+		t.Fatalf("initializeUsers on re-boot (pre-existing): %v", err)
+	}
+	if err := initializeUsers(store, data); err != nil {
+		t.Fatalf("initializeUsers on third boot: %v", err)
+	}
+
+	var count int64
+	if err := db.Model(&model.User{}).Where("username = ?", "rainysteven1").Count(&count).Error; err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 row for rainysteven1, got %d", count)
+	}
+
+	var after model.User
+	if err := db.Where("username = ?", "rainysteven1").First(&after).Error; err != nil {
+		t.Fatalf("re-fetch: %v", err)
+	}
+	if after.Password != preExisting.Password {
+		t.Fatalf("password clobbered: want %q got %q", preExisting.Password, after.Password)
+	}
+}
+
 func newDynamicConfigTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})


### PR DESCRIPTION
## Bug chain

#438 (declarative seeds idempotent on every boot) dropped the `producerSeedRequired` gate, so `initializeAdminUser` AND `initializeUsers` in `aegislab/src/boot/seed/producer.go` now run on every boot. On a cluster where users already exist (admin created by SSO bootstrap; rainysteven1/2/3 declared in `aegislab/data/initial_data/prod/data.yaml`), the seeds still call `createUser` — and the existing `errors.Is(err, consts.ErrAlreadyExists)` recovery branches turn out to be unreachable.

The race:

1. `InitialDataUser.ConvertToDBUser()` (`aegislab/src/boot/seed/types.go:240`) does NOT populate `Password` — it returns a `model.User{Password: ""}`.
2. The `model.User.BeforeCreate` GORM hook (`aegislab/src/platform/model/entity_iam.go:33-41`) fires BEFORE the INSERT and calls `crypto.HashPassword("")`.
3. `crypto.HashPassword` rejects strings shorter than 8 characters with `password must be at least 8 characters long`.
4. Therefore `gorm.ErrDuplicatedKey` never surfaces — the dup-key recovery branches are dead code on the re-boot path.

Symptom from bytecluster `exp` namespace, post-rebuild from main HEAD `6ba441d5`:

```
[Fx] HOOK OnStart  aegis/boot.registerProducerInitialization.func1() ... failed in 27.462312ms: failed to initialize system data for producer: failed to initialize admin user: failed to create admin user: failed to create user: failed to hash password: password must be at least 8 characters long
[Fx] ERROR  Failed to start, rolling back ...
```

## Fix

Same shape applied to both `initializeAdminUser` and `initializeUsers`: look up by username BEFORE attempting `createUser`. If found, skip the Create and reuse the existing row. If not (`consts.ErrNotFound`), do the Create — which surfaces real errors on the first-time install path. Drop the now-dead `errors.Is(err, consts.ErrAlreadyExists)` branches.

`createUserRole` / `createUserTeam` / `createUserProject` already use `OnConflict{DoNothing}`, so the downstream binding code in `initializeUsers` is already re-run-safe and needs no change.

### Why both functions in one PR

Same defect cluster (same `ConvertToDBUser`/`BeforeCreate`/missing-existence-check), and `prod/data.yaml` ships 3 non-admin users that hit it concretely — shipping the admin fix alone leaves boot broken on the same line of code 30 lines down.

## Tests

In `aegislab/src/boot/seed/producer_test.go`:

- `TestInitializeAdminUser_SkipsCreateWhenAdminAlreadyExists` — in-memory sqlite; pre-seed admin with a real (non-empty) password simulating SSO bootstrap; run `initializeAdminUser`; assert no error, returned user ID matches pre-existing row, password preserved (no clobber), exactly 1 admin row.
- `TestInitializeUsers_IdempotentOnSecondBoot` — same setup; pre-seed a non-admin user; run `initializeUsers` twice; assert no error, no duplicate row, password preserved.

## Out of scope

- Did NOT touch `ConvertToDBUser` — password belongs to SSO bootstrap, not the seed.

## Verification

- `go build -tags duckdb_arrow ./...`: green
- `go vet -tags duckdb_arrow ./boot/seed/... ./crud/iam/...`: green
- `go test -tags duckdb_arrow ./boot/seed/...`: green (all tests pass, two new tests green)
- `go test -tags duckdb_arrow ./crud/iam/...`: pre-existing `TestServiceListRolesSuccess` sqlmock-regex failure unrelated to this change (verified on base `6ba441d5`); all others green