### PR TITLE
fix(chaos): correct online-DDL syntax for chaos_points index migration

### DIFF
--- a/aegislab/src/crud/chaos/migrations.go
+++ b/aegislab/src/crud/chaos/migrations.go
@@ -57,7 +57,7 @@ func addPointSysUpdatedAtIndex(db *gorm.DB) error {
 		return nil
 	}
 	return db.Exec(
-		"CREATE INDEX idx_point_sys_updated_at ON chaos_points (system_name, updated_at) ALGORITHM=INPLACE, LOCK=NONE",
+		"ALTER TABLE chaos_points ADD INDEX idx_point_sys_updated_at (system_name, updated_at), ALGORITHM=INPLACE, LOCK=NONE",
 	).Error
 }
 


### PR DESCRIPTION
## Summary
Hotfix for the migration introduced in #464. MySQL's `CREATE INDEX` does not accept the `ALGORITHM=INPLACE, LOCK=NONE` clauses; those are only valid on `ALTER TABLE`. byte-cluster chaos pod entered CrashLoopBackOff on deploy of `cb66ad4c` with:

```
Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ', LOCK=NONE' at line 1
```

Switching to `ALTER TABLE chaos_points ADD INDEX ... ALGORITHM=INPLACE, LOCK=NONE` is the documented online-DDL form. Behavior on prod is unchanged (still INPLACE, LOCK=NONE).

## Test plan
- [x] byte-cluster MySQL repro of the failure (chaos pod crash log)
- [ ] redeploy + verify chaos pod boots clean
- [ ] verify index actually lands: `SHOW INDEX FROM chaos_points WHERE Key_name='idx_point_sys_updated_at'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)