### PR TITLE
fix(datapack): clamp abnormal window to planned end for one-shot chaos (PodKill empty-datapack)

### DIFF
--- a/aegislab/src/crud/hooks/chaos/handler.go
+++ b/aegislab/src/crud/hooks/chaos/handler.go
@@ -173,6 +173,16 @@ func (h *Handler) fireOnce(parentCtx context.Context, id, kind, terminal string,
 	if !finishedAt.IsZero() {
 		dp.EndTime = finishedAt
 	}
+	// One-shot chaos (PodKill, PodFailure with grace 0) completes the CR
+	// almost instantly, so finishedAt collapses to ~startedAt and the
+	// abnormal window never accumulates post-fault traffic — BuildDatapack's
+	// CH freshness probe (build_datapack.go) is satisfied immediately and
+	// prepare_inputs.py reads a near-empty abnormal_traces window. Duration
+	// chaos (NetworkDelay etc.) runs the CR for the full FixedAbnormalWindow,
+	// so finishedAt already sits at the planned end. Clamp EndTime up to the
+	// planned abnormal-window end so both paths defer the build until the
+	// post-fault observation window has elapsed.
+	dp.EndTime = clampAbnormalWindowEnd(dp.StartTime, dp.EndTime)
 
 	// chaos webhook path (id is the chaos-service ULID) needs a shadow
 	// fault_injections row so audit + BuildDatapack's FI-by-ID lookup work.
@@ -340,7 +350,7 @@ func (h *Handler) getOrCreateShadowFaultInjection(ctx context.Context, chaosInje
 		row.StartTime = &t
 	}
 	if !finishedAt.IsZero() {
-		t := finishedAt
+		t := clampAbnormalWindowEnd(startedAt, finishedAt)
 		row.EndTime = &t
 	}
 
@@ -374,6 +384,23 @@ func (h *Handler) getOrCreateShadowFaultInjection(ctx context.Context, chaosInje
 func (h *Handler) recordGate(ctx context.Context, id, kind, terminal string) error {
 	_, err := h.claimGate(ctx, id, kind, terminal)
 	return err
+}
+
+// clampAbnormalWindowEnd returns the later of the observed end and the
+// planned abnormal-window end (start + FixedAbnormalWindowSeconds). The
+// planned window is the protocol invariant every chaos spec is pinned to
+// (GuidedToChaosParams sets duration_s = FixedAbnormalWindowSeconds);
+// duration-based chaos already finishes there, so its end is unchanged.
+// A zero start (legacy CRD path that omits timestamps) is left untouched.
+func clampAbnormalWindowEnd(start, end time.Time) time.Time {
+	if start.IsZero() {
+		return end
+	}
+	planned := start.Add(consts.FixedAbnormalWindowSeconds * time.Second)
+	if planned.After(end) {
+		return planned
+	}
+	return end
 }
 
 func isTerminalSingleton(s string) bool {

--- a/aegislab/src/crud/hooks/chaos/handler_test.go
+++ b/aegislab/src/crud/hooks/chaos/handler_test.go
@@ -413,6 +413,59 @@ func TestSingletonCreatesShadowFaultInjection(t *testing.T) {
 	}
 }
 
+// TestOneShotChaosExtendsAbnormalWindow pins the one-shot timing fix: a
+// PodKill-shaped webhook whose CR finished ~3s after start must have the
+// downstream BuildDatapack's abnormal-window end pushed out to
+// start+FixedAbnormalWindowSeconds, so the CH freshness probe waits for the
+// post-fault observation window instead of firing on the collapsed window.
+func TestOneShotChaosExtendsAbnormalWindow(t *testing.T) {
+	_, rec, r := setupRig(t)
+	start := time.Now().Add(-3 * time.Second).UTC()
+	finished := start.Add(3 * time.Second) // CR completes near-instantly
+	body := SingletonWebhook{
+		InjectionID:    "inj-oneshot",
+		IdempotencyKey: "k-oneshot",
+		Status:         statusSucceeded,
+		StartedAt:      start,
+		FinishedAt:     finished,
+		CallerMetadata: sampleMeta(),
+	}
+	postJSON(t, r, "/api/v1/hooks/chaos", body, nil)
+	if rec.count() != 1 {
+		t.Fatalf("want 1 submit got %d", rec.count())
+	}
+	dp := rec.tasks[0].task.Payload[consts.BuildDatapack].(dto.InjectionItem)
+	want := start.Add(consts.FixedAbnormalWindowSeconds * time.Second)
+	if !dp.EndTime.Equal(want) {
+		t.Fatalf("one-shot EndTime: want %v (start+window) got %v", want, dp.EndTime)
+	}
+}
+
+// TestDurationChaosWindowUnchanged proves the fix is a no-op for
+// duration-based chaos: the CR ran the full FixedAbnormalWindow, so
+// finishedAt already sits at the planned end and EndTime must not move.
+func TestDurationChaosWindowUnchanged(t *testing.T) {
+	_, rec, r := setupRig(t)
+	start := time.Now().Add(-2 * consts.FixedAbnormalWindowSeconds * time.Second).UTC()
+	finished := start.Add((consts.FixedAbnormalWindowSeconds + 5) * time.Second)
+	body := SingletonWebhook{
+		InjectionID:    "inj-duration",
+		IdempotencyKey: "k-duration",
+		Status:         statusSucceeded,
+		StartedAt:      start,
+		FinishedAt:     finished,
+		CallerMetadata: sampleMeta(),
+	}
+	postJSON(t, r, "/api/v1/hooks/chaos", body, nil)
+	if rec.count() != 1 {
+		t.Fatalf("want 1 submit got %d", rec.count())
+	}
+	dp := rec.tasks[0].task.Payload[consts.BuildDatapack].(dto.InjectionItem)
+	if !dp.EndTime.Equal(finished) {
+		t.Fatalf("duration EndTime: want unchanged %v got %v", finished, dp.EndTime)
+	}
+}
+
 func TestW3CTraceparentBecomesParent(t *testing.T) {
 	_, rec, r := setupRig(t)
 	traceID := "11111111111111111111111111111111"


### PR DESCRIPTION
## Problem

One-shot chaos (PodKill) produced empty datapacks → `datapack.build.failed`. The PodChaos CR completes near-instantly, so the chaos webhook receiver set `dp.EndTime = finishedAt ≈ inject+3s`, making the abnormal window ~3s wide instead of the intended 60s. Consequences:
- `waitForCHFreshness` gates on `EndTime − watermark`, which lands *before* inject time → the freshness probe passes on its first iteration (pre-window spans already satisfy it) with no post-fault window observed.
- `ABNORMAL_END` env = `EndTime` → `prepare_inputs.py` reads a near-empty abnormal window → empty parquet.

Duration-based chaos (NetworkDelay etc.) runs the CR for the full `FixedAbnormalWindowSeconds` (60s), so its `finishedAt` already sits at the planned end — which is why only one-shot chaos broke.

## Root cause (code path)
Not the old `HandleCRDSucceeded` CRD-watcher (removed) — BuildDatapack is now submitted by the chaos **webhook receiver** `Handler.fireOnce` (`src/crud/hooks/chaos/handler.go:150`). It set `EndTime` from the CR completion time verbatim.

## Fix
`clampAbnormalWindowEnd(start, end)` = later of observed `end` and `start + consts.FixedAbnormalWindowSeconds` (60s). Applied to `dp.EndTime` before BuildDatapack submit and to the shadow `FaultInjection.EndTime`.
- One-shot: EndTime pushed to `start+60s`; freshness probe now correctly blocks until CH has the full window, then builds over real post-fault traffic.
- Duration chaos: `finishedAt ≥ start+60s` → unchanged (no-op), locked by `TestDurationChaosWindowUnchanged`.

Reused the existing `FixedAbnormalWindowSeconds` protocol invariant (consts.go:50) rather than adding a parallel config knob (the freshness max-wait/watermark remain the tunable knobs). No aegisctl flags → no schema-ack.

## Test plan
- [x] New `TestOneShotChaosExtendsAbnormalWindow` + `TestDurationChaosWindowUnchanged`; `go test ./crud/hooks/chaos/...` ok; build green; golangci-lint `--new-from-rev` 0 issues; existing freshness/builddatapack tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)