### PR TITLE
feat(reclaimer): per-system soft reclaim mode — rollout restart instead of helm uninstall (#468)

### DIFF
--- a/aegislab/manifests/byte-cluster/initial-data/data.yaml
+++ b/aegislab/manifests/byte-cluster/initial-data/data.yaml
@@ -1303,6 +1303,20 @@ dynamic_configs:
     is_secret: false
     min_value: -1
     max_value: 1
+  # Soft reclaim: idle ns gets `kubectl rollout restart` of non-DB deployments
+  # instead of helm uninstall + ns delete. SocialNetwork's helm chart bootstraps
+  # the social graph via a `data-init-job` Job (post-install,post-upgrade hook)
+  # that takes 5–10 min; mongodb/redis/memcached/mcrouter run with no PVC so
+  # `helm uninstall` silently drops their data. Soft reclaim preserves both the
+  # helm release and the DB state while still clearing any chaos-mesh residue
+  # on app pods. See ReclaimModeSoft in src/platform/config/chaos_system.go.
+  - key: injection.system.sn.reclaim_mode
+    default_value: soft
+    value_type: 0
+    scope: 2
+    category: injection.system.reclaim_mode
+    description: NamespaceReclaimer action — "soft" (rollout restart non-DB) or empty/"full" (helm uninstall + ns delete)
+    is_secret: false
   - key: injection.system.media.count
     default_value: '1'
     value_type: 2
@@ -1356,6 +1370,16 @@ dynamic_configs:
     is_secret: false
     min_value: -1
     max_value: 1
+  # See sn.reclaim_mode comment above — same rationale (DSB charts share the
+  # data-init-job subchart; MediaMicroservices initializes movies + users the
+  # same way SocialNetwork initializes the graph).
+  - key: injection.system.media.reclaim_mode
+    default_value: soft
+    value_type: 0
+    scope: 2
+    category: injection.system.reclaim_mode
+    description: NamespaceReclaimer action — "soft" (rollout restart non-DB) or empty/"full" (helm uninstall + ns delete)
+    is_secret: false
   - key: injection.system.teastore.count
     default_value: '1'
     value_type: 2

--- a/aegislab/src/core/orchestrator/namespace_reclaimer.go
+++ b/aegislab/src/core/orchestrator/namespace_reclaimer.go
@@ -113,6 +113,7 @@ type k8sNamespaceManager interface {
 	GetNamespaceLabels(ctx context.Context, name string) (map[string]string, error)
 	ListNamespaceChaosResources(ctx context.Context, namespace string) (map[string]int, []error)
 	DeleteNamespace(ctx context.Context, name string) error
+	SoftReclaimNamespace(ctx context.Context, namespace string) (restarted, skipped []string, err error)
 }
 
 type nsLockProbe interface {
@@ -360,6 +361,26 @@ func (r *NamespaceReclaimer) reclaimOne(ctx context.Context, c ReclaimCandidate,
 		"last_deployed": c.LastDeployed.Format(time.RFC3339),
 		"reason":        d.Reason,
 	})
+
+	// Per-system opt-in to soft reclaim. Default (empty / missing config) keeps
+	// the historical full-reclaim behavior so this change is no-op for every
+	// system that hasn't been explicitly migrated. See ReclaimModeSoft for the
+	// rationale and the seed entries adding "soft" for sn / media.
+	if sys, ok := r.systems.GetAll()[c.SystemName]; ok && sys.IsSoftReclaim() {
+		logEntry.Info("namespace reclaim: soft mode — rollout restart of non-DB deployments")
+		restarted, skipped, err := r.k8s.SoftReclaimNamespace(ctx, c.Namespace)
+		if err != nil {
+			return fmt.Errorf("soft reclaim %s: %w", c.Namespace, err)
+		}
+		logEntry.WithFields(logrus.Fields{
+			"restarted_count": len(restarted),
+			"skipped_count":   len(skipped),
+			"restarted":       restarted,
+			"skipped":         skipped,
+		}).Info("namespace reclaim: soft complete")
+		return nil
+	}
+
 	logEntry.Info("namespace reclaim: dropping helm release + namespace")
 
 	uctx, ucancel := context.WithTimeout(ctx, uninstallTO)

--- a/aegislab/src/core/orchestrator/namespace_reclaimer_test.go
+++ b/aegislab/src/core/orchestrator/namespace_reclaimer_test.go
@@ -206,6 +206,11 @@ type fakeK8s struct {
 	chaos      map[string]map[string]int
 	deleted    []string
 	deleteErr  error
+	// softReclaimed lists namespaces that received SoftReclaimNamespace calls.
+	// The fake assumes every ns has the same "all-non-DB" set of deployments
+	// since tests don't need finer granularity than "soft path was taken".
+	softReclaimed []string
+	softReclaimErr error
 }
 
 func (f *fakeK8s) ListClusterNamespaces(ctx context.Context) ([]string, error) {
@@ -242,6 +247,16 @@ func (f *fakeK8s) DeleteNamespace(ctx context.Context, name string) error {
 		}
 	}
 	return nil
+}
+
+func (f *fakeK8s) SoftReclaimNamespace(ctx context.Context, name string) ([]string, []string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.softReclaimErr != nil {
+		return nil, nil, f.softReclaimErr
+	}
+	f.softReclaimed = append(f.softReclaimed, name)
+	return []string{"app-frontend", "app-backend"}, []string{"mongodb", "redis"}, nil
 }
 
 type fakeLocks struct {
@@ -499,4 +514,36 @@ func TestReclaimer_TickActiveChaosBlocks(t *testing.T) {
 	_, processed, err := r.tick(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 0, processed)
+}
+
+func TestReclaimer_TickSoftReclaimSkipsHelmUninstall(t *testing.T) {
+	now := mustParse(t, "2026-05-17T12:00:00Z")
+	helmF := newFakeHelm()
+	helmF.releases["sn0/sn0"] = &helm.ReleaseInfo{
+		Name: "sn0", Namespace: "sn0", Status: "deployed",
+		LastDeployed: now.Add(-30 * time.Hour),
+	}
+	k8sF := &fakeK8s{
+		namespaces: []string{"sn0"},
+		labels:     map[string]map[string]string{"sn0": {managedByAegisLabel: managedByAegisValue}},
+		chaos:      map[string]map[string]int{},
+	}
+	systems := map[string]config.ChaosSystemConfig{
+		"sn": {System: "sn", NsPattern: `^sn\d+$`, ReclaimMode: config.ReclaimModeSoft},
+	}
+	withReclaimConfig(t, map[string]any{
+		"helm.reclaim.enabled":               true,
+		"helm.reclaim.idle_ttl_hours":        6,
+		"helm.reclaim.max_deletes_per_tick":  5,
+		"helm.reclaim.require_managed_label": true,
+	})
+	r := newTestReclaimer(now, helmF, k8sF, &fakeLocks{locked: map[string]bool{}}, systems)
+	candidates, processed, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, candidates)
+	require.Equal(t, 1, processed)
+	// Helm release must NOT be uninstalled; namespace must NOT be deleted.
+	require.Empty(t, helmF.uninstalled, "soft reclaim must not call helm uninstall")
+	require.Empty(t, k8sF.deleted, "soft reclaim must not delete namespace")
+	require.Equal(t, []string{"sn0"}, k8sF.softReclaimed)
 }

--- a/aegislab/src/platform/config/chaos_system.go
+++ b/aegislab/src/platform/config/chaos_system.go
@@ -20,6 +20,17 @@ const (
 	// kind cluster, short enough to fail loudly on a genuinely broken
 	// install.
 	DefaultReadinessTimeoutSeconds = 900
+
+	// ReclaimModeSoft makes NamespaceReclaimer perform a `kubectl rollout
+	// restart` of non-DB deployments instead of `helm uninstall + namespace
+	// delete`. Opt-in per system via `injection.system.<sys>.reclaim_mode=soft`.
+	// Use this when the chart bootstraps non-trivial seed data (DSB sn / media
+	// load social-graph / movies via a `data-init-job` Job; mongodb / redis are
+	// ephemeral with no PVC) that would cost 5–10 min to rebuild on every
+	// reclaim. Soft mode clears any chaos-mesh residue on app pods while
+	// preserving DB state and the helm release. Empty / any other value =
+	// "full" (existing behavior).
+	ReclaimModeSoft = "soft"
 )
 
 // ChaosSystemConfig is the aggregate of every injection.system.<name>.* key in
@@ -43,6 +54,18 @@ type ChaosSystemConfig struct {
 	// `injection.system.<sys>.readiness_timeout_seconds`. Zero / unset falls
 	// back to DefaultReadinessTimeoutSeconds (900 = 15 min).
 	ReadinessTimeoutSeconds int `mapstructure:"readiness_timeout_seconds"`
+	// ReclaimMode selects the NamespaceReclaimer action when this system's
+	// namespace becomes reclaim-eligible. "soft" → rollout restart of non-DB
+	// deployments (preserves helm release + DB state). Empty / anything else
+	// → existing helm uninstall + ns delete. See ReclaimModeSoft for the
+	// rationale (DSB charts that bootstrap seed data are expensive to rebuild).
+	ReclaimMode string `mapstructure:"reclaim_mode"`
+}
+
+// IsSoftReclaim reports whether this system opted into soft reclaim. Centralized
+// so callers don't need to know about the magic "soft" string.
+func (s *ChaosSystemConfig) IsSoftReclaim() bool {
+	return s.ReclaimMode == ReclaimModeSoft
 }
 
 // ReadinessTimeout returns the workload-readiness probe timeout for this

--- a/aegislab/src/platform/k8s/gateway.go
+++ b/aegislab/src/platform/k8s/gateway.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -157,6 +159,69 @@ func (g *Gateway) EnsureNamespace(ctx context.Context, name string) (bool, error
 		return false, fmt.Errorf("create namespace %q: %w", name, err)
 	}
 	return true, nil
+}
+
+// SoftReclaimNamespace rolls non-DB Deployments in <namespace> by patching their
+// `spec.template.metadata.annotations.kubectl.kubernetes.io/restartedAt`, the
+// same mechanism `kubectl rollout restart deployment <name>` uses. Returns the
+// names of the deployments that were restarted (those skipped because their
+// name matches the DB pattern are surfaced via the second return).
+//
+// Skip pattern catches the data-bearing services across our benchmark charts:
+// mongo*, redis*, memcached*, mcrouter*, mysql*, postgres*, etcd*. These pods
+// hold the loadgen-accumulated state we want to preserve across rounds (DSB
+// default standalone mode binds no PVC; restarting them silently drops social
+// graph / users / movies and forces a 5–10 min data-init-job rerun).
+//
+// StatefulSets, DaemonSets, and Jobs are intentionally NOT touched — restart
+// semantics there differ enough that one-shot logic would be a footgun.
+func (g *Gateway) SoftReclaimNamespace(ctx context.Context, namespace string) (restarted, skipped []string, err error) {
+	client, kerr := getK8sClient()
+	if kerr != nil {
+		return nil, nil, k8sClientNotAvailableErr(kerr)
+	}
+	deployList, listErr := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	if listErr != nil {
+		return nil, nil, fmt.Errorf("list deployments in %q: %w", namespace, listErr)
+	}
+	restartedAt := time.Now().UTC().Format(time.RFC3339)
+	patch := fmt.Appendf(nil, `{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":%q}}}}}`, restartedAt)
+	for i := range deployList.Items {
+		name := deployList.Items[i].Name
+		if isDBDeploymentName(name) {
+			skipped = append(skipped, name)
+			continue
+		}
+		if _, patchErr := client.AppsV1().Deployments(namespace).Patch(ctx, name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); patchErr != nil {
+			return restarted, skipped, fmt.Errorf("rollout restart deployment %s/%s: %w", namespace, name, patchErr)
+		}
+		restarted = append(restarted, name)
+	}
+	return restarted, skipped, nil
+}
+
+// isDBDeploymentName returns true when the deployment name looks like a
+// data-bearing component that soft-reclaim must NOT restart. Pattern matching
+// is intentionally name-based (substring) rather than label-based: DSB / sock
+// shop / hs charts do not use a consistent "role=db" label, but the convention
+// of including the engine name in the deployment name is uniform.
+func isDBDeploymentName(name string) bool {
+	for _, needle := range dbNameSubstrings {
+		if strings.Contains(name, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+var dbNameSubstrings = []string{
+	"mongo",
+	"redis",
+	"memcached",
+	"mcrouter",
+	"mysql",
+	"postgres",
+	"etcd",
 }
 
 // DeleteNamespace deletes <name> with foreground propagation so the call


### PR DESCRIPTION
Closes #468.

## Summary

- Adds `reclaim_mode` to `ChaosSystemConfig`. Empty / `"full"` → existing behavior (helm uninstall + namespace delete) preserved for every system that doesn't opt in. `"soft"` → branches `reclaimOne` into `SoftReclaimNamespace`, which patches `kubectl.kubernetes.io/restartedAt` on every Deployment in the namespace except those whose name contains a known DB substring (`mongo`, `redis`, `memcached`, `mcrouter`, `mysql`, `postgres`, `etcd`).
- Seeded `soft` for **sn** and **media** only. Every other system unchanged.

## Why soft for sn / media

DSB sn / media bootstrap state via a `data-init-job` subchart Job (post-install,post-upgrade hook) that takes 5–10 min to repopulate the social graph / movies / users. The standalone mongodb / redis / memcached / mcrouter run without PVCs, so `helm uninstall` silently drops their data. Across rounds of an injection campaign the accumulated loadgen state is closer to real long-running production than a freshly-bootstrapped one. chaos-mesh upstream finalizers already clean tc / iptables / JVM-agent residue on CR delete; the only real reason we currently redeploy is insurance against the aegis fork chaos-tproxy bridgeless variant possibly leaving netns state behind, and a `kubectl rollout restart` of the injected Deployment clears that in ~10s while preserving DB state and the helm release.

## What it does NOT do

- StatefulSets / DaemonSets / Jobs intentionally not touched — rollout semantics differ enough there that one-shot logic would be a footgun.
- No new CLI command, no new HTTP endpoint. The trigger (idle-TTL background reconciler) is unchanged; only the per-system **action** at the trigger is dispatched on `reclaim_mode`. Issue #468 lays out a future explicit CLI / endpoint surface; this PR keeps the diff to the minimum needed to give sn / media the cheap reset path.

## Test plan

- [x] `go test ./core/orchestrator/... -run Reclaim` — existing tests pass; new `TestReclaimer_TickSoftReclaimSkipsHelmUninstall` covers the dispatch branch.
- [x] `go build -tags duckdb_arrow ./...` clean; `golangci-lint --new-from-rev origin/main` clean.
- [ ] After merge: reseed byte-cluster → observe a sn / media ns going idle past 6h → confirm log line `namespace reclaim: soft mode — rollout restart of non-DB deployments` and that mongo / redis pods stay running while app pods cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)