### PR TITLE
feat(aegisctl): regression run --install-set/--install-set-string passthrough (#480)

### DIFF
--- a/aegislab/src/cli/cmd/inject_guided.go
+++ b/aegislab/src/cli/cmd/inject_guided.go
@@ -780,7 +780,7 @@ func bootstrapGuidedInstall(ctx context.Context, cfg guidedcli.GuidedConfig) err
 		installer = defaultChartInstaller
 	}
 	output.PrintInfo(fmt.Sprintf("--install: namespace %q is empty; installing chart for system %q", cfg.Namespace, cfg.System))
-	if err := installer(ctx, cfg.System, cfg.Namespace); err != nil {
+	if err := installer(ctx, cfg.System, cfg.Namespace, nil, nil); err != nil {
 		return fmt.Errorf("--install: chart install failed for system=%s namespace=%s: %w", cfg.System, cfg.Namespace, err)
 	}
 

--- a/aegislab/src/cli/cmd/inject_guided_install_test.go
+++ b/aegislab/src/cli/cmd/inject_guided_install_test.go
@@ -50,7 +50,7 @@ func TestBootstrapGuidedInstallNoopWhenPodsExist(t *testing.T) {
 
 	guidedPodListerHook = &fakeGuidedPodLister{initialPods: 3}
 	installerCalled := false
-	guidedInstallerHook = func(_ context.Context, _, _ string) error {
+	guidedInstallerHook = func(_ context.Context, _, _ string, _, _ []string) error {
 		installerCalled = true
 		return nil
 	}
@@ -82,7 +82,7 @@ func TestBootstrapGuidedInstallInstallsWhenEmptyAndWaitsForReady(t *testing.T) {
 		},
 	}
 	var installerSystem, installerNamespace string
-	guidedInstallerHook = func(_ context.Context, system, namespace string) error {
+	guidedInstallerHook = func(_ context.Context, system, namespace string, _, _ []string) error {
 		installerSystem = system
 		installerNamespace = namespace
 		return nil
@@ -106,7 +106,7 @@ func TestBootstrapGuidedInstallPropagatesInstallerError(t *testing.T) {
 	}()
 
 	guidedPodListerHook = &fakeGuidedPodLister{initialPods: 0}
-	guidedInstallerHook = func(_ context.Context, _, _ string) error {
+	guidedInstallerHook = func(_ context.Context, _, _ string, _, _ []string) error {
 		return errors.New("helm exploded")
 	}
 

--- a/aegislab/src/cli/cmd/regression.go
+++ b/aegislab/src/cli/cmd/regression.go
@@ -65,6 +65,8 @@ var (
 	regressionAppLabelKey       string
 	regressionAppOverride       string
 	regressionForceResubmit     bool
+	regressionInstallSet        []string
+	regressionInstallSetString  []string
 	regressionPodListerHook     PodLister // test injection seam; nil => real k8s client
 	regressionInstallerHook     chartInstaller
 	regressionSystemsHook       SystemsFetcher // test injection seam; nil => real HTTP client
@@ -87,7 +89,7 @@ type PodLister interface {
 	CountReadyPods(ctx context.Context, namespace, labelSelector string) (total int, ready int, err error)
 }
 
-type chartInstaller func(ctx context.Context, system, namespace string) error
+type chartInstaller func(ctx context.Context, system, namespace string, setValues, setStringValues []string) error
 
 // regressionTarget captures one (namespace, app, system) preflight subject
 // derived from a regression case's submit.specs entries.
@@ -836,7 +838,7 @@ func preflightRegressionCase(ctx context.Context, rc regressionCase, lister PodL
 				continue
 			}
 			installed[key] = struct{}{}
-			if err := installer(ctx, sys, m.Namespace); err != nil {
+			if err := installer(ctx, sys, m.Namespace, regressionInstallSet, regressionInstallSetString); err != nil {
 				return fmt.Errorf("preflight: auto-install failed for system=%s namespace=%s: %w", sys, m.Namespace, err)
 			}
 		}
@@ -898,12 +900,24 @@ func preflightRegressionCase(ctx context.Context, rc regressionCase, lister PodL
 // defaultChartInstaller shells out to the current aegisctl binary via
 // os.Args[0] so this module does not depend on the pedestal chart install
 // implementation (landed in parallel).
-func defaultChartInstaller(ctx context.Context, system, namespace string) error {
+func buildChartInstallArgv(system, namespace string, setValues, setStringValues []string) []string {
+	args := []string{"pedestal", "chart", "install", system, "--namespace", namespace}
+	for _, kv := range setValues {
+		args = append(args, "--set", kv)
+	}
+	for _, kv := range setStringValues {
+		args = append(args, "--set-string", kv)
+	}
+	return args
+}
+
+func defaultChartInstaller(ctx context.Context, system, namespace string, setValues, setStringValues []string) error {
 	bin := os.Args[0]
 	if bin == "" {
 		bin = "aegisctl"
 	}
-	cmd := exec.CommandContext(ctx, bin, "pedestal", "chart", "install", system, "--namespace", namespace)
+	args := buildChartInstallArgv(system, namespace, setValues, setStringValues)
+	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -970,6 +984,8 @@ func init() {
 	regressionRunCmd.Flags().StringVar(&regressionAppLabelKey, "app-label-key", "app", "Label key used to match pods against each spec's `app` value during preflight (always falls back to app.kubernetes.io/name when unset)")
 	regressionRunCmd.Flags().StringVar(&regressionAppOverride, "app", "", "Override the FIRST spec's `app` value without editing the YAML on disk (multi-spec cases: only spec[0] is changed)")
 	regressionRunCmd.Flags().BoolVar(&regressionForceResubmit, "force", false, "Bypass the server-side dedup check even when the previous batch is still Running. \"I know what I'm doing\" cases only — normal terminal-state retries no longer require this.")
+	regressionRunCmd.Flags().StringArrayVar(&regressionInstallSet, "install-set", nil, "Forwarded to `aegisctl pedestal chart install --set k=v` when --auto-install fires. Repeatable. Use for one-off upstream-chart toggles that aren't seed-managed (e.g. bitnami global.security.allowInsecureImages=true). No effect without --auto-install.")
+	regressionRunCmd.Flags().StringArrayVar(&regressionInstallSetString, "install-set-string", nil, "Forwarded to `aegisctl pedestal chart install --set-string k=v` when --auto-install fires. Repeatable. Use when the value must be sent as a string (e.g. numeric image tags). No effect without --auto-install.")
 
 	regressionCmd.AddCommand(regressionRunCmd)
 }

--- a/aegislab/src/cli/cmd/regression_test.go
+++ b/aegislab/src/cli/cmd/regression_test.go
@@ -281,7 +281,7 @@ func TestRegressionPreflight_AutoInstallInvokesInstaller(t *testing.T) {
 		"mm0|app=compose-post-service": 0,
 	}}
 	var installed []string
-	installer := func(_ context.Context, system, namespace string) error {
+	installer := func(_ context.Context, system, namespace string, _, _ []string) error {
 		installed = append(installed, system+"/"+namespace)
 		// Simulate the chart coming up Ready so wait-for-ready terminates.
 		lister.byNSApp["mm0|app=user-service"] = 1
@@ -297,6 +297,64 @@ func TestRegressionPreflight_AutoInstallInvokesInstaller(t *testing.T) {
 	}
 	if len(installed) != 1 || installed[0] != "mm/mm0" {
 		t.Fatalf("unexpected installs: %v", installed)
+	}
+}
+
+func TestRegressionPreflight_AutoInstallForwardsSetFlags(t *testing.T) {
+	rc := makePreflightCase()
+	lister := &fakePodLister{byNSApp: map[string]int{
+		"mm0|app=user-service":         0,
+		"mm0|app=compose-post-service": 0,
+	}}
+	var gotSet, gotSetString []string
+	installer := func(_ context.Context, _, _ string, set, setString []string) error {
+		gotSet = set
+		gotSetString = setString
+		lister.byNSApp["mm0|app=user-service"] = 1
+		lister.byNSApp["mm0|app=compose-post-service"] = 1
+		return nil
+	}
+	oldAuto := regressionAutoInstall
+	oldSet := regressionInstallSet
+	oldSetString := regressionInstallSetString
+	regressionAutoInstall = true
+	regressionInstallSet = []string{"global.security.allowInsecureImages=true", "foo=bar"}
+	regressionInstallSetString = []string{"image.tag=20260520"}
+	defer func() {
+		regressionAutoInstall = oldAuto
+		regressionInstallSet = oldSet
+		regressionInstallSetString = oldSetString
+	}()
+
+	if err := preflightRegressionCase(context.Background(), rc, lister, installer); err != nil {
+		t.Fatalf("expected auto-install success, got %v", err)
+	}
+	if len(gotSet) != 2 || gotSet[0] != "global.security.allowInsecureImages=true" || gotSet[1] != "foo=bar" {
+		t.Fatalf("unexpected --set forward: %v", gotSet)
+	}
+	if len(gotSetString) != 1 || gotSetString[0] != "image.tag=20260520" {
+		t.Fatalf("unexpected --set-string forward: %v", gotSetString)
+	}
+}
+
+func TestDefaultChartInstaller_ArgvContainsSetFlags(t *testing.T) {
+	argv := buildChartInstallArgv("mm", "mm0",
+		[]string{"global.security.allowInsecureImages=true", "foo=bar"},
+		[]string{"image.tag=20260520"},
+	)
+	want := []string{
+		"pedestal", "chart", "install", "mm", "--namespace", "mm0",
+		"--set", "global.security.allowInsecureImages=true",
+		"--set", "foo=bar",
+		"--set-string", "image.tag=20260520",
+	}
+	if len(argv) != len(want) {
+		t.Fatalf("argv len mismatch: got %v want %v", argv, want)
+	}
+	for i := range want {
+		if argv[i] != want[i] {
+			t.Fatalf("argv[%d] = %q, want %q (full: %v)", i, argv[i], want[i], argv)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #480.

## Summary
\`aegisctl regression run --auto-install\` shells out to \`aegisctl pedestal chart install\` when preflight finds missing charts. That shell-out previously didn't forward \`--set\` flags, so callers couldn't pass upstream chart toggles like \`global.security.allowInsecureImages=true\` (bitnami's image-verification gate).

## Change
- New repeated flags on \`regression run\`: \`--install-set k=v\` / \`--install-set-string k=v\`
- Both forwarded verbatim as \`--set\` / \`--set-string\` to underlying \`pedestal chart install\`
- Argv construction factored into testable \`buildChartInstallArgv\`
- \`chartInstaller\` type grew two trailing \`[]string\` params; \`inject guided --install\` passes \`nil, nil\` (#480 narrow scope)

## Test plan
- [x] \`TestRegressionPreflight_AutoInstallForwardsSetFlags\` — flags reach shell-out
- [x] \`TestDefaultChartInstaller_ArgvContainsSetFlags\` — argv shape
- [x] All existing regression / guided-install tests still pass after signature update

schema-changes-acknowledged: true

🤖 Generated with [Claude Code](https://claude.com/claude-code)