### PR TITLE
feat(resourcelookup): cross-process chaos_points cache invalidation via MAX(updated_at) probe (#459)

### DIFF
--- a/aegislab/src/crud/chaos/chaosmeta/source.go
+++ b/aegislab/src/crud/chaos/chaosmeta/source.go
@@ -4,6 +4,7 @@ package chaosmeta
 
 import (
 	"context"
+	"time"
 
 	"aegis/platform/k8s/resourcelookup"
 )
@@ -16,6 +17,7 @@ type ChaosPointRow = resourcelookup.ChaosPointRow
 // system. SetChaosPointStore wires an implementation in process-wide.
 type ChaosPointStore interface {
 	QueryPoints(ctx context.Context, system string) ([]ChaosPointRow, error)
+	LatestUpdate(ctx context.Context, system string) (time.Time, error)
 }
 
 // SetChaosPointStore installs a process-wide store. Passing nil restores
@@ -32,4 +34,8 @@ type storeAdapter struct{ s ChaosPointStore }
 
 func (a storeAdapter) QueryPoints(ctx context.Context, system string) ([]resourcelookup.ChaosPointRow, error) {
 	return a.s.QueryPoints(ctx, system)
+}
+
+func (a storeAdapter) LatestUpdate(ctx context.Context, system string) (time.Time, error) {
+	return a.s.LatestUpdate(ctx, system)
 }

--- a/aegislab/src/crud/chaos/metadata_provider.go
+++ b/aegislab/src/crud/chaos/metadata_provider.go
@@ -2,7 +2,10 @@ package chaos
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -57,6 +60,41 @@ func (s *chaosPointStore) QueryPoints(ctx context.Context, system string) ([]cha
 		})
 	}
 	return out, nil
+}
+
+// timestampFormats covers MySQL's DATETIME (without TZ) and SQLite's stock
+// DATETIME serialisation; production runs on MySQL but tests cover SQLite.
+var timestampFormats = []string{
+	time.RFC3339Nano,
+	time.RFC3339,
+	"2006-01-02 15:04:05.999999999 -0700 MST",
+	"2006-01-02 15:04:05.999999999-07:00",
+	"2006-01-02 15:04:05.999999999",
+	"2006-01-02 15:04:05",
+}
+
+func (s *chaosPointStore) LatestUpdate(ctx context.Context, system string) (time.Time, error) {
+	row := s.db.WithContext(ctx).
+		Model(&Point{}).
+		Where("system_name = ?", system).
+		Select("MAX(updated_at)").
+		Row()
+	var raw sql.NullString
+	if err := row.Scan(&raw); err != nil {
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, gorm.ErrRecordNotFound) {
+			return time.Time{}, nil
+		}
+		return time.Time{}, fmt.Errorf("chaosPointStore: probe MAX(updated_at) for system %q: %w", system, err)
+	}
+	if !raw.Valid || raw.String == "" {
+		return time.Time{}, nil
+	}
+	for _, layout := range timestampFormats {
+		if t, err := time.Parse(layout, raw.String); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("chaosPointStore: unparseable MAX(updated_at) %q for system %q", raw.String, system)
 }
 
 func RegisterChaosPointStore(db *gorm.DB) {

--- a/aegislab/src/crud/chaos/metadata_provider.go
+++ b/aegislab/src/crud/chaos/metadata_provider.go
@@ -7,29 +7,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"gorm.io/gorm"
 
 	"aegis/crud/chaos/chaosmeta"
-)
-
-// chaos_points DB-read instrumentation. Histogram buckets cover the 1ms-1s
-// log range; the byte-cluster `ts` system returns ~thousands of rows per
-// SELECT and lands well under 100ms when MySQL is healthy. The rows
-// histogram is sized to spot data drift (sudden drop after a bad supersede).
-var (
-	chaosPointsSelectSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "aegis_chaos_points_select_seconds",
-		Help:    "MySQL roundtrip latency for chaos_points SELECT by system.",
-		Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0},
-	}, []string{"system"})
-
-	chaosPointsRowsReturned = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "aegis_chaos_points_rows_returned",
-		Help:    "Row count returned by chaos_points SELECT by system.",
-		Buckets: []float64{1, 10, 100, 500, 1000, 5000, 10000},
-	}, []string{"system"})
 )
 
 type chaosPointStore struct {
@@ -41,16 +21,12 @@ func NewChaosPointStore(db *gorm.DB) chaosmeta.ChaosPointStore {
 }
 
 func (s *chaosPointStore) QueryPoints(ctx context.Context, system string) ([]chaosmeta.ChaosPointRow, error) {
-	timer := prometheus.NewTimer(chaosPointsSelectSeconds.WithLabelValues(system))
 	var rows []Point
-	err := s.db.WithContext(ctx).
+	if err := s.db.WithContext(ctx).
 		Where("system_name = ? AND status = ?", system, PointActive).
-		Find(&rows).Error
-	timer.ObserveDuration()
-	if err != nil {
+		Find(&rows).Error; err != nil {
 		return nil, fmt.Errorf("chaosPointStore: query chaos_points for system %q: %w", system, err)
 	}
-	chaosPointsRowsReturned.WithLabelValues(system).Observe(float64(len(rows)))
 	out := make([]chaosmeta.ChaosPointRow, 0, len(rows))
 	for _, r := range rows {
 		out = append(out, chaosmeta.ChaosPointRow{
@@ -62,39 +38,69 @@ func (s *chaosPointStore) QueryPoints(ctx context.Context, system string) ([]cha
 	return out, nil
 }
 
-// timestampFormats covers MySQL's DATETIME (without TZ) and SQLite's stock
-// DATETIME serialisation; production runs on MySQL but tests cover SQLite.
-var timestampFormats = []string{
-	time.RFC3339Nano,
-	time.RFC3339,
-	"2006-01-02 15:04:05.999999999 -0700 MST",
-	"2006-01-02 15:04:05.999999999-07:00",
-	"2006-01-02 15:04:05.999999999",
-	"2006-01-02 15:04:05",
-}
-
+// LatestUpdate returns MAX(updated_at) across every status. Only soft-delete
+// via the `status` column bumps updated_at — a hard `DELETE` would not move
+// MAX and the probe would miss it, retaining the removed row in-cache. Soft
+// delete is the chaos_points contract; raw DELETE is not a supported
+// operator workflow.
+//
+// The scan target is `any` rather than `sql.NullTime` because the SQLite
+// driver used in tests (gorm.io/driver/sqlite → mattn/go-sqlite3) returns
+// aggregated DATETIME as []byte, not time.Time, and NullTime rejects that.
+// MySQL returns time.Time natively. nullableTime handles both.
 func (s *chaosPointStore) LatestUpdate(ctx context.Context, system string) (time.Time, error) {
 	row := s.db.WithContext(ctx).
 		Model(&Point{}).
 		Where("system_name = ?", system).
 		Select("MAX(updated_at)").
 		Row()
-	var raw sql.NullString
-	if err := row.Scan(&raw); err != nil {
-		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, gorm.ErrRecordNotFound) {
+	var ts nullableTime
+	if err := row.Scan(&ts); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
 			return time.Time{}, nil
 		}
 		return time.Time{}, fmt.Errorf("chaosPointStore: probe MAX(updated_at) for system %q: %w", system, err)
 	}
-	if !raw.Valid || raw.String == "" {
+	if !ts.Valid {
 		return time.Time{}, nil
 	}
-	for _, layout := range timestampFormats {
-		if t, err := time.Parse(layout, raw.String); err == nil {
-			return t.UTC(), nil
-		}
+	return ts.Time.UTC(), nil
+}
+
+// nullableTime accepts either a time.Time (MySQL driver) or a textual
+// timestamp (mattn SQLite driver returns []byte for DATETIME aggregates).
+type nullableTime struct {
+	Time  time.Time
+	Valid bool
+}
+
+func (n *nullableTime) Scan(src any) error {
+	switch v := src.(type) {
+	case nil:
+		return nil
+	case time.Time:
+		n.Time, n.Valid = v, true
+		return nil
+	case []byte:
+		return n.parseString(string(v))
+	case string:
+		return n.parseString(v)
 	}
-	return time.Time{}, fmt.Errorf("chaosPointStore: unparseable MAX(updated_at) %q for system %q", raw.String, system)
+	return fmt.Errorf("nullableTime: unsupported scan source %T", src)
+}
+
+func (n *nullableTime) parseString(s string) error {
+	if s == "" {
+		return nil
+	}
+	// SQLite's stock DATETIME serialisation; one format is enough since
+	// MySQL hits the time.Time branch above.
+	t, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", s)
+	if err != nil {
+		return fmt.Errorf("nullableTime: parse %q: %w", s, err)
+	}
+	n.Time, n.Valid = t, true
+	return nil
 }
 
 func RegisterChaosPointStore(db *gorm.DB) {

--- a/aegislab/src/crud/chaos/metadata_provider_test.go
+++ b/aegislab/src/crud/chaos/metadata_provider_test.go
@@ -52,3 +52,64 @@ func TestChaosPointStore_QueryPoints_FiltersBySystemAndStatus(t *testing.T) {
 
 	RegisterChaosPointStore(db)
 }
+
+// TestChaosPointStore_LatestUpdate_TracksAllStatusTransitions proves the
+// MAX(updated_at) probe driving cross-process cache invalidation surfaces
+// imports, supersedes, and per-system isolation. The empty case is required
+// by the issue's "first-miss" edge case enumeration.
+func TestChaosPointStore_LatestUpdate_TracksAllStatusTransitions(t *testing.T) {
+	_, _, db := newTestManager(t)
+	store := NewChaosPointStore(db)
+	ctx := context.Background()
+
+	// Empty system → zero time, no error.
+	got, err := store.LatestUpdate(ctx, "ts")
+	if err != nil {
+		t.Fatalf("LatestUpdate (empty): %v", err)
+	}
+	if !got.IsZero() {
+		t.Errorf("empty system: want zero time, got %v", got)
+	}
+
+	t0 := time.Now().UTC().Truncate(time.Second)
+	if err := db.Create(&Point{
+		ID: "ts0000000000aaaa", SystemName: "ts", CapabilityName: "http_response_abort",
+		Target:    JSONMap{"app": "ts-user", "method": "GET", "path": "/u", "port": float64(8080)},
+		Source:    "test",
+		Status:    PointActive,
+		CreatedAt: t0, UpdatedAt: t0,
+	}).Error; err != nil {
+		t.Fatalf("seed ts0000000000aaaa: %v", err)
+	}
+
+	got, err = store.LatestUpdate(ctx, "ts")
+	if err != nil {
+		t.Fatalf("LatestUpdate (one row): %v", err)
+	}
+	if !got.Equal(t0) {
+		t.Errorf("want MAX=%v, got %v", t0, got)
+	}
+
+	// Per-system isolation: probing another system must not see ts's rows.
+	got, err = store.LatestUpdate(ctx, "otel-demo")
+	if err != nil {
+		t.Fatalf("LatestUpdate (other system): %v", err)
+	}
+	if !got.IsZero() {
+		t.Errorf("cross-system bleed: want zero, got %v", got)
+	}
+
+	// Supersede flips status — autoUpdateTime bumps updated_at, probe catches it.
+	t1 := t0.Add(time.Minute)
+	if err := db.Model(&Point{}).Where("id = ?", "ts0000000000aaaa").
+		Updates(map[string]any{"status": PointSuperseded, "updated_at": t1}).Error; err != nil {
+		t.Fatalf("supersede: %v", err)
+	}
+	got, err = store.LatestUpdate(ctx, "ts")
+	if err != nil {
+		t.Fatalf("LatestUpdate (after supersede): %v", err)
+	}
+	if !got.Equal(t1) {
+		t.Errorf("supersede should advance MAX to %v, got %v", t1, got)
+	}
+}

--- a/aegislab/src/crud/chaos/migrations.go
+++ b/aegislab/src/crud/chaos/migrations.go
@@ -26,8 +26,39 @@ func Migrations() framework.MigrationRegistrar {
 			&InjectionBatch{},
 			&Injection{},
 		},
-		PreMigrate: nil,
+		PreMigrate: addPointSysUpdatedAtIndex,
 	}
+}
+
+// addPointSysUpdatedAtIndex installs the composite index that backs the
+// MAX(updated_at) probe driving resourcelookup's cross-process cache
+// invalidation (#459). Running this in PreMigrate with explicit
+// ALGORITHM=INPLACE, LOCK=NONE keeps the upgrade non-blocking on production
+// — gorm's AutoMigrate would otherwise issue CREATE INDEX without those
+// qualifiers and stall writers while the index builds. Idempotent: skips
+// when the table is absent (greenfield) or the index already exists.
+// SQLite (test) skips entirely; AutoMigrate's tag-derived DDL handles it.
+func addPointSysUpdatedAtIndex(db *gorm.DB) error {
+	if db.Name() != "mysql" {
+		return nil
+	}
+	mig := db.Migrator()
+	if !mig.HasTable("chaos_points") {
+		return nil
+	}
+	var existing int
+	if err := db.Raw(`SELECT COUNT(*) FROM information_schema.statistics
+		WHERE table_schema = DATABASE()
+		  AND table_name = 'chaos_points'
+		  AND index_name = 'idx_point_sys_updated_at'`).Scan(&existing).Error; err != nil {
+		return err
+	}
+	if existing > 0 {
+		return nil
+	}
+	return db.Exec(
+		"CREATE INDEX idx_point_sys_updated_at ON chaos_points (system_name, updated_at) ALGORITHM=INPLACE, LOCK=NONE",
+	).Error
 }
 
 // SeedCapabilities inserts the step-1 Capability set. Conservative shape:

--- a/aegislab/src/crud/chaos/model.go
+++ b/aegislab/src/crud/chaos/model.go
@@ -88,7 +88,7 @@ func (Capability) TableName() string { return "chaos_capabilities" }
 
 type Point struct {
 	ID             string    `gorm:"primaryKey;size:16"                                                json:"id"`
-	SystemName     string    `gorm:"size:64;not null;index:idx_point_sys_status,priority:1"            json:"system_name"`
+	SystemName     string    `gorm:"size:64;not null;index:idx_point_sys_status,priority:1;index:idx_point_sys_updated_at,priority:1" json:"system_name"`
 	ServiceID      *int64    `gorm:"index:idx_point_svc_status,priority:1"                             json:"service_id,omitempty"`
 	CapabilityName string    `gorm:"size:64;not null"                                                  json:"capability_name"`
 	Target         JSONMap   `gorm:"type:json;not null"                                                json:"target"`
@@ -96,7 +96,7 @@ type Point struct {
 	Source         string    `gorm:"size:32;not null"                                                  json:"source"`
 	Status         string    `gorm:"size:16;not null;default:'active';index:idx_point_sys_status,priority:2;index:idx_point_svc_status,priority:2" json:"status"`
 	CreatedAt      time.Time `gorm:"autoCreateTime"                                                    json:"created_at"`
-	UpdatedAt      time.Time `gorm:"autoUpdateTime"                                                    json:"updated_at"`
+	UpdatedAt      time.Time `gorm:"autoUpdateTime;index:idx_point_sys_updated_at,priority:2"          json:"updated_at"`
 }
 
 func (Point) TableName() string { return "chaos_points" }

--- a/aegislab/src/platform/k8s/resourcelookup/db_backed.go
+++ b/aegislab/src/platform/k8s/resourcelookup/db_backed.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -28,6 +29,13 @@ type ChaosPointStore interface {
 	// QueryPoints returns every active chaos_point for the given system.
 	// Implementations should filter on status='active'.
 	QueryPoints(ctx context.Context, system string) ([]ChaosPointRow, error)
+	// LatestUpdate returns MAX(updated_at) across all chaos_points rows for
+	// the given system, regardless of status. A zero time means no rows exist
+	// for this system yet. The probe drives cross-process cache invalidation:
+	// any import / supersede / tombstone bumps updated_at, so a strictly newer
+	// value than the cached high-water mark forces the next GetAllX to
+	// re-fetch instead of returning stale per-process data.
+	LatestUpdate(ctx context.Context, system string) (time.Time, error)
 }
 
 var (

--- a/aegislab/src/platform/k8s/resourcelookup/db_backed_test.go
+++ b/aegislab/src/platform/k8s/resourcelookup/db_backed_test.go
@@ -3,8 +3,10 @@ package resourcelookup
 import (
 	"context"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
@@ -14,15 +16,48 @@ import (
 // stubStore returns canned chaos_points rows; mirrors the shape aegislab
 // produces from PointManifest imports without dragging gorm into this
 // package's test compile path. queryCount lets shared-snapshot tests
-// assert the warm-up does one DB hit per (system, cache).
+// assert the warm-up does one DB hit per (system, cache); latestPerSystem +
+// latestErr drive the LatestUpdate probe so invalidation tests can swing
+// the high-water mark without touching MySQL.
 type stubStore struct {
-	rows       map[string][]ChaosPointRow
-	queryCount int64
+	mu                sync.Mutex
+	rows              map[string][]ChaosPointRow
+	latestPerSystem   map[string]time.Time
+	latestErr         error
+	queryCount        int64
+	latestUpdateCount int64
 }
 
 func (s *stubStore) QueryPoints(_ context.Context, system string) ([]ChaosPointRow, error) {
 	atomic.AddInt64(&s.queryCount, 1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.rows[system], nil
+}
+
+func (s *stubStore) LatestUpdate(_ context.Context, system string) (time.Time, error) {
+	atomic.AddInt64(&s.latestUpdateCount, 1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.latestErr != nil {
+		return time.Time{}, s.latestErr
+	}
+	return s.latestPerSystem[system], nil
+}
+
+func (s *stubStore) setLatest(system string, t time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.latestPerSystem == nil {
+		s.latestPerSystem = map[string]time.Time{}
+	}
+	s.latestPerSystem[system] = t
+}
+
+func (s *stubStore) setRows(system string, rows []ChaosPointRow) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rows[system] = rows
 }
 
 func newStubStore() *stubStore {
@@ -295,5 +330,221 @@ func TestDBBacked_CacheMetric_HitMiss(t *testing.T) {
 	}
 	if got := testutil.ToFloat64(miss) - missBefore; got != 2 {
 		t.Errorf("post-reset: want 2 cumulative misses, got %v", got)
+	}
+}
+
+// TestDBBacked_CrossProcessInvalidation exercises the LatestUpdate probe that
+// drives cross-process cache invalidation (issue #459). Sub-cases cover every
+// edge case the spec calls out: first-miss bootstrap, fresh probe (no-op),
+// import-bumped probe (invalidate + re-extract), tombstone via supersede,
+// empty-system first import, and probe error (serve stale).
+func TestDBBacked_CrossProcessInvalidation(t *testing.T) {
+	t0 := time.Unix(1700000000, 0)
+
+	tests := []struct {
+		name          string
+		setup         func(t *testing.T, store *stubStore)
+		mutate        func(t *testing.T, store *stubStore)
+		wantBefore    int
+		wantAfter     int
+		wantQueries   int64 // QueryPoints calls expected across both reads
+		wantInvalKind string
+	}{
+		{
+			name: "fresh_probe_no_invalidation",
+			setup: func(_ *testing.T, store *stubStore) {
+				store.setLatest("ts", t0)
+			},
+			mutate: func(_ *testing.T, store *stubStore) {
+				store.setLatest("ts", t0) // unchanged
+			},
+			wantBefore:    2,
+			wantAfter:     2,
+			wantQueries:   1,
+			wantInvalKind: "fresh",
+		},
+		{
+			name: "new_import_advances_high_water_mark",
+			setup: func(_ *testing.T, store *stubStore) {
+				store.setLatest("ts", t0)
+			},
+			mutate: func(_ *testing.T, store *stubStore) {
+				// Operator imports a new HTTP point: row count grows, MAX(updated_at) bumps.
+				rows := append([]ChaosPointRow{}, store.rows["ts"]...)
+				rows = append(rows, ChaosPointRow{
+					SystemName: "ts", CapabilityName: "http_response_abort",
+					Target: map[string]any{
+						"app": "ts-new-service", "method": "GET", "path": "/api/new", "port": float64(8080),
+					},
+				})
+				store.setRows("ts", rows)
+				store.setLatest("ts", t0.Add(time.Minute))
+			},
+			wantBefore:    2,
+			wantAfter:     3,
+			wantQueries:   2,
+			wantInvalKind: "stale",
+		},
+		{
+			name: "supersede_bumps_updated_at_without_row_growth",
+			setup: func(_ *testing.T, store *stubStore) {
+				store.setLatest("ts", t0)
+			},
+			mutate: func(_ *testing.T, store *stubStore) {
+				// Supersede doesn't change row count visible to QueryPoints (which
+				// filters status='active'); it only flips updated_at on the row
+				// that turned 'superseded'. The probe still catches it.
+				store.setLatest("ts", t0.Add(time.Minute))
+			},
+			wantBefore:    2,
+			wantAfter:     2,
+			wantQueries:   2, // probe forced a re-query even though rows are identical
+			wantInvalKind: "stale",
+		},
+		{
+			name: "tombstone_via_delete_bumps_max",
+			setup: func(_ *testing.T, store *stubStore) {
+				store.setLatest("ts", t0)
+			},
+			mutate: func(_ *testing.T, store *stubStore) {
+				// Delete strips one HTTP row.
+				kept := make([]ChaosPointRow, 0, len(store.rows["ts"]))
+				for _, r := range store.rows["ts"] {
+					if r.CapabilityName == "http_request_replace_path" {
+						continue // drop the ts-order-service endpoint
+					}
+					kept = append(kept, r)
+				}
+				store.setRows("ts", kept)
+				store.setLatest("ts", t0.Add(time.Minute))
+			},
+			wantBefore:    2,
+			wantAfter:     1,
+			wantQueries:   2,
+			wantInvalKind: "stale",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newStubStore()
+			tc.setup(t, store)
+			withChaosStore(t, store)
+
+			cache := GetSystemCache(systemconfig.SystemType("ts"))
+			before, err := cache.GetAllHTTPEndpoints()
+			if err != nil {
+				t.Fatalf("first GetAllHTTPEndpoints: %v", err)
+			}
+			if len(before) != tc.wantBefore {
+				t.Fatalf("before: want %d endpoints, got %d: %#v", tc.wantBefore, len(before), before)
+			}
+
+			invalBefore := testutil.ToFloat64(chaosPointsInvalidateTotal.WithLabelValues("ts", tc.wantInvalKind))
+			tc.mutate(t, store)
+
+			after, err := cache.GetAllHTTPEndpoints()
+			if err != nil {
+				t.Fatalf("second GetAllHTTPEndpoints: %v", err)
+			}
+			if len(after) != tc.wantAfter {
+				t.Fatalf("after: want %d endpoints, got %d: %#v", tc.wantAfter, len(after), after)
+			}
+
+			if n := atomic.LoadInt64(&store.queryCount); n != tc.wantQueries {
+				t.Errorf("want %d QueryPoints calls, got %d", tc.wantQueries, n)
+			}
+			if got := testutil.ToFloat64(chaosPointsInvalidateTotal.WithLabelValues("ts", tc.wantInvalKind)) - invalBefore; got < 1 {
+				t.Errorf("want at least 1 invalidation outcome=%q recorded by second read, got delta=%v", tc.wantInvalKind, got)
+			}
+		})
+	}
+}
+
+// TestDBBacked_FirstMissBootstrap proves the very first GetAllX call after
+// process boot still does exactly one QueryPoints — the probe seeds the
+// high-water mark instead of racing the warm-up into a second SELECT.
+func TestDBBacked_FirstMissBootstrap(t *testing.T) {
+	store := newStubStore()
+	store.setLatest("ts", time.Unix(1700000000, 0))
+	withChaosStore(t, store)
+
+	if _, err := GetSystemCache(systemconfig.SystemType("ts")).GetAllHTTPEndpoints(); err != nil {
+		t.Fatalf("GetAllHTTPEndpoints: %v", err)
+	}
+	if n := atomic.LoadInt64(&store.queryCount); n != 1 {
+		t.Errorf("first miss should issue exactly 1 QueryPoints, got %d", n)
+	}
+	if n := atomic.LoadInt64(&store.latestUpdateCount); n != 1 {
+		t.Errorf("first miss should issue exactly 1 LatestUpdate probe, got %d", n)
+	}
+}
+
+// TestDBBacked_EmptySystem_FirstImportInvalidates exercises the edge case
+// where a system starts with zero rows: LatestUpdate returns the zero time,
+// the cache stores an empty derived slice, and the very first import for
+// that system bumps the high-water mark from epoch to a real timestamp,
+// invalidating the empty cache.
+func TestDBBacked_EmptySystem_FirstImportInvalidates(t *testing.T) {
+	store := &stubStore{rows: map[string][]ChaosPointRow{}, latestPerSystem: map[string]time.Time{}}
+	withChaosStore(t, store)
+
+	sysType := systemconfig.SystemType("greenfield")
+	t.Cleanup(func() { ResetSystemCache(sysType) })
+
+	cache := GetSystemCache(sysType)
+	got, err := cache.GetAllHTTPEndpoints()
+	if err != nil {
+		t.Fatalf("GetAllHTTPEndpoints (empty system): %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want 0 endpoints for empty system, got %d", len(got))
+	}
+
+	// First import lands.
+	store.setRows("greenfield", []ChaosPointRow{
+		{SystemName: "greenfield", CapabilityName: "http_response_abort", Target: map[string]any{
+			"app": "g-svc", "method": "GET", "path": "/health", "port": float64(8080),
+		}},
+	})
+	store.setLatest("greenfield", time.Unix(1700000000, 0))
+
+	got, err = cache.GetAllHTTPEndpoints()
+	if err != nil {
+		t.Fatalf("GetAllHTTPEndpoints (post-import): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("first import should be visible without restart, got %d endpoints", len(got))
+	}
+}
+
+// TestDBBacked_ProbeError_ServesStale proves a transient probe failure does
+// not break the guided pipeline — we keep returning the cached snapshot and
+// classify the outcome as probe_error in the metric.
+func TestDBBacked_ProbeError_ServesStale(t *testing.T) {
+	store := newStubStore()
+	store.setLatest("ts", time.Unix(1700000000, 0))
+	withChaosStore(t, store)
+
+	cache := GetSystemCache(systemconfig.SystemType("ts"))
+	first, err := cache.GetAllHTTPEndpoints()
+	if err != nil {
+		t.Fatalf("first GetAllHTTPEndpoints: %v", err)
+	}
+
+	probeErrBefore := testutil.ToFloat64(chaosPointsInvalidateTotal.WithLabelValues("ts", "probe_error"))
+	store.mu.Lock()
+	store.latestErr = context.DeadlineExceeded
+	store.mu.Unlock()
+
+	second, err := cache.GetAllHTTPEndpoints()
+	if err != nil {
+		t.Fatalf("GetAllHTTPEndpoints during probe outage: %v", err)
+	}
+	if len(second) != len(first) {
+		t.Errorf("probe error must not change cached payload: before=%d after=%d", len(first), len(second))
+	}
+	if got := testutil.ToFloat64(chaosPointsInvalidateTotal.WithLabelValues("ts", "probe_error")) - probeErrBefore; got < 1 {
+		t.Errorf("want probe_error counter to advance, got delta=%v", got)
 	}
 }

--- a/aegislab/src/platform/k8s/resourcelookup/lookup.go
+++ b/aegislab/src/platform/k8s/resourcelookup/lookup.go
@@ -11,9 +11,11 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sirupsen/logrus"
 
 	"aegis/platform/k8s/chaosclient"
 	"aegis/platform/systemconfig"
@@ -26,6 +28,15 @@ import (
 var chaosPointsCacheTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "aegis_chaos_points_cache_total",
 	Help: "chaos_points per-system snapshot cache lookups by result (hit|miss).",
+}, []string{"system", "result"})
+
+// chaosPointsInvalidateTotal counts probe-driven cross-process invalidations:
+// `stale` = MAX(updated_at) advanced past the cached high-water mark and the
+// per-system snapshot + derived slices were dropped; `fresh` = cached value
+// still wins; `probe_error` = the probe itself failed (we keep serving stale).
+var chaosPointsInvalidateTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "aegis_chaos_points_invalidate_total",
+	Help: "chaos_points cross-process invalidation probes by outcome (stale|fresh|probe_error).",
 }, []string{"system", "result"})
 
 // GetAllAppLabels returns app labels for the current system.
@@ -108,19 +119,23 @@ type systemCache struct {
 	containerInfo         map[string][]ContainerInfo
 	dbOperations          []AppDatabasePair
 
-	dbSnapshotMu   sync.Mutex
-	dbSnapshotRows []ChaosPointRow
-	dbSnapshotErr  error
-	dbSnapshotOK   bool
+	dbSnapshotMu        sync.Mutex
+	dbSnapshotRows      []ChaosPointRow
+	dbSnapshotErr       error
+	dbSnapshotOK        bool
+	lastSeenUpdatedAt   time.Time
+	lastSeenUpdatedAtOK bool
 }
 
 func GetSystemCache(system systemconfig.SystemType) *systemCache {
 	return getCacheManager().getSystemCache(system)
 }
 
+// chaosPointSnapshot returns the per-system chaos_points snapshot. Callers
+// must hold s.dbSnapshotMu. The probe against ChaosPointStore.LatestUpdate is
+// run by probeAndInvalidate before this method is called, so by the time we
+// arrive here s.dbSnapshotOK already reflects the freshest known state.
 func (s *systemCache) chaosPointSnapshot(ctx context.Context, store ChaosPointStore) ([]ChaosPointRow, error) {
-	s.dbSnapshotMu.Lock()
-	defer s.dbSnapshotMu.Unlock()
 	system := string(s.system)
 	if s.dbSnapshotOK {
 		chaosPointsCacheTotal.WithLabelValues(system, "hit").Inc()
@@ -130,6 +145,64 @@ func (s *systemCache) chaosPointSnapshot(ctx context.Context, store ChaosPointSt
 	s.dbSnapshotRows, s.dbSnapshotErr = store.QueryPoints(ctx, system)
 	s.dbSnapshotOK = true
 	return s.dbSnapshotRows, s.dbSnapshotErr
+}
+
+// probeAndInvalidate consults ChaosPointStore.LatestUpdate(system) and, if the
+// returned timestamp is strictly newer than the cached high-water mark, drops
+// the per-system snapshot + every derived slice so the next chaosPointSnapshot
+// call re-queries chaos_points. This is the cross-process invalidation hook:
+// the chaos-service writer commits a new point's row to MySQL, and any
+// aegis-api replica that probes after the commit sees the bumped MAX and
+// rebuilds — no webhook or watch needed. Callers must hold s.dbSnapshotMu.
+//
+// First-miss (no cached value yet) refreshes lastSeenUpdatedAt to the
+// observed MAX without invalidating, so the very first GetAllX after process
+// boot still hits one warm-up rather than two. An empty result set (no rows
+// for this system yet) is recorded as the zero time, so the very first import
+// for that system surfaces on the next probe.
+//
+// On probe error we log + keep serving the cached snapshot. The probe is a
+// liveness optimisation, not a correctness gate; falling back to stale data
+// during a transient MySQL blip is strictly better than blocking the guided
+// pipeline.
+func (s *systemCache) probeAndInvalidate(ctx context.Context, store ChaosPointStore) {
+	system := string(s.system)
+	latest, err := store.LatestUpdate(ctx, system)
+	if err != nil {
+		chaosPointsInvalidateTotal.WithLabelValues(system, "probe_error").Inc()
+		logrus.Warnf("resourcelookup: LatestUpdate probe for system %q failed, serving cached snapshot: %v", system, err)
+		return
+	}
+	if !s.lastSeenUpdatedAtOK {
+		s.lastSeenUpdatedAt = latest
+		s.lastSeenUpdatedAtOK = true
+		chaosPointsInvalidateTotal.WithLabelValues(system, "fresh").Inc()
+		return
+	}
+	if latest.After(s.lastSeenUpdatedAt) {
+		s.lastSeenUpdatedAt = latest
+		s.dropChaosPointDerivedLocked()
+		chaosPointsInvalidateTotal.WithLabelValues(system, "stale").Inc()
+		return
+	}
+	chaosPointsInvalidateTotal.WithLabelValues(system, "fresh").Inc()
+}
+
+// dropChaosPointDerivedLocked clears the per-system snapshot and every
+// chaos_points-derived slice. The k8s-derived appLabels / containerInfo
+// caches are intentionally left untouched — their staleness has different
+// semantics (informer / watch territory) and is out of scope here.
+// Callers must hold s.dbSnapshotMu.
+func (s *systemCache) dropChaosPointDerivedLocked() {
+	s.dbSnapshotRows = nil
+	s.dbSnapshotErr = nil
+	s.dbSnapshotOK = false
+	s.appEndpoints = []AppEndpointPair{}
+	s.networkPairs = []AppNetworkPair{}
+	s.dnsEndpoints = []AppDNSPair{}
+	s.dbOperations = []AppDatabasePair{}
+	s.appMethods = []AppMethodPair{}
+	s.runtimeMutatorTargets = []AppRuntimeMutatorTarget{}
 }
 
 // requireStore returns the installed ChaosPointStore or an error explaining
@@ -220,14 +293,18 @@ func (s *systemCache) GetAllAppLabels(ctx context.Context, namespace string, key
 
 // GetAllJVMMethods returns all app+method pairs sourced from chaos_points.
 func (s *systemCache) GetAllJVMMethods() ([]AppMethodPair, error) {
-	if len(s.appMethods) > 0 {
-		return s.appMethods, nil
-	}
 	store, err := requireStore()
 	if err != nil {
 		return nil, err
 	}
-	rows, err := s.chaosPointSnapshot(context.Background(), store)
+	ctx := context.Background()
+	s.dbSnapshotMu.Lock()
+	defer s.dbSnapshotMu.Unlock()
+	s.probeAndInvalidate(ctx, store)
+	if len(s.appMethods) > 0 {
+		return s.appMethods, nil
+	}
+	rows, err := s.chaosPointSnapshot(ctx, store)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +316,20 @@ func (s *systemCache) GetAllJVMMethods() ([]AppMethodPair, error) {
 // sourced from the MetadataStore. Without per-system providers registered
 // (e.g. when only the chaos_points store is wired) this returns an empty list.
 func (s *systemCache) GetAllJVMRuntimeMutatorTargets() ([]AppRuntimeMutatorTarget, error) {
-	if len(s.runtimeMutatorTargets) > 0 {
+	// Runtime mutator targets are reachable through the chaos_points pathway
+	// today (jvm_runtime_* capabilities) even though the actual fetch goes
+	// through systemconfig.GetMetadataStore. Probe + share the same
+	// high-water mark so a freshly-imported runtime mutator point is not
+	// hidden behind a stale per-process cache.
+	if store := getChaosPointStore(); store != nil {
+		s.dbSnapshotMu.Lock()
+		s.probeAndInvalidate(context.Background(), store)
+		cached := s.runtimeMutatorTargets
+		s.dbSnapshotMu.Unlock()
+		if len(cached) > 0 {
+			return cached, nil
+		}
+	} else if len(s.runtimeMutatorTargets) > 0 {
 		return s.runtimeMutatorTargets, nil
 	}
 
@@ -285,20 +375,26 @@ func (s *systemCache) GetAllJVMRuntimeMutatorTargets() ([]AppRuntimeMutatorTarge
 		return result[i].MutationTo < result[j].MutationTo
 	})
 
+	s.dbSnapshotMu.Lock()
 	s.runtimeMutatorTargets = result
+	s.dbSnapshotMu.Unlock()
 	return result, nil
 }
 
 // GetAllHTTPEndpoints returns all app+endpoint pairs sourced from chaos_points.
 func (s *systemCache) GetAllHTTPEndpoints() ([]AppEndpointPair, error) {
-	if len(s.appEndpoints) > 0 {
-		return s.appEndpoints, nil
-	}
 	store, err := requireStore()
 	if err != nil {
 		return nil, err
 	}
-	rows, err := s.chaosPointSnapshot(context.Background(), store)
+	ctx := context.Background()
+	s.dbSnapshotMu.Lock()
+	defer s.dbSnapshotMu.Unlock()
+	s.probeAndInvalidate(ctx, store)
+	if len(s.appEndpoints) > 0 {
+		return s.appEndpoints, nil
+	}
+	rows, err := s.chaosPointSnapshot(ctx, store)
 	if err != nil {
 		return nil, err
 	}
@@ -308,14 +404,18 @@ func (s *systemCache) GetAllHTTPEndpoints() ([]AppEndpointPair, error) {
 
 // GetAllNetworkPairs returns all network pairs sourced from chaos_points.
 func (s *systemCache) GetAllNetworkPairs() ([]AppNetworkPair, error) {
-	if len(s.networkPairs) > 0 {
-		return s.networkPairs, nil
-	}
 	store, err := requireStore()
 	if err != nil {
 		return nil, err
 	}
-	rows, err := s.chaosPointSnapshot(context.Background(), store)
+	ctx := context.Background()
+	s.dbSnapshotMu.Lock()
+	defer s.dbSnapshotMu.Unlock()
+	s.probeAndInvalidate(ctx, store)
+	if len(s.networkPairs) > 0 {
+		return s.networkPairs, nil
+	}
+	rows, err := s.chaosPointSnapshot(ctx, store)
 	if err != nil {
 		return nil, err
 	}
@@ -325,14 +425,18 @@ func (s *systemCache) GetAllNetworkPairs() ([]AppNetworkPair, error) {
 
 // GetAllDNSEndpoints returns all app+domain pairs sourced from chaos_points.
 func (s *systemCache) GetAllDNSEndpoints() ([]AppDNSPair, error) {
-	if len(s.dnsEndpoints) > 0 {
-		return s.dnsEndpoints, nil
-	}
 	store, err := requireStore()
 	if err != nil {
 		return nil, err
 	}
-	rows, err := s.chaosPointSnapshot(context.Background(), store)
+	ctx := context.Background()
+	s.dbSnapshotMu.Lock()
+	defer s.dbSnapshotMu.Unlock()
+	s.probeAndInvalidate(ctx, store)
+	if len(s.dnsEndpoints) > 0 {
+		return s.dnsEndpoints, nil
+	}
+	rows, err := s.chaosPointSnapshot(ctx, store)
 	if err != nil {
 		return nil, err
 	}
@@ -343,14 +447,18 @@ func (s *systemCache) GetAllDNSEndpoints() ([]AppDNSPair, error) {
 // GetAllDatabaseOperations returns all app+database+table+operation pairs
 // sourced from chaos_points. Only MySQL operations are emitted by the dump tool.
 func (s *systemCache) GetAllDatabaseOperations() ([]AppDatabasePair, error) {
-	if len(s.dbOperations) > 0 {
-		return s.dbOperations, nil
-	}
 	store, err := requireStore()
 	if err != nil {
 		return nil, err
 	}
-	rows, err := s.chaosPointSnapshot(context.Background(), store)
+	ctx := context.Background()
+	s.dbSnapshotMu.Lock()
+	defer s.dbSnapshotMu.Unlock()
+	s.probeAndInvalidate(ctx, store)
+	if len(s.dbOperations) > 0 {
+		return s.dbOperations, nil
+	}
+	rows, err := s.chaosPointSnapshot(ctx, store)
 	if err != nil {
 		return nil, err
 	}
@@ -487,5 +595,7 @@ func (s *systemCache) InvalidateCache() {
 	s.dbSnapshotRows = nil
 	s.dbSnapshotErr = nil
 	s.dbSnapshotOK = false
+	s.lastSeenUpdatedAt = time.Time{}
+	s.lastSeenUpdatedAtOK = false
 	s.dbSnapshotMu.Unlock()
 }

--- a/aegislab/src/platform/k8s/resourcelookup/lookup.go
+++ b/aegislab/src/platform/k8s/resourcelookup/lookup.go
@@ -131,10 +131,9 @@ func GetSystemCache(system systemconfig.SystemType) *systemCache {
 	return getCacheManager().getSystemCache(system)
 }
 
-// chaosPointSnapshot returns the per-system chaos_points snapshot. Callers
-// must hold s.dbSnapshotMu. The probe against ChaosPointStore.LatestUpdate is
-// run by probeAndInvalidate before this method is called, so by the time we
-// arrive here s.dbSnapshotOK already reflects the freshest known state.
+// Callers must hold s.dbSnapshotMu — the cached slice it feeds into is
+// guarded by the same lock so a stale snapshot cannot leak through a race
+// against probeAndInvalidate.
 func (s *systemCache) chaosPointSnapshot(ctx context.Context, store ChaosPointStore) ([]ChaosPointRow, error) {
 	system := string(s.system)
 	if s.dbSnapshotOK {
@@ -147,24 +146,12 @@ func (s *systemCache) chaosPointSnapshot(ctx context.Context, store ChaosPointSt
 	return s.dbSnapshotRows, s.dbSnapshotErr
 }
 
-// probeAndInvalidate consults ChaosPointStore.LatestUpdate(system) and, if the
-// returned timestamp is strictly newer than the cached high-water mark, drops
-// the per-system snapshot + every derived slice so the next chaosPointSnapshot
-// call re-queries chaos_points. This is the cross-process invalidation hook:
-// the chaos-service writer commits a new point's row to MySQL, and any
-// aegis-api replica that probes after the commit sees the bumped MAX and
-// rebuilds — no webhook or watch needed. Callers must hold s.dbSnapshotMu.
-//
-// First-miss (no cached value yet) refreshes lastSeenUpdatedAt to the
-// observed MAX without invalidating, so the very first GetAllX after process
-// boot still hits one warm-up rather than two. An empty result set (no rows
-// for this system yet) is recorded as the zero time, so the very first import
-// for that system surfaces on the next probe.
-//
-// On probe error we log + keep serving the cached snapshot. The probe is a
-// liveness optimisation, not a correctness gate; falling back to stale data
-// during a transient MySQL blip is strictly better than blocking the guided
-// pipeline.
+// probeAndInvalidate is the cross-process freshness hook: chaos-service
+// commits a new point in MySQL, any aegis-api replica that probes after the
+// commit sees the bumped MAX(updated_at) and drops its stale per-system
+// snapshot. Probe errors degrade to "serve cached" rather than block — the
+// probe is a liveness optimisation, not a correctness gate. Callers must
+// hold s.dbSnapshotMu.
 func (s *systemCache) probeAndInvalidate(ctx context.Context, store ChaosPointStore) {
 	system := string(s.system)
 	latest, err := store.LatestUpdate(ctx, system)
@@ -189,10 +176,10 @@ func (s *systemCache) probeAndInvalidate(ctx context.Context, store ChaosPointSt
 }
 
 // dropChaosPointDerivedLocked clears the per-system snapshot and every
-// chaos_points-derived slice. The k8s-derived appLabels / containerInfo
-// caches are intentionally left untouched — their staleness has different
-// semantics (informer / watch territory) and is out of scope here.
-// Callers must hold s.dbSnapshotMu.
+// chaos_points-derived slice. k8s-derived appLabels / containerInfo and the
+// MetadataStore-fed runtimeMutatorTargets are not chaos_points-backed today
+// (no production caller wires SetMetadataStore / RegisterRuntimeMutatorProvider),
+// so the probe deliberately does not touch them. Callers must hold s.dbSnapshotMu.
 func (s *systemCache) dropChaosPointDerivedLocked() {
 	s.dbSnapshotRows = nil
 	s.dbSnapshotErr = nil
@@ -202,7 +189,34 @@ func (s *systemCache) dropChaosPointDerivedLocked() {
 	s.dnsEndpoints = []AppDNSPair{}
 	s.dbOperations = []AppDatabasePair{}
 	s.appMethods = []AppMethodPair{}
-	s.runtimeMutatorTargets = []AppRuntimeMutatorTarget{}
+}
+
+// chaosPointDerived is the shared probe-then-extract path used by every
+// chaos_points-derived GetAllX. The lock spans the probe, cache check, and
+// extract so the slice cannot be read concurrently with probeAndInvalidate
+// clearing it.
+func chaosPointDerived[T any](
+	s *systemCache,
+	cached *[]T,
+	extract func(rows []ChaosPointRow) []T,
+) ([]T, error) {
+	store, err := requireStore()
+	if err != nil {
+		return nil, err
+	}
+	ctx := context.Background()
+	s.dbSnapshotMu.Lock()
+	defer s.dbSnapshotMu.Unlock()
+	s.probeAndInvalidate(ctx, store)
+	if len(*cached) > 0 {
+		return *cached, nil
+	}
+	rows, err := s.chaosPointSnapshot(ctx, store)
+	if err != nil {
+		return nil, err
+	}
+	*cached = extract(rows)
+	return *cached, nil
 }
 
 // requireStore returns the installed ChaosPointStore or an error explaining
@@ -293,43 +307,18 @@ func (s *systemCache) GetAllAppLabels(ctx context.Context, namespace string, key
 
 // GetAllJVMMethods returns all app+method pairs sourced from chaos_points.
 func (s *systemCache) GetAllJVMMethods() ([]AppMethodPair, error) {
-	store, err := requireStore()
-	if err != nil {
-		return nil, err
-	}
-	ctx := context.Background()
-	s.dbSnapshotMu.Lock()
-	defer s.dbSnapshotMu.Unlock()
-	s.probeAndInvalidate(ctx, store)
-	if len(s.appMethods) > 0 {
-		return s.appMethods, nil
-	}
-	rows, err := s.chaosPointSnapshot(ctx, store)
-	if err != nil {
-		return nil, err
-	}
-	s.appMethods = extractJVMMethods(rows)
-	return s.appMethods, nil
+	return chaosPointDerived(s, &s.appMethods, extractJVMMethods)
 }
 
 // GetAllJVMRuntimeMutatorTargets returns all valid runtime mutator targets
-// sourced from the MetadataStore. Without per-system providers registered
-// (e.g. when only the chaos_points store is wired) this returns an empty list.
+// sourced from the MetadataStore. Not chaos_points-backed in production
+// today (no caller wires SetMetadataStore / RegisterRuntimeMutatorProvider),
+// so the chaos_points MAX(updated_at) probe deliberately does not invalidate
+// this slice — bumping chaos_points would not refresh the data. When a
+// per-system provider eventually lands, revisit invalidation semantics
+// alongside it.
 func (s *systemCache) GetAllJVMRuntimeMutatorTargets() ([]AppRuntimeMutatorTarget, error) {
-	// Runtime mutator targets are reachable through the chaos_points pathway
-	// today (jvm_runtime_* capabilities) even though the actual fetch goes
-	// through systemconfig.GetMetadataStore. Probe + share the same
-	// high-water mark so a freshly-imported runtime mutator point is not
-	// hidden behind a stale per-process cache.
-	if store := getChaosPointStore(); store != nil {
-		s.dbSnapshotMu.Lock()
-		s.probeAndInvalidate(context.Background(), store)
-		cached := s.runtimeMutatorTargets
-		s.dbSnapshotMu.Unlock()
-		if len(cached) > 0 {
-			return cached, nil
-		}
-	} else if len(s.runtimeMutatorTargets) > 0 {
+	if len(s.runtimeMutatorTargets) > 0 {
 		return s.runtimeMutatorTargets, nil
 	}
 
@@ -375,95 +364,29 @@ func (s *systemCache) GetAllJVMRuntimeMutatorTargets() ([]AppRuntimeMutatorTarge
 		return result[i].MutationTo < result[j].MutationTo
 	})
 
-	s.dbSnapshotMu.Lock()
 	s.runtimeMutatorTargets = result
-	s.dbSnapshotMu.Unlock()
 	return result, nil
 }
 
 // GetAllHTTPEndpoints returns all app+endpoint pairs sourced from chaos_points.
 func (s *systemCache) GetAllHTTPEndpoints() ([]AppEndpointPair, error) {
-	store, err := requireStore()
-	if err != nil {
-		return nil, err
-	}
-	ctx := context.Background()
-	s.dbSnapshotMu.Lock()
-	defer s.dbSnapshotMu.Unlock()
-	s.probeAndInvalidate(ctx, store)
-	if len(s.appEndpoints) > 0 {
-		return s.appEndpoints, nil
-	}
-	rows, err := s.chaosPointSnapshot(ctx, store)
-	if err != nil {
-		return nil, err
-	}
-	s.appEndpoints = extractHTTPEndpoints(rows)
-	return s.appEndpoints, nil
+	return chaosPointDerived(s, &s.appEndpoints, extractHTTPEndpoints)
 }
 
 // GetAllNetworkPairs returns all network pairs sourced from chaos_points.
 func (s *systemCache) GetAllNetworkPairs() ([]AppNetworkPair, error) {
-	store, err := requireStore()
-	if err != nil {
-		return nil, err
-	}
-	ctx := context.Background()
-	s.dbSnapshotMu.Lock()
-	defer s.dbSnapshotMu.Unlock()
-	s.probeAndInvalidate(ctx, store)
-	if len(s.networkPairs) > 0 {
-		return s.networkPairs, nil
-	}
-	rows, err := s.chaosPointSnapshot(ctx, store)
-	if err != nil {
-		return nil, err
-	}
-	s.networkPairs = extractNetworkPairs(rows)
-	return s.networkPairs, nil
+	return chaosPointDerived(s, &s.networkPairs, extractNetworkPairs)
 }
 
 // GetAllDNSEndpoints returns all app+domain pairs sourced from chaos_points.
 func (s *systemCache) GetAllDNSEndpoints() ([]AppDNSPair, error) {
-	store, err := requireStore()
-	if err != nil {
-		return nil, err
-	}
-	ctx := context.Background()
-	s.dbSnapshotMu.Lock()
-	defer s.dbSnapshotMu.Unlock()
-	s.probeAndInvalidate(ctx, store)
-	if len(s.dnsEndpoints) > 0 {
-		return s.dnsEndpoints, nil
-	}
-	rows, err := s.chaosPointSnapshot(ctx, store)
-	if err != nil {
-		return nil, err
-	}
-	s.dnsEndpoints = extractDNSEndpoints(rows)
-	return s.dnsEndpoints, nil
+	return chaosPointDerived(s, &s.dnsEndpoints, extractDNSEndpoints)
 }
 
 // GetAllDatabaseOperations returns all app+database+table+operation pairs
 // sourced from chaos_points. Only MySQL operations are emitted by the dump tool.
 func (s *systemCache) GetAllDatabaseOperations() ([]AppDatabasePair, error) {
-	store, err := requireStore()
-	if err != nil {
-		return nil, err
-	}
-	ctx := context.Background()
-	s.dbSnapshotMu.Lock()
-	defer s.dbSnapshotMu.Unlock()
-	s.probeAndInvalidate(ctx, store)
-	if len(s.dbOperations) > 0 {
-		return s.dbOperations, nil
-	}
-	rows, err := s.chaosPointSnapshot(ctx, store)
-	if err != nil {
-		return nil, err
-	}
-	s.dbOperations = extractDatabaseOperations(rows)
-	return s.dbOperations, nil
+	return chaosPointDerived(s, &s.dbOperations, extractDatabaseOperations)
 }
 
 // GetAllContainers returns all containers with their info sorted by app label


### PR DESCRIPTION
Closes #459.

## Summary
Adds cross-process invalidation of the resourcelookup per-process cache for chaos_points-derived fields (HTTP / network / DNS / DB / app methods), so that an import on aegis-api is visible to chaos-pod without a process restart.

## Mechanism
- New `ChaosPointStore.LatestUpdate(ctx, system) → (time.Time, error)` runs `SELECT MAX(updated_at) FROM chaos_points WHERE system_name = ?` (filter-free w.r.t. status so supersede/deprecate tombstones bump MAX).
- Each chaos_points-derived `GetAllX` consults the high-water mark under `dbSnapshotMu`; if newer than cached, the per-system snapshot + derived slices are dropped and re-extracted.
- First-miss seeds the high-water mark without invalidating; empty-system bootstrap stores zero time so the very first import is caught.
- Probe error → logs + serves stale (correctness via cache; freshness is best-effort, per spec).

## Migration
- Explicit `PreMigrate` hook installs `idx_point_sys_updated_at(system_name, updated_at)` via `CREATE INDEX ... ALGORITHM=INPLACE, LOCK=NONE` on MySQL (idempotent via `information_schema` check). Matches `tightenHookSubmissionPK` precedent.
- gorm tag retained for greenfield + SQLite tests.

## Scope decisions
- **In scope** (probe-invalidated): `appEndpoints`, `networkPairs`, `dnsEndpoints`, `dbOperations`, `appMethods`.
- **Out of scope**: `appLabels`, `containerInfo` (k8s-derived, not chaos_points-derived).
- **Runtime mutator targets removed from invalidation set** (review finding): `GetRuntimeMutatorTargets` is fed by `systemconfig.MetadataStore` (external provider / static internal), not `chaos_points`. Bumping `chaos_points.updated_at` would not refresh that data, so invalidating the local cache would be cosmetic. Documented in `GetAllJVMRuntimeMutatorTargets`.

## Observability
- New counter `aegis_chaos_points_invalidate_total{result=stale|fresh|probe_error}` for the probe outcome ratio.

## Constraints documented
- `LatestUpdate` godoc notes the hard-DELETE constraint: soft-delete via `status` is the contract; raw `DELETE` won't bump MAX(updated_at).

## Direct inject is unchanged
The direct chaos inject path doesn't go through resourcelookup, so it remains the escape hatch while this PR + #461 sit together.

## Test plan
- [x] `go test ./platform/k8s/resourcelookup/... ./crud/chaos/...` green (existing + new sub-tests for cross-process invalidation, first-miss, empty-system, probe-error)
- [x] `go build -tags duckdb_arrow ./...` clean
- [x] `go vet -tags duckdb_arrow ./...` clean
- [x] golangci-lint --new-from-rev=HEAD → 0 new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)