### PR TITLE
chore(algo-random): build in-tree from rcabench-platform/v2 container CLI

### DIFF
--- a/aegislab/data/initial_data/prod/data.yaml
+++ b/aegislab/data/initial_data/prod/data.yaml
@@ -13,7 +13,7 @@ containers:
     status: 1
     versions:
       - name: 1.0.0
-        image_ref: pair-diag-cn-guangzhou.cr.volces.com/pair/rca-algo-random:latest
+        image_ref: docker.io/opspai/rca-algo-random:latest
         command: bash /entrypoint.sh
   - type: 0
     name: traceback

--- a/aegislab/manifests/byte-cluster/initial-data/data.yaml
+++ b/aegislab/manifests/byte-cluster/initial-data/data.yaml
@@ -20,7 +20,7 @@ containers:
     status: 1
     versions:
       - name: 1.0.0
-        image_ref: pair-diag-cn-guangzhou.cr.volces.com/pair/rca-algo-random:latest
+        image_ref: docker.io/opspai/rca-algo-random:latest
         command: bash /entrypoint.sh
   - type: 0
     name: traceback

--- a/rcabench-platform/docker/algo-random/Dockerfile
+++ b/rcabench-platform/docker/algo-random/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+# Self-contained slim image for the `random` RCA algorithm. Builds from
+# python:3.13-slim and installs the [sdk,internal] extras — `internal`
+# pulls `rcabench.openapi`, `sdk` pulls `polars`/`pandas`/`s3fs` needed
+# by the v2 container CLI's S3 staging + datapack conversion path.
+#
+# Build context must be `rcabench-platform/` so the COPYs resolve to
+# repo-subdir paths. Run:
+#   docker build -f rcabench-platform/docker/algo-random/Dockerfile \
+#                -t docker.io/opspai/rca-algo-random:dev rcabench-platform
+
+# ---------- builder: full uv venv install in a throw-away stage ----------
+FROM python:3.13-slim AS builder
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --extra sdk --extra internal --no-dev --frozen --no-install-project
+
+COPY README.md ./
+COPY src/ ./src/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --extra sdk --extra internal --no-dev --frozen
+
+# ---------- runtime: copy only what's needed ----------
+FROM python:3.13-slim
+
+ENV TZ=Asia/Shanghai \
+    PATH="/app/.venv/bin:$PATH"
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/src /app/src
+
+COPY docker/algo-random/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/rcabench-platform/docker/algo-random/entrypoint.sh
+++ b/rcabench-platform/docker/algo-random/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eux
+cd /app
+
+exec .venv/bin/python -m rcabench_platform.v2.cli.container run \
+    --algorithm random \
+    --input-path "${INPUT_PATH}" \
+    --output-path "${OUTPUT_PATH}"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -50,6 +50,11 @@ profiles:
           docker:
             dockerfile: docker/detector/Dockerfile
             network: host
+        - image: opspai/rca-algo-random
+          context: rcabench-platform
+          docker:
+            dockerfile: docker/algo-random/Dockerfile
+            network: host
         - image: opspai/rcabench
           context: .
           docker:
@@ -117,6 +122,11 @@ profiles:
           context: rcabench-platform
           docker:
             dockerfile: docker/detector/Dockerfile
+            network: host
+        - image: 10.10.10.240/library/rca-algo-random
+          context: rcabench-platform
+          docker:
+            dockerfile: docker/algo-random/Dockerfile
             network: host
         - image: 10.10.10.240/library/rcabench
           context: aegislab
@@ -215,6 +225,11 @@ profiles:
           context: rcabench-platform
           docker:
             dockerfile: docker/detector/Dockerfile
+            network: host
+        - image: docker.io/opspai/rca-algo-random
+          context: rcabench-platform
+          docker:
+            dockerfile: docker/algo-random/Dockerfile
             network: host
         - image: docker.io/opspai/rcabench
           context: .


### PR DESCRIPTION
## Summary

The external `pair-diag-cn-guangzhou.cr.volces.com/pair/rca-algo-random:latest` image was stuck on a pre-2026-05-19 version of `v2/cli/container.py` that coerced INPUT_PATH through `pathlib.Path`, collapsing `s3://...` to `s3:/...` and failing `is_dir()`. The S3-staging fix landed at `8bb0da30` but never propagated because that image is built outside the monorepo.

This PR brings the build in-tree so the next commit to `v2/cli/container.py` actually ships:

- `rcabench-platform/docker/algo-random/Dockerfile` — slim multi-stage from `python:3.13-slim`, installs `[sdk,internal]` extras only
- `rcabench-platform/docker/algo-random/entrypoint.sh` — hardcodes `--algorithm random`, wires INPUT_PATH/OUTPUT_PATH
- `skaffold.yaml` — adds artifact in `local` (`opspai/...`), `staging` (`10.10.10.240/library/...`), `byte-cluster` (`docker.io/opspai/...`)
- `data.yaml` seeds (prod + byte-cluster) repointed to `docker.io/opspai/rca-algo-random:latest`; staging entry already matched `10.10.10.240/library/rca-algo-random:latest`

Discovered while debugging HS regression failure today — `random` algo job AssertionError on `s3:/aegis-datapack/<id>` (single slash). Fix is the bytecluster image rebuild, but the precondition is having a Dockerfile to rebuild from.

## Out of scope

- `rca-algo-traceback` — same external-image problem, but it bakes in a specific A7/A8/A9/A10 variant; defer to a follow-up that picks the right flavor
- Image push — `ENV_MODE=byte-cluster skaffold build` will publish after merge

## Test plan

- [x] `docker build -f rcabench-platform/docker/algo-random/Dockerfile rcabench-platform` succeeds locally
- [x] Built image runs `python -m rcabench_platform.v2.cli.container run --help` (exit 0)
- [x] Entrypoint with missing INPUT_PATH errors on unbound variable (set -u behavior)
- [ ] Post-merge: `ENV_MODE=byte-cluster skaffold build`, then `aegisctl container version set-image` on container_versions row to bump `random:1.0.0`, then re-run `hotelreservation-guided.yaml` regression