### PR TITLE
fix(chaos): load Global config scope so guided resolver sees registered systems

### DIFF
--- a/aegislab/src/boot/chaos/options.go
+++ b/aegislab/src/boot/chaos/options.go
@@ -3,16 +3,22 @@
 package chaos
 
 import (
+	"context"
 	"strings"
 
 	app "aegis/boot"
 	httpapi "aegis/boot/wiring/http"
 	ssoclient "aegis/clients/sso"
+	"aegis/core/orchestrator/common"
 	chaos "aegis/crud/chaos"
+	"aegis/platform/consts"
+	"aegis/platform/etcd"
 	"aegis/platform/router"
 
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 	"go.uber.org/fx"
+	"gorm.io/gorm"
 )
 
 func Options(confPath, port string) fx.Option {
@@ -20,6 +26,9 @@ func Options(confPath, port string) fx.Option {
 		app.BaseOptions(confPath),
 		app.ObserveOptions(),
 		app.DataOptions(),
+		// etcd.Gateway is required by the global config-scope listener below;
+		// DataOptions only wires db/redis, so pull in CoordinationOptions too.
+		app.CoordinationOptions(),
 
 		app.WithRemoteVerifier(),
 		ssoclient.Module,
@@ -36,7 +45,29 @@ func Options(confPath, port string) fx.Option {
 		httpapi.Module,
 
 		fx.Decorate(decorateEngineWithHealthz),
+
+		// The guided resolver (crud/chaos/guided) reads system registrations
+		// (ns_pattern / app_label_key) through systemconfig → Viper key
+		// `injection.system.*`. Those values live in the Global config scope
+		// and are only mirrored into Viper by ConfigUpdateListener; without
+		// this the chaos service sees zero systems and every guided submit
+		// fails with "system does not match any registered namespace pattern".
+		// The api-gateway / runtime-worker get this via their seed boot; the
+		// standalone chaos service did not until now.
+		fx.Invoke(activateGlobalConfigScope),
 	)
+}
+
+func activateGlobalConfigScope(lc fx.Lifecycle, db *gorm.DB, etcdGw *etcd.Gateway) {
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			listener := common.NewConfigUpdateListener(context.Background(), db, etcdGw)
+			if err := listener.EnsureScope(consts.ConfigScopeGlobal); err != nil {
+				logrus.WithError(err).Warn("aegis-chaos: failed to activate global config scope; guided resolver will see no systems")
+			}
+			return nil
+		},
+	})
 }
 
 func decorateEngineWithHealthz(engine *gin.Engine) *gin.Engine {


### PR DESCRIPTION
## Symptom

Every `aegisctl inject guided --apply` against byte-cluster failed for **all** systems:

```
guided resolver failed for chaos_type=PodFailure:
system "sn" does not match any registered namespace pattern or system name
```

even though `aegisctl system list` showed all 7 systems registered with correct `ns_pattern`s.

## Root cause

The guided resolver (`crud/chaos/guided/systems.go`) validates the requested system via `systemconfig.GetAllSystemTypes()` / `GetRegistration()`, which read Viper key `injection.system.*` (`ns_pattern`, `app_label_key`). Those keys live in the **Global config scope** and are mirrored into Viper only by `ConfigUpdateListener.EnsureScope(Global)`.

The api-gateway and runtime-worker run that listener during their seed boot, so their `system list` (also Viper-backed) works. But the **standalone aegis-chaos service** — which actually serves `/v1beta/.../guided/resolve` — never wired the listener, so its Viper had zero `injection.system.*` keys → resolver saw **no systems** → every `--system` value (name or namespace instance) failed to match.

This was masked until now because injections that bypass the guided resolver (regression/batch paths) don't hit this code.

## Fix

`boot/chaos/options.go`:
- Add `app.CoordinationOptions()` (etcd Gateway — previously absent; `DataOptions()` only wires db/redis).
- Add an fx `OnStart` hook that builds a `ConfigUpdateListener` and calls `EnsureScope(ConfigScopeGlobal)`, mirroring the global-scope `injection.system.*` config into the chaos service's Viper. Best-effort: failure logs WARN and boot continues (same posture as the dynamic-viper bootstrap).

## Test plan

- [x] `go build -tags duckdb_arrow ./main.go` + `./cmd/aegis-chaos` clean; `golangci-lint --new-from-rev origin/main` 0 issues.
- [ ] Deploy `byte-20260529-chaos-globalscope` to `rcabench-chaos`; confirm `aegisctl inject guided --reset-config` returns a populated `systems:` list and a `--system sn0 ... --apply` no longer errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)