### PR TITLE
fix(seed): add otelCollector.image.repository to byte-cluster ts overlay (#479)

### DIFF
--- a/aegislab/manifests/byte-cluster/initial-data/ts.yaml
+++ b/aegislab/manifests/byte-cluster/initial-data/ts.yaml
@@ -20,3 +20,8 @@ loadgenerator:
     tag: "023"
   initContainer:
     image: pair-diag-cn-guangzhou.cr.volces.com/pair/netshoot:v0.14
+
+otelCollector:
+  image:
+    repository: pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib
+    tag: "0.142.0"


### PR DESCRIPTION
Closes #479.

## Summary
Adds `otelCollector.image.{repository,tag}` to `aegislab/manifests/byte-cluster/initial-data/ts.yaml`. Without it the chart default `docker.io/otel/opentelemetry-collector-contrib:0.142.0` is used, which byte-cluster nodes can't reach → otel-collector ImagePullBackOff every ts install.

## Test plan
- [x] YAML parses
- [x] Verified `pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib:0.142.0` resolves on byte-cluster (probe 401 = path exists with auth)
- [x] Confirmed during 2026-05-22 ts E2E: identical override applied via `kubectl set image` on otel-collector deploy unblocked the install

🤖 Generated with [Claude Code](https://claude.com/claude-code)