### PR TITLE
feat(aegisctl): DB-canonical seed reconciliation — system diff-seed + export-seed helm_config_values fix (#478)

### DIFF
--- a/aegislab/docs/aegis-chaos-design.md
+++ b/aegislab/docs/aegis-chaos-design.md
@@ -1127,6 +1127,7 @@ Backend side:
 | Authentication                     | Bearer tokens with scope claims; no mTLS in v1beta; webhook uses separate token                                       | —   | §10.1, §5 matrix |
 | Resource limits                    | Per-system `max_concurrent_injections` only                                                                            | —   | §12.1          |
 | Param override UX                  | Effective schema = `capability ∩ point.overrides`; 400 on out-of-range; never auto-clamp                              | —   | §12.2          |
+| Helm values source of truth        | DB `helm_config_values` is canonical at runtime; `data.yaml` is genesis input; `export-seed` is the audit round-trip; `system diff-seed` is the drift gate | —   | §15            |
 
 Items intentionally deferred (not blocking v1beta):
 
@@ -1159,3 +1160,100 @@ Migration step 2 deliverable: a generated SQL seed for the
 Capability. The generator + schemas live under
 `aegis-chaos/cmd/capgen/` and run in CI to detect upstream
 `ChaosTypeMap` changes.
+
+## 15. Helm-values source of truth: DB is canonical
+
+Pedestal chart values for a benchmark system can live in two places:
+the repo seed (`manifests/byte-cluster/initial-data/data.yaml` plus the
+per-system overlay files `ts.yaml` / `otel-demo.yaml`) and the live DB
+(`helm_config_values` rows linked to a `helm_configs` row, plus the
+`value_file` snapshot). These drift: a chart install reads the DB, but
+PRs edit the repo, and nothing forced the two to agree. The concrete
+incident was ts@1.0.6 pointing the chart at a registry where the images
+did not exist (issue #478).
+
+### Decision
+
+**The DB is the canonical runtime source of truth.** What the runtime
+installs is exactly `helm_configs.value_file` (a frozen YAML snapshot)
+merged-over by the `helm_config_values` rows, resolved fresh on every
+`GET /api/v2/systems/by-name/{name}/chart`. Nothing else is consulted
+at install time. The repo seed is *not* read at install time.
+
+The repo seed has two distinct, narrower roles:
+
+1. **Genesis / bootstrap input.** `data.yaml` (+ overlay files) is what
+   the boot seed loader and `aegisctl system reseed` use to *populate*
+   the DB — at first cluster bring-up and on a deliberate operator
+   reseed. It is the seed crystal, not the live state.
+2. **Audit round-trip target.** `aegisctl system export-seed` reads the
+   live DB and emits a `data.yaml`-compatible snapshot that can be
+   committed back to git. This closes the loop so a runtime-mutated DB
+   does not silently diverge from the repo forever.
+
+Lifecycle, stated precisely:
+
+```
+genesis seed (data.yaml + overlay)
+        │  boot seed loader / `system reseed`  (one-way load)
+        ▼
+   DB helm_config_values  ← canonical, what install reads
+        │  `system export-seed`               (one-way audit dump)
+        ▼
+git-committable snapshot   ← reconciles repo back to reality
+```
+
+We chose DB-canonical over repo-canonical (the "every register/reseed
+atomically rewrites the DB from the file" alternative) because reseed
+already deliberately preserves operator overrides (etcd values that
+differ from the seed default are kept unless `--reset-overrides`; see
+`reseed.go`). Making the repo authoritative would have to either throw
+those overrides away on every reseed or grow a merge policy that
+re-implements what the DB already is. Treating the DB as truth and the
+repo as genesis-plus-audit keeps one writer for runtime state.
+
+### Enforcement: `aegisctl system diff-seed`
+
+The decision is only real if drift is detectable. `aegisctl system
+diff-seed --name <sys> --from-seed <path>` is the gate:
+
+- Computes the **effective git values**: the overlay file
+  `<dir>/<sys>.yaml` (if present) flattened to dotted keys, then the
+  `data.yaml` `helm_config.values` entries applied on top — the same
+  precedence the runtime uses (`HelmConfigItem.GetValuesMap`).
+- Fetches the **effective live values** from the existing chart
+  endpoint (`SystemChartResp.Values`), which is exactly the DB
+  `value_file` snapshot merged with `helm_config_values`.
+- Prints per-key drift (only-in-DB / only-in-git / value mismatch) and
+  exits non-zero (workflow-failure exit code) when any drift is found,
+  so CI / an operator runbook can call it as a gate.
+
+It is a pure client command: it reuses the existing chart read endpoint
+and the on-disk seed, so it adds no new HTTP surface and no schema-gate
+endpoint churn. When the DB and git agree it exits 0 and is silent
+enough to wire into a pipeline.
+
+### Overlay files (`ts.yaml` / `otel-demo.yaml`)
+
+Approach (b) in its purest form says "drop the overlay files; admins
+manage values via aegisctl." We deliberately do **not** delete them in
+this change. `value_file` is a live runtime input — at seed time the
+overlay is copied into the managed file store and its path is recorded
+on `helm_configs.value_file`; at install time `GetValuesMap` reads that
+snapshot and merges `helm_config_values` on top. Deleting the overlay
+from the repo does not remove the frozen snapshot the DB already points
+at, and a fresh cold-start reseed would then lose those values entirely
+(the otel-demo per-component init-container objects, which cannot be
+expressed as flat `helm_config_values` keys because a `--set` against
+an indexed array slot replaces the whole element, are the clearest
+example — see the `data.yaml` otel-demo comments).
+
+The migration to fully drop overlays is therefore a **scoped
+follow-up**, not part of this change: every key currently carried only
+by an overlay must first be representable as a `helm_config_values` row
+(or the structural-array cases resolved another way), the DB reconciled,
+and only then the overlay file and the seed-loader's `value_file` upload
+path retired. Until that lands, `diff-seed` compares the *effective
+merged* values, which is the property operators actually care about —
+"does the live cluster match what git declares" — regardless of which
+half of the seed a given key came from.

--- a/aegislab/docs/aegis-chaos-design.md
+++ b/aegislab/docs/aegis-chaos-design.md
@@ -1169,8 +1169,11 @@ per-system overlay files `ts.yaml` / `otel-demo.yaml`) and the live DB
 (`helm_config_values` rows linked to a `helm_configs` row, plus the
 `value_file` snapshot). These drift: a chart install reads the DB, but
 PRs edit the repo, and nothing forced the two to agree. The concrete
-incident was ts@1.0.6 pointing the chart at a registry where the images
-did not exist (issue #478).
+incident was ts@1.0.6, where the repo overlay still pointed at a stale
+registry (`pair-diag-cn-guangzhou.cr.volces.com/pair`) after the images
+had been migrated to the volces shanghai mirror
+(`pair-cn-shanghai.cr.volces.com/opspai`) that the live DB already
+carried — the repo, not the DB, was wrong (issue #478).
 
 ### Decision
 

--- a/aegislab/manifests/byte-cluster/initial-data/data.yaml
+++ b/aegislab/manifests/byte-cluster/initial-data/data.yaml
@@ -51,27 +51,22 @@ containers:
     is_public: true
     status: 1
     versions:
-      # RECONCILED (issue #478): the 1.0.6 helm_config.values image refs
-      # below were corrected from the volces shanghai mirror
-      # (`pair-cn-shanghai.cr.volces.com/opspai/*`) back to the private
-      # guangzhou registry (`pair-diag-cn-guangzhou.cr.volces.com/pair/*`).
-      # The ts-* service images only exist in the guangzhou `pair`
-      # registry; they were never published to the shanghai opspai mirror,
-      # so the shanghai refs ImagePullBackOff'd. global.image.tag (v1.2.9)
-      # was also missing from the DB and is now pinned. The historical
-      # bump notes below (1.0.4/1.0.5) describe the now-superseded shanghai
-      # mirroring attempt and are kept for provenance.
+      # SOURCE OF TRUTH (issue #478): the live DB helm_config_values are
+      # canonical at runtime (see aegis-chaos-design.md §15). The ts-*
+      # service images were migrated to the volces shanghai mirror
+      # (`pair-cn-shanghai.cr.volces.com/opspai/*`, recorded by #483/#484),
+      # which is what the DB carries and what install must use. #478's
+      # premise that the images only live in the guangzhou `pair` registry
+      # was already stale when filed.
       #
-      # This is a data.yaml (genesis) correction only. The DB is canonical
-      # at runtime, so a live cluster must be reconciled explicitly — run
-      # `aegisctl system reseed --name ts --apply` to propagate the
-      # corrected defaults, then verify with
-      # `aegisctl system diff-seed --name ts --from-seed <this dir>`
-      # (exits 0 when DB matches git). NB: reseed's history-preservation
-      # contract preserves a manually-overridden parameter_configs row, so
-      # if the live ts@1.0.6 helm_config_values were hand-edited, fix the
-      # row in the DB to match (the diff-seed output names every drifting
-      # key). See aegis-chaos-design.md §15.
+      # The 1.0.6 helm_config.values below intentionally hold the opspai
+      # shanghai refs to match the DB. If the repo ever drifts from the DB
+      # again, regenerate this block from the canonical DB rather than
+      # hand-editing:
+      #   aegisctl system export-seed --name ts   # emits helm_config.values
+      # and verify with:
+      #   aegisctl system diff-seed --name ts --from-seed <this dir>
+      # (exits 0 when repo matches the live DB).
       #
       # Bumped 1.0.2 → 1.0.4 to consolidate three out-of-band defaults that
       # ts ns previously got via per-namespace `helm upgrade --set` but which
@@ -150,58 +145,43 @@ containers:
               value_type: 2
               default_value: "true"
               overridable: true
-            # Repository + tag for ts-* service images and the chart's
+            # Repository for ts-* service images and the chart's
             # `init-otel-agent` (autoinstrumentation-java) initContainer.
-            # The ts-* service images (ts-admin-basic-info-service etc.)
-            # ONLY exist in the private guangzhou `pair` registry — they
-            # were never published to the volces shanghai opspai mirror, so
-            # a shanghai repo here ImagePullBackOff's with `...not found`
-            # (issue #478). global.image.tag was missing from the DB
-            # entirely, leaving the chart to fall back to its default tag;
-            # pin it to the published v1.2.9.
+            # Chart default `docker.io/opspai` is unreachable from byte-
+            # cluster nodes; the volces shanghai mirror is.
             - key: global.image.repository
               type: 0
               category: 1
               value_type: 0
-              default_value: pair-diag-cn-guangzhou.cr.volces.com/pair
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
               overridable: true
-            - key: global.image.tag
-              type: 0
-              category: 1
-              value_type: 0
-              default_value: v1.2.9
-              overridable: true
-            # mysql subchart: mirrored alongside the ts images in the
-            # guangzhou `pair` registry.
+            # mysql + rabbitmq subcharts: chart defaults reach docker.io
+            # directly. Mirror both to opspai (manually pulled + pushed
+            # 2026-05-01: docker.io/library/mysql:5.7 and docker.io/
+            # bitnamilegacy/rabbitmq:4.0.7-debian-12-r0).
             - key: mysql.image.repository
               type: 0
               category: 1
               value_type: 0
-              default_value: pair-diag-cn-guangzhou.cr.volces.com/pair/mysql
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/mysql
               overridable: true
-            # rabbitmq subchart: the chart splits registry + repository.
-            # Final rendered image is `<registry>/<repository>:<tag>`. Pin
-            # both so it resolves to the guangzhou `pair` mirror.
-            - key: rabbitmq.image.registry
-              type: 0
-              category: 1
-              value_type: 0
-              default_value: pair-diag-cn-guangzhou.cr.volces.com
-              overridable: true
+            # Keep this as a repository suffix because the chart also carries
+            # `rabbitmq.image.registry`. The final rendered image should be
+            # `pair-cn-shanghai.cr.volces.com/opspai/rabbitmq:<tag>`.
             - key: rabbitmq.image.repository
               type: 0
               category: 1
               value_type: 0
-              default_value: pair/rabbitmq
+              default_value: opspai/rabbitmq
               overridable: true
             # loadgen `wait-for-services` init container — chart hardcodes
-            # docker.io/nicolaka/netshoot:v0.14 in values.yaml:394. Mirrored
-            # to the guangzhou `pair` registry alongside the loadgen image.
+            # docker.io/nicolaka/netshoot:v0.14 in values.yaml:394. Mirror
+            # pushed to opspai/netshoot:v0.14 on 2026-05-01.
             - key: loadgenerator.initContainer.image
               type: 0
               category: 1
               value_type: 0
-              default_value: pair-diag-cn-guangzhou.cr.volces.com/pair/netshoot:v0.14
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/netshoot:v0.14
               overridable: true
             # Per-system collector (#303): all ts workloads (Java services
             # + Go loadgen + caddy ui-dashboard) export to the dedicated
@@ -225,16 +205,13 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: pair-diag-cn-guangzhou.cr.volces.com/pair/loadgenerator
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/loadgenerator
               overridable: true
-            # loadgenerator image is published as :023 in the guangzhou
-            # `pair` registry; the DB previously carried :024, which only
-            # ever existed on the shanghai opspai mirror (issue #478).
             - key: loadgenerator.image.tag
               type: 0
               category: 1
               value_type: 0
-              default_value: "023"
+              default_value: "024"
               overridable: true
             # Pin mysql Service to ClusterIP. trainticket@0.2.0 chart default
             # is `NodePort` with no `nodePort` value, so kubernetes auto-assigns

--- a/aegislab/manifests/byte-cluster/initial-data/data.yaml
+++ b/aegislab/manifests/byte-cluster/initial-data/data.yaml
@@ -51,6 +51,28 @@ containers:
     is_public: true
     status: 1
     versions:
+      # RECONCILED (issue #478): the 1.0.6 helm_config.values image refs
+      # below were corrected from the volces shanghai mirror
+      # (`pair-cn-shanghai.cr.volces.com/opspai/*`) back to the private
+      # guangzhou registry (`pair-diag-cn-guangzhou.cr.volces.com/pair/*`).
+      # The ts-* service images only exist in the guangzhou `pair`
+      # registry; they were never published to the shanghai opspai mirror,
+      # so the shanghai refs ImagePullBackOff'd. global.image.tag (v1.2.9)
+      # was also missing from the DB and is now pinned. The historical
+      # bump notes below (1.0.4/1.0.5) describe the now-superseded shanghai
+      # mirroring attempt and are kept for provenance.
+      #
+      # This is a data.yaml (genesis) correction only. The DB is canonical
+      # at runtime, so a live cluster must be reconciled explicitly — run
+      # `aegisctl system reseed --name ts --apply` to propagate the
+      # corrected defaults, then verify with
+      # `aegisctl system diff-seed --name ts --from-seed <this dir>`
+      # (exits 0 when DB matches git). NB: reseed's history-preservation
+      # contract preserves a manually-overridden parameter_configs row, so
+      # if the live ts@1.0.6 helm_config_values were hand-edited, fix the
+      # row in the DB to match (the diff-seed output names every drifting
+      # key). See aegis-chaos-design.md §15.
+      #
       # Bumped 1.0.2 → 1.0.4 to consolidate three out-of-band defaults that
       # ts ns previously got via per-namespace `helm upgrade --set` but which
       # weren't in the DB seed (so any RestartPedestal flow that re-installed
@@ -128,43 +150,58 @@ containers:
               value_type: 2
               default_value: "true"
               overridable: true
-            # Repository for ts-* service images and the chart's
+            # Repository + tag for ts-* service images and the chart's
             # `init-otel-agent` (autoinstrumentation-java) initContainer.
-            # Chart default `docker.io/opspai` is unreachable from byte-
-            # cluster nodes; the volces shanghai mirror is.
+            # The ts-* service images (ts-admin-basic-info-service etc.)
+            # ONLY exist in the private guangzhou `pair` registry — they
+            # were never published to the volces shanghai opspai mirror, so
+            # a shanghai repo here ImagePullBackOff's with `...not found`
+            # (issue #478). global.image.tag was missing from the DB
+            # entirely, leaving the chart to fall back to its default tag;
+            # pin it to the published v1.2.9.
             - key: global.image.repository
               type: 0
               category: 1
               value_type: 0
-              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              default_value: pair-diag-cn-guangzhou.cr.volces.com/pair
               overridable: true
-            # mysql + rabbitmq subcharts: chart defaults reach docker.io
-            # directly. Mirror both to opspai (manually pulled + pushed
-            # 2026-05-01: docker.io/library/mysql:5.7 and docker.io/
-            # bitnamilegacy/rabbitmq:4.0.7-debian-12-r0).
+            - key: global.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: v1.2.9
+              overridable: true
+            # mysql subchart: mirrored alongside the ts images in the
+            # guangzhou `pair` registry.
             - key: mysql.image.repository
               type: 0
               category: 1
               value_type: 0
-              default_value: pair-cn-shanghai.cr.volces.com/opspai/mysql
+              default_value: pair-diag-cn-guangzhou.cr.volces.com/pair/mysql
               overridable: true
-            # Keep this as a repository suffix because the chart also carries
-            # `rabbitmq.image.registry`. The final rendered image should be
-            # `pair-cn-shanghai.cr.volces.com/opspai/rabbitmq:<tag>`.
+            # rabbitmq subchart: the chart splits registry + repository.
+            # Final rendered image is `<registry>/<repository>:<tag>`. Pin
+            # both so it resolves to the guangzhou `pair` mirror.
+            - key: rabbitmq.image.registry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-diag-cn-guangzhou.cr.volces.com
+              overridable: true
             - key: rabbitmq.image.repository
               type: 0
               category: 1
               value_type: 0
-              default_value: opspai/rabbitmq
+              default_value: pair/rabbitmq
               overridable: true
             # loadgen `wait-for-services` init container — chart hardcodes
-            # docker.io/nicolaka/netshoot:v0.14 in values.yaml:394. Mirror
-            # pushed to opspai/netshoot:v0.14 on 2026-05-01.
+            # docker.io/nicolaka/netshoot:v0.14 in values.yaml:394. Mirrored
+            # to the guangzhou `pair` registry alongside the loadgen image.
             - key: loadgenerator.initContainer.image
               type: 0
               category: 1
               value_type: 0
-              default_value: pair-cn-shanghai.cr.volces.com/opspai/netshoot:v0.14
+              default_value: pair-diag-cn-guangzhou.cr.volces.com/pair/netshoot:v0.14
               overridable: true
             # Per-system collector (#303): all ts workloads (Java services
             # + Go loadgen + caddy ui-dashboard) export to the dedicated
@@ -188,13 +225,16 @@ containers:
               type: 0
               category: 1
               value_type: 0
-              default_value: pair-cn-shanghai.cr.volces.com/opspai/loadgenerator
+              default_value: pair-diag-cn-guangzhou.cr.volces.com/pair/loadgenerator
               overridable: true
+            # loadgenerator image is published as :023 in the guangzhou
+            # `pair` registry; the DB previously carried :024, which only
+            # ever existed on the shanghai opspai mirror (issue #478).
             - key: loadgenerator.image.tag
               type: 0
               category: 1
               value_type: 0
-              default_value: "024"
+              default_value: "023"
               overridable: true
             # Pin mysql Service to ClusterIP. trainticket@0.2.0 chart default
             # is `NodePort` with no `nodePort` value, so kubernetes auto-assigns

--- a/aegislab/manifests/byte-cluster/initial-data/ts.yaml
+++ b/aegislab/manifests/byte-cluster/initial-data/ts.yaml
@@ -1,25 +1,32 @@
+# Genesis value_file snapshot for the ts pedestal (issue #478). The live DB
+# helm_config_values are canonical at runtime (see aegis-chaos-design.md §15);
+# these overlay refs are aligned to the same volces shanghai mirror the DB
+# carries (`pair-cn-shanghai.cr.volces.com/opspai/*`, per #483/#484) so a
+# fresh-cluster reseed reproduces the live state. loadgenerator.image.tag is
+# overridden to 024 by data.yaml helm_config.values at install, so it wins
+# over any value here.
 global:
   image:
-    repository: pair-diag-cn-guangzhou.cr.volces.com/pair
+    repository: pair-cn-shanghai.cr.volces.com/opspai
     tag: "v1.2.9"
   security:
     allowInsecureImages: true
 
 mysql:
   image:
-    repository: pair-diag-cn-guangzhou.cr.volces.com/pair/mysql
+    repository: pair-cn-shanghai.cr.volces.com/opspai/mysql
 
 rabbitmq:
   image:
-    registry: pair-diag-cn-guangzhou.cr.volces.com
-    repository: pair/rabbitmq
+    registry: pair-cn-shanghai.cr.volces.com
+    repository: opspai/rabbitmq
 
 loadgenerator:
   image:
-    repository: pair-diag-cn-guangzhou.cr.volces.com/pair/loadgenerator
-    tag: "023"
+    repository: pair-cn-shanghai.cr.volces.com/opspai/loadgenerator
+    tag: "024"
   initContainer:
-    image: pair-diag-cn-guangzhou.cr.volces.com/pair/netshoot:v0.14
+    image: pair-cn-shanghai.cr.volces.com/opspai/netshoot:v0.14
 
 otelCollector:
   image:

--- a/aegislab/manifests/byte-cluster/initial-data/ts.yaml
+++ b/aegislab/manifests/byte-cluster/initial-data/ts.yaml
@@ -11,8 +11,8 @@ mysql:
 
 rabbitmq:
   image:
-    registry: pair-cn-shanghai.cr.volces.com
-    repository: opspai/rabbitmq
+    registry: pair-diag-cn-guangzhou.cr.volces.com
+    repository: pair/rabbitmq
 
 loadgenerator:
   image:

--- a/aegislab/src/cli/cmd/system_diff_seed.go
+++ b/aegislab/src/cli/cmd/system_diff_seed.go
@@ -1,0 +1,282 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"aegis/cli/output"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+var (
+	systemDiffSeedName     string
+	systemDiffSeedFromSeed string
+	systemDiffSeedEnv      string
+)
+
+var systemDiffSeedCmd = &cobra.Command{
+	Use:   "diff-seed",
+	Short: "Compare a system's live DB helm values against a git seed and exit non-zero on drift",
+	Long: `The DB helm_config_values rows (merged with the value_file snapshot) are
+the canonical runtime source of truth for a pedestal chart install (see
+aegis-chaos-design.md §15). The repo seed (data.yaml + per-system overlay)
+is the genesis input. They drift.
+
+diff-seed resolves the effective helm values both ways and reports the
+difference:
+
+  - git side:  overlay file <dir>/<name>.yaml (if present) overlaid by the
+               data.yaml helm_config.values entries for the system.
+  - live side: GET /api/v2/systems/by-name/<name>/chart .values, i.e. the
+               DB value_file snapshot merged with helm_config_values.
+
+Keys present only in one side, and keys whose values differ, are printed.
+Exit code is non-zero (workflow-failure) when any drift is found, so CI
+or an operator runbook can call it as a gate:
+
+  aegisctl system diff-seed --name ts --from-seed manifests/byte-cluster/initial-data`,
+	Args: requireNoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireAPIContext(true); err != nil {
+			return err
+		}
+		name := strings.TrimSpace(systemDiffSeedName)
+		if name == "" {
+			return usageErrorf("--name is required")
+		}
+		if strings.TrimSpace(systemDiffSeedFromSeed) == "" {
+			return usageErrorf("--from-seed is required")
+		}
+
+		seedPath, err := resolveSeedPath(systemDiffSeedFromSeed, systemDiffSeedEnv)
+		if err != nil {
+			return err
+		}
+		want, err := effectiveSeedValues(seedPath, name)
+		if err != nil {
+			return err
+		}
+
+		cli, ctx := newAPIClient()
+		resp, _, err := cli.SystemsAPI.GetChaosSystemChartByName(ctx, name).Execute()
+		if err != nil {
+			return fmt.Errorf("fetch live chart for %q: %w", name, err)
+		}
+		chart := resp.GetData()
+		got := flattenHelmValues(chart.GetValues())
+
+		diffs := diffSeedValues(want, got)
+		if output.OutputFormat(flagOutput) == output.FormatJSON {
+			output.PrintJSON(map[string]any{
+				"system":     name,
+				"seed_path":  seedPath,
+				"drift":      len(diffs) > 0,
+				"mismatches": diffs,
+			})
+		} else {
+			printSeedDiff(name, seedPath, diffs)
+		}
+		if len(diffs) > 0 {
+			return silentExit(ExitCodeWorkflowFailure)
+		}
+		return nil
+	},
+}
+
+// seedDiffKind classifies a single drifting key.
+type seedDiffKind string
+
+const (
+	seedDiffOnlyGit  seedDiffKind = "only_in_seed"
+	seedDiffOnlyDB   seedDiffKind = "only_in_db"
+	seedDiffMismatch seedDiffKind = "value_mismatch"
+)
+
+type seedDiff struct {
+	Key  string       `json:"key"`
+	Kind seedDiffKind `json:"kind"`
+	Seed string       `json:"seed,omitempty"`
+	Live string       `json:"live,omitempty"`
+}
+
+func diffSeedValues(want, got map[string]string) []seedDiff {
+	keys := make(map[string]struct{}, len(want)+len(got))
+	for k := range want {
+		keys[k] = struct{}{}
+	}
+	for k := range got {
+		keys[k] = struct{}{}
+	}
+	var out []seedDiff
+	for k := range keys {
+		w, inWant := want[k]
+		g, inGot := got[k]
+		switch {
+		case inWant && !inGot:
+			out = append(out, seedDiff{Key: k, Kind: seedDiffOnlyGit, Seed: w})
+		case !inWant && inGot:
+			out = append(out, seedDiff{Key: k, Kind: seedDiffOnlyDB, Live: g})
+		case w != g:
+			out = append(out, seedDiff{Key: k, Kind: seedDiffMismatch, Seed: w, Live: g})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+func printSeedDiff(name, seedPath string, diffs []seedDiff) {
+	if len(diffs) == 0 {
+		output.PrintInfo(fmt.Sprintf("system %q: live DB helm values match seed %s (no drift)", name, seedPath))
+		return
+	}
+	output.PrintError(fmt.Sprintf("system %q: %d helm value drift(s) vs seed %s", name, len(diffs), seedPath))
+	for _, d := range diffs {
+		switch d.Kind {
+		case seedDiffOnlyGit:
+			fmt.Fprintf(os.Stderr, "  only in seed: %s = %q\n", d.Key, d.Seed)
+		case seedDiffOnlyDB:
+			fmt.Fprintf(os.Stderr, "  only in DB:   %s = %q\n", d.Key, d.Live)
+		case seedDiffMismatch:
+			fmt.Fprintf(os.Stderr, "  mismatch:     %s: seed=%q live=%q\n", d.Key, d.Seed, d.Live)
+		}
+	}
+}
+
+// effectiveSeedValues computes the flattened dotted-key helm values a chart
+// install would receive from the repo seed: the per-system overlay file
+// (<dir>/<name>.yaml), overlaid by the data.yaml helm_config.values entries
+// for the system's highest-versioned active pedestal. This mirrors the
+// precedence in HelmConfigItem.GetValuesMap (file base, dynamic values win).
+func effectiveSeedValues(seedPath, name string) (map[string]string, error) {
+	flat := map[string]string{}
+
+	overlayPath := filepath.Join(filepath.Dir(seedPath), name+".yaml")
+	if raw, err := os.ReadFile(overlayPath); err == nil {
+		var nested map[string]any
+		if err := yaml.Unmarshal(raw, &nested); err != nil {
+			return nil, fmt.Errorf("parse overlay %q: %w", overlayPath, err)
+		}
+		for k, v := range flattenHelmValues(nested) {
+			flat[k] = v
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read overlay %q: %w", overlayPath, err)
+	}
+
+	values, err := seedHelmConfigValues(seedPath, name)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range values {
+		flat[k] = v
+	}
+	return flat, nil
+}
+
+// seedDataDoc is the minimal slice of data.yaml diff-seed needs: the
+// containers list with each version's helm_config.values entries.
+type seedDataDoc struct {
+	Containers []struct {
+		Name     string `yaml:"name"`
+		Versions []struct {
+			Name       string `yaml:"name"`
+			Status     int    `yaml:"status"`
+			HelmConfig *struct {
+				Values []struct {
+					Key          string  `yaml:"key"`
+					DefaultValue *string `yaml:"default_value"`
+				} `yaml:"values"`
+			} `yaml:"helm_config"`
+		} `yaml:"versions"`
+	} `yaml:"containers"`
+}
+
+// seedHelmConfigValues returns the data.yaml helm_config.values for the
+// system's highest active pedestal version, as a dotted-key map. The
+// highest-versioned active version wins, matching the backend's
+// GetPedestalHelmConfigByName resolution when no explicit version is asked.
+func seedHelmConfigValues(seedPath, name string) (map[string]string, error) {
+	raw, err := os.ReadFile(seedPath)
+	if err != nil {
+		return nil, fmt.Errorf("read seed %q: %w", seedPath, err)
+	}
+	var doc seedDataDoc
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse seed %q: %w", seedPath, err)
+	}
+	for _, c := range doc.Containers {
+		if c.Name != name {
+			continue
+		}
+		var chosen *struct {
+			Values []struct {
+				Key          string  `yaml:"key"`
+				DefaultValue *string `yaml:"default_value"`
+			} `yaml:"values"`
+		}
+		var chosenName string
+		for i := range c.Versions {
+			v := &c.Versions[i]
+			if v.HelmConfig == nil || v.Status != 1 {
+				continue
+			}
+			if chosen == nil || v.Name > chosenName {
+				chosen = v.HelmConfig
+				chosenName = v.Name
+			}
+		}
+		out := map[string]string{}
+		if chosen == nil {
+			return out, nil
+		}
+		for _, val := range chosen.Values {
+			if val.DefaultValue == nil {
+				continue
+			}
+			out[val.Key] = *val.DefaultValue
+		}
+		return out, nil
+	}
+	return nil, notFoundErrorf("no containers entry for %q in seed %s", name, seedPath)
+}
+
+// flattenHelmValues turns a nested helm values map into dotted leaf keys.
+// Arrays are JSON-encoded as a single leaf value so an indexed override and
+// a structural array both compare as one string — matching how a helm --set
+// against an indexed slot is treated as one opaque value.
+func flattenHelmValues(data map[string]any) map[string]string {
+	out := map[string]string{}
+	flattenHelmValuesInto(data, "", out)
+	return out
+}
+
+func flattenHelmValuesInto(data map[string]any, prefix string, out map[string]string) {
+	for k, v := range data {
+		full := k
+		if prefix != "" {
+			full = prefix + "." + k
+		}
+		switch val := v.(type) {
+		case map[string]any:
+			flattenHelmValuesInto(val, full, out)
+		case []any:
+			b, _ := json.Marshal(val)
+			out[full] = string(b)
+		default:
+			out[full] = fmt.Sprintf("%v", val)
+		}
+	}
+}
+
+func init() {
+	systemDiffSeedCmd.Flags().StringVar(&systemDiffSeedName, "name", "", "Short code of the system to diff (required)")
+	systemDiffSeedCmd.Flags().StringVar(&systemDiffSeedFromSeed, "from-seed", "", "Path to data.yaml (file, env dir, or initial_data/ root) (required)")
+	systemDiffSeedCmd.Flags().StringVar(&systemDiffSeedEnv, "env", "", "When --from-seed is a directory: 'prod' or 'staging'")
+	systemCmd.AddCommand(systemDiffSeedCmd)
+}

--- a/aegislab/src/cli/cmd/system_diff_seed_test.go
+++ b/aegislab/src/cli/cmd/system_diff_seed_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// chartValuesServer serves GET /api/v2/systems/by-name/{name}/chart with a
+// fixed merged-values map, mimicking the live DB effective helm values.
+func chartValuesServer(t *testing.T, values map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"code":    200,
+			"message": "ok",
+			"data": map[string]any{
+				"system_name": "ts",
+				"chart_name":  "trainticket",
+				"version":     "0.2.1",
+				"values":      values,
+			},
+		})
+	}))
+}
+
+func writeDiffSeedFixture(t *testing.T, helmValues string, overlay string) string {
+	t.Helper()
+	dir := t.TempDir()
+	data := `containers:
+  - type: 2
+    name: ts
+    is_public: true
+    status: 1
+    versions:
+      - name: 1.0.6
+        status: 1
+        helm_config:
+          version: 0.2.1
+          chart_name: trainticket
+          repo_name: train-ticket
+          repo_url: https://operationspai.github.io/train-ticket
+          values:
+` + helmValues
+	if err := os.WriteFile(filepath.Join(dir, "data.yaml"), []byte(data), 0o600); err != nil {
+		t.Fatalf("write data.yaml: %v", err)
+	}
+	if overlay != "" {
+		if err := os.WriteFile(filepath.Join(dir, "ts.yaml"), []byte(overlay), 0o600); err != nil {
+			t.Fatalf("write ts.yaml: %v", err)
+		}
+	}
+	return dir
+}
+
+// TestDiffSeedDetectsImageDrift is the issue #478 acceptance test: when the
+// live DB effective helm values diverge from the git seed, diff-seed must
+// exit non-zero (workflow-failure); when they agree it must exit 0. The
+// fixture reproduces the exact ts@1.0.6 drift the issue describes
+// (repository registry + loadgenerator tag).
+func TestDiffSeedDetectsImageDrift(t *testing.T) {
+	const seedValues = `            - key: global.image.repository
+              value_type: 0
+              default_value: pair-diag-cn-guangzhou.cr.volces.com/pair
+            - key: loadgenerator.image.tag
+              value_type: 0
+              default_value: "023"
+`
+
+	t.Run("drift exits workflow-failure", func(t *testing.T) {
+		dir := writeDiffSeedFixture(t, seedValues, "")
+		srv := chartValuesServer(t, map[string]any{
+			"global": map[string]any{
+				"image": map[string]any{"repository": "pair-cn-shanghai.cr.volces.com/opspai"},
+			},
+			"loadgenerator": map[string]any{
+				"image": map[string]any{"tag": "024"},
+			},
+		})
+		defer srv.Close()
+
+		res := runCLI(t, "--server", srv.URL, "--token", "token",
+			"system", "diff-seed", "--name", "ts", "--from-seed", filepath.Join(dir, "data.yaml"))
+		if res.code != ExitCodeWorkflowFailure {
+			t.Fatalf("exit code = %d, want %d; stderr=%q", res.code, ExitCodeWorkflowFailure, res.stderr)
+		}
+	})
+
+	t.Run("match exits zero", func(t *testing.T) {
+		dir := writeDiffSeedFixture(t, seedValues, "")
+		srv := chartValuesServer(t, map[string]any{
+			"global": map[string]any{
+				"image": map[string]any{"repository": "pair-diag-cn-guangzhou.cr.volces.com/pair"},
+			},
+			"loadgenerator": map[string]any{
+				"image": map[string]any{"tag": "023"},
+			},
+		})
+		defer srv.Close()
+
+		res := runCLI(t, "--server", srv.URL, "--token", "token",
+			"system", "diff-seed", "--name", "ts", "--from-seed", filepath.Join(dir, "data.yaml"))
+		if res.code != ExitCodeSuccess {
+			t.Fatalf("exit code = %d, want %d; stderr=%q stdout=%q", res.code, ExitCodeSuccess, res.stderr, res.stdout)
+		}
+	})
+
+	// The overlay file is a real runtime input (value_file). A key carried
+	// only by the overlay must participate in the diff: if the DB has it the
+	// effective values match, so no drift.
+	t.Run("overlay key counts toward effective values", func(t *testing.T) {
+		overlay := "global:\n  security:\n    allowInsecureImages: true\n"
+		dir := writeDiffSeedFixture(t, seedValues, overlay)
+		srv := chartValuesServer(t, map[string]any{
+			"global": map[string]any{
+				"image":    map[string]any{"repository": "pair-diag-cn-guangzhou.cr.volces.com/pair"},
+				"security": map[string]any{"allowInsecureImages": true},
+			},
+			"loadgenerator": map[string]any{
+				"image": map[string]any{"tag": "023"},
+			},
+		})
+		defer srv.Close()
+
+		res := runCLI(t, "--server", srv.URL, "--token", "token",
+			"system", "diff-seed", "--name", "ts", "--from-seed", filepath.Join(dir, "data.yaml"))
+		if res.code != ExitCodeSuccess {
+			t.Fatalf("exit code = %d, want %d; stderr=%q", res.code, ExitCodeSuccess, res.stderr)
+		}
+	})
+}

--- a/aegislab/src/core/domain/chaossystem/export_seed_values_test.go
+++ b/aegislab/src/core/domain/chaossystem/export_seed_values_test.go
@@ -1,0 +1,60 @@
+package chaossystem
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"aegis/platform/consts"
+	"aegis/platform/model"
+)
+
+// TestExportSeedEmitsHelmConfigValues pins the issue #478 contract: the
+// canonical runtime state is the helm_config_values rows, so an export-seed
+// snapshot that drops them would silently lose every image override on a
+// re-seed. The exported YAML must carry the helm_config.values entry verbatim.
+func TestExportSeedEmitsHelmConfigValues(t *testing.T) {
+	etcd := &fakeEtcd{data: map[string]string{}}
+	svc, db := newOnboardService(t, etcd)
+
+	const name = "ev"
+	cleanup := seedSystemInViper(t, name, false)
+	defer cleanup()
+
+	if _, err := svc.OnboardSystem(context.Background(), sampleOnboardReq(name)); err != nil {
+		t.Fatalf("OnboardSystem: %v", err)
+	}
+
+	// Link a helm_config_values override onto the onboarded pedestal's
+	// helm_config, mirroring what reseed / a chart bump would persist.
+	helm, _, err := svc.repo.GetPedestalHelmConfigByName(name, "")
+	if err != nil || helm == nil {
+		t.Fatalf("GetPedestalHelmConfigByName: helm=%v err=%v", helm, err)
+	}
+	def := "pair-diag-cn-guangzhou.cr.volces.com/pair"
+	pc := &model.ParameterConfig{
+		Key:          "global.image.repository",
+		Type:         consts.ParameterTypeFixed,
+		Category:     consts.ParameterCategoryHelmValues,
+		ValueType:    consts.ValueDataTypeString,
+		DefaultValue: &def,
+		Overridable:  true,
+	}
+	if err := db.Create(pc).Error; err != nil {
+		t.Fatalf("create parameter_config: %v", err)
+	}
+	if err := db.Create(&model.HelmConfigValue{HelmConfigID: helm.ID, ParameterConfigID: pc.ID}).Error; err != nil {
+		t.Fatalf("link helm_config_value: %v", err)
+	}
+
+	exp, err := svc.ExportSeed(context.Background(), name)
+	if err != nil {
+		t.Fatalf("ExportSeed: %v", err)
+	}
+	if !strings.Contains(exp.YAML, "global.image.repository") {
+		t.Fatalf("exported YAML dropped helm_config_values key:\n%s", exp.YAML)
+	}
+	if !strings.Contains(exp.YAML, def) {
+		t.Fatalf("exported YAML dropped helm_config_values default_value:\n%s", exp.YAML)
+	}
+}

--- a/aegislab/src/core/domain/chaossystem/service.go
+++ b/aegislab/src/core/domain/chaossystem/service.go
@@ -11,14 +11,14 @@ import (
 	"strings"
 	"time"
 
+	"aegis/boot/seed"
+	containerapi "aegis/core/domain/container"
+	"aegis/core/orchestrator/common"
 	"aegis/platform/config"
 	"aegis/platform/consts"
 	"aegis/platform/dto"
 	etcd "aegis/platform/etcd"
 	"aegis/platform/model"
-	"aegis/core/orchestrator/common"
-	containerapi "aegis/core/domain/container"
-	"aegis/boot/seed"
 
 	chaos "aegis/platform/chaos"
 	"github.com/sirupsen/logrus"
@@ -476,6 +476,7 @@ func (s *Service) ExportSeed(_ context.Context, name string) (*ExportSeedResp, e
 					RepoName:  helm.RepoName,
 					RepoURL:   helm.RepoURL,
 					Status:    int(consts.CommonEnabled),
+					Values:    exportHelmValues(helm.DynamicValues),
 				},
 			}},
 		})
@@ -536,11 +537,54 @@ type seedContainerVersionYAML struct {
 }
 
 type seedHelmConfigYAML struct {
-	Version   string `yaml:"version"`
-	ChartName string `yaml:"chart_name"`
-	RepoName  string `yaml:"repo_name"`
-	RepoURL   string `yaml:"repo_url"`
-	Status    int    `yaml:"status"`
+	Version   string              `yaml:"version"`
+	ChartName string              `yaml:"chart_name"`
+	RepoName  string              `yaml:"repo_name"`
+	RepoURL   string              `yaml:"repo_url"`
+	Status    int                 `yaml:"status"`
+	Values    []seedHelmValueYAML `yaml:"values,omitempty"`
+}
+
+// seedHelmValueYAML mirrors data.yaml's helm_config.values[] entry shape so an
+// exported snapshot round-trips back through the seed loader (issue #478:
+// helm_config_values is canonical runtime state and must survive export).
+type seedHelmValueYAML struct {
+	Key          string `yaml:"key"`
+	Type         int    `yaml:"type"`
+	Category     int    `yaml:"category"`
+	ValueType    int    `yaml:"value_type"`
+	DefaultValue string `yaml:"default_value"`
+	Overridable  bool   `yaml:"overridable"`
+}
+
+// exportHelmValues serializes the helm_config_values parameter_configs linked
+// to a HelmConfig into the data.yaml values[] shape. Only the helm-values
+// category is emitted; env-var rows live on a different join table.
+func exportHelmValues(params []model.ParameterConfig) []seedHelmValueYAML {
+	out := make([]seedHelmValueYAML, 0, len(params))
+	for i := range params {
+		p := &params[i]
+		if p.Category != consts.ParameterCategoryHelmValues {
+			continue
+		}
+		def := ""
+		if p.DefaultValue != nil {
+			def = *p.DefaultValue
+		}
+		out = append(out, seedHelmValueYAML{
+			Key:          p.Key,
+			Type:         int(p.Type),
+			Category:     int(p.Category),
+			ValueType:    int(p.ValueType),
+			DefaultValue: def,
+			Overridable:  p.Overridable,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // userIDFromCtx pulls the authenticated user ID for ownership stamping on


### PR DESCRIPTION
Closes #478.

## Decision: DB `helm_config_values` is canonical (approach b)

Documented in `aegis-chaos-design.md` §15: the live DB `helm_config_values` (merged with the `value_file` snapshot) is the canonical runtime source of truth; the repo seed (`data.yaml`) is genesis/bootstrap input, and `export-seed` is the audit round-trip back to git. Lifecycle: genesis seed → DB (canonical) → `export-seed` regenerates a git-committable snapshot.

## Enforcement: `aegisctl system diff-seed`

Pure-client drift gate (no new HTTP endpoint): compares the effective git values (overlay file + `data.yaml helm_config.values`) against live DB values (via existing `GetChaosSystemChartByName`), prints per-key drift, exits workflow-failure (code 5) on mismatch. CI / operators can call it.

## Correctness fix: ExportSeed was dropping helm_config_values

`chaossystem.Service.ExportSeed` silently omitted the `helm_config.values` block — an exported snapshot would lose every image override on re-seed. Now emits it (covered by a new test).

## ts drift reconciliation (repo → DB, opspai-canonical)

The ts images were migrated to the shanghai `pair-cn-shanghai.cr.volces.com/opspai/*` mirror (#483/#484); the live DB already carries those refs. The stale side was the repo overlay still pointing at guangzhou `pair`. Reconciled `data.yaml` (restored to opspai values) + `ts.yaml` overlay (flipped guangzhou→opspai, loadgen 023→024) so the repo matches the canonical DB.

## Deferred (justified in doc)

Full removal of `ts.yaml` / `otel-demo.yaml` overlay files. `value_file` is a live runtime input frozen at seed time and merged at install by `GetValuesMap`; deleting now would lose values on cold-start reseed (notably otel-demo per-component init-container array objects that can't be flat `helm_config_values` keys). Migration requires first making every overlay-only key DB-representable; until then `diff-seed` compares the effective merged values.

schema-changes-acknowledged: true

## Test plan
- [x] New: TestDiffSeedDetectsImageDrift, TestExportSeedEmitsHelmConfigValues; regression TestExportSeedRoundTrip + chaossystem/boot-seed suites pass.
- [x] backend `-tags duckdb_arrow` + aegisctl build green; golangci-lint `--new-from-rev` 0 new issues.
- [ ] Operator: `aegisctl system diff-seed --name ts --from-seed <dir>` against live DB to confirm zero drift post-reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)