### PR TITLE
feat(orchestrator): traffic-presence readiness gate + per-system warmup floor for cold-start inject

### DIFF
--- a/aegislab/manifests/byte-cluster/initial-data/data.yaml
+++ b/aegislab/manifests/byte-cluster/initial-data/data.yaml
@@ -1304,6 +1304,21 @@ dynamic_configs:
     is_secret: false
     min_value: -1
     max_value: 1
+  # Post-Ready warmup floor for RestartPedestal. HotelReservation goes
+  # pod-Ready fast but the load-generator ramps over a few minutes; the global
+  # 1-min default injects before traffic flows → empty abnormal window →
+  # no-spans BuildDatapack. The traffic-presence gate confirms spans before
+  # injecting; this floor bounds the wait when ClickHouse is unreachable and
+  # guards against the gate passing on a too-small early burst.
+  - key: injection.system.hs.warmup_seconds
+    default_value: '300'
+    value_type: 2
+    scope: 2
+    category: injection.system.warmup_seconds
+    description: Post-Ready warmup floor (seconds) for HotelReservation before fault injection
+    is_secret: false
+    min_value: 0
+    max_value: 1800
   - key: injection.system.sn.count
     default_value: '1'
     value_type: 2
@@ -1371,6 +1386,19 @@ dynamic_configs:
     category: injection.system.reclaim_mode
     description: NamespaceReclaimer action — "soft" (rollout restart non-DB) or empty/"full" (helm uninstall + ns delete)
     is_secret: false
+  # SocialNetwork's data-init-job seeds the social graph (init_social_graph)
+  # before the load-generator produces real traffic; that takes several
+  # minutes, so the global 1-min warmup default injected into a span-empty
+  # window. See hs.warmup_seconds for the gate/floor rationale.
+  - key: injection.system.sn.warmup_seconds
+    default_value: '420'
+    value_type: 2
+    scope: 2
+    category: injection.system.warmup_seconds
+    description: Post-Ready warmup floor (seconds) for SocialNetwork before fault injection
+    is_secret: false
+    min_value: 0
+    max_value: 1800
   - key: injection.system.media.count
     default_value: '1'
     value_type: 2
@@ -1434,6 +1462,18 @@ dynamic_configs:
     category: injection.system.reclaim_mode
     description: NamespaceReclaimer action — "soft" (rollout restart non-DB) or empty/"full" (helm uninstall + ns delete)
     is_secret: false
+  # MediaMicroservices seeds movies + users via the same data-init-job subchart
+  # as SocialNetwork; same multi-minute ramp before traffic flows. See
+  # hs.warmup_seconds for the gate/floor rationale.
+  - key: injection.system.media.warmup_seconds
+    default_value: '420'
+    value_type: 2
+    scope: 2
+    category: injection.system.warmup_seconds
+    description: Post-Ready warmup floor (seconds) for MediaMicroservices before fault injection
+    is_secret: false
+    min_value: 0
+    max_value: 1800
   - key: injection.system.teastore.count
     default_value: '1'
     value_type: 2

--- a/aegislab/src/core/orchestrator/freshness.go
+++ b/aegislab/src/core/orchestrator/freshness.go
@@ -16,8 +16,8 @@ import (
 
 	"aegis/platform/config"
 	"aegis/platform/consts"
-	"aegis/platform/dto"
 	db "aegis/platform/db"
+	"aegis/platform/dto"
 )
 
 // FreshnessProbe is the minimum surface waitForCHFreshness needs to read
@@ -69,8 +69,8 @@ func (p *clickHouseFreshnessProbe) MaxTraceTimestamp(ctx context.Context, namesp
 	defer func() { _ = conn.Close() }()
 
 	var (
-		row chrow.Row
-		ts  time.Time
+		row  chrow.Row
+		ts   time.Time
 		stmt string
 	)
 	// Why the Timestamp >= now() - INTERVAL 1 HOUR + max_partitions_to_read=2:
@@ -109,6 +109,60 @@ func (p *clickHouseFreshnessProbe) MaxTraceTimestamp(ctx context.Context, namesp
 		return time.Time{}, false, nil
 	}
 	return ts, true, nil
+}
+
+// trafficProbe is the seam the RestartPedestal traffic-presence gate needs:
+// "how many spans has this namespace emitted in the recent window". Kept
+// separate from FreshnessProbe so the BuildDatapack test fakes don't have to
+// grow a method they never exercise. The production clickHouseFreshnessProbe
+// satisfies both interfaces; the gate type-asserts deps.FreshnessProbe to
+// trafficProbe at the call site.
+type trafficProbe interface {
+	RecentSpanCount(ctx context.Context, namespace string, window time.Duration) (uint64, error)
+}
+
+// RecentSpanCount returns the number of spans this namespace has emitted into
+// otel.otel_traces within the trailing window. Used by the RestartPedestal
+// traffic-presence gate to confirm the freshly-bootstrapped workload is
+// actually generating traffic before computing the inject start time. Reuses
+// the same short-lived HTTP connection + service.namespace predicate as
+// MaxTraceTimestamp; the COUNT is bounded to the trailing window so it stays a
+// recent-granule scan rather than a full-partition aggregate.
+func (p *clickHouseFreshnessProbe) RecentSpanCount(ctx context.Context, namespace string, window time.Duration) (uint64, error) {
+	ctx, span := otel.Tracer("aegis/observability").Start(ctx, "observability/clickhouse/RecentSpanCount")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("db.system", "clickhouse"),
+		attribute.String("db.namespace", namespace),
+	)
+
+	if p.cfg == nil || p.cfg.Host == "" {
+		return 0, fmt.Errorf("clickhouse host not configured")
+	}
+	if window <= 0 {
+		window = time.Minute
+	}
+	conn, err := chdriver.Open(freshnessProbeOptions(p.cfg))
+	if err != nil {
+		return 0, fmt.Errorf("clickhouse open: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	windowSecs := int64(window / time.Second)
+	if windowSecs <= 0 {
+		windowSecs = 60
+	}
+	stmt := "SELECT count() FROM otel.otel_traces " +
+		"WHERE ResourceAttributes['service.namespace'] = ? " +
+		"AND Timestamp >= now() - INTERVAL ? SECOND " +
+		"SETTINGS max_partitions_to_read = 2"
+	span.SetAttributes(attribute.String("db.statement", truncateStmt(stmt, 500)))
+
+	var n uint64
+	if err := conn.QueryRow(ctx, stmt, namespace, windowSecs).Scan(&n); err != nil {
+		return 0, fmt.Errorf("clickhouse query count(): %w", err)
+	}
+	return n, nil
 }
 
 // freshnessProbeOptions builds the clickhouse-go/v2 driver options used by

--- a/aegislab/src/core/orchestrator/restart_pedestal.go
+++ b/aegislab/src/core/orchestrator/restart_pedestal.go
@@ -1,6 +1,7 @@
 package consumer
 
 import (
+	"aegis/core/orchestrator/common"
 	"aegis/platform/config"
 	"aegis/platform/consts"
 	"aegis/platform/dto"
@@ -8,7 +9,6 @@ import (
 	k8s "aegis/platform/k8s"
 	redis "aegis/platform/redis"
 	"aegis/platform/tracing"
-	"aegis/core/orchestrator/common"
 	"aegis/platform/utils"
 	"context"
 	"errors"
@@ -72,15 +72,98 @@ func restartWorkloadReadyTimeout() time.Duration {
 }
 
 // restartPostReadySoakDuration is the warmup window between workload-Ready
-// and the start of the normal-data window. Config key
-// `orchestrator.pedestal.warmup_seconds` (falls back to
-// consts.DefaultFixedPedestalWarmupSeconds).
-func restartPostReadySoakDuration() time.Duration {
+// and the start of the normal-data window. The per-system override
+// (`injection.system.<sys>.warmup_seconds`, exposed as cfg.Warmup()) wins when
+// set; otherwise it falls back to the global `orchestrator.pedestal.warmup_seconds`
+// and finally to consts.DefaultFixedPedestalWarmupSeconds. This duration is
+// the floor — even when the traffic-presence gate confirms spans earlier, the
+// inject time is never pulled in before readyAt + this soak.
+func restartPostReadySoakDuration(cfg config.ChaosSystemConfig) time.Duration {
+	if d := cfg.Warmup(); d > 0 {
+		return d
+	}
 	secs := config.GetInt("orchestrator.pedestal.warmup_seconds")
 	if secs <= 0 {
 		secs = consts.DefaultFixedPedestalWarmupSeconds
 	}
 	return time.Duration(secs) * time.Second
+}
+
+// trafficGateParams resolves the traffic-presence gate knobs from dynamic
+// config, falling back to the consts defaults. Read on each call so a runtime
+// etcd push applies without a rebuild (same pattern as the freshness probe).
+func trafficGateParams() (minSpans uint64, poll, timeout time.Duration) {
+	min := config.GetInt(consts.PedestalTrafficGateMinSpansKey)
+	if min <= 0 {
+		min = consts.DefaultPedestalTrafficGateMinSpans
+	}
+	p := config.GetInt(consts.PedestalTrafficGatePollKey)
+	if p <= 0 {
+		p = consts.DefaultPedestalTrafficGatePollSeconds
+	}
+	t := config.GetInt(consts.PedestalTrafficGateTimeoutKey)
+	if t <= 0 {
+		t = consts.DefaultPedestalTrafficGateTimeoutSeconds
+	}
+	return uint64(min), time.Duration(p) * time.Second, time.Duration(t) * time.Second
+}
+
+// waitForTrafficPresence polls ClickHouse for spans emitted by the target
+// namespace and returns once at least minSpans have arrived in the trailing
+// poll window. Returns true when traffic was confirmed; false (without error)
+// when the bounded timeout was exhausted or the probe is unavailable — the
+// caller then degrades to the fixed warmup timer rather than hard-failing.
+//
+// This is the correctness fix for cold-start DSB bootstraps (sn/media/hs):
+// pods go Ready in seconds but the chart's data-init-job + load-generator take
+// minutes to emit the first spans, so injecting at the fixed 1-min warmup
+// produced an empty abnormal window and a no-spans BuildDatapack.
+func waitForTrafficPresence(ctx context.Context, probe trafficProbe, namespace string, logEntry *logrus.Entry) bool {
+	if probe == nil {
+		logEntry.Warn("traffic-presence gate skipped: no ClickHouse probe wired; falling back to fixed warmup timer")
+		return false
+	}
+
+	minSpans, poll, timeout := trafficGateParams()
+	deadline := time.Now().Add(timeout)
+	attempt := 0
+	for {
+		attempt++
+		n, err := probe.RecentSpanCount(ctx, namespace, poll)
+		if err != nil {
+			// CH unreachable / misconfigured: don't block the restart on a
+			// probe we can't run. Degrade to the warmup timer (the per-system
+			// floor still applies). Logged at WARN so ops can see the gate was
+			// bypassed.
+			logEntry.WithError(err).WithField("namespace", namespace).
+				Warn("traffic-presence gate: ClickHouse probe failed; falling back to fixed warmup timer")
+			return false
+		}
+		logEntry.WithFields(logrus.Fields{
+			"attempt":    attempt,
+			"namespace":  namespace,
+			"span_count": n,
+			"min_spans":  minSpans,
+		}).Info("traffic-presence gate probe")
+		if n >= minSpans {
+			return true
+		}
+		if time.Now().After(deadline) {
+			logEntry.WithFields(logrus.Fields{
+				"namespace":  namespace,
+				"waited":     timeout.String(),
+				"span_count": n,
+				"min_spans":  minSpans,
+			}).Warn("traffic-presence gate timed out; falling back to fixed warmup timer")
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			logEntry.WithField("namespace", namespace).Warn("traffic-presence gate cancelled; falling back to fixed warmup timer")
+			return false
+		case <-time.After(poll):
+		}
+	}
 }
 
 // pedestalRestartTimeout returns the workload-readiness timeout for a
@@ -143,7 +226,10 @@ func extractPreDuration(injectPayload map[string]any) time.Duration {
 //
 // Followed by the post-ready soak, used to ensure the inject window doesn't
 // fire mid-warmup.
-func waitForPedestalWorkloadReady(ctx context.Context, gateway *k8s.Gateway, namespace string, readinessTimeout time.Duration) (time.Time, error) {
+func waitForPedestalWorkloadReady(ctx context.Context, gateway *k8s.Gateway, probe trafficProbe, cfg config.ChaosSystemConfig, namespace string, readinessTimeout time.Duration, logEntry *logrus.Entry) (time.Time, error) {
+	if logEntry == nil {
+		logEntry = logrus.NewEntry(logrus.StandardLogger())
+	}
 	if gateway == nil {
 		logrus.Warnf("k8s gateway is nil; skipping workload-ready wait for namespace %q", namespace)
 		return time.Now(), nil
@@ -161,27 +247,59 @@ func waitForPedestalWorkloadReady(ctx context.Context, gateway *k8s.Gateway, nam
 		return time.Time{}, err
 	}
 
-	soak := restartPostReadySoakDuration()
+	readyAt := time.Now()
+	soak := restartPostReadySoakDuration(cfg)
+
+	// Traffic-presence gate: prefer confirmed span flow over a blind timer.
+	// When the gate confirms traffic, the warmup floor (soak, measured from
+	// pod-Ready) still applies so we never inject before the per-system
+	// warmup_seconds elapses. When the gate times out or CH is unavailable we
+	// degrade silently to the fixed soak — the gate is a correctness
+	// optimization, not a new failure mode.
+	trafficConfirmed := waitForTrafficPresence(ctx, probe, namespace, logEntry)
+
+	floorReachedAt := readyAt.Add(soak)
+	if trafficConfirmed {
+		// Spans are flowing. Respect the warmup floor but don't soak further.
+		if remaining := time.Until(floorReachedAt); remaining > 0 {
+			if err := sleepCtx(ctx, remaining); err != nil {
+				return time.Time{}, err
+			}
+		}
+		return time.Now(), nil
+	}
+
 	if soak <= 0 {
 		return time.Now(), nil
 	}
 
-	var readyAt time.Time
+	var warmedAt time.Time
 	err := tracing.WithSpanNamed(ctx, "helm.post_ready_soak", func(c context.Context) error {
-		timer := time.NewTimer(soak)
-		defer timer.Stop()
-		select {
-		case <-c.Done():
-			return c.Err()
-		case <-timer.C:
-			readyAt = time.Now()
-			return nil
+		if remaining := time.Until(floorReachedAt); remaining > 0 {
+			if serr := sleepCtx(c, remaining); serr != nil {
+				return serr
+			}
 		}
+		warmedAt = time.Now()
+		return nil
 	})
 	if err != nil {
 		return time.Time{}, err
 	}
-	return readyAt, nil
+	return warmedAt, nil
+}
+
+// sleepCtx blocks for d, returning early with the context error if ctx is
+// cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func adjustInjectTimeAfterWarmup(injectTime, warmupReadyAt time.Time, injectPayload map[string]any) time.Time {
@@ -531,10 +649,15 @@ func executeRestartPedestal(ctx context.Context, task *dto.UnifiedTask, deps Run
 		tokens.warming = true
 		logEntry.Infof("acquired warming token for ns %s", namespace)
 
+		// deps.FreshnessProbe is the shared clickHouseFreshnessProbe (wired in
+		// worker/module.go); it also satisfies trafficProbe. The assertion is
+		// nil-safe — a nil or non-trafficProbe value yields a nil probe and
+		// the gate degrades to the fixed warmup timer.
+		trafficGateProbe, _ := deps.FreshnessProbe.(trafficProbe)
 		var warmupReadyAt time.Time
 		err = tracing.WithSpanNamed(childCtx, "helm.wait_ready", func(c context.Context) error {
 			var werr error
-			warmupReadyAt, werr = waitForPedestalWorkloadReady(c, deps.K8sGateway, namespace, pedestalRestartTimeout())
+			warmupReadyAt, werr = waitForPedestalWorkloadReady(c, deps.K8sGateway, trafficGateProbe, cfg, namespace, pedestalRestartTimeout(), logEntry)
 			return werr
 		})
 		if err != nil {

--- a/aegislab/src/core/orchestrator/traffic_gate_test.go
+++ b/aegislab/src/core/orchestrator/traffic_gate_test.go
@@ -1,0 +1,111 @@
+package consumer
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+
+	"aegis/platform/config"
+	"aegis/platform/consts"
+)
+
+// fakeTrafficProbe returns a scripted span count per call. A negative entry
+// signals a probe error for that call.
+type fakeTrafficProbe struct {
+	counts []int
+	calls  atomic.Int32
+}
+
+func (f *fakeTrafficProbe) RecentSpanCount(_ context.Context, _ string, _ time.Duration) (uint64, error) {
+	i := int(f.calls.Add(1)) - 1
+	v := f.counts[len(f.counts)-1]
+	if i < len(f.counts) {
+		v = f.counts[i]
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("clickhouse unreachable")
+	}
+	return uint64(v), nil
+}
+
+// setGateConfig shrinks the poll to 1s so the gate loop runs fast under the
+// 60s test budget; iteration count is bounded by the scripted probe.
+func setGateConfig(t *testing.T, minSpans, timeoutSecs int) {
+	t.Helper()
+	viper.Set(consts.PedestalTrafficGateMinSpansKey, minSpans)
+	viper.Set(consts.PedestalTrafficGatePollKey, 1)
+	viper.Set(consts.PedestalTrafficGateTimeoutKey, timeoutSecs)
+	t.Cleanup(func() {
+		viper.Set(consts.PedestalTrafficGateMinSpansKey, nil)
+		viper.Set(consts.PedestalTrafficGatePollKey, nil)
+		viper.Set(consts.PedestalTrafficGateTimeoutKey, nil)
+	})
+}
+
+func TestWaitForTrafficPresence_TrafficSeenReturnsTrue(t *testing.T) {
+	setGateConfig(t, 50, 5)
+	probe := &fakeTrafficProbe{counts: []int{0, 10, 75}}
+
+	got := waitForTrafficPresence(context.Background(), probe, "sn0", logrus.NewEntry(logrus.New()))
+	if !got {
+		t.Fatalf("expected gate to confirm traffic once span_count >= min_spans, got false")
+	}
+}
+
+func TestWaitForTrafficPresence_TimeoutFallsBack(t *testing.T) {
+	setGateConfig(t, 50, 1)
+	// Always below threshold → gate must exhaust the bounded timeout and fall
+	// back (return false) rather than block forever.
+	probe := &fakeTrafficProbe{counts: []int{0, 1, 2}}
+
+	got := waitForTrafficPresence(context.Background(), probe, "sn0", logrus.NewEntry(logrus.New()))
+	if got {
+		t.Fatalf("expected gate to fall back to timer (false) when threshold never met, got true")
+	}
+}
+
+func TestWaitForTrafficPresence_ProbeErrorFallsBack(t *testing.T) {
+	setGateConfig(t, 50, 1)
+	probe := &fakeTrafficProbe{counts: []int{-1}}
+
+	got := waitForTrafficPresence(context.Background(), probe, "sn0", logrus.NewEntry(logrus.New()))
+	if got {
+		t.Fatalf("expected gate to fall back (false) on probe error, got true")
+	}
+}
+
+func TestWaitForTrafficPresence_NilProbeFallsBack(t *testing.T) {
+	got := waitForTrafficPresence(context.Background(), nil, "sn0", logrus.NewEntry(logrus.New()))
+	if got {
+		t.Fatalf("expected gate to fall back (false) when no probe is wired, got true")
+	}
+}
+
+func TestRestartPostReadySoakDuration_PerSystemWarmupWins(t *testing.T) {
+	viper.Set("orchestrator.pedestal.warmup_seconds", 60)
+	t.Cleanup(func() { viper.Set("orchestrator.pedestal.warmup_seconds", nil) })
+
+	withOverride := config.ChaosSystemConfig{WarmupSeconds: 420}
+	if got := restartPostReadySoakDuration(withOverride); got != 420*time.Second {
+		t.Fatalf("per-system warmup_seconds should win: got %s, want 420s", got)
+	}
+
+	noOverride := config.ChaosSystemConfig{}
+	if got := restartPostReadySoakDuration(noOverride); got != 60*time.Second {
+		t.Fatalf("no per-system override should fall back to global warmup_seconds: got %s, want 60s", got)
+	}
+}
+
+func TestRestartPostReadySoakDuration_FallsBackToConstDefault(t *testing.T) {
+	viper.Set("orchestrator.pedestal.warmup_seconds", nil)
+
+	if got := restartPostReadySoakDuration(config.ChaosSystemConfig{}); got != consts.DefaultFixedPedestalWarmupSeconds*time.Second {
+		t.Fatalf("with neither override nor global set, want const default %ds, got %s",
+			consts.DefaultFixedPedestalWarmupSeconds, got)
+	}
+}

--- a/aegislab/src/platform/config/chaos_system.go
+++ b/aegislab/src/platform/config/chaos_system.go
@@ -54,6 +54,18 @@ type ChaosSystemConfig struct {
 	// `injection.system.<sys>.readiness_timeout_seconds`. Zero / unset falls
 	// back to DefaultReadinessTimeoutSeconds (900 = 15 min).
 	ReadinessTimeoutSeconds int `mapstructure:"readiness_timeout_seconds"`
+	// WarmupSeconds is the post-Ready soak this system needs before its
+	// workload emits enough traffic to inject against. It acts both as a floor
+	// (RestartPedestal never injects earlier than this even when the
+	// traffic-presence gate confirms spans sooner) and as the fallback bound
+	// when ClickHouse is unreachable and the gate cannot run. DSB systems
+	// (SocialNetwork, MediaMicroservices, HotelReservation) chain a
+	// data-init-job + load-generator ramp that takes several minutes; the
+	// global default (consts.DefaultFixedPedestalWarmupSeconds = 1 min) is far
+	// too short for them. Per-system override via etcd key
+	// `injection.system.<sys>.warmup_seconds`. Zero / unset falls back to the
+	// global `orchestrator.pedestal.warmup_seconds` (resolved by the caller).
+	WarmupSeconds int `mapstructure:"warmup_seconds"`
 	// ReclaimMode selects the NamespaceReclaimer action when this system's
 	// namespace becomes reclaim-eligible. "soft" → rollout restart of non-DB
 	// deployments (preserves helm release + DB state). Empty / anything else
@@ -77,6 +89,17 @@ func (s *ChaosSystemConfig) ReadinessTimeout() time.Duration {
 		secs = DefaultReadinessTimeoutSeconds
 	}
 	return time.Duration(secs) * time.Second
+}
+
+// Warmup returns the per-system post-Ready warmup duration, or zero when the
+// system has no override. A zero result tells the caller to fall back to the
+// global `orchestrator.pedestal.warmup_seconds` default. Kept as a duration
+// (not a raw int) so call sites don't repeat the seconds conversion.
+func (s *ChaosSystemConfig) Warmup() time.Duration {
+	if s.WarmupSeconds <= 0 {
+		return 0
+	}
+	return time.Duration(s.WarmupSeconds) * time.Second
 }
 
 // chaosSystemConfigManager is now a stateless façade over Viper — every call

--- a/aegislab/src/platform/consts/consts.go
+++ b/aegislab/src/platform/consts/consts.go
@@ -471,10 +471,26 @@ const (
 	// service.namespace, or the bounded retry budget is exhausted. The
 	// two keys are read on every probe via config.GetInt so a runtime
 	// `aegisctl etcd put` applies without a backend rebuild.
-	MaxTokensKeyBuildDatapackFreshnessWatermark    = "rate_limiting.build_datapack_freshness_watermark_seconds"
-	MaxTokensKeyBuildDatapackFreshnessMaxWait      = "rate_limiting.build_datapack_freshness_max_wait_seconds"
-	DefaultBuildDatapackFreshnessWatermarkSeconds  = 30
-	DefaultBuildDatapackFreshnessMaxWaitSeconds    = 300
+	MaxTokensKeyBuildDatapackFreshnessWatermark   = "rate_limiting.build_datapack_freshness_watermark_seconds"
+	MaxTokensKeyBuildDatapackFreshnessMaxWait     = "rate_limiting.build_datapack_freshness_max_wait_seconds"
+	DefaultBuildDatapackFreshnessWatermarkSeconds = 30
+	DefaultBuildDatapackFreshnessMaxWaitSeconds   = 300
+
+	// RestartPedestal traffic-presence readiness gate. After the pedestal
+	// workload reports Ready, the executor polls otel.otel_traces for spans
+	// from the target namespace and only treats the namespace as warmed once
+	// traffic is confirmed flowing. Closes the cold-start race where DSB
+	// charts go pod-Ready in seconds but their data-init-job + load-generator
+	// take minutes to emit the first spans — injecting at the fixed 1-min
+	// warmup produced an empty abnormal window and a no-spans BuildDatapack.
+	// All three keys are read via config.GetInt so a runtime etcd push applies
+	// without a backend rebuild.
+	PedestalTrafficGateMinSpansKey           = "orchestrator.pedestal.traffic_gate_min_spans"
+	PedestalTrafficGatePollKey               = "orchestrator.pedestal.traffic_gate_poll_seconds"
+	PedestalTrafficGateTimeoutKey            = "orchestrator.pedestal.traffic_gate_timeout_seconds"
+	DefaultPedestalTrafficGateMinSpans       = 50
+	DefaultPedestalTrafficGatePollSeconds    = 15
+	DefaultPedestalTrafficGateTimeoutSeconds = 600
 
 	// Algorithm execution rate limiting
 	AlgoExecutionTokenBucket   = "token_bucket:algo_execution"


### PR DESCRIPTION
## Problem

Cold-start bootstrap of DSB sn/media via `inject guided --auto --allow-bootstrap` runs end-to-end (RestartPedestal → inject → BuildDatapack) but BuildDatapack fails on **no-spans**. RestartPedestal waited for pod-Ready (`checkNamespaceWorkloadsReady` — verifies Deployment/StatefulSet/DaemonSet/Job readyReplicas, which is correct) then only a **fixed 1-min** soak (`DefaultFixedPedestalWarmupSeconds`) before computing the inject window. DSB pods go Ready fast but the chart's `data-init-job` (init_social_graph / register_movies) + load-generator ramp take several minutes, so the abnormal window had zero traffic. Verified today: both sn and media cold injects failed identically at `datapack.build.failed` ~1 min after `restart.pedestal.completed`.

## Fix (both, per request)

**1. Traffic-presence gate (primary).** After pod-state-Ready, poll ClickHouse for spans from the target namespace and only proceed once traffic is confirmed flowing. In-process via the existing `RuntimeDeps.FreshnessProbe` (already wired in runtime-worker) — added `RecentSpanCount(ctx, ns, window)` reusing the freshness probe's connection pattern, exposed through a small `trafficProbe` interface (type-asserted, nil-safe). Defaults: `traffic_gate_min_spans=50`, `traffic_gate_poll_seconds=15`, `traffic_gate_timeout_seconds=600`. On timeout / probe error / nil probe → logs WARN and **degrades to the fixed soak** (no hard fail — the gate is a correctness optimization, not a new failure mode).

**2. Per-system warmup floor (fallback).** `ChaosSystemConfig.WarmupSeconds` + `Warmup()` (mirrors `readiness_timeout_seconds`); `restartPostReadySoakDuration(cfg)` prefers it over the global `orchestrator.pedestal.warmup_seconds`. The gate never injects before `readyAt + warmup`. Seeded `injection.system.{hs:300, sn:420, media:420}.warmup_seconds`.

New chain: **workload pod-state Ready → traffic present (≥N spans) → warmup floor → inject.**

No aegisctl flags changed (config-driven) → no schema-gate token.

## Test plan
- [x] `go build -tags duckdb_arrow ./main.go` + aegisctl green; golangci-lint `--new-from-rev` clean; new `traffic_gate_test.go` (traffic-seen→ready / timeout→timer fallback / per-system floor).
- [ ] Rebuild + redeploy rcabench-chaos AND runtime-worker (RP runs in worker), apply warmup seeds to etcd, then clean cold-start sn/media → BuildDatapack green (validating now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)