### PR TITLE
fix(regression): hotelreservation expects algorithm.result.collection

### DIFF
--- a/aegislab/regression/hotelreservation-guided.yaml
+++ b/aegislab/regression/hotelreservation-guided.yaml
@@ -29,13 +29,18 @@ submit:
 validation:
   timeout_seconds: 3000
   min_events: 6
-  expected_final_event: datapack.no_anomaly
+  # HS ships dsb-wrk2 as the bundled loadgen, so PodFailure on `profile`
+  # lands inside live traffic and the detector finds real anomaly signal
+  # (verified 2026-05-22: anomaly_count=2 on the smoke run). The chain
+  # therefore terminates at `algorithm.result.collection`, not the
+  # quieter-pedestal shortcut `datapack.no_anomaly`.
+  expected_final_event: algorithm.result.collection
   required_events:
     - restart.pedestal.started
     - fault.injection.started
     - datapack.build.started
     - algorithm.run.started
-    - datapack.no_anomaly
+    - algorithm.result.collection
   required_task_chain:
     - RestartPedestal
     - FaultInjection


### PR DESCRIPTION
## Summary

- HS ships dsb-wrk2 as bundled loadgen → PodFailure on `profile` lands in live traffic → detector finds real anomaly signal.
- Verified 2026-05-22 on bytecluster: smoke run produced `anomaly_count=2` and terminated at `algorithm.result.collection`, not `datapack.no_anomaly`.
- Aligns HS with the sockshop pattern (already correct); the original expectation was a copy-paste from the quieter-pedestal template.

## Test plan

- [x] Local smoke run on bytecluster confirmed the new expected_final_event matches actual behavior.
- [ ] Re-run `aegisctl regression run --file aegislab/regression/hotelreservation-guided.yaml` post-merge to confirm the validator now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)