### PR TITLE
fix(aegisctl): count distinct leaf paths in 'merged X overrides' log (#476)

### DIFF
--- a/aegislab/src/cli/cmd/pedestal_chart.go
+++ b/aegislab/src/cli/cmd/pedestal_chart.go
@@ -285,7 +285,11 @@ func runPedestalChartInstall(systemCode, namespace, tgz, repo, chartName, versio
 		if tag == "" {
 			tag = apiQueryVersion
 		}
-		output.PrintInfo(fmt.Sprintf("merged %d helm_config_values overrides for %s@%s", len(src.values), systemCode, tag))
+		// Count distinct leaf paths, not top-level keys: a chart whose 11
+		// overrides nest under 5 top-level groups (global.*, mysql.*, ...)
+		// would otherwise log "merged 5" and look like 6 rows got lost —
+		// the actual root cause of issue #476's confusion.
+		output.PrintInfo(fmt.Sprintf("merged %d helm_config_values overrides for %s@%s", countLeafPaths(src.values), systemCode, tag))
 	}
 
 	// "upgrade --install" is the upsert idiom — works whether the release
@@ -328,6 +332,23 @@ func runPedestalChartInstall(systemCode, namespace, tgz, repo, chartName, versio
 	}
 	output.PrintInfo(fmt.Sprintf("installed chart %q as release %q in namespace %q", src.positional, namespace, namespace))
 	return nil
+}
+
+// countLeafPaths returns the number of scalar / array / nil leaves reachable
+// from values. Nested maps are descended into; everything else is one leaf.
+// Used to log a count that matches the user-facing "override key" notion
+// (e.g. global.image.repository + global.image.tag = 2 leaves) instead of
+// the top-level-map cardinality, which collapses sibling keys.
+func countLeafPaths(values map[string]any) int {
+	n := 0
+	for _, v := range values {
+		if sub, ok := v.(map[string]any); ok {
+			n += countLeafPaths(sub)
+			continue
+		}
+		n++
+	}
+	return n
 }
 
 // isURL returns true for http(s), oci, and file URLs that helm accepts as a

--- a/aegislab/src/cli/cmd/pedestal_chart_test.go
+++ b/aegislab/src/cli/cmd/pedestal_chart_test.go
@@ -478,6 +478,28 @@ func TestPedestalChartInstallApplyOverrides(t *testing.T) {
 	})
 }
 
+// TestCountLeafPaths_DistinctOverrideCount covers issue #476: the
+// "merged N helm_config_values overrides" log line must count distinct
+// leaf paths in the rendered values map, not top-level groups. The ts@1.0.6
+// scenario has 11 distinct override keys collapsed under 5 top-level groups
+// (global / mysql / rabbitmq / loadgenerator / services); the prior
+// len(map) idiom reported 5 and looked like 6 rows were lost.
+func TestCountLeafPaths_DistinctOverrideCount(t *testing.T) {
+	values := map[string]any{
+		"services":      map[string]any{"tsUiDashboard": map[string]any{"type": "NodePort"}},
+		"global":        map[string]any{"security": map[string]any{"allowInsecureImages": true}, "image": map[string]any{"repository": "repo"}, "otelcollector": "x"},
+		"mysql":         map[string]any{"image": map[string]any{"repository": "repo"}, "service": map[string]any{"type": "ClusterIP"}},
+		"rabbitmq":      map[string]any{"image": map[string]any{"repository": "repo"}},
+		"loadgenerator": map[string]any{"initContainer": map[string]any{"image": "init"}, "opentelemetry": map[string]any{"endpoint": "e"}, "image": map[string]any{"repository": "repo", "tag": "tag"}},
+	}
+	if got := countLeafPaths(values); got != 11 {
+		t.Fatalf("expected 11 leaf paths (matching distinct helm_config_values keys), got %d", got)
+	}
+	if got := len(values); got == 11 {
+		t.Fatalf("regression guard: top-level len should be 5, got %d — the test data drifted", got)
+	}
+}
+
 func containsArg(args []string, want string) bool {
 	for _, a := range args {
 		if a == want {

--- a/aegislab/src/platform/dto/container_test.go
+++ b/aegislab/src/platform/dto/container_test.go
@@ -6,6 +6,94 @@ import (
 	"testing"
 )
 
+// countLeaves walks a values map and counts scalar leaves. Mirrors the
+// CLI's countLeafPaths so the assertion lines up with the user-facing
+// "merged N overrides" log.
+func countLeaves(m map[string]any) int {
+	n := 0
+	for _, v := range m {
+		if sub, ok := v.(map[string]any); ok {
+			n += countLeaves(sub)
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// TestGetValuesMap_DistinctKeysFromHelmConfigValues regresses issue #476:
+// the 11 distinct config_key rows on ts@1.0.6's helm_config_values must
+// each surface as a leaf in the rendered values map, even when seed has
+// been applied twice and the resolver sees 22 rows (every key duplicated).
+// The historical bug: callers saw "merged 5 helm_config_values overrides"
+// because the log line counted top-level groups (global, mysql, …) rather
+// than distinct leaf paths.
+func TestGetValuesMap_DistinctKeysFromHelmConfigValues(t *testing.T) {
+	keys := []string{
+		"services.tsUiDashboard.type",
+		"global.security.allowInsecureImages",
+		"global.image.repository",
+		"mysql.image.repository",
+		"rabbitmq.image.repository",
+		"loadgenerator.initContainer.image",
+		"global.otelcollector",
+		"loadgenerator.opentelemetry.endpoint",
+		"loadgenerator.image.repository",
+		"loadgenerator.image.tag",
+		"mysql.service.type",
+	}
+
+	items := make([]ParameterItem, 0, len(keys)*2)
+	for i, k := range keys {
+		items = append(items, ParameterItem{Key: k, Value: i})
+	}
+	// Duplicate every row — matches the live DB state where reseed inserted
+	// each parameter_config twice (22 rows for 11 distinct keys).
+	for i, k := range keys {
+		items = append(items, ParameterItem{Key: k, Value: i})
+	}
+
+	hci := &HelmConfigItem{DynamicValues: items}
+	got := hci.GetValuesMap()
+
+	if n := countLeaves(got); n != len(keys) {
+		t.Fatalf("expected %d distinct leaf paths, got %d (values=%#v)", len(keys), n, got)
+	}
+
+	mustLeaf := func(path ...string) {
+		cur := any(got)
+		for i, p := range path {
+			m, ok := cur.(map[string]any)
+			if !ok {
+				t.Fatalf("expected map at %v[:%d], got %T", path, i, cur)
+			}
+			cur, ok = m[p]
+			if !ok {
+				t.Fatalf("missing key %q at %v[:%d]", p, path, i+1)
+			}
+		}
+		if _, isMap := cur.(map[string]any); isMap {
+			t.Fatalf("expected leaf at %v, got map", path)
+		}
+	}
+	for _, k := range keys {
+		mustLeaf(splitDotPath(k)...)
+	}
+}
+
+func splitDotPath(s string) []string {
+	out := []string{}
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '.' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	out = append(out, s[start:])
+	return out
+}
+
 // TestGetValuesMap_EmptyValueFile_NoPanic regresses the live byte-cluster
 // outage where a 0-byte helm-values yaml caused 79 worker panics with
 // "assignment to entry in nil map" inside GetValuesMap. The defensive guard


### PR DESCRIPTION
Closes #476.

## Summary
The merge logic was correct all along. The reported "merged 5 of 11" was a **logging artifact**: `pedestal_chart.go:288` reported `len(src.values)` — top-level map cardinality (5: global / mysql / rabbitmq / loadgenerator / services) — instead of distinct leaf paths (11).

Real cause of the byte-cluster ts0 install pain was the upstream issue #477 (reseed didn't carry overrides forward on version bump → ts@1.0.7 had only 3 keys vs ts@1.0.6's 11).

## Change
- Add `countLeafPaths`; use it in the log so the figure matches `SELECT COUNT(DISTINCT pc.config_key)` from the issue
- Regression tests at two layers: `dto` asserts merge yields N leaf paths for N seeded keys (incl. duplicate-row case); `cli/cmd` asserts the log counts 11 not 5 for ts@1.0.6 shape

## Out of scope
- Actual data drift on ts@1.0.7: covered by #477
- `chartLookupResp` dead type at line 603: separate cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)