### PR TITLE
fix(seed): align teastore/media namespace prefix with system name (fixes inject-by-namespace 500)

### DIFF
--- a/aegislab/data/initial_data/prod/data.yaml
+++ b/aegislab/data/initial_data/prod/data.yaml
@@ -799,14 +799,14 @@ dynamic_configs:
     min_value: 1
     max_value: 20
   - key: injection.system.media.ns_pattern
-    default_value: ^mm\d+$
+    default_value: ^media\d+$
     value_type: 0
     scope: 2
     category: injection.system.ns_pattern
     description: Namespace pattern for system MediaMicroservices instances
     is_secret: false
   - key: injection.system.media.extract_pattern
-    default_value: ^(mm)(\d+)$
+    default_value: ^(media)(\d+)$
     value_type: 0
     scope: 2
     category: injection.system.extract_pattern
@@ -852,14 +852,14 @@ dynamic_configs:
     min_value: 1
     max_value: 20
   - key: injection.system.teastore.ns_pattern
-    default_value: ^tea\d+$
+    default_value: ^teastore\d+$
     value_type: 0
     scope: 2
     category: injection.system.ns_pattern
     description: Namespace pattern for system TeaStore instances
     is_secret: false
   - key: injection.system.teastore.extract_pattern
-    default_value: ^(tea)(\d+)$
+    default_value: ^(teastore)(\d+)$
     value_type: 0
     scope: 2
     category: injection.system.extract_pattern

--- a/aegislab/manifests/byte-cluster/initial-data/data.yaml
+++ b/aegislab/manifests/byte-cluster/initial-data/data.yaml
@@ -1381,14 +1381,14 @@ dynamic_configs:
     min_value: 1
     max_value: 20
   - key: injection.system.media.ns_pattern
-    default_value: ^mm\d+$
+    default_value: ^media\d+$
     value_type: 0
     scope: 2
     category: injection.system.ns_pattern
     description: Namespace pattern for system MediaMicroservices instances
     is_secret: false
   - key: injection.system.media.extract_pattern
-    default_value: ^(mm)(\d+)$
+    default_value: ^(media)(\d+)$
     value_type: 0
     scope: 2
     category: injection.system.extract_pattern
@@ -1444,14 +1444,14 @@ dynamic_configs:
     min_value: 1
     max_value: 20
   - key: injection.system.teastore.ns_pattern
-    default_value: ^tea\d+$
+    default_value: ^teastore\d+$
     value_type: 0
     scope: 2
     category: injection.system.ns_pattern
     description: Namespace pattern for system TeaStore instances
     is_secret: false
   - key: injection.system.teastore.extract_pattern
-    default_value: ^(tea)(\d+)$
+    default_value: ^(teastore)(\d+)$
     value_type: 0
     scope: 2
     category: injection.system.extract_pattern

--- a/aegislab/regression/mediamicroservices-guided.yaml
+++ b/aegislab/regression/mediamicroservices-guided.yaml
@@ -23,7 +23,7 @@ submit:
   specs:
     - - system: media
         system_type: media
-        namespace: mm0
+        namespace: media0
         app: user-service
         chaos_type: PodKill
 validation:

--- a/aegislab/regression/teastore-guided.yaml
+++ b/aegislab/regression/teastore-guided.yaml
@@ -23,7 +23,7 @@ submit:
   specs:
     - - system: teastore
         system_type: teastore
-        namespace: tea0
+        namespace: teastore0
         app: auth
         chaos_type: PodKill
 validation:

--- a/aegislab/src/cli/cmd/pedestal_reclaim.go
+++ b/aegislab/src/cli/cmd/pedestal_reclaim.go
@@ -93,8 +93,8 @@ var systemNsPatterns = map[string]string{
 	"hs":        `^hs\d+$`,
 	"ts":        `^ts\d+$`,
 	"sn":        `^sn\d+$`,
-	"mm":        `^mm\d+$`,
-	"tea":       `^tea\d+$`,
+	"media":     `^media\d+$`,
+	"teastore":  `^teastore\d+$`,
 	"sockshop":  `^sockshop\d+$`,
 	"otel-demo": `^otel-demo\d+$`,
 }

--- a/aegislab/src/core/domain/injection/guided_submit_test.go
+++ b/aegislab/src/core/domain/injection/guided_submit_test.go
@@ -117,6 +117,31 @@ func TestParseBatchGuidedSpecs(t *testing.T) {
 	require.Equal(t, cfg.ChaosType, item.guidedConfigs[0].ChaosType)
 }
 
+func TestParseBatchGuidedSpecsSystemTypeDerivation(t *testing.T) {
+	base := sampleGuidedConfig()
+
+	t.Run("namespace-form code matches multi-letter pedestal", func(t *testing.T) {
+		cfg := base
+		cfg.System = "teastore0"
+		_, _, err := parseBatchGuidedSpecs(context.Background(), "teastore", 0, []guidedcli.GuidedConfig{cfg})
+		require.NoError(t, err)
+	})
+
+	t.Run("prefix not equal to pedestal name is rejected", func(t *testing.T) {
+		cfg := base
+		cfg.System = "tea0"
+		_, _, err := parseBatchGuidedSpecs(context.Background(), "teastore", 0, []guidedcli.GuidedConfig{cfg})
+		require.ErrorContains(t, err, "mismatched system type tea for pedestal teastore")
+	})
+
+	t.Run("empty system skips the check", func(t *testing.T) {
+		cfg := base
+		cfg.System = ""
+		_, _, err := parseBatchGuidedSpecs(context.Background(), "teastore", 0, []guidedcli.GuidedConfig{cfg})
+		require.NoError(t, err)
+	})
+}
+
 func TestParseBatchGuidedSpecsWarnsOnDuplicateServices(t *testing.T) {
 	cfg := sampleGuidedConfig()
 


### PR DESCRIPTION
## Problem

Guided inject resolved **by namespace** 500s for teastore and media:
```
failed to parse guided spec batch 0: mismatched system type tea for pedestal teastore at index 0
```
Root cause (`src/core/domain/injection/submit.go:286`): `system_type` is derived as `stripTrailingDigits(namespace)`, so `tea0` → `tea`, but the pedestal/system is named `teastore` → mismatch → HTTP 500. Same for media (`mm0` → `mm` ≠ `media`). Systems where the ns prefix already equals the system name (sn, hs, ts, sockshop, otel-demo) were never affected.

## Fix (naming consistency — per request)

Align the namespace prefix with the system name so every system has **ns-prefix == system-name == pedestal-name** (and the existing `deployment-teastore-collector` / `deployment-media-collector` OTel routing already matches):
- teastore: ns_pattern `^tea\d+$` → `^teastore\d+$`, extract `^(tea)(\d+)$` → `^(teastore)(\d+)$` (namespaces become `teastore0`…)
- media: `^mm\d+$` → `^media\d+$`, `^(mm)(\d+)$` → `^(media)(\d+)$` (namespaces become `media0`…)

No code-side derivation change needed — once namespaces are `teastore0`/`media0`, `stripTrailingDigits` returns the right system name.

### Changed
- `manifests/byte-cluster/initial-data/data.yaml` + `data/initial_data/prod/data.yaml`: the 4 ns_pattern/extract_pattern values.
- `src/cli/cmd/pedestal_reclaim.go`: built-in `systemNsPatterns` map keys+values (so `pedestal reclaim` still recognizes the renamed namespaces). Internal map only — no cobra flag changed, **no schema-changes-acknowledged needed**.
- `regression/teastore-guided.yaml` (`tea0`→`teastore0`), `regression/mediamicroservices-guided.yaml` (`mm0`→`media0`).
- New test `TestParseBatchGuidedSpecsSystemTypeDerivation`.

### Deliberately left as-is (self-consistent, unrelated)
`data/initial_data/staging/data.yaml` (system NAME is the short code `mm`/`tea` there — prefix==name already), test fixtures using `tea`/`mm` as arbitrary short codes, and the kind-only runbook (`manifests/kind/lgu-fork-systems.md`).

## Deploy implication
Existing `tea0`/`mm0` namespaces won't match the new patterns — after merge + reseed, reclaim/clean them manually; allocator creates `teastore0`/`media0` going forward.

## Test plan
- [x] backend `-tags duckdb_arrow` + aegisctl build green; golangci-lint `--new-from-rev` 0 issues; injection + reclaim tests green; YAML parses.
- [ ] After merge: reseed byte-cluster, clean stale tea0/mm0, then `inject guided --namespace teastore0 ...` no longer 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)