### PR TITLE
feat(chaos): enforce per-capability JSON Schema on PointManifest import + injection submit (#457)

### DIFF
--- a/aegislab/src/crud/chaos/handler.go
+++ b/aegislab/src/crud/chaos/handler.go
@@ -16,6 +16,22 @@ type Handler struct {
 
 func NewHandler(m *Manager) *Handler { return &Handler{Mgr: m} }
 
+// schemaValidationBody is the response payload when ErrSchemaValidation
+// fires: leaf-level field paths the caller can attribute directly,
+// instead of re-parsing a flattened message string.
+type schemaValidationBody struct {
+	Errors []SchemaLeaf `json:"errors"`
+}
+
+func writeSchemaOrPlainError(c *gin.Context, err error, code int) {
+	var sve *SchemaValidationError
+	if errors.As(err, &sve) {
+		dto.JSONResponse(c, code, "schema validation failed", schemaValidationBody{Errors: sve.Leaves})
+		return
+	}
+	dto.ErrorResponse(c, code, err.Error())
+}
+
 type upsertSystemReq struct {
 	NsPattern               string `json:"ns_pattern"                            binding:"required"`
 	AppLabelKey             string `json:"app_label_key"                         binding:"required"`
@@ -127,7 +143,7 @@ func (h *Handler) ImportPoints(c *gin.Context) {
 	}
 	res, err := h.Mgr.ImportPoints(c.Request.Context(), sysName, m, dryRun)
 	if err != nil {
-		dto.ErrorResponse(c, http.StatusBadRequest, err.Error())
+		writeSchemaOrPlainError(c, err, http.StatusBadRequest)
 		return
 	}
 	dto.SuccessResponse(c, res)
@@ -190,7 +206,7 @@ func (h *Handler) CreateInjection(c *gin.Context) {
 		case errors.Is(err, ErrSystemAtCapacity):
 			code = http.StatusTooManyRequests
 		}
-		dto.ErrorResponse(c, code, err.Error())
+		writeSchemaOrPlainError(c, err, code)
 		return
 	}
 	dto.JSONResponse(c, http.StatusAccepted, "Injection accepted", inj)

--- a/aegislab/src/crud/chaos/handler.go
+++ b/aegislab/src/crud/chaos/handler.go
@@ -184,7 +184,8 @@ func (h *Handler) CreateInjection(c *gin.Context) {
 			errors.Is(err, ErrCapabilityNotFound):
 			code = http.StatusNotFound
 		case errors.Is(err, ErrSystemDisabled), errors.Is(err, ErrPointNotActive),
-			errors.Is(err, ErrCapabilityUnsupported), errors.Is(err, ErrIdempotencyMismatch):
+			errors.Is(err, ErrCapabilityUnsupported), errors.Is(err, ErrIdempotencyMismatch),
+			errors.Is(err, ErrSchemaValidation):
 			code = http.StatusBadRequest
 		case errors.Is(err, ErrSystemAtCapacity):
 			code = http.StatusTooManyRequests

--- a/aegislab/src/crud/chaos/import.go
+++ b/aegislab/src/crud/chaos/import.go
@@ -83,7 +83,7 @@ func (s *Manager) ImportPoints(ctx context.Context, systemName string, m PointMa
 		return nil, err
 	}
 
-	caps, err := s.loadCapabilityNames(tx)
+	caps, err := s.loadCapabilities(tx)
 	if err != nil {
 		return nil, err
 	}
@@ -91,10 +91,28 @@ func (s *Manager) ImportPoints(ctx context.Context, systemName string, m PointMa
 	out := &ImportResult{DryRun: dryRun}
 	newIDs := make(map[string]struct{}, len(m.Spec.Points))
 
+	sc := newSchemaCompiler()
 	rows := make([]Point, 0, len(m.Spec.Points))
-	for _, p := range m.Spec.Points {
-		if _, ok := caps[p.Capability]; !ok {
+	for i, p := range m.Spec.Points {
+		capRow, ok := caps[p.Capability]
+		if !ok {
 			return nil, fmt.Errorf("chaos: unknown capability %q", p.Capability)
+		}
+		targetSchema, err := sc.forTarget(capRow)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateInstance(targetSchema, p.Target, fmt.Sprintf("points[%d].target", i)); err != nil {
+			return nil, err
+		}
+		if len(p.ParamOverrides) > 0 {
+			subset, err := sc.forParamsSubset(capRow)
+			if err != nil {
+				return nil, err
+			}
+			if err := validateInstance(subset, p.ParamOverrides, fmt.Sprintf("points[%d].param_overrides", i)); err != nil {
+				return nil, err
+			}
 		}
 		ident := PointIdentity{
 			System: systemName, Service: m.Metadata.Service,
@@ -263,14 +281,14 @@ func (s *Manager) upsertService(tx *gorm.DB, m PointManifest) (int64, error) {
 	return row.ID, nil
 }
 
-func (s *Manager) loadCapabilityNames(tx *gorm.DB) (map[string]struct{}, error) {
+func (s *Manager) loadCapabilities(tx *gorm.DB) (map[string]*Capability, error) {
 	var rows []Capability
 	if err := tx.Find(&rows).Error; err != nil {
 		return nil, err
 	}
-	out := make(map[string]struct{}, len(rows))
-	for _, r := range rows {
-		out[r.Name] = struct{}{}
+	out := make(map[string]*Capability, len(rows))
+	for i := range rows {
+		out[rows[i].Name] = &rows[i]
 	}
 	return out, nil
 }

--- a/aegislab/src/crud/chaos/schema_validate.go
+++ b/aegislab/src/crud/chaos/schema_validate.go
@@ -12,9 +12,33 @@ import (
 // checks (target / param_overrides / params). The handler maps it to 400.
 var ErrSchemaValidation = errors.New("chaos: schema validation failed")
 
-// schemaCompiler builds a per-request cache so the same capability's
-// target/param schema is compiled at most twice (once full, once subset)
-// even when a manifest references it on many points.
+// SchemaLeaf carries one leaf-level field path and message from a failed
+// validation. The handler exposes these on the HTTP response so callers
+// can attribute errors without re-parsing a flattened string.
+type SchemaLeaf struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+// SchemaValidationError is returned wrapped in ErrSchemaValidation; the
+// HTTP handler unwraps to surface Leaves verbatim in the response body.
+type SchemaValidationError struct {
+	Leaves []SchemaLeaf
+}
+
+func (e *SchemaValidationError) Error() string {
+	parts := make([]string, len(e.Leaves))
+	for i, l := range e.Leaves {
+		parts[i] = fmt.Sprintf("%s: %s", l.Path, l.Message)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func (e *SchemaValidationError) Unwrap() error { return ErrSchemaValidation }
+
+// schemaCompiler caches compiled target/param/subset schemas across
+// every Point in a manifest import or every child in an injection batch,
+// so the same capability isn't recompiled per row.
 type schemaCompiler struct {
 	target map[string]*jsonschema.Schema
 	params map[string]*jsonschema.Schema
@@ -41,7 +65,8 @@ func (sc *schemaCompiler) forTarget(c *Capability) (*jsonschema.Schema, error) {
 	if s, ok := sc.target[c.Name]; ok {
 		return s, nil
 	}
-	s, err := compileSchema(map[string]any(c.TargetSchema))
+	cloned := cloneStrictObjects(map[string]any(c.TargetSchema))
+	s, err := compileSchema(cloned)
 	if err != nil {
 		return nil, fmt.Errorf("compile target_schema for %q: %w", c.Name, err)
 	}
@@ -53,7 +78,8 @@ func (sc *schemaCompiler) forParams(c *Capability) (*jsonschema.Schema, error) {
 	if s, ok := sc.params[c.Name]; ok {
 		return s, nil
 	}
-	s, err := compileSchema(map[string]any(c.ParamSchema))
+	cloned := cloneStrictObjects(map[string]any(c.ParamSchema))
+	s, err := compileSchema(cloned)
 	if err != nil {
 		return nil, fmt.Errorf("compile param_schema for %q: %w", c.Name, err)
 	}
@@ -62,14 +88,14 @@ func (sc *schemaCompiler) forParams(c *Capability) (*jsonschema.Schema, error) {
 }
 
 // forParamsSubset returns the param_schema with `required` stripped at
-// every level, so partial param_overrides (which intentionally specify
-// only a subset of params) still get type / additionalProperties checks
-// without being rejected for missing fields.
+// object-schema positions, so partial param_overrides still get type /
+// additionalProperties checks without being rejected for missing fields.
 func (sc *schemaCompiler) forParamsSubset(c *Capability) (*jsonschema.Schema, error) {
 	if s, ok := sc.subset[c.Name]; ok {
 		return s, nil
 	}
-	cloned := deepCloneStripRequired(map[string]any(c.ParamSchema))
+	cloned := cloneStrictObjects(map[string]any(c.ParamSchema))
+	stripRequiredAtObjects(cloned)
 	s, err := compileSchema(cloned)
 	if err != nil {
 		return nil, fmt.Errorf("compile param_schema (subset) for %q: %w", c.Name, err)
@@ -78,39 +104,187 @@ func (sc *schemaCompiler) forParamsSubset(c *Capability) (*jsonschema.Schema, er
 	return s, nil
 }
 
-func deepCloneStripRequired(v any) map[string]any {
+// cloneStrictObjects deep-clones a schema and forces
+// additionalProperties:false on every object schema that doesn't set it.
+// Seed audits are easy to miss, so the server makes "strict" structural
+// rather than depending on every author remembering the keyword.
+func cloneStrictObjects(v any) map[string]any {
 	src, ok := v.(map[string]any)
 	if !ok {
 		return map[string]any{}
 	}
 	out := make(map[string]any, len(src))
 	for k, val := range src {
-		if k == "required" {
-			continue
+		out[k] = cloneSchemaNode(val)
+	}
+	if isObjectSchema(out) {
+		if _, set := out["additionalProperties"]; !set {
+			out["additionalProperties"] = false
 		}
-		out[k] = cloneStrip(val)
 	}
 	return out
 }
 
-func cloneStrip(v any) any {
+// cloneSchemaNode recurses into known JSON Schema keywords whose values
+// are themselves schemas (or maps of schemas / arrays of schemas). For
+// any other key the value is returned as-is — that way a user-defined
+// `properties.required` (an OBJECT field literally named "required")
+// keeps its sub-schema instead of being mistaken for the `required`
+// keyword that gates "this key must appear in the instance".
+func cloneSchemaNode(v any) any {
 	switch t := v.(type) {
 	case map[string]any:
-		return deepCloneStripRequired(t)
-	case []any:
-		out := make([]any, len(t))
-		for i, e := range t {
-			out[i] = cloneStrip(e)
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			switch k {
+			case "properties", "patternProperties", "$defs", "definitions":
+				out[k] = cloneSchemaMap(val)
+			case "items", "additionalProperties", "contains",
+				"not", "if", "then", "else",
+				"propertyNames", "unevaluatedItems", "unevaluatedProperties":
+				out[k] = cloneSchemaOrBool(val)
+			case "allOf", "anyOf", "oneOf", "prefixItems":
+				out[k] = cloneSchemaArray(val)
+			default:
+				out[k] = cloneRaw(val)
+			}
+		}
+		if isObjectSchema(out) {
+			if _, set := out["additionalProperties"]; !set {
+				out["additionalProperties"] = false
+			}
 		}
 		return out
+	case []any:
+		dup := make([]any, len(t))
+		for i, e := range t {
+			dup[i] = cloneRaw(e)
+		}
+		return dup
 	default:
 		return v
 	}
 }
 
+func cloneSchemaMap(v any) any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return cloneRaw(v)
+	}
+	out := make(map[string]any, len(m))
+	for k, val := range m {
+		out[k] = cloneSchemaOrBool(val)
+	}
+	return out
+}
+
+func cloneSchemaArray(v any) any {
+	a, ok := v.([]any)
+	if !ok {
+		return cloneRaw(v)
+	}
+	out := make([]any, len(a))
+	for i, e := range a {
+		out[i] = cloneSchemaOrBool(e)
+	}
+	return out
+}
+
+func cloneSchemaOrBool(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		// Recurse via cloneSchemaNode so additionalProperties:false is
+		// injected at nested object schemas.
+		return cloneSchemaNode(t)
+	default:
+		return cloneRaw(t)
+	}
+}
+
+func cloneRaw(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			out[k] = cloneRaw(val)
+		}
+		return out
+	case []any:
+		dup := make([]any, len(t))
+		for i, e := range t {
+			dup[i] = cloneRaw(e)
+		}
+		return dup
+	default:
+		return v
+	}
+}
+
+// isObjectSchema returns true when the map looks like an object-typed
+// schema position: explicit `type:"object"`, or carrying object-shaped
+// keywords (properties / additionalProperties / required …) without a
+// conflicting non-object `type`.
+func isObjectSchema(m map[string]any) bool {
+	switch t := m["type"].(type) {
+	case string:
+		return t == "object"
+	case []any:
+		for _, e := range t {
+			if s, ok := e.(string); ok && s == "object" {
+				return true
+			}
+		}
+		return false
+	}
+	if _, ok := m["properties"]; ok {
+		return true
+	}
+	if _, ok := m["patternProperties"]; ok {
+		return true
+	}
+	if _, ok := m["required"]; ok {
+		return true
+	}
+	return false
+}
+
+// stripRequiredAtObjects removes the `required` keyword at any
+// object-schema position reachable via JSON Schema keywords. A user
+// property literally named "required" survives because we never recurse
+// into `properties` values as if they were keyword maps.
+func stripRequiredAtObjects(m map[string]any) {
+	if isObjectSchema(m) {
+		delete(m, "required")
+	}
+	for k, v := range m {
+		switch k {
+		case "properties", "patternProperties", "$defs", "definitions":
+			if sub, ok := v.(map[string]any); ok {
+				for _, child := range sub {
+					if cm, ok := child.(map[string]any); ok {
+						stripRequiredAtObjects(cm)
+					}
+				}
+			}
+		case "items", "additionalProperties", "contains",
+			"not", "if", "then", "else",
+			"propertyNames", "unevaluatedItems", "unevaluatedProperties":
+			if cm, ok := v.(map[string]any); ok {
+				stripRequiredAtObjects(cm)
+			}
+		case "allOf", "anyOf", "oneOf", "prefixItems":
+			if arr, ok := v.([]any); ok {
+				for _, e := range arr {
+					if cm, ok := e.(map[string]any); ok {
+						stripRequiredAtObjects(cm)
+					}
+				}
+			}
+		}
+	}
+}
+
 func validateInstance(schema *jsonschema.Schema, instance map[string]any, prefix string) error {
-	// jsonschema/v6 requires the instance to be plain interface{} (the
-	// shape json.Unmarshal would produce). map[string]any qualifies.
 	var doc any = instance
 	if instance == nil {
 		doc = map[string]any{}
@@ -121,14 +295,13 @@ func validateInstance(schema *jsonschema.Schema, instance map[string]any, prefix
 	}
 	var verr *jsonschema.ValidationError
 	if !errors.As(err, &verr) {
-		return fmt.Errorf("%w: %s: %v", ErrSchemaValidation, prefix, err)
+		return &SchemaValidationError{Leaves: []SchemaLeaf{{Path: prefix, Message: err.Error()}}}
 	}
-	leaves := flattenSchemaLeaves(verr, prefix)
-	return fmt.Errorf("%w: %s", ErrSchemaValidation, strings.Join(leaves, "; "))
+	return &SchemaValidationError{Leaves: flattenSchemaLeaves(verr, prefix)}
 }
 
-func flattenSchemaLeaves(ve *jsonschema.ValidationError, prefix string) []string {
-	var out []string
+func flattenSchemaLeaves(ve *jsonschema.ValidationError, prefix string) []SchemaLeaf {
+	var out []SchemaLeaf
 	var walk func(e *jsonschema.ValidationError)
 	walk = func(e *jsonschema.ValidationError) {
 		if len(e.Causes) == 0 {
@@ -136,7 +309,7 @@ func flattenSchemaLeaves(ve *jsonschema.ValidationError, prefix string) []string
 			if len(e.InstanceLocation) > 0 {
 				path = prefix + "." + strings.Join(e.InstanceLocation, ".")
 			}
-			out = append(out, fmt.Sprintf("%s: %s", path, e.Error()))
+			out = append(out, SchemaLeaf{Path: path, Message: e.Error()})
 			return
 		}
 		for _, c := range e.Causes {
@@ -145,21 +318,34 @@ func flattenSchemaLeaves(ve *jsonschema.ValidationError, prefix string) []string
 	}
 	walk(ve)
 	if len(out) == 0 {
-		out = append(out, fmt.Sprintf("%s: %s", prefix, ve.Error()))
+		out = append(out, SchemaLeaf{Path: prefix, Message: ve.Error()})
 	}
 	return out
 }
 
-// mergeParams returns overrides ⨁ params: caller-supplied params win
-// over baked-in point.param_overrides. The merge is shallow — the same
-// semantics every aegis caller already assumes for params payloads.
-func mergeParams(overrides, params map[string]any) map[string]any {
-	out := make(map[string]any, len(overrides)+len(params))
-	for k, v := range overrides {
-		out[k] = v
+// mergeParams deep-merges caller-supplied params with the point's
+// param_overrides; **overrides win** at every leaf. param_overrides are
+// the manifest author's lockdown of permitted runtime values for a
+// published Point — a caller that sends `duration_s:9999` for a Point
+// that pinned `duration_s:30` gets 30. Nested objects are merged
+// recursively; arrays and scalars are replaced wholesale by the
+// override side. Callers can still fill in keys the override didn't
+// pin.
+func mergeParams(callerParams, overrides map[string]any) map[string]any {
+	out := make(map[string]any, len(callerParams)+len(overrides))
+	for k, v := range callerParams {
+		out[k] = cloneRaw(v)
 	}
-	for k, v := range params {
-		out[k] = v
+	for k, ov := range overrides {
+		if existing, ok := out[k]; ok {
+			if em, eok := existing.(map[string]any); eok {
+				if om, ook := ov.(map[string]any); ook {
+					out[k] = mergeParams(em, om)
+					continue
+				}
+			}
+		}
+		out[k] = cloneRaw(ov)
 	}
 	return out
 }

--- a/aegislab/src/crud/chaos/schema_validate.go
+++ b/aegislab/src/crud/chaos/schema_validate.go
@@ -1,0 +1,165 @@
+package chaos
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// ErrSchemaValidation marks failures from per-capability JSON Schema
+// checks (target / param_overrides / params). The handler maps it to 400.
+var ErrSchemaValidation = errors.New("chaos: schema validation failed")
+
+// schemaCompiler builds a per-request cache so the same capability's
+// target/param schema is compiled at most twice (once full, once subset)
+// even when a manifest references it on many points.
+type schemaCompiler struct {
+	target map[string]*jsonschema.Schema
+	params map[string]*jsonschema.Schema
+	subset map[string]*jsonschema.Schema
+}
+
+func newSchemaCompiler() *schemaCompiler {
+	return &schemaCompiler{
+		target: map[string]*jsonschema.Schema{},
+		params: map[string]*jsonschema.Schema{},
+		subset: map[string]*jsonschema.Schema{},
+	}
+}
+
+func compileSchema(raw map[string]any) (*jsonschema.Schema, error) {
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource("mem:///schema.json", any(raw)); err != nil {
+		return nil, err
+	}
+	return c.Compile("mem:///schema.json")
+}
+
+func (sc *schemaCompiler) forTarget(c *Capability) (*jsonschema.Schema, error) {
+	if s, ok := sc.target[c.Name]; ok {
+		return s, nil
+	}
+	s, err := compileSchema(map[string]any(c.TargetSchema))
+	if err != nil {
+		return nil, fmt.Errorf("compile target_schema for %q: %w", c.Name, err)
+	}
+	sc.target[c.Name] = s
+	return s, nil
+}
+
+func (sc *schemaCompiler) forParams(c *Capability) (*jsonschema.Schema, error) {
+	if s, ok := sc.params[c.Name]; ok {
+		return s, nil
+	}
+	s, err := compileSchema(map[string]any(c.ParamSchema))
+	if err != nil {
+		return nil, fmt.Errorf("compile param_schema for %q: %w", c.Name, err)
+	}
+	sc.params[c.Name] = s
+	return s, nil
+}
+
+// forParamsSubset returns the param_schema with `required` stripped at
+// every level, so partial param_overrides (which intentionally specify
+// only a subset of params) still get type / additionalProperties checks
+// without being rejected for missing fields.
+func (sc *schemaCompiler) forParamsSubset(c *Capability) (*jsonschema.Schema, error) {
+	if s, ok := sc.subset[c.Name]; ok {
+		return s, nil
+	}
+	cloned := deepCloneStripRequired(map[string]any(c.ParamSchema))
+	s, err := compileSchema(cloned)
+	if err != nil {
+		return nil, fmt.Errorf("compile param_schema (subset) for %q: %w", c.Name, err)
+	}
+	sc.subset[c.Name] = s
+	return s, nil
+}
+
+func deepCloneStripRequired(v any) map[string]any {
+	src, ok := v.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(src))
+	for k, val := range src {
+		if k == "required" {
+			continue
+		}
+		out[k] = cloneStrip(val)
+	}
+	return out
+}
+
+func cloneStrip(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return deepCloneStripRequired(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = cloneStrip(e)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func validateInstance(schema *jsonschema.Schema, instance map[string]any, prefix string) error {
+	// jsonschema/v6 requires the instance to be plain interface{} (the
+	// shape json.Unmarshal would produce). map[string]any qualifies.
+	var doc any = instance
+	if instance == nil {
+		doc = map[string]any{}
+	}
+	err := schema.Validate(doc)
+	if err == nil {
+		return nil
+	}
+	var verr *jsonschema.ValidationError
+	if !errors.As(err, &verr) {
+		return fmt.Errorf("%w: %s: %v", ErrSchemaValidation, prefix, err)
+	}
+	leaves := flattenSchemaLeaves(verr, prefix)
+	return fmt.Errorf("%w: %s", ErrSchemaValidation, strings.Join(leaves, "; "))
+}
+
+func flattenSchemaLeaves(ve *jsonschema.ValidationError, prefix string) []string {
+	var out []string
+	var walk func(e *jsonschema.ValidationError)
+	walk = func(e *jsonschema.ValidationError) {
+		if len(e.Causes) == 0 {
+			path := prefix
+			if len(e.InstanceLocation) > 0 {
+				path = prefix + "." + strings.Join(e.InstanceLocation, ".")
+			}
+			out = append(out, fmt.Sprintf("%s: %s", path, e.Error()))
+			return
+		}
+		for _, c := range e.Causes {
+			walk(c)
+		}
+	}
+	walk(ve)
+	if len(out) == 0 {
+		out = append(out, fmt.Sprintf("%s: %s", prefix, ve.Error()))
+	}
+	return out
+}
+
+// mergeParams returns overrides ⨁ params: caller-supplied params win
+// over baked-in point.param_overrides. The merge is shallow — the same
+// semantics every aegis caller already assumes for params payloads.
+func mergeParams(overrides, params map[string]any) map[string]any {
+	out := make(map[string]any, len(overrides)+len(params))
+	for k, v := range overrides {
+		out[k] = v
+	}
+	for k, v := range params {
+		out[k] = v
+	}
+	return out
+}

--- a/aegislab/src/crud/chaos/schema_validate_test.go
+++ b/aegislab/src/crud/chaos/schema_validate_test.go
@@ -1,0 +1,99 @@
+package chaos
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Import target validation: a manifest with target missing the required
+// `app` key must fail at points[0].target with a leaf-level message; the
+// happy baseline (covered by import_test.go) already exercises the OK case.
+func TestImportPoints_TargetSchemaViolation(t *testing.T) {
+	mgr := newImportTestManager(t)
+	m := baseManifest()
+	m.Spec.Points = []PointManifestEntry{
+		{Capability: "pod_kill", Target: map[string]any{"namespace": "ts"}},
+	}
+	_, err := mgr.ImportPoints(t.Context(), "ts", m, true)
+	if err == nil {
+		t.Fatalf("expected schema validation error, got nil")
+	}
+	if !errors.Is(err, ErrSchemaValidation) {
+		t.Fatalf("want ErrSchemaValidation, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "points[0].target") {
+		t.Fatalf("error must surface field path points[0].target; got %v", err)
+	}
+}
+
+// Import param_overrides validation: extra unknown key trips
+// additionalProperties:false (subset still enforces it). A required-key
+// omission must NOT trip subset validation — overrides are partial by
+// design.
+func TestImportPoints_ParamOverridesSubsetRejectsUnknownKey(t *testing.T) {
+	mgr := newImportTestManager(t)
+	m := baseManifest()
+	m.Spec.Points = []PointManifestEntry{
+		{
+			Capability:     "pod_kill",
+			Target:         map[string]any{"namespace": "ts", "app": "frontend"},
+			ParamOverrides: map[string]any{"unknown_knob": 1},
+		},
+	}
+	_, err := mgr.ImportPoints(t.Context(), "ts", m, true)
+	if err == nil {
+		t.Fatalf("expected schema validation error, got nil")
+	}
+	if !errors.Is(err, ErrSchemaValidation) {
+		t.Fatalf("want ErrSchemaValidation, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "points[0].param_overrides") {
+		t.Fatalf("error must surface points[0].param_overrides; got %v", err)
+	}
+}
+
+func TestImportPoints_ParamOverridesPartialAllowed(t *testing.T) {
+	mgr := newImportTestManager(t)
+	m := baseManifest()
+	m.Spec.Points = []PointManifestEntry{
+		{
+			Capability:     "pod_kill",
+			Target:         map[string]any{"namespace": "ts", "app": "frontend"},
+			ParamOverrides: map[string]any{"duration_s": 5},
+		},
+	}
+	if _, err := mgr.ImportPoints(t.Context(), "ts", m, true); err != nil {
+		t.Fatalf("partial param_overrides should pass subset validation: %v", err)
+	}
+}
+
+// CreateInjection happy path with valid params is covered by
+// TestCreateInjection_IdempotentReplay; this exercises the failure side:
+// out-of-range integer must fail with field path `params.duration_s`.
+func TestCreateInjection_ParamSchemaViolation(t *testing.T) {
+	mgr, _, db := newTestManager(t)
+	_, pointID := seedSystemAndPoint(t, db)
+
+	_, err := mgr.CreateInjection(t.Context(), CreateInjectionInput{
+		PointID: pointID, Namespace: "ns0", IdempotencyKey: "k-bad-params",
+		Params: map[string]any{"duration_s": 9999},
+	})
+	if err == nil {
+		t.Fatalf("expected schema validation error, got nil")
+	}
+	if !errors.Is(err, ErrSchemaValidation) {
+		t.Fatalf("want ErrSchemaValidation, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "params") {
+		t.Fatalf("error must surface params path; got %v", err)
+	}
+
+	var count int64
+	if err := db.Model(&Injection{}).Where("idempotency_key = ?", "k-bad-params").Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("rejected injection must not persist; got %d rows", count)
+	}
+}

--- a/aegislab/src/crud/chaos/schema_validate_test.go
+++ b/aegislab/src/crud/chaos/schema_validate_test.go
@@ -22,8 +22,12 @@ func TestImportPoints_TargetSchemaViolation(t *testing.T) {
 	if !errors.Is(err, ErrSchemaValidation) {
 		t.Fatalf("want ErrSchemaValidation, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "points[0].target") {
-		t.Fatalf("error must surface field path points[0].target; got %v", err)
+	var sve *SchemaValidationError
+	if !errors.As(err, &sve) {
+		t.Fatalf("expected SchemaValidationError, got %T", err)
+	}
+	if len(sve.Leaves) == 0 || !strings.HasPrefix(sve.Leaves[0].Path, "points[0].target") {
+		t.Fatalf("leaf path must start with points[0].target; got %+v", sve.Leaves)
 	}
 }
 
@@ -68,9 +72,7 @@ func TestImportPoints_ParamOverridesPartialAllowed(t *testing.T) {
 	}
 }
 
-// CreateInjection happy path with valid params is covered by
-// TestCreateInjection_IdempotentReplay; this exercises the failure side:
-// out-of-range integer must fail with field path `params.duration_s`.
+// Out-of-range integer must fail with field path `params.duration_s`.
 func TestCreateInjection_ParamSchemaViolation(t *testing.T) {
 	mgr, _, db := newTestManager(t)
 	_, pointID := seedSystemAndPoint(t, db)
@@ -96,4 +98,122 @@ func TestCreateInjection_ParamSchemaViolation(t *testing.T) {
 	if count != 0 {
 		t.Fatalf("rejected injection must not persist; got %d rows", count)
 	}
+}
+
+// Precedence: a Point that pins duration_s=30 must override a caller
+// that requests 9999, even though 9999 alone would fail param_schema
+// validation. The pinned value reaches the executor and the persisted row.
+func TestCreateInjection_PointOverrideWins(t *testing.T) {
+	mgr, exec, db := newTestManager(t)
+	_, pointID := seedSystemAndPoint(t, db)
+	if err := db.Model(&Point{}).Where("id = ?", pointID).
+		Update("param_overrides", JSONMap{"duration_s": 30}).Error; err != nil {
+		t.Fatalf("set override: %v", err)
+	}
+
+	inj, err := mgr.CreateInjection(t.Context(), CreateInjectionInput{
+		PointID: pointID, Namespace: "ns0", IdempotencyKey: "k-override-wins",
+		Params: map[string]any{"duration_s": 9999},
+	})
+	if err != nil {
+		t.Fatalf("override should clobber caller value; got err %v", err)
+	}
+	if v := exec.lastParams["duration_s"]; toInt(v) != 30 {
+		t.Fatalf("Apply got duration_s=%v; want 30 (override wins)", v)
+	}
+	if v := inj.Params["duration_s"]; toInt(v) != 30 {
+		t.Fatalf("persisted Params duration_s=%v; want 30", v)
+	}
+}
+
+// Deep merge: caller fills a sibling key the override didn't pin while
+// the override's pinned subtree wins.
+func TestMergeParams_DeepMerge(t *testing.T) {
+	caller := map[string]any{
+		"http": map[string]any{"timeout_ms": 100, "retries": 5},
+		"tag":  "caller-tag",
+	}
+	override := map[string]any{
+		"http": map[string]any{"timeout_ms": 250},
+	}
+	got := mergeParams(caller, override)
+	httpMap, _ := got["http"].(map[string]any)
+	if toInt(httpMap["timeout_ms"]) != 250 {
+		t.Fatalf("override should pin nested timeout_ms; got %v", httpMap["timeout_ms"])
+	}
+	if toInt(httpMap["retries"]) != 5 {
+		t.Fatalf("unpinned nested retries should survive from caller; got %v", httpMap["retries"])
+	}
+	if got["tag"] != "caller-tag" {
+		t.Fatalf("unpinned top-level tag should survive from caller; got %v", got["tag"])
+	}
+}
+
+// Strict-mode injection: a seed schema that does NOT declare
+// additionalProperties:false must still reject unknown keys, because
+// the server injects the keyword at every object-schema position.
+func TestSchemaCompiler_InjectsAdditionalPropertiesFalse(t *testing.T) {
+	sc := newSchemaCompiler()
+	cap := &Capability{
+		Name: "loose",
+		TargetSchema: JSONMap{
+			"type": "object",
+			"properties": map[string]any{
+				"app": map[string]any{"type": "string"},
+			},
+		},
+	}
+	schema, err := sc.forTarget(cap)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if err := validateInstance(schema, map[string]any{"app": "x"}, "target"); err != nil {
+		t.Fatalf("known key should pass; got %v", err)
+	}
+	if err := validateInstance(schema, map[string]any{"app": "x", "unknown": 1}, "target"); err == nil {
+		t.Fatalf("unknown key must be rejected after additionalProperties injection")
+	}
+}
+
+// `required` keyword stripping must not eat a user property literally
+// named "required". A schema whose object has a `properties.required`
+// child still validates the child's type after subset cloning.
+func TestParamsSubset_PreservesUserPropertyNamedRequired(t *testing.T) {
+	sc := newSchemaCompiler()
+	cap := &Capability{
+		Name: "weird",
+		ParamSchema: JSONMap{
+			"type":     "object",
+			"required": []any{"required"},
+			"properties": map[string]any{
+				"required": map[string]any{"type": "boolean"},
+			},
+		},
+	}
+	subset, err := sc.forParamsSubset(cap)
+	if err != nil {
+		t.Fatalf("compile subset: %v", err)
+	}
+	// Required keyword stripped → omitting the field is fine.
+	if err := validateInstance(subset, map[string]any{}, "params"); err != nil {
+		t.Fatalf("subset should drop required; got %v", err)
+	}
+	// Type check on the user-named property survives.
+	if err := validateInstance(subset, map[string]any{"required": "not-a-bool"}, "params"); err == nil {
+		t.Fatalf("type check on properties.required must survive subset strip")
+	}
+}
+
+func toInt(v any) int {
+	switch t := v.(type) {
+	case int:
+		return t
+	case int64:
+		return int(t)
+	case float64:
+		return int(t)
+	case float32:
+		return int(t)
+	}
+	return -1
 }

--- a/aegislab/src/crud/chaos/service.go
+++ b/aegislab/src/crud/chaos/service.go
@@ -144,7 +144,7 @@ func (s *Manager) CreateInjection(ctx context.Context, in CreateInjectionInput) 
 		return nil, ErrCapabilityUnsupported
 	}
 
-	effectiveParams := mergeParams(map[string]any(point.ParamOverrides), in.Params)
+	effectiveParams := mergeParams(in.Params, map[string]any(point.ParamOverrides))
 	sc := newSchemaCompiler()
 	paramSchema, err := sc.forParams(&capRow)
 	if err != nil {
@@ -175,16 +175,12 @@ func (s *Manager) CreateInjection(ctx context.Context, in CreateInjectionInput) 
 		return nil, err
 	}
 
-	params := in.Params
-	if params == nil {
-		params = JSONMap{}
-	}
 	now := time.Now().UTC()
 	id := ulid.Make().String()
 	row := Injection{
 		ID:             id,
 		PointID:        point.ID,
-		Params:         params,
+		Params:         JSONMap(effectiveParams),
 		IdempotencyKey: in.IdempotencyKey,
 		ExecutorName:   s.Executor.Name(),
 		ExecutorHandle: handle,
@@ -198,7 +194,7 @@ func (s *Manager) CreateInjection(ctx context.Context, in CreateInjectionInput) 
 	}
 
 	applyAt := time.Now().UTC()
-	if applyErr := s.Executor.Apply(ctx, sysCtx, capRow.Name, handle, target, in.Params); applyErr != nil {
+	if applyErr := s.Executor.Apply(ctx, sysCtx, capRow.Name, handle, target, effectiveParams); applyErr != nil {
 		fin := applyAt
 		updates := map[string]any{
 			"status":      StatusFailed,

--- a/aegislab/src/crud/chaos/service.go
+++ b/aegislab/src/crud/chaos/service.go
@@ -144,6 +144,16 @@ func (s *Manager) CreateInjection(ctx context.Context, in CreateInjectionInput) 
 		return nil, ErrCapabilityUnsupported
 	}
 
+	effectiveParams := mergeParams(map[string]any(point.ParamOverrides), in.Params)
+	sc := newSchemaCompiler()
+	paramSchema, err := sc.forParams(&capRow)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateInstance(paramSchema, effectiveParams, "params"); err != nil {
+		return nil, err
+	}
+
 	sys, err := s.GetSystem(ctx, point.SystemName)
 	if err != nil {
 		return nil, err

--- a/aegislab/src/crud/chaos/service_batch.go
+++ b/aegislab/src/crud/chaos/service_batch.go
@@ -68,6 +68,7 @@ func (s *Manager) CreateInjectionBatch(ctx context.Context, in CreateBatchInput)
 	}
 
 	childRows := make([]Injection, 0, len(in.Children))
+	compiler := newSchemaCompiler()
 	for _, c := range in.Children {
 		if c.IdempotencyKey == "" {
 			return nil, fmt.Errorf("chaos: child idempotency_key is required")
@@ -75,7 +76,7 @@ func (s *Manager) CreateInjectionBatch(ctx context.Context, in CreateBatchInput)
 		if c.Namespace == "" {
 			return nil, fmt.Errorf("chaos: child namespace is required")
 		}
-		row, applyErr := s.createBatchChild(ctx, batch.ID, c)
+		row, applyErr := s.createBatchChild(ctx, batch.ID, c, compiler)
 		if row != nil {
 			childRows = append(childRows, *row)
 		}
@@ -109,7 +110,7 @@ func (s *Manager) CreateInjectionBatch(ctx context.Context, in CreateBatchInput)
 // createBatchChild mirrors CreateInjection but stamps batch_id and never
 // returns an error to the caller — failed children are persisted as
 // status=failed and the batch as a whole accepts mixed outcomes.
-func (s *Manager) createBatchChild(ctx context.Context, batchID string, c CreateBatchChild) (*Injection, error) {
+func (s *Manager) createBatchChild(ctx context.Context, batchID string, c CreateBatchChild, compiler *schemaCompiler) (*Injection, error) {
 	var existing Injection
 	err := s.DB.WithContext(ctx).Where("idempotency_key = ?", c.IdempotencyKey).Take(&existing).Error
 	if err == nil {
@@ -153,8 +154,7 @@ func (s *Manager) createBatchChild(ctx context.Context, batchID string, c Create
 		return row, ErrCapabilityUnsupported
 	}
 
-	effectiveParams := mergeParams(map[string]any(point.ParamOverrides), c.Params)
-	compiler := newSchemaCompiler()
+	effectiveParams := mergeParams(c.Params, map[string]any(point.ParamOverrides))
 	paramSchema, cerr := compiler.forParams(&capRow)
 	if cerr != nil {
 		row := s.persistFailedChild(ctx, batchID, c, cerr)
@@ -187,17 +187,13 @@ func (s *Manager) createBatchChild(ctx context.Context, batchID string, c Create
 		return row, err
 	}
 
-	params := c.Params
-	if params == nil {
-		params = map[string]any{}
-	}
 	now := time.Now().UTC()
 	bid := batchID
 	row := Injection{
 		ID:             ulid.Make().String(),
 		BatchID:        &bid,
 		PointID:        point.ID,
-		Params:         JSONMap(params),
+		Params:         JSONMap(effectiveParams),
 		IdempotencyKey: c.IdempotencyKey,
 		ExecutorName:   s.Executor.Name(),
 		ExecutorHandle: handle,
@@ -211,7 +207,7 @@ func (s *Manager) createBatchChild(ctx context.Context, batchID string, c Create
 	}
 
 	applyAt := time.Now().UTC()
-	if applyErr := s.Executor.Apply(ctx, sysCtx, capRow.Name, handle, target, c.Params); applyErr != nil {
+	if applyErr := s.Executor.Apply(ctx, sysCtx, capRow.Name, handle, target, effectiveParams); applyErr != nil {
 		fin := applyAt
 		updates := map[string]any{
 			"status":      StatusFailed,

--- a/aegislab/src/crud/chaos/service_batch.go
+++ b/aegislab/src/crud/chaos/service_batch.go
@@ -153,6 +153,18 @@ func (s *Manager) createBatchChild(ctx context.Context, batchID string, c Create
 		return row, ErrCapabilityUnsupported
 	}
 
+	effectiveParams := mergeParams(map[string]any(point.ParamOverrides), c.Params)
+	compiler := newSchemaCompiler()
+	paramSchema, cerr := compiler.forParams(&capRow)
+	if cerr != nil {
+		row := s.persistFailedChild(ctx, batchID, c, cerr)
+		return row, cerr
+	}
+	if verr := validateInstance(paramSchema, effectiveParams, "params"); verr != nil {
+		row := s.persistFailedChild(ctx, batchID, c, verr)
+		return row, verr
+	}
+
 	sys, err := s.GetSystem(ctx, point.SystemName)
 	if err != nil {
 		row := s.persistFailedChild(ctx, batchID, c, err)

--- a/aegislab/src/crud/chaos/service_test.go
+++ b/aegislab/src/crud/chaos/service_test.go
@@ -22,6 +22,7 @@ type fakeExecutor struct {
 	destroyCount atomic.Int64
 	applyErr     error
 	destroyErr   error
+	lastParams   map[string]any
 }
 
 func (e *fakeExecutor) Name() string { return "fake" }
@@ -38,6 +39,7 @@ func (e *fakeExecutor) DeriveHandle(capability, key, requestNamespace string, ta
 }
 func (e *fakeExecutor) Apply(ctx context.Context, sysCtx SystemContext, capability, handle string, target, params map[string]any) error {
 	e.applyCount.Add(1)
+	e.lastParams = params
 	return e.applyErr
 }
 func (e *fakeExecutor) Status(ctx context.Context, handle string) (ExecState, map[string]any, error) {


### PR DESCRIPTION
Closes #457.

## Summary
Server-side enforcement of `capabilities.target_schema` and `capabilities.param_schema` at the two boundaries the issue calls out, using the same `github.com/santhosh-tekuri/jsonschema/v6` engine aegisctl already uses for offline validation.

1. **PointManifest import** (`POST /v1beta/systems/{sys}/points/import`): each point's `target` is validated against `capability.target_schema`; `param_overrides` is validated against a subset-cloned `param_schema` (`required` stripped at object-schema positions only, `additionalProperties:false` preserved).
2. **Injection submit** (`POST /v1beta/injections` + batch path): effective params = deep-merge of caller `in.Params` with `point.ParamOverrides` (**point overrides win** — author lockdown semantics); the merged object is validated against the full `param_schema`. The same effective params are what get passed to `Executor.Apply` and what land in `Injection.Params`.

## Strict mode is actually strict
- `cloneStrictObjects` walks every cloned schema (keyword-aware: `properties`, `patternProperties`, `$defs`, `items`, `additionalProperties`, `contains`, `not`, `if/then/else`, `propertyNames`, `unevaluated{Items,Properties}`, `allOf`, `anyOf`, `oneOf`, `prefixItems`) and injects `additionalProperties:false` at any object-schema position missing it. No reliance on seed-author discipline.
- `stripRequiredAtObjects` drops `required` only at object-schema positions reached via schema keywords; a user property literally named `required` (under `properties`) survives. Tested.

## Structured errors
- New `SchemaValidationError{Leaves []SchemaLeaf{Path, Message}}` carries leaf-level errors.
- New `writeSchemaOrPlainError` handler helper returns `dto.JSONResponse[schemaValidationBody]{Errors: leaves}` so clients get structured field paths, not regex-parsable strings.

## Batch schema compile
One `schemaCompiler` plumbed through `CreateInjectionBatch → createBatchChild`. N-child batches hitting the same capability compile once.

## Out of scope (per spec)
- Selector-count probe (#3 in the issue)
- Webhook root-cause surfacing into `chaos_injections.webhook_error` (#4)
- Migrating existing chaos_points rows lacking schemas

## Test plan
- [x] `go test -tags duckdb_arrow -count=1 ./crud/chaos/...` green (full suite + 4 new tests: PointOverrideWins, MergeParamsDeepMerge, SchemaCompilerInjectsAdditionalPropertiesFalse, ParamsSubsetPreservesUserPropertyNamedRequired)
- [x] `go build -tags duckdb_arrow ./main.go` clean
- [x] `golangci-lint` count went 9 → 7 (remaining 7 pre-existing)
- [ ] Pre-merge audit query on prod `chaos_points` for rows that may already violate new strict schemas (recommend running before deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)