### PR TITLE
fix(aegis-points): substitute real chart_version on PointManifest import so supersede works

### DIFF
--- a/aegislab/docs/aegis-chaos/point-manifest-spec.md
+++ b/aegislab/docs/aegis-chaos/point-manifest-spec.md
@@ -143,8 +143,14 @@ Bumping `chart_version` is how the catalog rotates — each install of a
 new chart version writes a fresh PointManifest row binding to that
 version. Historical rows survive for reproducibility (ADR-0008).
 
-In chart-bound delivery (§7), helm fills this in via templating —
-authors don't hardcode it.
+In chart-bound delivery (§7), the import overrides whatever `chart_version`
+is baked into the manifest file with the consumer chart's actual
+`.Chart.Version`: the library Job runs `aegisctl manifest import-dir
+--chart-version {{ .Chart.Version }}`. So authors can leave a placeholder
+(e.g. `seed-genesis`) in the file — the version that lands in `chaos_points`
+is the chart's, which is what the supersede logic keys on. Standalone
+`aegisctl manifest import` without `--chart-version` uses the file value
+verbatim.
 
 ## 7. Chart-bound integration (the canonical delivery path)
 
@@ -197,7 +203,10 @@ ships. No manual `aegisctl manifest import` step.
    ```
 
 3. Put one PointManifest per service under `aegis-points/<service>.yaml`
-   inside your chart, and set the required values in `values.yaml`:
+   inside your chart, and set the required values in `values.yaml`. The
+   `metadata.chart_version` in each file is a placeholder — the library Job
+   overrides it with `{{ .Chart.Version }}` at import time (§6), so a single
+   literal like `seed-genesis` is fine across all files:
 
    ```yaml
    aegis:

--- a/aegislab/helm/aegis-points/README.md
+++ b/aegislab/helm/aegis-points/README.md
@@ -15,8 +15,12 @@ at least one file matching `aegis-points/*.yaml`, the include emits:
 
 1. A `ConfigMap` with every `aegis-points/*.yaml` mounted as a key
    (hook weight `-6`).
-2. A `Job` that runs `aegisctl manifest import-dir /etc/aegis-points`
-   on `post-install` / `post-upgrade` (hook weight `-5`, `backoffLimit: 0`).
+2. A `Job` that runs `aegisctl manifest import-dir /etc/aegis-points
+   --chart-version {{ .Chart.Version }}` on `post-install` / `post-upgrade`
+   (hook weight `-5`, `backoffLimit: 0`). The `--chart-version` override
+   binds every imported point to the consumer chart's actual version, so a
+   chart upgrade supersedes the prior version's points instead of upserting
+   over a stale literal (point-manifest-spec §6).
 
 Slots between the system-onboard Job (`-10`, ships separately via #458)
 and the consumer chart's workloads (`0`).
@@ -45,7 +49,9 @@ manifests.
    ```
 
 3. Put one PointManifest per service under your chart at
-   `aegis-points/<service>.yaml` and add the required values:
+   `aegis-points/<service>.yaml` (the `metadata.chart_version` in each file
+   is a placeholder — the Job overrides it with `{{ .Chart.Version }}`) and
+   add the required values:
 
    ```yaml
    aegis:

--- a/aegislab/helm/aegis-points/templates/_aegis-points.tpl
+++ b/aegislab/helm/aegis-points/templates/_aegis-points.tpl
@@ -13,6 +13,11 @@ When enabled, it emits a Job + ConfigMap that POSTs every
 aegis-points/*.yaml under the consumer chart to
 /v1beta/systems/{sys}/points/import via 'aegisctl manifest import-dir'.
 
+The import passes --chart-version {{ .Chart.Version }} so every point binds
+to the consumer chart's actual version, not the chart_version literal baked
+into the manifest files. This is what lets a chart upgrade supersede the
+prior version's points (point-manifest-spec §6/§7).
+
 Hook weight ordering (pairs with #458 onboard Job):
 
   -10  aegis-onboard-job        (system identity + chart binding)
@@ -104,6 +109,8 @@ spec:
             - manifest
             - import-dir
             - /etc/aegis-points
+            - --chart-version
+            - {{ .Chart.Version | quote }}
             {{- if $keepGoing }}
             - --keep-going
             {{- end }}

--- a/aegislab/src/cli/cmd/manifest.go
+++ b/aegislab/src/cli/cmd/manifest.go
@@ -34,6 +34,8 @@ var (
 
 	flagImportDirConcurrency int
 	flagImportDirKeepGoing   bool
+
+	flagImportChartVersion string
 )
 
 var manifestCmd = &cobra.Command{
@@ -227,6 +229,9 @@ func manifestToImportReq(raw []byte) (apiclient.ChaosChaosImportPointsReq, strin
 	}
 	if req.Metadata == nil || req.Metadata.System == nil || *req.Metadata.System == "" {
 		return apiclient.ChaosChaosImportPointsReq{}, "", usageErrorf("manifest metadata.system is required")
+	}
+	if flagImportChartVersion != "" {
+		req.Metadata.SetChartVersion(flagImportChartVersion)
 	}
 	return req, *req.Metadata.System, nil
 }
@@ -603,6 +608,13 @@ func init() {
 
 	manifestImportDirCmd.Flags().IntVar(&flagImportDirConcurrency, "concurrency", 4, "Max parallel imports")
 	manifestImportDirCmd.Flags().BoolVar(&flagImportDirKeepGoing, "keep-going", false, "Continue past per-file failures (exit non-zero if any failed)")
+
+	for _, c := range []*cobra.Command{manifestImportCmd, manifestImportDirCmd} {
+		c.Flags().StringVar(&flagImportChartVersion, "chart-version", "",
+			"Override metadata.chart_version on every imported manifest. Chart-bound "+
+				"hooks pass the consumer chart's {{ .Chart.Version }} so points bind to "+
+				"the real chart version instead of the file literal (point-manifest-spec §6/§7).")
+	}
 
 	manifestCmd.AddCommand(manifestValidateCmd)
 	manifestCmd.AddCommand(manifestImportCmd)

--- a/aegislab/src/cli/cmd/manifest_test.go
+++ b/aegislab/src/cli/cmd/manifest_test.go
@@ -109,6 +109,44 @@ func TestManifestImport_DryRun_SendsCorrectPathBodyAndQuery(t *testing.T) {
 	}
 }
 
+func TestManifestImport_ChartVersionOverride(t *testing.T) {
+	captureChartVersion := func(t *testing.T, extraArgs ...string) string {
+		t.Helper()
+		var gotChartVersion string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			var sent map[string]any
+			_ = json.Unmarshal(body, &sent)
+			if md, ok := sent["metadata"].(map[string]any); ok {
+				if cv, ok := md["chart_version"].(string); ok {
+					gotChartVersion = cv
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"upserted":1,"superseded":0,"dry_run":true,"point_ids":["abc"]}}`))
+		}))
+		defer srv.Close()
+		t.Setenv("AEGIS_CHAOS_SERVER", srv.URL)
+
+		args := append([]string{"manifest", "import", "--dry-run"}, extraArgs...)
+		args = append(args, "testdata/manifest-valid.yaml")
+		if rc := executeArgs(args); rc != 0 {
+			t.Fatalf("import returned non-zero: %d", rc)
+		}
+		return gotChartVersion
+	}
+
+	resetManifestTestState(t)
+	if got := captureChartVersion(t, "--chart-version", "9.9.9"); got != "9.9.9" {
+		t.Errorf("with --chart-version: forwarded chart_version got %q want 9.9.9", got)
+	}
+
+	resetManifestTestState(t)
+	if got := captureChartVersion(t); got != "v3.2.0" {
+		t.Errorf("without --chart-version: forwarded chart_version got %q want file value v3.2.0", got)
+	}
+}
+
 func TestResolveChaosServer_DefaultsToGatewayUnderServer(t *testing.T) {
 	resetManifestTestState(t)
 	t.Setenv(chaosServerEnv, "")
@@ -249,6 +287,7 @@ func resetManifestTestState(t *testing.T) {
 	flagQuiet = true
 	flagImportDirConcurrency = 0
 	flagImportDirKeepGoing = false
+	flagImportChartVersion = ""
 	chaosServerDeprecationOnce = sync.Once{}
 }
 


### PR DESCRIPTION
## Problem

Chart-bound PointManifest imports always registered points with the file-literal `metadata.chart_version` (`seed-genesis`) regardless of the real chart version — the `aegis-points` library Job mounts manifests verbatim and `aegisctl manifest import` reads chart_version straight from the file, with no substitution (spec §7 overstated "helm fills this in").

This breaks **supersede**: `chart_version` is part of `PointIdentity` → `ServiceBoundPointID` (`src/crud/chaos/import.go:159-179`). When old and new chart versions both import as `seed-genesis`, the point IDs are identical → upsert no-op, never supersede. Each chart version must produce a distinct point-ID set so `replace_scope: service` retires the prior version's active points.

## Fix (approach b)

- Added CLI-only `--chart-version` to `aegisctl manifest import` + `import-dir`: rewrites `metadata.chart_version` on each parsed request (the DTO field `Metadata.SetChartVersion` already existed — no server/DTO/SDK change).
- Library Job template (`helm/aegis-points/templates/_aegis-points.tpl`) now passes `--chart-version {{ .Chart.Version }}`. Verified via helm-template fixture that inside the library named-template `.Chart.Version` resolves to the **consumer** chart's version (rendered 7.7.7), not the library's.
- Updated `point-manifest-spec.md` §7 + README to match what's implemented (code is source of truth).
- Test `TestManifestImport_ChartVersionOverride` (override wins / absent falls back to file value).

schema-changes-acknowledged: true

## Follow-ups (noted, not done here)
- The 3 fork PRs (DeathStarBench#61, TeaStore#12, sockshop#26) vendor the OLD library chart → need a re-vendor to pick up the `--chart-version` Job arg.
- Consumer charts must pin an `aegis.aegisctlImage` new enough to recognize `--chart-version` (older image would reject the flag and fail the import Job).

## Test plan
- [x] backend + aegisctl build green; golangci-lint `--new-from-rev` clean; `helm lint`/`template` render; new unit test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)