### PR TITLE
fix(seed): reseed carries prior helm_config_values forward on container_version bump (#477)

### DIFF
--- a/aegislab/src/boot/seed/reseed.go
+++ b/aegislab/src/boot/seed/reseed.go
@@ -223,6 +223,16 @@ func reseedContainerVersions(db *gorm.DB, seed *InitialDataContainer, valuesDir 
 			if err := db.Create(helm).Error; err != nil {
 				return fmt.Errorf("insert helm_config for %s@%s: %w", seed.Name, versionName, err)
 			}
+			// Carry forward helm_config_values from the most-recent prior
+			// container_version on the same container, minus any keys the
+			// new seed entry redefines. data.yaml convention is that a
+			// version bump only needs to list deltas, not the full overlay
+			// (issue #477: ts 1.0.6 → 1.0.7 dropped 8 of 11 overrides
+			// because the new seed block only carried the 3 keys that
+			// actually changed).
+			if err := inheritHelmConfigValuesFromPriorVersion(db, helm, existing, versionName, vSeed.HelmConfig, seed.Name, report); err != nil {
+				return err
+			}
 			if err := backfillHelmConfigValues(db, helm, versionName, vSeed.HelmConfig, seed.Name, dryRun, "new helm value for new version", report); err != nil {
 				return err
 			}
@@ -603,6 +613,76 @@ func backfillHelmConfigValues(db *gorm.DB, helm *model.HelmConfig, versionName s
 		have[key] = actualCfg
 	}
 
+	return nil
+}
+
+// inheritHelmConfigValuesFromPriorVersion links every helm_config_values row
+// from the most-recent prior container_version on the same container into the
+// freshly-created helm_configs row, EXCLUDING any (key, type, category) the
+// new seed entry already redefines (the seed wins). Returns nil when there is
+// no prior version, no prior helm_configs row, or nothing to carry forward.
+//
+// "Most-recent prior" is the highest container_versions.id among the rows
+// enumerated before this insert — same ordering used by helm-version
+// resolution elsewhere (newer rows always have higher autoinc ids). priors
+// MUST exclude the just-inserted row; we pass the pre-insert slice in.
+func inheritHelmConfigValuesFromPriorVersion(db *gorm.DB, newHelm *model.HelmConfig, priors []model.ContainerVersion, newVersionName string, newSeed *InitialHelmConfig, systemName string, report *ReseedReport) error {
+	if newHelm == nil || newHelm.ID == 0 || len(priors) == 0 {
+		return nil
+	}
+	var priorID int
+	for i := range priors {
+		if priors[i].ID > priorID {
+			priorID = priors[i].ID
+		}
+	}
+	if priorID == 0 {
+		return nil
+	}
+	var priorHelm model.HelmConfig
+	if err := db.Where("container_version_id = ?", priorID).First(&priorHelm).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		return fmt.Errorf("lookup prior helm_config for inheritance into %s@%s: %w", systemName, newVersionName, err)
+	}
+
+	seedKeys := make(map[string]struct{}, len(newSeed.Values))
+	for _, v := range newSeed.Values {
+		cfg := v.ConvertToDBParameterConfig()
+		seedKeys[parameterConfigIdentity(cfg)] = struct{}{}
+	}
+
+	var priorValues []model.ParameterConfig
+	if err := db.Table("parameter_configs").
+		Joins("JOIN helm_config_values ON helm_config_values.parameter_config_id = parameter_configs.id").
+		Where("helm_config_values.helm_config_id = ? AND parameter_configs.category = ?", priorHelm.ID, consts.ParameterCategoryHelmValues).
+		Find(&priorValues).Error; err != nil {
+		return fmt.Errorf("list prior helm_config_values for %s@%s: %w", systemName, newVersionName, err)
+	}
+
+	for i := range priorValues {
+		pc := &priorValues[i]
+		if _, redefined := seedKeys[parameterConfigIdentity(pc)]; redefined {
+			continue
+		}
+		rel := model.HelmConfigValue{
+			HelmConfigID:      newHelm.ID,
+			ParameterConfigID: pc.ID,
+		}
+		if err := db.Clauses(clause.OnConflict{DoNothing: true}).Create(&rel).Error; err != nil {
+			return fmt.Errorf("inherit helm value %s into %s@%s: %w", pc.Key, systemName, newVersionName, err)
+		}
+		report.Actions = append(report.Actions, ReseedAction{
+			Layer:    "helm_config_values",
+			System:   systemName,
+			Key:      fmt.Sprintf("%s@%s:%s", systemName, newVersionName, pc.Key),
+			OldValue: "",
+			NewValue: parameterConfigSummary(pc),
+			Note:     "inherited helm value from prior container_version on version bump",
+			Applied:  true,
+		})
+	}
 	return nil
 }
 

--- a/aegislab/src/boot/seed/reseed_test.go
+++ b/aegislab/src/boot/seed/reseed_test.go
@@ -1306,3 +1306,169 @@ func TestReseedResnapshotNoOpWhenValueFileEmpty(t *testing.T) {
 		t.Fatalf("value_file populated when initially empty: %s", got.ValueFile)
 	}
 }
+
+// TestReseedVersionBumpInheritsPriorHelmConfigValues pins issue #477: a
+// data.yaml version bump where the new versions[] entry lists only a small
+// delta of helm values must carry forward (link to the new helm_configs row)
+// every helm_config_values key from the most-recent prior version that the
+// new seed entry does NOT redefine. The seed's own deltas win when they
+// share a key, and the prior version's links are left intact.
+func TestReseedVersionBumpInheritsPriorHelmConfigValues(t *testing.T) {
+	db := newReseedTestDB(t)
+
+	mustExec(t, db, `INSERT INTO containers (id, name, type, status) VALUES (1, 'ts', 2, 1)`)
+	mustExec(t, db, `INSERT INTO container_versions (id, name, container_id, user_id, status) VALUES (10, '1.0.6', 1, 0, 1)`)
+	mustExec(t, db, `INSERT INTO helm_configs (id, chart_name, version, container_version_id, repo_url, repo_name) VALUES (20, 'trainticket', '0.2.1', 10, 'https://x', 'r')`)
+
+	// Seed 4 prior helm_config_values keys against the existing version.
+	priorVals := []struct {
+		Key string
+		Def string
+	}{
+		{"global.image.repository", "pair-cn-shanghai.cr.volces.com/opspai"},
+		{"mysql.image.repository", "pair-cn-shanghai.cr.volces.com/opspai/mysql"},
+		{"mysql.service.type", "NodePort"},
+		{"loadgenerator.image.tag", "024"},
+	}
+	for _, pv := range priorVals {
+		def := pv.Def
+		cfg := model.ParameterConfig{
+			Key:          pv.Key,
+			Type:         consts.ParameterTypeFixed,
+			Category:     consts.ParameterCategoryHelmValues,
+			ValueType:    consts.ValueDataTypeString,
+			DefaultValue: &def,
+			Overridable:  true,
+		}
+		if err := db.Create(&cfg).Error; err != nil {
+			t.Fatalf("seed prior parameter_config %s: %v", pv.Key, err)
+		}
+		if err := db.Create(&model.HelmConfigValue{HelmConfigID: 20, ParameterConfigID: cfg.ID}).Error; err != nil {
+			t.Fatalf("seed prior helm_config_value link %s: %v", pv.Key, err)
+		}
+	}
+
+	// New version 1.0.7 redefines mysql.service.type (NodePort -> ClusterIP)
+	// and introduces one brand-new key (otelCollector.image.repository).
+	// The other 3 prior keys must be inherited.
+	seed := writeSeedFile(t, `
+containers:
+  - type: 2
+    name: ts
+    is_public: true
+    status: 1
+    versions:
+      - name: 1.0.6
+        helm_config:
+          version: 0.2.1
+          chart_name: trainticket
+          repo_name: r
+          repo_url: https://x
+      - name: 1.0.7
+        helm_config:
+          version: 0.3.1
+          chart_name: trainticket
+          repo_name: r
+          repo_url: https://x
+          values:
+            - key: mysql.service.type
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: ClusterIP
+              overridable: true
+            - key: otelCollector.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib
+              overridable: true
+`)
+
+	report, err := ReseedFromDataFile(context.Background(), db, nil, ReseedRequest{DataPath: seed})
+	if err != nil {
+		t.Fatalf("reseed: %v", err)
+	}
+	if report.NewVersions != 1 {
+		t.Fatalf("NewVersions = %d, want 1; actions=%+v", report.NewVersions, report.Actions)
+	}
+
+	// Find the new container_versions + helm_configs row ids.
+	var newCV struct{ ID int }
+	if err := db.Raw(`SELECT id FROM container_versions WHERE container_id = 1 AND name = '1.0.7'`).Scan(&newCV).Error; err != nil || newCV.ID == 0 {
+		t.Fatalf("new container_version row missing: err=%v id=%d", err, newCV.ID)
+	}
+	var newHelm struct{ ID int }
+	if err := db.Raw(`SELECT id FROM helm_configs WHERE container_version_id = ?`, newCV.ID).Scan(&newHelm).Error; err != nil || newHelm.ID == 0 {
+		t.Fatalf("new helm_configs row missing: err=%v id=%d", err, newHelm.ID)
+	}
+
+	// New helm_configs row must have 5 linked helm_config_values:
+	// 3 inherited + 1 redefined (mysql.service.type) + 1 brand-new.
+	var newLinked []struct {
+		Key string
+		Def *string
+	}
+	if err := db.Raw(`
+		SELECT pc.config_key AS key, pc.default_value AS def
+		FROM parameter_configs pc
+		JOIN helm_config_values hcv ON hcv.parameter_config_id = pc.id
+		WHERE hcv.helm_config_id = ?
+		ORDER BY pc.config_key
+	`, newHelm.ID).Scan(&newLinked).Error; err != nil {
+		t.Fatalf("list new helm_config_values: %v", err)
+	}
+	wantKeys := map[string]string{
+		"global.image.repository":         "pair-cn-shanghai.cr.volces.com/opspai",
+		"loadgenerator.image.tag":         "024",
+		"mysql.image.repository":          "pair-cn-shanghai.cr.volces.com/opspai/mysql",
+		"mysql.service.type":              "ClusterIP", // redefined: ClusterIP wins
+		"otelCollector.image.repository":  "pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib",
+	}
+	if len(newLinked) != len(wantKeys) {
+		t.Fatalf("new helm_configs has %d linked values, want %d: %+v", len(newLinked), len(wantKeys), newLinked)
+	}
+	for _, l := range newLinked {
+		wantDef, ok := wantKeys[l.Key]
+		if !ok {
+			t.Fatalf("unexpected linked key %q on new helm_configs", l.Key)
+		}
+		if l.Def == nil || *l.Def != wantDef {
+			t.Fatalf("linked key %q default = %v, want %q", l.Key, l.Def, wantDef)
+		}
+	}
+
+	// Prior helm_configs still has its 4 original links — inheritance must
+	// not move the prior rows.
+	var priorCount int
+	db.Raw(`SELECT COUNT(*) FROM helm_config_values WHERE helm_config_id = 20`).Scan(&priorCount)
+	if priorCount != 4 {
+		t.Fatalf("prior helm_configs link count = %d, want 4", priorCount)
+	}
+
+	// Inheritance actions must be present in the report.
+	inheritedSeen := 0
+	for _, a := range report.Actions {
+		if a.Note == "inherited helm value from prior container_version on version bump" && a.Applied {
+			inheritedSeen++
+		}
+	}
+	if inheritedSeen != 3 {
+		t.Fatalf("inherited helm-value actions = %d, want 3; actions=%+v", inheritedSeen, report.Actions)
+	}
+
+	// Idempotent: rerunning the reseed is a no-op (no new container_versions,
+	// no new helm_config_values links).
+	r2, err := ReseedFromDataFile(context.Background(), db, nil, ReseedRequest{DataPath: seed})
+	if err != nil {
+		t.Fatalf("second reseed: %v", err)
+	}
+	if r2.NewVersions != 0 {
+		t.Fatalf("second reseed NewVersions = %d, want 0", r2.NewVersions)
+	}
+	for _, a := range r2.Actions {
+		if a.Applied {
+			t.Fatalf("second reseed produced applied action: %+v", a)
+		}
+	}
+}


### PR DESCRIPTION
Closes #477.

## Root cause
\`reseedContainerVersions\` treats each new \`versions[]\` entry as self-contained: INSERTs a new \`container_versions\` + \`helm_configs\` row, then \`backfillHelmConfigValues\` only writes overrides explicitly listed in that block. data.yaml comments around ts 1.0.7 (and otel-demo 0.1.10, sn 1.1.6, …) claim "Inherits 1.0.6's full values block via reseed auto-backfill" — but that auto-backfill never existed. Result: ts@1.0.7 has only 3 keys vs 1.0.6's 11; \`--apply-overrides\` (picks "latest status=1") gets an incomplete view → install hits image-pull failures.

## Fix
Add \`inheritHelmConfigValuesFromPriorVersion\` in \`reseed.go\`. After INSERTing the new \`helm_configs\` row, before existing seed-driven backfill: find highest-id prior \`container_versions\` on same container → pull \`parameter_configs\` linked via \`helm_config_values\` to that prior \`helm_configs.id\` → create new links from the new \`helm_configs.id\` to the same parameter_configs IDs, skipping any \`(config_key, type, category)\` tuple the new seed entry redefines (deltas win).

Prior helm_configs rows untouched; only new links created. Idempotent. Each inherited link emits \`ReseedAction{Layer: "helm_config_values", ...}\`.

## Note on existing drift
Existing ts@1.0.7 row (helm_configs.id=38) NOT repaired by this PR — separate operator task once this lands (manual \`INSERT ... SELECT\` or re-invoke ReseedHelmConfigForVersion).

## Test plan
- [x] New \`TestReseedVersionBumpInheritsPriorHelmConfigValues\` exercises full inherit + delta-wins
- [x] \`go test ./boot/seed/...\` green
- [x] \`go build -tags duckdb_arrow ./main.go\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)