### PR TITLE
fix(prepare-inputs): stop chaos-mesh k8s Events leaking into abnormal log slice

### DIFF
--- a/aegislab/manifests/byte-cluster/otel-kube-stack.values.yaml
+++ b/aegislab/manifests/byte-cluster/otel-kube-stack.values.yaml
@@ -548,6 +548,25 @@ collectors:
             - context: resource
               statements:
                 - set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where attributes["k8s.namespace.name"] != nil
+        # k8sobjects receiver (enabled via presets.kubernetesEvents) emits each
+        # Kubernetes Event as a log record with event.domain="k8s" and
+        # k8s.namespace.name = the involved object's namespace. The transform
+        # above then copies that into service.namespace, which makes the Event
+        # masquerade as an application log of the benchmark namespace.
+        # rcabench-platform/cli/prepare_inputs.py:query_logs slices logs by
+        # `service.namespace = '<ns>'`, so chaos-mesh-emitted Events (kind=
+        # PodChaos/NetworkChaos/HTTPChaos/..., apiVersion chaos-mesh.org/v1alpha1,
+        # reason in {Started,Applied,Recovered,TimeUp,...}) plus correlated
+        # Pod Killing/BackOff events land directly in the abnormal-window log
+        # slice that RCA algorithms consume — a hard ground-truth leak.
+        # Pin Event log records to a sentinel service.namespace so they stay
+        # queryable for cluster ops but never collide with per-namespace
+        # benchmark log slices.
+        transform/strip_k8s_event_service_namespace:
+          log_statements:
+            - context: log
+              statements:
+                - set(resource.attributes["service.namespace"], "__k8s_events__") where attributes["event.domain"] == "k8s"
       connectors:
         spanmetrics: {}
       receivers:
@@ -569,7 +588,7 @@ collectors:
         pipelines:
           logs:
             exporters: [clickhouse]
-            processors: [memory_limiter, k8sattributes, transform/service_namespace, batch]
+            processors: [memory_limiter, k8sattributes, transform/service_namespace, transform/strip_k8s_event_service_namespace, batch]
             receivers: [otlp]
           metrics:
             exporters: [clickhouse]

--- a/rcabench-platform/cli/prepare_inputs.py
+++ b/rcabench-platform/cli/prepare_inputs.py
@@ -161,6 +161,18 @@ def query_metrics_histogram(save_path: Path, namespace: str, start_time: str, en
 
 @timeit()
 def query_logs(save_path: Path, namespace: str, start_time: str, end_time: str):
+    # Ground-truth leak guard: the deploy-mode collector enables the
+    # k8sobjects receiver (presets.kubernetesEvents=true) and pipes K8s
+    # Events through the same logs table with service.namespace stamped
+    # from the involved object's namespace. For benchmark namespaces that
+    # means chaos-mesh-emitted Events for the chaos CR (kind PodChaos /
+    # NetworkChaos / HTTPChaos, apiVersion chaos-mesh.org/v1alpha1, reason
+    # Started/Applied/Recovered/TimeUp) plus correlated Pod Killing/BackOff
+    # events land in the abnormal-window slice — a direct cleartext leak
+    # of fault type and timing. The collector side now pins event logs to
+    # service.namespace='__k8s_events__', but old data and any collector
+    # that hasn't picked up the config will still carry them, so filter
+    # here too on the receiver-set log attribute.
     query = f"""
     SELECT
         Timestamp,
@@ -178,6 +190,7 @@ def query_logs(save_path: Path, namespace: str, start_time: str, end_time: str):
     WHERE
         ol.ResourceAttributes['service.namespace'] = '{namespace}'
         AND ol.Timestamp BETWEEN '{start_time}' AND '{end_time}'
+        AND ol.LogAttributes['event.domain'] != 'k8s'
     """
 
     with get_clickhouse_client() as client:

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/fault_kind.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/fault_kind.py
@@ -65,7 +65,7 @@ class FaultKind(str, Enum):
     UNKNOWN = "unknown"
 
     @classmethod
-    def _missing_(cls, value: object) -> "FaultKind | None":
+    def _missing_(cls, value: object) -> FaultKind | None:
         """Accept legacy string values from earlier SDK versions."""
         if isinstance(value, str):
             new = _LEGACY_ALIASES.get(value)

--- a/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/tests/test_evaluator.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/evaluation/tests/test_evaluator.py
@@ -15,7 +15,6 @@ from typing import Any
 
 import polars as pl
 
-from rcabench_platform.v3.sdk.evaluation.causal_graph import CausalGraph
 from rcabench_platform.v3.sdk.evaluation import (
     AgentRCAOutput,
     Evidence,
@@ -32,6 +31,7 @@ from rcabench_platform.v3.sdk.evaluation import (
     map_chaos_type,
     verify_evidence,
 )
+from rcabench_platform.v3.sdk.evaluation.causal_graph import CausalGraph
 
 # ──────────────────────────────────────────────────────────────────────
 # Fault-kind controlled vocabulary
@@ -1248,8 +1248,8 @@ def test_evaluate_judge_failure_isolates_per_evidence(tmp_path: Path) -> None:
 
 def _judge_call(content: str) -> Any:
     """Helper: run evidence_support against a stub that returns ``content``."""
-    from rcabench_platform.v3.sdk.evaluation.chain_judge import evidence_support
     from rcabench_platform.v3.sdk.evaluation.agent_output import Evidence as Ev
+    from rcabench_platform.v3.sdk.evaluation.chain_judge import evidence_support
     from rcabench_platform.v3.sdk.evaluation.sql_verify import EvidenceStatus, EvidenceVerifyResult
 
     client = type("C", (), {"chat": _StubChat(content)})()
@@ -1297,8 +1297,8 @@ def test_evidence_judge_unparseable_value_returns_none() -> None:
 def test_evidence_judge_no_response_format_param() -> None:
     """Regression: gateways like litellm 400 on response_format=json_object;
     the judge must rely on prompt-only formatting, not that flag."""
-    from rcabench_platform.v3.sdk.evaluation.chain_judge import evidence_support
     from rcabench_platform.v3.sdk.evaluation.agent_output import Evidence as Ev
+    from rcabench_platform.v3.sdk.evaluation.chain_judge import evidence_support
     from rcabench_platform.v3.sdk.evaluation.sql_verify import EvidenceStatus, EvidenceVerifyResult
 
     completions = _StubCompletions(json.dumps({"supported": True, "reasoning": "ok"}))


### PR DESCRIPTION
## Summary

The byte-cluster deploy collector enables `presets.kubernetesEvents` (k8sobjects receiver on the logs pipeline) plus a `transform/service_namespace` processor that unconditionally copies `k8s.namespace.name` → `service.namespace`. Together they make every chaos-mesh-emitted Event on a Chaos CR (PodChaos/NetworkChaos/HTTPChaos/…, reasons Started/Applied/Recovered/TimeUp) plus correlated Pod Killing/BackOff/Failed events appear in `otel_logs` with `service.namespace = <benchmark_ns>`. `prepare_inputs.query_logs` filters by exactly that field, so RCA datapacks have been receiving cleartext ground truth (fault type, target service, timing) in `abnormal_logs.parquet`.

Verified in production CH: 158 chaos-mesh-tagged Events/day on `hs0`, plus 208 Pod Killing events strongly correlated with PodChaos windows. Sample row carried `aegis-pod-failure-…` / `hs0-profile-pod-failure-dw9hnv` in the Event body — fault type and target service in cleartext.

Two defences:

- **Collector** (`aegislab/manifests/byte-cluster/otel-kube-stack.values.yaml`): add log-context `transform/strip_k8s_event_service_namespace` after `service_namespace` that pins `event.domain="k8s"` records to `service.namespace="__k8s_events__"`. Events remain queryable for cluster ops; benchmark-ns log slices no longer see them. Other manifests (`cn_mirror`, `otel-collector`, kind) have no `transform/service_namespace` or no `kubernetesEvents` preset, so they never reached the leaky state.
- **prepare_inputs** (`rcabench-platform/cli/prepare_inputs.py`): add `AND LogAttributes['event.domain'] != 'k8s'` as belt-and-suspenders for historical data and collectors that have not picked up the new config.

Aegislab itself does not call `EventRecorder` and only creates Chaos CRs (in target ns) — no other event-emission channel found. Note: `aegislab/src/crud/chaos/idempotency.go` derives CR names as `aegis-<action>-<hash>`, which still encodes the action in Event metadata; not changed here because the new filters keep those Events out of the RCA slice regardless. Follow-up worth considering: rename to `aegis-<sha256(action+key)[:16]>` to strip the capability name entirely.

## Test plan

- [ ] Apply collector change via seed-update-cycle (CM apply + restart deploy collector pods).
- [ ] After ~5 min, verify in CH: `SELECT count() FROM otel.otel_logs WHERE ResourceAttributes['service.namespace']='hs0' AND LogAttributes['event.domain']='k8s' AND Timestamp > now() - INTERVAL 5 MINUTE` returns 0.
- [ ] Confirm events migrated: `SELECT count() FROM otel.otel_logs WHERE ResourceAttributes['service.namespace']='__k8s_events__' AND Timestamp > now() - INTERVAL 5 MINUTE` > 0.
- [ ] Run a fresh `prepare_inputs` job on hs0 / otel-demo0, grep produced `abnormal_logs.parquet` for `chaos-mesh.org` / `PodChaos` — should be empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)