### PR TITLE
fix(chaos/guided): allow zero-instance bootstrap submit by skipping live app discovery under --auto/--allow-bootstrap

### DIFF
--- a/aegislab/src/cli/apiclient/model_chaos_guided_config.go
+++ b/aegislab/src/cli/apiclient/model_chaos_guided_config.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &ChaosGuidedConfig{}
 
 // ChaosGuidedConfig struct for ChaosGuidedConfig
 type ChaosGuidedConfig struct {
-	App                  *string `json:"app,omitempty"`
+	AllowBootstrap *bool   `json:"allow_bootstrap,omitempty"`
+	App            *string `json:"app,omitempty"`
+	// Auto / AllowBootstrap mirror the submit-time --auto / --allow-bootstrap flags (#166), carried into resolve so the resolver can skip live pod discovery for zero-instance systems: the namespace is server-allocated (and possibly bootstrapped) at apply, so there are no pods to enumerate at resolve time. Per-invocation only, never persisted to the saved session (yaml:\"-\").
+	Auto                 *bool   `json:"auto,omitempty"`
 	BodyType             *string `json:"body_type,omitempty"`
 	Buffer               *int32  `json:"buffer,omitempty"`
 	ChaosType            *string `json:"chaos_type,omitempty"`
@@ -85,6 +88,38 @@ func NewChaosGuidedConfigWithDefaults() *ChaosGuidedConfig {
 	return &this
 }
 
+// GetAllowBootstrap returns the AllowBootstrap field value if set, zero value otherwise.
+func (o *ChaosGuidedConfig) GetAllowBootstrap() bool {
+	if o == nil || IsNil(o.AllowBootstrap) {
+		var ret bool
+		return ret
+	}
+	return *o.AllowBootstrap
+}
+
+// GetAllowBootstrapOk returns a tuple with the AllowBootstrap field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ChaosGuidedConfig) GetAllowBootstrapOk() (*bool, bool) {
+	if o == nil || IsNil(o.AllowBootstrap) {
+		return nil, false
+	}
+	return o.AllowBootstrap, true
+}
+
+// HasAllowBootstrap returns a boolean if a field has been set.
+func (o *ChaosGuidedConfig) HasAllowBootstrap() bool {
+	if o != nil && !IsNil(o.AllowBootstrap) {
+		return true
+	}
+
+	return false
+}
+
+// SetAllowBootstrap gets a reference to the given bool and assigns it to the AllowBootstrap field.
+func (o *ChaosGuidedConfig) SetAllowBootstrap(v bool) {
+	o.AllowBootstrap = &v
+}
+
 // GetApp returns the App field value if set, zero value otherwise.
 func (o *ChaosGuidedConfig) GetApp() string {
 	if o == nil || IsNil(o.App) {
@@ -115,6 +150,38 @@ func (o *ChaosGuidedConfig) HasApp() bool {
 // SetApp gets a reference to the given string and assigns it to the App field.
 func (o *ChaosGuidedConfig) SetApp(v string) {
 	o.App = &v
+}
+
+// GetAuto returns the Auto field value if set, zero value otherwise.
+func (o *ChaosGuidedConfig) GetAuto() bool {
+	if o == nil || IsNil(o.Auto) {
+		var ret bool
+		return ret
+	}
+	return *o.Auto
+}
+
+// GetAutoOk returns a tuple with the Auto field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ChaosGuidedConfig) GetAutoOk() (*bool, bool) {
+	if o == nil || IsNil(o.Auto) {
+		return nil, false
+	}
+	return o.Auto, true
+}
+
+// HasAuto returns a boolean if a field has been set.
+func (o *ChaosGuidedConfig) HasAuto() bool {
+	if o != nil && !IsNil(o.Auto) {
+		return true
+	}
+
+	return false
+}
+
+// SetAuto gets a reference to the given bool and assigns it to the Auto field.
+func (o *ChaosGuidedConfig) SetAuto(v bool) {
+	o.Auto = &v
 }
 
 // GetBodyType returns the BodyType field value if set, zero value otherwise.
@@ -1471,8 +1538,14 @@ func (o ChaosGuidedConfig) MarshalJSON() ([]byte, error) {
 
 func (o ChaosGuidedConfig) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.AllowBootstrap) {
+		toSerialize["allow_bootstrap"] = o.AllowBootstrap
+	}
 	if !IsNil(o.App) {
 		toSerialize["app"] = o.App
+	}
+	if !IsNil(o.Auto) {
+		toSerialize["auto"] = o.Auto
 	}
 	if !IsNil(o.BodyType) {
 		toSerialize["body_type"] = o.BodyType
@@ -1622,7 +1695,9 @@ func (o *ChaosGuidedConfig) UnmarshalJSON(data []byte) (err error) {
 	additionalProperties := make(map[string]interface{})
 
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "allow_bootstrap")
 		delete(additionalProperties, "app")
+		delete(additionalProperties, "auto")
 		delete(additionalProperties, "body_type")
 		delete(additionalProperties, "buffer")
 		delete(additionalProperties, "chaos_type")

--- a/aegislab/src/cli/apiclient/model_injection_guided_spec.go
+++ b/aegislab/src/cli/apiclient/model_injection_guided_spec.go
@@ -20,7 +20,10 @@ var _ MappedNullable = &InjectionGuidedSpec{}
 
 // InjectionGuidedSpec struct for InjectionGuidedSpec
 type InjectionGuidedSpec struct {
-	App                  *string `json:"app,omitempty"`
+	AllowBootstrap *bool   `json:"allow_bootstrap,omitempty"`
+	App            *string `json:"app,omitempty"`
+	// Auto / AllowBootstrap mirror the submit-time --auto / --allow-bootstrap flags (#166), carried into resolve so the resolver can skip live pod discovery for zero-instance systems: the namespace is server-allocated (and possibly bootstrapped) at apply, so there are no pods to enumerate at resolve time. Per-invocation only, never persisted to the saved session (yaml:\"-\").
+	Auto                 *bool   `json:"auto,omitempty"`
 	BodyType             *string `json:"body_type,omitempty"`
 	Buffer               *int32  `json:"buffer,omitempty"`
 	ChaosType            *string `json:"chaos_type,omitempty"`
@@ -85,6 +88,38 @@ func NewInjectionGuidedSpecWithDefaults() *InjectionGuidedSpec {
 	return &this
 }
 
+// GetAllowBootstrap returns the AllowBootstrap field value if set, zero value otherwise.
+func (o *InjectionGuidedSpec) GetAllowBootstrap() bool {
+	if o == nil || IsNil(o.AllowBootstrap) {
+		var ret bool
+		return ret
+	}
+	return *o.AllowBootstrap
+}
+
+// GetAllowBootstrapOk returns a tuple with the AllowBootstrap field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *InjectionGuidedSpec) GetAllowBootstrapOk() (*bool, bool) {
+	if o == nil || IsNil(o.AllowBootstrap) {
+		return nil, false
+	}
+	return o.AllowBootstrap, true
+}
+
+// HasAllowBootstrap returns a boolean if a field has been set.
+func (o *InjectionGuidedSpec) HasAllowBootstrap() bool {
+	if o != nil && !IsNil(o.AllowBootstrap) {
+		return true
+	}
+
+	return false
+}
+
+// SetAllowBootstrap gets a reference to the given bool and assigns it to the AllowBootstrap field.
+func (o *InjectionGuidedSpec) SetAllowBootstrap(v bool) {
+	o.AllowBootstrap = &v
+}
+
 // GetApp returns the App field value if set, zero value otherwise.
 func (o *InjectionGuidedSpec) GetApp() string {
 	if o == nil || IsNil(o.App) {
@@ -115,6 +150,38 @@ func (o *InjectionGuidedSpec) HasApp() bool {
 // SetApp gets a reference to the given string and assigns it to the App field.
 func (o *InjectionGuidedSpec) SetApp(v string) {
 	o.App = &v
+}
+
+// GetAuto returns the Auto field value if set, zero value otherwise.
+func (o *InjectionGuidedSpec) GetAuto() bool {
+	if o == nil || IsNil(o.Auto) {
+		var ret bool
+		return ret
+	}
+	return *o.Auto
+}
+
+// GetAutoOk returns a tuple with the Auto field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *InjectionGuidedSpec) GetAutoOk() (*bool, bool) {
+	if o == nil || IsNil(o.Auto) {
+		return nil, false
+	}
+	return o.Auto, true
+}
+
+// HasAuto returns a boolean if a field has been set.
+func (o *InjectionGuidedSpec) HasAuto() bool {
+	if o != nil && !IsNil(o.Auto) {
+		return true
+	}
+
+	return false
+}
+
+// SetAuto gets a reference to the given bool and assigns it to the Auto field.
+func (o *InjectionGuidedSpec) SetAuto(v bool) {
+	o.Auto = &v
 }
 
 // GetBodyType returns the BodyType field value if set, zero value otherwise.
@@ -1471,8 +1538,14 @@ func (o InjectionGuidedSpec) MarshalJSON() ([]byte, error) {
 
 func (o InjectionGuidedSpec) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
+	if !IsNil(o.AllowBootstrap) {
+		toSerialize["allow_bootstrap"] = o.AllowBootstrap
+	}
 	if !IsNil(o.App) {
 		toSerialize["app"] = o.App
+	}
+	if !IsNil(o.Auto) {
+		toSerialize["auto"] = o.Auto
 	}
 	if !IsNil(o.BodyType) {
 		toSerialize["body_type"] = o.BodyType
@@ -1622,7 +1695,9 @@ func (o *InjectionGuidedSpec) UnmarshalJSON(data []byte) (err error) {
 	additionalProperties := make(map[string]interface{})
 
 	if err = json.Unmarshal(data, &additionalProperties); err == nil {
+		delete(additionalProperties, "allow_bootstrap")
 		delete(additionalProperties, "app")
+		delete(additionalProperties, "auto")
 		delete(additionalProperties, "body_type")
 		delete(additionalProperties, "buffer")
 		delete(additionalProperties, "chaos_type")

--- a/aegislab/src/cli/cmd/guided_config_io.go
+++ b/aegislab/src/cli/cmd/guided_config_io.go
@@ -288,6 +288,8 @@ func overlayGuidedConfig(dst *chaos.GuidedConfig, src chaos.GuidedConfig) {
 	if src.StatusCode != nil {
 		dst.StatusCode = src.StatusCode
 	}
+	dst.Auto = src.Auto
+	dst.AllowBootstrap = src.AllowBootstrap
 	dst.SaveConfig = src.SaveConfig
 	dst.ResetConfig = src.ResetConfig
 }

--- a/aegislab/src/cli/cmd/inject_guided.go
+++ b/aegislab/src/cli/cmd/inject_guided.go
@@ -272,8 +272,10 @@ datapack, no algorithm, always fresh catalog state — use
 			MemType:        guidedMemType,
 			BodyType:       guidedBodyType,
 			ReplaceMethod:  guidedReplaceMethod,
-			SaveConfig:  effectiveSave,
-			ResetConfig: guidedResetConfig,
+			Auto:           guidedAutoAllocate,
+			AllowBootstrap: guidedAllowBootstrap,
+			SaveConfig:     effectiveSave,
+			ResetConfig:    guidedResetConfig,
 		}
 
 		setInt := func(dst **int, v int, allowZero bool) {

--- a/aegislab/src/crud/chaos/guided/builders.go
+++ b/aegislab/src/crud/chaos/guided/builders.go
@@ -547,6 +547,20 @@ func buildJVMRuntimeMutator(ctx context.Context, cfg GuidedConfig, systemType sy
 }
 
 func resolveAppLevel(ctx context.Context, cfg GuidedConfig, systemType systemconfig.SystemType) (int, int, int, error) {
+	systemIdx, err := systemTypeIndex(systemType.String())
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	// Zero-instance bootstrap: the namespace is server-allocated at apply, so
+	// there are no live pods to enumerate the app from. The real injection is
+	// addressed by app name at dispatch time (GuidedChaosPointID) and pod
+	// existence is enforced post-bootstrap, so resolve-time app-index lookup is
+	// redundant here. The returned appIdx is unused by the name-based dispatch.
+	if bootstrapBypassAppDiscovery(cfg) {
+		return 0, systemIdx, normalizedDuration(cfg), nil
+	}
+
 	apps, err := safeAppLabels(ctx, cfg.Namespace, systemType)
 	if err != nil {
 		return 0, 0, 0, err
@@ -555,11 +569,15 @@ func resolveAppLevel(ctx context.Context, cfg GuidedConfig, systemType systemcon
 	if appIdx < 0 {
 		return 0, 0, 0, fmt.Errorf("app %q not found in namespace %q; available apps: %s", cfg.App, cfg.Namespace, formatAppList(apps))
 	}
-	systemIdx, err := systemTypeIndex(systemType.String())
-	if err != nil {
-		return 0, 0, 0, err
-	}
 	return appIdx, systemIdx, normalizedDuration(cfg), nil
+}
+
+// bootstrapBypassAppDiscovery reports whether live pod discovery should be
+// skipped: the caller provided an explicit app and asked the server to
+// allocate (--auto) and/or bootstrap (--allow-bootstrap) the namespace, so no
+// pods exist yet at resolve time.
+func bootstrapBypassAppDiscovery(cfg GuidedConfig) bool {
+	return cfg.App != "" && (cfg.Auto || cfg.AllowBootstrap)
 }
 
 func resolveContainerLevel(cfg GuidedConfig, systemType systemconfig.SystemType) (int, int, int, error) {

--- a/aegislab/src/crud/chaos/guided/session_test.go
+++ b/aegislab/src/crud/chaos/guided/session_test.go
@@ -1,6 +1,45 @@
 package guided
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
+
+// Zero-instance + bootstrap: a registered system with no live namespace must
+// still resolve to ready_to_apply when the app is provided and --auto /
+// --allow-bootstrap are set. Without the bypass this hit live pod discovery
+// against the un-allocated namespace and failed with "no labels found for key
+// app in namespace <ns>" (the #166 chicken-and-egg). The namespace is left
+// empty so the server allocates it at apply.
+func TestResolveBootstrapSkipsLivePodDiscovery(t *testing.T) {
+	cfg := GuidedConfig{
+		System:         "sn",
+		App:            "user-service",
+		ChaosType:      "PodKill",
+		Auto:           true,
+		AllowBootstrap: true,
+	}
+
+	resp, err := Resolve(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if resp.Stage != "ready_to_apply" || !resp.CanApply {
+		t.Fatalf("expected ready_to_apply/can_apply, got stage=%q can_apply=%v errors=%v", resp.Stage, resp.CanApply, resp.Errors)
+	}
+	if len(resp.Errors) != 0 {
+		t.Fatalf("expected no resolver errors, got %v", resp.Errors)
+	}
+	if resp.Config.Namespace != "" {
+		t.Fatalf("expected namespace to stay empty for server-side allocation, got %q", resp.Config.Namespace)
+	}
+	if resp.Config.App != "user-service" {
+		t.Fatalf("expected app to be preserved, got %q", resp.Config.App)
+	}
+	if resp.ApplyPayload == nil {
+		t.Fatal("expected a non-nil apply payload")
+	}
+}
 
 func TestMergeConfigClearsDownstreamWhenAppChanges(t *testing.T) {
 	fileCfg := &ConfigFile{

--- a/aegislab/src/crud/chaos/guided/systems.go
+++ b/aegislab/src/crud/chaos/guided/systems.go
@@ -135,7 +135,10 @@ func normalizeSystemSelection(cfg *GuidedConfig) error {
 			return fmt.Errorf("system %q does not match any registered namespace pattern or system name", cfg.System)
 		}
 		cfg.SystemType = system.String()
-		if cfg.Namespace == "" {
+		// With --auto the namespace is server-allocated at apply, so leave it
+		// empty here instead of pinning the literal system name — a bogus
+		// namespace only triggers a doomed live-pod lookup at resolve time.
+		if cfg.Namespace == "" && !cfg.Auto {
 			cfg.Namespace = cfg.System
 		}
 		return nil

--- a/aegislab/src/docs/openapi2/docs.go
+++ b/aegislab/src/docs/openapi2/docs.go
@@ -21442,8 +21442,15 @@ const docTemplate = `{
         "chaos.GuidedConfig": {
             "type": "object",
             "properties": {
+                "allow_bootstrap": {
+                    "type": "boolean"
+                },
                 "app": {
                     "type": "string"
+                },
+                "auto": {
+                    "description": "Auto / AllowBootstrap mirror the submit-time --auto / --allow-bootstrap\nflags (#166), carried into resolve so the resolver can skip live pod\ndiscovery for zero-instance systems: the namespace is server-allocated\n(and possibly bootstrapped) at apply, so there are no pods to enumerate\nat resolve time. Per-invocation only, never persisted to the saved\nsession (yaml:\"-\").",
+                    "type": "boolean"
                 },
                 "body_type": {
                     "type": "string"
@@ -29795,8 +29802,15 @@ const docTemplate = `{
         "injection.GuidedSpec": {
             "type": "object",
             "properties": {
+                "allow_bootstrap": {
+                    "type": "boolean"
+                },
                 "app": {
                     "type": "string"
+                },
+                "auto": {
+                    "description": "Auto / AllowBootstrap mirror the submit-time --auto / --allow-bootstrap\nflags (#166), carried into resolve so the resolver can skip live pod\ndiscovery for zero-instance systems: the namespace is server-allocated\n(and possibly bootstrapped) at apply, so there are no pods to enumerate\nat resolve time. Per-invocation only, never persisted to the saved\nsession (yaml:\"-\").",
+                    "type": "boolean"
                 },
                 "body_type": {
                     "type": "string"

--- a/aegislab/src/docs/openapi2/swagger.json
+++ b/aegislab/src/docs/openapi2/swagger.json
@@ -21435,8 +21435,15 @@
         "chaos.GuidedConfig": {
             "type": "object",
             "properties": {
+                "allow_bootstrap": {
+                    "type": "boolean"
+                },
                 "app": {
                     "type": "string"
+                },
+                "auto": {
+                    "description": "Auto / AllowBootstrap mirror the submit-time --auto / --allow-bootstrap\nflags (#166), carried into resolve so the resolver can skip live pod\ndiscovery for zero-instance systems: the namespace is server-allocated\n(and possibly bootstrapped) at apply, so there are no pods to enumerate\nat resolve time. Per-invocation only, never persisted to the saved\nsession (yaml:\"-\").",
+                    "type": "boolean"
                 },
                 "body_type": {
                     "type": "string"
@@ -29788,8 +29795,15 @@
         "injection.GuidedSpec": {
             "type": "object",
             "properties": {
+                "allow_bootstrap": {
+                    "type": "boolean"
+                },
                 "app": {
                     "type": "string"
+                },
+                "auto": {
+                    "description": "Auto / AllowBootstrap mirror the submit-time --auto / --allow-bootstrap\nflags (#166), carried into resolve so the resolver can skip live pod\ndiscovery for zero-instance systems: the namespace is server-allocated\n(and possibly bootstrapped) at apply, so there are no pods to enumerate\nat resolve time. Per-invocation only, never persisted to the saved\nsession (yaml:\"-\").",
+                    "type": "boolean"
                 },
                 "body_type": {
                     "type": "string"

--- a/aegislab/src/docs/openapi2/swagger.yaml
+++ b/aegislab/src/docs/openapi2/swagger.yaml
@@ -1057,8 +1057,19 @@ definitions:
     type: object
   chaos.GuidedConfig:
     properties:
+      allow_bootstrap:
+        type: boolean
       app:
         type: string
+      auto:
+        description: |-
+          Auto / AllowBootstrap mirror the submit-time --auto / --allow-bootstrap
+          flags (#166), carried into resolve so the resolver can skip live pod
+          discovery for zero-instance systems: the namespace is server-allocated
+          (and possibly bootstrapped) at apply, so there are no pods to enumerate
+          at resolve time. Per-invocation only, never persisted to the saved
+          session (yaml:"-").
+        type: boolean
       body_type:
         type: string
       buffer:
@@ -6626,8 +6637,19 @@ definitions:
     type: object
   injection.GuidedSpec:
     properties:
+      allow_bootstrap:
+        type: boolean
       app:
         type: string
+      auto:
+        description: |-
+          Auto / AllowBootstrap mirror the submit-time --auto / --allow-bootstrap
+          flags (#166), carried into resolve so the resolver can skip live pod
+          discovery for zero-instance systems: the namespace is server-allocated
+          (and possibly bootstrapped) at apply, so there are no pods to enumerate
+          at resolve time. Per-invocation only, never persisted to the saved
+          session (yaml:"-").
+        type: boolean
       body_type:
         type: string
       buffer:

--- a/aegislab/src/platform/chaos/guidedcli.go
+++ b/aegislab/src/platform/chaos/guidedcli.go
@@ -47,9 +47,19 @@ type GuidedConfig struct {
 	BodyType        string `json:"body_type,omitempty" yaml:"body_type,omitempty"`
 	ReplaceMethod   string `json:"replace_method,omitempty" yaml:"replace_method,omitempty"`
 	StatusCode      *int   `json:"status_code,omitempty" yaml:"status_code,omitempty"`
-	SaveConfig      bool   `json:"-" yaml:"-"`
-	ResetConfig     bool   `json:"-" yaml:"-"`
-	Apply           bool   `json:"-" yaml:"-"`
+
+	// Auto / AllowBootstrap mirror the submit-time --auto / --allow-bootstrap
+	// flags (#166), carried into resolve so the resolver can skip live pod
+	// discovery for zero-instance systems: the namespace is server-allocated
+	// (and possibly bootstrapped) at apply, so there are no pods to enumerate
+	// at resolve time. Per-invocation only, never persisted to the saved
+	// session (yaml:"-").
+	Auto           bool `json:"auto,omitempty" yaml:"-"`
+	AllowBootstrap bool `json:"allow_bootstrap,omitempty" yaml:"-"`
+
+	SaveConfig  bool `json:"-" yaml:"-"`
+	ResetConfig bool `json:"-" yaml:"-"`
+	Apply       bool `json:"-" yaml:"-"`
 }
 
 // GuidedResponse mirrors the chaos-service /v1beta/guided/resolve response.


### PR DESCRIPTION
## Problem

A benchmark system with **zero live namespaces** (e.g. sn / media before first deploy) cannot be submitted through guided inject even with `--auto --allow-bootstrap` — the flag whose purpose is "let the server bootstrap a fresh slot" (#166 PR-C, routes through RestartPedestal).

```
aegisctl inject guided --system sn --app user-service --chaos-type PodKill \
  --auto --allow-bootstrap --apply ...
# Error: no labels found for key app in namespace sn
```

Chicken-and-egg: guided resolve does **live pod label discovery** to validate the `app`, but the namespace has no pods until bootstrap, and bootstrap only happens at apply (after resolve). So zero-instance systems can never reach the aegis-managed bootstrap path; the only workaround was the `pedestal chart install` side door.

## Root cause

- `crud/chaos/guided/systems.go` `normalizeSystemSelection` pinned `cfg.Namespace` to the literal system name under `--auto`, then `resolveAppLevel` ran live discovery (`safeAppLabels`) against that empty namespace → "no labels found".
- The backend injection is **name-based** (`GuidedChaosPointID` / `GuidedToChaosParams` read `cfg.App`/`cfg.System`/`cfg.ChaosType`); the resolver's discovered `AppIdx` is only a validation/preview artifact and is discarded at dispatch. So skipping discovery is safe — pod existence is enforced post-bootstrap at inject time.

## Fix (approach 1 + 3)

- Thread the existing `--auto` / `--allow-bootstrap` flags into `GuidedConfig` (`Auto`, `AllowBootstrap`; json-tagged to cross the chaos HTTP boundary, `yaml:"-"` so they never pollute the saved session).
- `resolveAppLevel`: skip live `safeAppLabels` discovery when an app is provided **and** a bootstrap flag is set.
- `normalizeSystemSelection`: under `--auto`, leave `cfg.Namespace` empty for server-side allocation instead of pinning the literal system name.
- Regenerated Go SDK + openapi2 docs in the same commit (additive `auto`/`allow_bootstrap` fields) so the swagger-freshness gate passes.

**No new aegisctl flags** → no `schema-changes-acknowledged` needed (flag set + help unchanged; only DTO/SDK models gained fields).

## Scope

Covers the app-level path (PodKill / PodFailure / JVMGarbageCollector) — the repro and all app-only chaos. Container-level chaos still does live discovery (out of scope; needs a container index with no clean catalog source). Network/HTTP/DNS/JVM-method/DB already resolve off the catalog cache, never affected.

## Test

`TestResolveBootstrapSkipsLivePodDiscovery`: zero-instance `sn` + `App=user-service` + `PodKill` + `Auto+AllowBootstrap` now reaches `ready_to_apply` with an empty (server-allocated) namespace.

## Validation pending

Needs image rebuild + `kubectl set image rcabench-chaos` on byte-cluster to confirm end-to-end sn/media zero-instance bootstrap submit (doing this now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)