### PR TITLE
fix(share): unblock presigned upload (TLS + Host port) and drop --legacy

### DIFF
--- a/aegislab/helm/templates/edge-proxy-config.yaml
+++ b/aegislab/helm/templates/edge-proxy-config.yaml
@@ -91,14 +91,17 @@ data:
         # Presigned-URL passthrough for rustfs (in-cluster S3 backend).
         # aegis-blob signs URLs against this edge host (see each
         # `blob.buckets.*.public_endpoint`), so the browser PUTs/GETs
-        # land here. Preserve the original Host header — SigV4 includes
-        # it in the signature, and the upstream rustfs validates it.
+        # land here. Preserve the original Host header verbatim — SigV4
+        # canonicalises the host including the port, so we MUST forward
+        # `host:port` (use `{http.request.hostport}`, not `{host}` which
+        # drops the port and yields SignatureDoesNotMatch on non-443
+        # public endpoints like `118.196.98.178:8082`).
         @rustfs {
             path /aegis-*
         }
         handle @rustfs {
             reverse_proxy {{ .Release.Name }}-rustfs:9000 {
-                header_up Host {host}
+                header_up Host {http.request.hostport}
             }
         }
         {{- if .Values.devAnchors.enabled }}

--- a/aegislab/src/cli/cmd/blob.go
+++ b/aegislab/src/cli/cmd/blob.go
@@ -78,7 +78,10 @@ func httpPutFromReader(rawURL string, body io.Reader, contentType string, conten
 		req.ContentLength = contentLength
 	}
 	// Presigned URLs MUST NOT carry Authorization (the signature is the auth).
-	httpClient := &http.Client{Transport: client.DefaultTransport()}
+	// Use the resolved TLS options (flag/env/context) so internal CAs and
+	// --insecure-skip-tls-verify apply to the direct PUT to object storage,
+	// not just the aegislab API hop.
+	httpClient := &http.Client{Transport: client.TransportFor(resolveTLSOptions())}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("PUT %s: %w", rawURL, err)

--- a/aegislab/src/cli/cmd/share.go
+++ b/aegislab/src/cli/cmd/share.go
@@ -37,7 +37,6 @@ goes through the unauthenticated /s/<code> endpoint.`,
 var (
 	shareUploadTTL      string
 	shareUploadMaxViews int
-	shareUploadLegacy   bool
 	shareUploadNoSHA256 bool
 )
 
@@ -46,7 +45,7 @@ var shareUploadCmd = &cobra.Command{
 	Short: "Upload a file and produce a public /s/<code> link",
 	Long: `Upload a file and produce a public /s/<code> link.
 
-By default uses the three-step presigned-PUT flow:
+Uses the three-step presigned-PUT flow:
 
   1. POST /api/v2/share/init                — reserve a short code + presigned PUT URL
   2. PUT  <presigned_url>                   — stream the file body directly to object storage (no aegislab hop)
@@ -54,10 +53,7 @@ By default uses the three-step presigned-PUT flow:
 
 This bypasses the aegislab and edge-proxy buffers, restoring full bandwidth
 for users on slow / lossy international links. SHA-256 is computed on the
-client during the PUT and forwarded to commit for integrity verification.
-
-Pass --legacy to fall back to the multipart POST /api/v2/share/upload
-endpoint (the SDK-generated path) for debugging / very small files.`,
+client during the PUT and forwarded to commit for integrity verification.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path := args[0]
@@ -78,39 +74,8 @@ endpoint (the SDK-generated path) for debugging / very small files.`,
 			ttlSecs = secs
 		}
 
-		if shareUploadLegacy {
-			return shareUploadLegacyMultipart(path, ttlSecs, shareUploadMaxViews)
-		}
 		return shareUploadPresigned(path, st.Size(), ttlSecs, shareUploadMaxViews, !shareUploadNoSHA256)
 	},
-}
-
-// shareUploadLegacyMultipart drives the deprecated SDK path
-// (multipart POST through aegislab). Kept behind --legacy for debugging.
-func shareUploadLegacyMultipart(path string, ttlSecs int64, maxViews int) error {
-	f, err := os.Open(path) //nolint:gosec // caller-supplied path is intentional.
-	if err != nil {
-		return fmt.Errorf("open %q: %w", path, err)
-	}
-	defer func() { _ = f.Close() }()
-
-	cli, ctx := newAPIClient()
-	req := cli.ShareAPI.ShareUpload(ctx).File(f)
-	if ttlSecs > 0 {
-		req = req.TtlSeconds(int32(ttlSecs))
-	}
-	if maxViews > 0 {
-		req = req.MaxViews(int32(maxViews))
-	}
-	resp, _, err := req.Execute()
-	if err != nil {
-		return fmt.Errorf("share upload: %w", err)
-	}
-	data := resp.Data
-	if data == nil {
-		return fmt.Errorf("share upload: empty response")
-	}
-	return printShareUploadResult(data.GetShortCode(), data.GetShareUrl(), int64(data.GetSize()), data.GetExpiresAt())
 }
 
 // shareInitResponse mirrors initUploadResp on the server side. Hand-rolled
@@ -519,7 +484,6 @@ func joinURL(base, rel string) string {
 func init() {
 	shareUploadCmd.Flags().StringVar(&shareUploadTTL, "ttl", "", "Link lifetime: seconds, e.g. 3600, 30m, 24h, 7d (server default if unset)")
 	shareUploadCmd.Flags().IntVar(&shareUploadMaxViews, "max-views", 0, "Cap on download count (server default if 0)")
-	shareUploadCmd.Flags().BoolVar(&shareUploadLegacy, "legacy", false, "Fall back to the deprecated multipart POST /api/v2/share/upload (no presigned PUT)")
 	shareUploadCmd.Flags().BoolVar(&shareUploadNoSHA256, "no-sha256", false, "Skip streaming sha256 computation during PUT (faster, no integrity hint)")
 
 	shareListCmd.Flags().IntVar(&shareListPage, "page", 1, "Page number")

--- a/aegislab/src/cli/cmd/share_test.go
+++ b/aegislab/src/cli/cmd/share_test.go
@@ -17,24 +17,11 @@ func TestShareUploadHelpMentionsPresignFlow(t *testing.T) {
 		"presigned-PUT",
 		"share/init",
 		"share/<code>/commit",
-		"--legacy",
 		"sha256",
 	} {
 		if !strings.Contains(res.stdout, want) {
 			t.Fatalf("share upload --help missing %q\nstdout=%s", want, res.stdout)
 		}
-	}
-}
-
-// TestShareUploadLegacyFlagParses confirms cobra accepts --legacy on the
-// upload command; the runtime path still errors out (no server set), but
-// the flag must be recognised by the parser.
-func TestShareUploadLegacyFlagParses(t *testing.T) {
-	res := runCLI(t, "share", "upload", "/nonexistent/path", "--legacy")
-	// stat will fail before any network call — but the failure must be
-	// the stat one, not "unknown flag --legacy".
-	if strings.Contains(res.stderr, "unknown flag") {
-		t.Fatalf("--legacy not registered: %s", res.stderr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `aegisctl share upload` presigned-PUT path was completely broken: TLS verification ignored context CA / `--insecure-skip-tls-verify`, and even past TLS the upload failed with `SignatureDoesNotMatch`. `--legacy` (multipart through aegislab) was the only working route.
- Fixed both: client honours resolved TLS options; edge-proxy forwards Host with port intact.
- Removed `--legacy` flag and the multipart fallback from the CLI now that the fast path works. Server-side handler retained for SDK / frontend consumers.

## Root causes

1. `aegislab/src/cli/cmd/blob.go` — `httpPutFromReader` used `client.DefaultTransport()`, bypassing `resolveTLSOptions()`. Internal-CA clusters always hit x509 unknown authority on the PUT to rustfs.
2. `aegislab/helm/templates/edge-proxy-config.yaml` — `header_up Host {host}` strips the port (Caddy `{host}` is hostname-only). SigV4 signs `host:port` (`118.196.98.178:8082`); upstream rustfs saw hostname only → canonical request mismatch → 403 SignatureDoesNotMatch. Switched to `{http.request.hostport}`.

## Test plan

- [x] Rebuilt aegisctl; presigned upload verified on byte-cluster (PUT + `/s/<code>` GET returns the file).
- [x] `go test ./cli/cmd/ -run TestShareUpload` green.
- [x] `go vet ./cli/...` clean.
- [x] `go build -tags duckdb_arrow ./main.go` clean.
- [x] edge-proxy ConfigMap was patched in-place (no Service / Deployment change — EIP preserved) and pod recycled to pick up the new Caddyfile.

schema-changes-acknowledged: true

🤖 Generated with [Claude Code](https://claude.com/claude-code)