### PR TITLE
chore(byte-cluster/seed): bump sn/media/teastore/sockshop to fork charts 0.2.2/0.2.2/0.1.5/1.2.2

### DIFF
--- a/aegislab/manifests/byte-cluster/initial-data/data.yaml
+++ b/aegislab/manifests/byte-cluster/initial-data/data.yaml
@@ -568,6 +568,69 @@ containers:
               default_value: "false"
               overridable: true
           status: 1
+      # Bumped 1.1.4 → 1.1.5 to pick up sockshop chart 1.2.2 (fork PR
+      # LGU-SE-Internal/coherence-helidon-sockshop-sample#26): adds aegis-points
+      # chart-bound import. sockshop-lgu index moved to 1.2.2 (1.2.1 dropped) so
+      # RP install of 1.2.1 now 404s. aegis.points.enabled=false until
+      # opspai/aegisctl + chaosServer wired (catalog via manual import-dir).
+      - name: 1.1.5
+        github_link: LGU-SE-Internal/coherence-helidon-sockshop-sample
+        status: 1
+        helm_config:
+          version: 1.2.2
+          chart_name: sockshop
+          repo_name: sockshop-lgu
+          repo_url: https://lgu-se-internal.github.io/coherence-helidon-sockshop-sample
+          values:
+            - key: global.imageRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            - key: global.imageTag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-3ecac5f
+              overridable: true
+            - key: frontend.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-3ecac5f
+              overridable: true
+            - key: loadgen.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-3ecac5f
+              overridable: true
+            - key: otel.instrumentation
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: monitoring/otel-instr-sockshop
+              overridable: true
+            - key: otel.collectorEndpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://opentelemetry-kube-stack-deployment-sockshop-collector.monitoring.svc.cluster.local:4317
+              overridable: true
+            - key: otelCollector.enabled
+              type: 0
+              category: 1
+              value_type: 1
+              default_value: "false"
+              overridable: true
+            - key: aegis.points.enabled
+              type: 0
+              category: 1
+              value_type: 1
+              default_value: "false"
+              overridable: true
+          status: 1
     # issue #115: sockshop's coherence-helidon variant requires the
     # Coherence operator installed cluster-wide before the chart can be
     # rendered. `aegisctl system reconcile-prereqs --name sockshop` installs
@@ -796,6 +859,68 @@ containers:
               default_value: pair-cn-shanghai.cr.volces.com/opspai/python
               overridable: true
           status: 1
+      # Bumped 0.1.6 → 0.1.7 to pick up social-network chart 0.2.2 (fork PR
+      # LGU-SE-Internal/DeathStarBench#61): adds the aegis-points chart-bound
+      # PointManifest auto-import. lgu-dsb index dropped 0.2.1 on republish, so
+      # RP helm install of 0.2.1 now 404s — must move to 0.2.2. Disable the
+      # bundled aegis-points import Job for now (aegis.points.enabled=false):
+      # the chart defaults chaosServer=http://aegis-chaos.aegis.svc:8082 (wrong
+      # for byte-cluster, which runs rcabench-chaos in ns exp) and aegisctlImage
+      # =opspai/aegisctl:latest (not yet published). Catalog stays populated via
+      # `aegisctl manifest import-dir`. Re-enable once opspai/aegisctl is built
+      # + chaosServer is wired (follow-up).
+      - name: 0.1.7
+        github_link: LGU-SE-Internal/DeathStarBench
+        status: 1
+        helm_config:
+          version: 0.2.2
+          chart_name: social-network
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 2
+              value_type: 0
+              default_value: 20260427-9397c2e
+              overridable: true
+            - key: global.otel.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: otel-collector:4318
+              overridable: true
+            - key: otelCollector.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib
+              overridable: true
+            - key: data-init-job.container.image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/python
+              overridable: true
+            - key: load-generator.initContainer.image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/python
+              overridable: true
+            - key: aegis.points.enabled
+              type: 0
+              category: 1
+              value_type: 1
+              default_value: "false"
+              overridable: true
+          status: 1
   - type: 2
     name: media
     is_public: true
@@ -890,6 +1015,61 @@ containers:
               default_value: pair-cn-shanghai.cr.volces.com/opspai/python
               overridable: true
           status: 1
+      # Bumped 0.1.6 → 0.1.7 for media-microservices chart 0.2.2 (fork PR #61).
+      # Same rationale as sn 0.1.7: 0.2.1 dropped from index on republish;
+      # aegis.points.enabled=false until opspai/aegisctl + chaosServer wired.
+      - name: 0.1.7
+        github_link: LGU-SE-Internal/DeathStarBench
+        status: 1
+        helm_config:
+          version: 0.2.2
+          chart_name: media-microservices
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 3
+              value_type: 0
+              default_value: 20260427-9397c2e
+              overridable: true
+            - key: global.otel.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: otel-collector:4318
+              overridable: true
+            - key: otelCollector.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib
+              overridable: true
+            - key: data-init-job.container.image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/python
+              overridable: true
+            - key: load-generator.initContainer.image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/python
+              overridable: true
+            - key: aegis.points.enabled
+              type: 0
+              category: 1
+              value_type: 1
+              default_value: "false"
+              overridable: true
+          status: 1
   - type: 2
     name: teastore
     is_public: true
@@ -966,6 +1146,81 @@ containers:
               category: 1
               value_type: 0
               default_value: IfNotPresent
+              overridable: true
+          status: 1
+      # Bumped 0.1.6 → 0.1.7 to pick up teastore chart 0.1.5 (fork PR
+      # LGU-SE-Internal/TeaStore#12): adds aegis-points chart-bound import.
+      # lgu-tea index moved to 0.1.5 on republish (0.1.4 dropped), so RP
+      # install of 0.1.4 now 404s. aegis.points.enabled=false until
+      # opspai/aegisctl + chaosServer wired (catalog via manual import-dir).
+      - name: 0.1.7
+        github_link: LGU-SE-Internal/TeaStore
+        status: 1
+        helm_config:
+          version: 0.1.5
+          chart_name: teastore
+          repo_name: lgu-tea
+          repo_url: https://lgu-se-internal.github.io/TeaStore
+          values:
+            - key: global.image.registry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            - key: global.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-2b3fd43
+              overridable: true
+            - key: opentelemetry.otlpEndpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://opentelemetry-kube-stack-deployment-teastore-collector.monitoring.svc.cluster.local:4317
+              overridable: true
+            - key: opentelemetry.monitoringNamespace
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: monitoring
+              overridable: true
+            - key: opentelemetry.instrumentationName
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: otel-instr-teastore
+              overridable: true
+            - key: jmeter.waitForRegistryImage.registry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            - key: jmeter.waitForRegistryImage.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: busybox
+              overridable: true
+            - key: jmeter.waitForRegistryImage.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "1.36"
+              overridable: true
+            - key: jmeter.waitForRegistryImage.pullPolicy
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: IfNotPresent
+              overridable: true
+            - key: aegis.points.enabled
+              type: 0
+              category: 1
+              value_type: 1
+              default_value: "false"
               overridable: true
           status: 1
 datasets:


### PR DESCRIPTION
## Summary
Fork aegis-points PRs (DeathStarBench#61, TeaStore#12, sockshop#26) merged + republished, bumping chart versions and dropping the prior versions from the gh-pages indexes → RestartPedestal install of the old pinned versions 404s. New pedestal versions:
- sn 0.1.7 / media 0.1.7 → chart 0.2.2
- teastore 0.1.7 → chart 0.1.5
- sockshop 1.1.5 → chart 1.2.2

All carry forward existing overrides + `aegis.points.enabled=false` (the new charts' aegis-points import Job can't run on byte-cluster yet: chart default `chaosServer` points at `aegis-chaos.aegis.svc` not `rcabench-chaos.exp`, and `opspai/aegisctl:latest` isn't published). Catalog stays populated via manual `manifest import-dir`. Re-enabling chart-bound import is a follow-up (build opspai/aegisctl + wire chaosServer).

## Test plan
- [x] YAML parses; reseed applied (new container_versions 0.1.7/1.1.5 + helm values incl aegis.points.enabled=false)
- [ ] cold-start inject all 4 systems green (validating now on byte-cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)