### PR TITLE
chore(byte-cluster/seed): override data-init-job python image for sn/media (chart 0.2.1 docker.io blocker)

### DIFF
--- a/aegislab/manifests/byte-cluster/initial-data/data.yaml
+++ b/aegislab/manifests/byte-cluster/initial-data/data.yaml
@@ -757,6 +757,18 @@ containers:
               value_type: 0
               default_value: pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib
               overridable: true
+            # data-init-job subchart hardcodes `image: python` (defaults to
+            # docker.io/library/python:3.9-slim). byte-cluster nodes can NOT
+            # egress docker.io → init job ImagePullBackOff blocks helm install.
+            # Mirrored 2026-05-22: `docker buildx imagetools create --tag
+            # docker.io/opspai/python:3.9-slim docker.io/library/python:3.9-slim`
+            # → volces auto-mirrors opspai/python at the path below.
+            - key: data-init-job.container.image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/python
+              overridable: true
           status: 1
   - type: 2
     name: media
@@ -834,6 +846,14 @@ containers:
               category: 1
               value_type: 0
               default_value: pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib
+              overridable: true
+            # See sn 0.1.6 — data-init-job hardcodes docker.io/library/python.
+            # Mirror at docker.io/opspai/python:3.9-slim (2026-05-22).
+            - key: data-init-job.container.image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/python
               overridable: true
           status: 1
   - type: 2


### PR DESCRIPTION
## Summary

lgu-dsb chart 0.2.1 added a `data-init-job` subchart whose values hardcode `image: python` / `imageVersion: 3.9-slim` → resolves to `docker.io/library/python:3.9-slim`. byte-cluster nodes can NOT egress docker.io directly, so today's first install attempts of `sn0` and `mm0` (PR #466 + #471 reseed) ImagePullBackOff'd on this init container and helm timed out.

Mirrored the image to docker.io/opspai (multi-arch preserved via `docker buildx imagetools create`) so the volces auto-mirror at `pair-cn-shanghai.cr.volces.com/opspai/python` becomes reachable.

Adds one helm value to sn 0.1.6 and media 0.1.6:

```
data-init-job.container.image = pair-cn-shanghai.cr.volces.com/opspai/python
```

The chart's `imageVersion: 3.9-slim` default is fine — only the registry needs to change.

Long-term cleanup is an upstream chart PR routing the data-init container through `global.infraDockerRegistry` (already set on the seed); not in scope here.

## Test plan

- [ ] CI seed validation passes
- [ ] After merge: CM apply + restart api-gateway + reseed
- [ ] `helm uninstall sn0 mm0` + retry `aegisctl pedestal chart install sn|media --apply-overrides --from-pedestal-version 0.1.6 --wait` → data-init-job pulls succeed, helm install returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)