### PR TITLE
fix(aegisctl): helm install --atomic so regression auto-install survives desynced releases (#481)

### DIFF
--- a/aegislab/src/cli/cmd/pedestal_chart.go
+++ b/aegislab/src/cli/cmd/pedestal_chart.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -178,6 +179,8 @@ var (
 	pedestalChartInstallChart              string
 	pedestalChartInstallVersion            string
 	pedestalChartInstallWait               bool
+	pedestalChartInstallAtomic             bool
+	pedestalChartInstallCleanupOnFail      bool
 	pedestalChartInstallApplyOverrides     bool
 	pedestalChartInstallFromPedestalVerArg string
 	pedestalChartInstallHelmSet            []string
@@ -219,12 +222,21 @@ Use --set / --set-string (repeatable) for ad-hoc upstream-chart toggles
 that aren't seed-managed — e.g.
 "--set global.security.allowInsecureImages=true" for charts that pull
 bitnami subcharts. These are passed straight to helm AFTER the values
-file, so they win over both value_file and helm_config_values.`,
+file, so they win over both value_file and helm_config_values.
+
+By default the install is --atomic (implies --wait) with --cleanup-on-fail,
+and a pre-existing release in a non-deployed state (failed / pending-*) is
+helm-uninstalled first. Together these keep a failed/timed-out install from
+leaving a release whose stored manifest is out of sync with the cluster — the
+desync that makes a later "helm upgrade --install --wait" error
+'deployments.apps "<svc>" not found' on a healthy cluster (#481). Pass
+--atomic=false / --cleanup-on-fail=false to opt out.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runPedestalChartInstall(args[0], pedestalChartInstallNamespace,
 			pedestalChartInstallTgz, pedestalChartInstallRepo, pedestalChartInstallChart,
 			pedestalChartInstallVersion, pedestalChartInstallWait,
+			pedestalChartInstallAtomic, pedestalChartInstallCleanupOnFail,
 			pedestalChartInstallApplyOverrides, pedestalChartInstallFromPedestalVerArg,
 			pedestalChartInstallHelmSet, pedestalChartInstallHelmSetString)
 	},
@@ -244,7 +256,7 @@ type chartSource struct {
 	pedestalTag    string
 }
 
-func runPedestalChartInstall(systemCode, namespace, tgz, repo, chartName, version string, wait bool, applyOverrides bool, fromPedestalVersion string, helmSet, helmSetString []string) error {
+func runPedestalChartInstall(systemCode, namespace, tgz, repo, chartName, version string, wait bool, atomic bool, cleanupOnFail bool, applyOverrides bool, fromPedestalVersion string, helmSet, helmSetString []string) error {
 	if strings.TrimSpace(systemCode) == "" {
 		return usageErrorf("system short-code is required")
 	}
@@ -292,6 +304,19 @@ func runPedestalChartInstall(systemCode, namespace, tgz, repo, chartName, versio
 		output.PrintInfo(fmt.Sprintf("merged %d helm_config_values overrides for %s@%s", countLeafPaths(src.values), systemCode, tag))
 	}
 
+	// A prior failed/aborted install leaves the release in a "failed" or
+	// "pending-*" state whose stored manifest can reference objects the
+	// cluster no longer has (e.g. a Deployment removed by a manual kubectl
+	// patch during recovery). `helm upgrade --install` over such a release
+	// does a 3-way merge against that stale manifest and then, under --wait,
+	// polls a Deployment the cluster doesn't have — surfacing
+	// `deployments.apps "<svc>" not found` on an otherwise-healthy cluster
+	// (aegis #481). Uninstall the desynced release first so the next install
+	// starts from a clean slate instead of upgrading over the poison.
+	if err := uninstallIfDesynced(namespace, namespace); err != nil {
+		return err
+	}
+
 	// "upgrade --install" is the upsert idiom — works whether the release
 	// exists or not. Previously this was bare `install`, which crashed on
 	// re-runs with "cannot re-use a name that is still in use" when the
@@ -318,8 +343,17 @@ func runPedestalChartInstall(systemCode, namespace, tgz, repo, chartName, versio
 	for _, kv := range helmSetString {
 		helmArgs = append(helmArgs, "--set-string", kv)
 	}
-	if wait {
+	// --atomic implies --wait and rolls the release back on any failure /
+	// timeout, so a failed install can't leave behind the desynced manifest
+	// that poisons the next upgrade (the #481 loop). --cleanup-on-fail deletes
+	// resources newly created by a failed run. Both default on.
+	if atomic {
+		helmArgs = append(helmArgs, "--atomic")
+	} else if wait {
 		helmArgs = append(helmArgs, "--wait")
+	}
+	if cleanupOnFail {
+		helmArgs = append(helmArgs, "--cleanup-on-fail")
 	}
 	// Mirror kubectl's --v=2-style preview so operators can copy-paste.
 	output.PrintInfo(fmt.Sprintf("+ helm %s", strings.Join(helmArgs, " ")))
@@ -331,6 +365,42 @@ func runPedestalChartInstall(systemCode, namespace, tgz, repo, chartName, versio
 		return fmt.Errorf("helm install failed: %w", err)
 	}
 	output.PrintInfo(fmt.Sprintf("installed chart %q as release %q in namespace %q", src.positional, namespace, namespace))
+	return nil
+}
+
+// uninstallIfDesynced helm-uninstalls release in namespace when it exists in a
+// non-deployed state (failed / pending-install / pending-upgrade /
+// pending-rollback / uninstalling). Such a release's stored manifest can be out
+// of sync with the cluster; `helm upgrade --install --wait` over it polls
+// objects that aren't there and errors `<kind> "<name>" not found` even though
+// the cluster is healthy (aegis #481). A clean uninstall lets the subsequent
+// install start fresh. A successfully "deployed" release is left untouched so
+// the normal idempotent upgrade path still applies.
+func uninstallIfDesynced(release, namespace string) error {
+	out, err := chartRunner.Run("helm", "status", release, "-n", namespace, "-o", "json")
+	if err != nil {
+		// No such release (or status unavailable) — nothing to clean up; let
+		// `upgrade --install` handle the create path.
+		return nil
+	}
+	var status struct {
+		Info struct {
+			Status string `json:"status"`
+		} `json:"info"`
+	}
+	if jerr := json.Unmarshal(out, &status); jerr != nil {
+		return nil
+	}
+	if status.Info.Status == "deployed" || status.Info.Status == "" {
+		return nil
+	}
+	output.PrintInfo(fmt.Sprintf("release %q in %q is %q (not deployed) — uninstalling before reinstall to clear desynced manifest", release, namespace, status.Info.Status))
+	if uout, uerr := chartRunner.Run("helm", "uninstall", release, "-n", namespace, "--wait"); uerr != nil {
+		if len(uout) > 0 {
+			output.PrintInfo(strings.TrimRight(string(uout), "\n"))
+		}
+		return fmt.Errorf("uninstall desynced release %q: %w", release, uerr)
+	}
 	return nil
 }
 
@@ -669,7 +739,9 @@ func init() {
 	pedestalChartInstallCmd.Flags().StringVar(&pedestalChartInstallRepo, "repo", "", "Helm chart repo URL (use with --chart)")
 	pedestalChartInstallCmd.Flags().StringVar(&pedestalChartInstallChart, "chart", "", "Chart name in the repo given by --repo")
 	pedestalChartInstallCmd.Flags().StringVar(&pedestalChartInstallVersion, "version", "", "Chart version (passed to helm --version)")
-	pedestalChartInstallCmd.Flags().BoolVar(&pedestalChartInstallWait, "wait", false, "Pass --wait to helm install")
+	pedestalChartInstallCmd.Flags().BoolVar(&pedestalChartInstallWait, "wait", false, "Pass --wait to helm install (ignored when --atomic is set, which already implies --wait)")
+	pedestalChartInstallCmd.Flags().BoolVar(&pedestalChartInstallAtomic, "atomic", true, "Pass --atomic to helm: roll the release back on failure/timeout so a failed install can't leave a desynced manifest that poisons the next upgrade (#481). Implies --wait. Disable with --atomic=false.")
+	pedestalChartInstallCmd.Flags().BoolVar(&pedestalChartInstallCleanupOnFail, "cleanup-on-fail", true, "Pass --cleanup-on-fail to helm: delete resources created during a failed install/upgrade. Disable with --cleanup-on-fail=false.")
 	pedestalChartInstallCmd.Flags().BoolVar(&pedestalChartInstallApplyOverrides, "apply-overrides", false, "Merge helm_config_values rows for the matched pedestal version into the values file before helm install (matches RestartPedestal behaviour). Default: false (current behaviour preserved).")
 	pedestalChartInstallCmd.Flags().StringVar(&pedestalChartInstallFromPedestalVerArg, "from-pedestal-version", "", "Pin which container_versions.name the backend should resolve helm_config_values for (default: latest status=1 row for this system).")
 	pedestalChartInstallCmd.Flags().StringArrayVar(&pedestalChartInstallHelmSet, "set", nil, "Ad-hoc helm --set k=v; repeatable. Applied AFTER --apply-overrides / value file so it wins. Use for upstream-chart toggles that aren't seed-managed (e.g. bitnami global.security.allowInsecureImages=true).")

--- a/aegislab/src/cli/cmd/pedestal_chart_test.go
+++ b/aegislab/src/cli/cmd/pedestal_chart_test.go
@@ -169,21 +169,21 @@ func TestNsPatternToNamespace(t *testing.T) {
 // via TestNsPatternToNamespace.
 func TestPedestalChartInstallValidation(t *testing.T) {
 	t.Run("missing_code", func(t *testing.T) {
-		err := runPedestalChartInstall("", "ts0", "/tmp/x.tgz", "", "", "", false, false, "", nil, nil)
+		err := runPedestalChartInstall("", "ts0", "/tmp/x.tgz", "", "", "", false, false, false, false, "", nil, nil)
 		if err == nil || !strings.Contains(err.Error(), "short-code") {
 			t.Fatalf("want short-code error, got %v", err)
 		}
 	})
 
 	t.Run("repo_without_chart_rejected", func(t *testing.T) {
-		err := runPedestalChartInstall("ts", "ts0", "", "https://example.com/charts", "", "", false, false, "", nil, nil)
+		err := runPedestalChartInstall("ts", "ts0", "", "https://example.com/charts", "", "", false, false, false, false, "", nil, nil)
 		if err == nil || !strings.Contains(err.Error(), "--repo and --chart must be provided together") {
 			t.Fatalf("want repo/chart pairing error, got %v", err)
 		}
 	})
 
 	t.Run("tgz_not_found", func(t *testing.T) {
-		err := runPedestalChartInstall("ts", "ts0", "/does/not/exist.tgz", "", "", "", false, false, "", nil, nil)
+		err := runPedestalChartInstall("ts", "ts0", "/does/not/exist.tgz", "", "", "", false, false, false, false, "", nil, nil)
 		if err == nil || !strings.Contains(err.Error(), "not found") {
 			t.Fatalf("want not-found error, got %v", err)
 		}
@@ -196,7 +196,7 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 		if err := os.WriteFile(tgz, []byte("pkg"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		err := runPedestalChartInstall("ts", "ts0", tgz, "", "", "", false, false, "", nil, nil)
+		err := runPedestalChartInstall("ts", "ts0", tgz, "", "", "", false, false, false, false, "", nil, nil)
 		if err == nil || !strings.Contains(err.Error(), "helm not found") {
 			t.Fatalf("want helm-missing error, got %v", err)
 		}
@@ -212,7 +212,7 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 		}
 		withFakeRunner(t, f)
 		url := "https://example.com/charts/foo-0.1.0.tgz"
-		if err := runPedestalChartInstall("ts", "ts0", url, "", "", "", false, false, "", nil, nil); err != nil {
+		if err := runPedestalChartInstall("ts", "ts0", url, "", "", "", false, false, false, false, "", nil, nil); err != nil {
 			t.Fatalf("url install failed: %v", err)
 		}
 		if len(got) == 0 || got[0] != "helm" || !containsArg(got, url) {
@@ -229,7 +229,7 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 			},
 		}
 		withFakeRunner(t, f)
-		if err := runPedestalChartInstall("ts", "ts0", "", "https://charts.example.com", "foo", "1.0.0", false, false, "", nil, nil); err != nil {
+		if err := runPedestalChartInstall("ts", "ts0", "", "https://charts.example.com", "foo", "1.0.0", false, false, false, false, "", nil, nil); err != nil {
 			t.Fatalf("repo install failed: %v", err)
 		}
 		if !containsArg(got, "--repo") || !containsArg(got, "https://charts.example.com") || !containsArg(got, "foo") {
@@ -248,13 +248,10 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 		if err := os.WriteFile(tgz, []byte("pkg"), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		if err := runPedestalChartInstall("ts", "ts0", tgz, "", "", "1.2.3", true, false, "", nil, nil); err != nil {
+		if err := runPedestalChartInstall("ts", "ts0", tgz, "", "", "1.2.3", true, false, false, false, "", nil, nil); err != nil {
 			t.Fatalf("install failed: %v", err)
 		}
-		if len(f.calls) != 1 {
-			t.Fatalf("want 1 helm call, got %d: %v", len(f.calls), f.calls)
-		}
-		call := f.calls[0]
+		call := findHelmUpgradeCall(t, f.calls)
 		if call[0] != "helm" || call[1] != "upgrade" || call[2] != "--install" || call[3] != "ts0" {
 			t.Fatalf("bad helm args: %v", call)
 		}
@@ -263,6 +260,97 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 			if !strings.Contains(joined, want) {
 				t.Errorf("helm args missing %q: %s", want, joined)
 			}
+		}
+	})
+
+	// #481: --atomic (default on) must reach helm so a failed install rolls
+	// back instead of leaving a desynced manifest. It implies --wait, and
+	// --cleanup-on-fail tags along.
+	t.Run("atomic_default_passes_atomic_and_cleanup_on_fail", func(t *testing.T) {
+		f := &fakeChartExec{
+			fallback: func(name string, args []string) ([]byte, error) {
+				return []byte("ok"), nil
+			},
+		}
+		withFakeRunner(t, f)
+		tgz := filepath.Join(t.TempDir(), "chart.tgz")
+		if err := os.WriteFile(tgz, []byte("pkg"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		// wait=false but atomic=true: --atomic implies --wait, so --wait is
+		// NOT added separately, but the release still waits.
+		if err := runPedestalChartInstall("ts", "ts0", tgz, "", "", "1.2.3", false, true, true, false, "", nil, nil); err != nil {
+			t.Fatalf("install failed: %v", err)
+		}
+		call := findHelmUpgradeCall(t, f.calls)
+		if !containsArg(call, "--atomic") {
+			t.Errorf("expected --atomic in helm args: %v", call)
+		}
+		if !containsArg(call, "--cleanup-on-fail") {
+			t.Errorf("expected --cleanup-on-fail in helm args: %v", call)
+		}
+		if containsArg(call, "--wait") {
+			t.Errorf("--wait should not be added alongside --atomic (atomic implies wait): %v", call)
+		}
+	})
+
+	// #481: a release stuck in a non-deployed state (e.g. "failed" after a
+	// timed-out install whose manifest now references a missing Deployment) is
+	// uninstalled before reinstall, so `upgrade --install --wait` doesn't poll
+	// objects the cluster lacks.
+	t.Run("desynced_failed_release_is_uninstalled_first", func(t *testing.T) {
+		var uninstalled bool
+		f := &fakeChartExec{
+			results: map[string]fakeExecResult{
+				"helm status ts0 -n ts0 -o json": {out: []byte(`{"info":{"status":"failed"}}`)},
+			},
+			fallback: func(name string, args []string) ([]byte, error) {
+				if name == "helm" && len(args) > 0 && args[0] == "uninstall" {
+					uninstalled = true
+				}
+				return []byte("ok"), nil
+			},
+		}
+		withFakeRunner(t, f)
+		tgz := filepath.Join(t.TempDir(), "chart.tgz")
+		if err := os.WriteFile(tgz, []byte("pkg"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := runPedestalChartInstall("ts", "ts0", tgz, "", "", "1.2.3", false, true, true, false, "", nil, nil); err != nil {
+			t.Fatalf("install failed: %v", err)
+		}
+		if !uninstalled {
+			t.Fatalf("expected helm uninstall of the failed release before reinstall; calls: %v", f.calls)
+		}
+		// And the reinstall still happens afterwards.
+		_ = findHelmUpgradeCall(t, f.calls)
+	})
+
+	// A healthy "deployed" release must NOT be uninstalled — the normal
+	// idempotent upgrade path applies.
+	t.Run("deployed_release_is_not_uninstalled", func(t *testing.T) {
+		var uninstalled bool
+		f := &fakeChartExec{
+			results: map[string]fakeExecResult{
+				"helm status ts0 -n ts0 -o json": {out: []byte(`{"info":{"status":"deployed"}}`)},
+			},
+			fallback: func(name string, args []string) ([]byte, error) {
+				if name == "helm" && len(args) > 0 && args[0] == "uninstall" {
+					uninstalled = true
+				}
+				return []byte("ok"), nil
+			},
+		}
+		withFakeRunner(t, f)
+		tgz := filepath.Join(t.TempDir(), "chart.tgz")
+		if err := os.WriteFile(tgz, []byte("pkg"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := runPedestalChartInstall("ts", "ts0", tgz, "", "", "1.2.3", false, true, true, false, "", nil, nil); err != nil {
+			t.Fatalf("install failed: %v", err)
+		}
+		if uninstalled {
+			t.Fatalf("deployed release should not be uninstalled; calls: %v", f.calls)
 		}
 	})
 
@@ -301,19 +389,10 @@ func TestPedestalChartInstallValidation(t *testing.T) {
 		}
 		withFakeRunner(t, f)
 
-		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, false, "", nil, nil); err != nil {
+		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, false, false, false, "", nil, nil); err != nil {
 			t.Fatalf("backend chart install failed: %v", err)
 		}
-		var helmCalls [][]string
-		for _, c := range f.calls {
-			if len(c) > 0 && c[0] == "helm" {
-				helmCalls = append(helmCalls, c)
-			}
-		}
-		if len(helmCalls) != 1 {
-			t.Fatalf("want 1 helm call, got %d: %v", len(helmCalls), helmCalls)
-		}
-		call := helmCalls[0]
+		call := findHelmUpgradeCall(t, f.calls)
 		if !containsArg(call, "-f") {
 			t.Fatalf("expected helm values file flag, got %v", call)
 		}
@@ -380,7 +459,7 @@ func TestPedestalChartInstallApplyOverrides(t *testing.T) {
 		f := captureValues(t, &got)
 		withFakeRunner(t, f)
 
-		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, false, "", nil, nil); err != nil {
+		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, false, false, false, "", nil, nil); err != nil {
 			t.Fatalf("install: %v", err)
 		}
 		if !strings.Contains(got, "otel/opentelemetry-collector-contrib") {
@@ -403,7 +482,7 @@ func TestPedestalChartInstallApplyOverrides(t *testing.T) {
 		f := captureValues(t, &got)
 		withFakeRunner(t, f)
 
-		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, true, "", nil, nil); err != nil {
+		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, false, false, true, "", nil, nil); err != nil {
 			t.Fatalf("install: %v", err)
 		}
 		if !strings.Contains(got, mergedRepo) {
@@ -432,7 +511,7 @@ func TestPedestalChartInstallApplyOverrides(t *testing.T) {
 		f := &fakeChartExec{fallback: func(name string, args []string) ([]byte, error) { return []byte("ok"), nil }}
 		withFakeRunner(t, f)
 
-		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, true, "1.0.7", nil, nil); err != nil {
+		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, false, false, true, "1.0.7", nil, nil); err != nil {
 			t.Fatalf("install: %v", err)
 		}
 		if gotQuery != "1.0.7" {
@@ -461,7 +540,7 @@ func TestPedestalChartInstallApplyOverrides(t *testing.T) {
 		f := &fakeChartExec{fallback: func(name string, args []string) ([]byte, error) { return []byte("ok"), nil }}
 		withFakeRunner(t, f)
 
-		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, true, "", nil, nil); err != nil {
+		if err := runPedestalChartInstall("ts", "ts0", "", "", "", "", false, false, false, true, "", nil, nil); err != nil {
 			t.Fatalf("install: %v", err)
 		}
 		var sawValuesFlag bool
@@ -507,4 +586,21 @@ func containsArg(args []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// findHelmUpgradeCall returns the single `helm upgrade --install` invocation,
+// skipping the `helm status` desync probe that runs first. Fails the test if
+// there isn't exactly one upgrade call.
+func findHelmUpgradeCall(t *testing.T, calls [][]string) []string {
+	t.Helper()
+	var found [][]string
+	for _, c := range calls {
+		if len(c) >= 2 && c[0] == "helm" && c[1] == "upgrade" {
+			found = append(found, c)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("want 1 helm upgrade call, got %d: %v", len(found), calls)
+	}
+	return found[0]
 }


### PR DESCRIPTION
## schema-changes-acknowledged: true

(Adds `--atomic` and `--cleanup-on-fail` flags to `pedestal chart install` and reworded `--wait` help — CLI schema change.)

## Root cause — it's the install path, not the chart

#481 reported `helm upgrade --install ts0 ... --wait` exiting non-zero with
`Error: deployments.apps "ts-route-plan-service" not found` even though all
pods come up Running, breaking `aegisctl regression run --auto-install`.

Investigation ruled the **trainticket chart out**:
- Chart 0.3.1 renders 47 Deployments + 45 HPAs; every HPA `scaleTargetRef.name`
  resolves to a real same-release Deployment (0 mismatches), including
  `ts-route-plan-service`. No NOTES.txt/hook reference, no duplicate resources.
- Helm's `--wait` readiness checker (`pkg/kube/ready.go`) has **no HPA case** —
  HPAs are never polled — so an HPA can't produce that error.

The error comes from Helm's **Deployment** readiness path
(`GetNewReplicaSet`), which GETs the live Deployment and propagates any error.
`deployments.apps "..." not found` therefore means the Deployment was
**genuinely absent from the cluster** when Helm polled it — a **desynced
release**: a prior failed/timed-out install (or a manual `kubectl` patch during
recovery, per the repro's "after a manual otel-collector image patch") leaves
the stored release manifest referencing objects the cluster no longer has, and
the next `upgrade --install --wait` 3-way-merges against that stale manifest
then waits on the missing Deployment.

## Fix (in `aegisctl pedestal chart install`)

1. **`--atomic` (default on, implies `--wait`)** — a failed/timed-out install
   rolls back instead of leaving a desynced release that poisons the next run.
   `--cleanup-on-fail` (default on) deletes resources from a failed run. Opt out
   with `--atomic=false` / `--cleanup-on-fail=false`.
2. **Desync recovery before install** — `helm status -o json` the release; if it
   is in a non-deployed state (`failed` / `pending-*` / `uninstalling`),
   `helm uninstall` it first so the reinstall starts clean. A `deployed` release
   is left untouched (normal idempotent upgrade preserved).

`regression run --auto-install` shells to this command with defaults, so it
inherits both behaviors with **no caller change**.

## Tests

`src/cli/cmd/pedestal_chart_test.go`:
- `--atomic`/`--cleanup-on-fail` reach the helm argv; `--wait` is not duplicated
  (atomic implies it).
- A `failed` release is `helm uninstall`ed before the reinstall.
- A `deployed` release is **not** uninstalled.

## Verification

- `cd src && go build -o /tmp/aegisctl ./cli` — green; `go build -tags duckdb_arrow -o /dev/null ./main.go` — green.
- `golangci-lint run --new-from-rev origin/main ./cli/cmd/...` — 0 issues.
- New + adjusted pedestal_chart tests pass. (Two pre-existing, config-context-dependent panics in `cli/cmd` — `TestSubmitGuidedApplyDryRunJSON` and the `backend_chart_values...` subtest via `config.GetCurrentContext` — fail identically on clean `origin/main`; not touched here.)

## Companion cleanup

The earlier chart-side PRs were closed as not-the-cause: OperationsPAI/train-ticket#26 and OperationsPAI/aegis#487.

Fixes #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)