### PR TITLE
fix(reconciler): longer stuck threshold for restart.pedestal.started (DSB cold-start)

### DIFF
--- a/aegislab/manifests/byte-cluster/initial-data/data.yaml
+++ b/aegislab/manifests/byte-cluster/initial-data/data.yaml
@@ -568,6 +568,69 @@ containers:
               default_value: "false"
               overridable: true
           status: 1
+      # Bumped 1.1.4 → 1.1.5 to pick up sockshop chart 1.2.2 (fork PR
+      # LGU-SE-Internal/coherence-helidon-sockshop-sample#26): adds aegis-points
+      # chart-bound import. sockshop-lgu index moved to 1.2.2 (1.2.1 dropped) so
+      # RP install of 1.2.1 now 404s. aegis.points.enabled=false until
+      # opspai/aegisctl + chaosServer wired (catalog via manual import-dir).
+      - name: 1.1.5
+        github_link: LGU-SE-Internal/coherence-helidon-sockshop-sample
+        status: 1
+        helm_config:
+          version: 1.2.2
+          chart_name: sockshop
+          repo_name: sockshop-lgu
+          repo_url: https://lgu-se-internal.github.io/coherence-helidon-sockshop-sample
+          values:
+            - key: global.imageRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            - key: global.imageTag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-3ecac5f
+              overridable: true
+            - key: frontend.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-3ecac5f
+              overridable: true
+            - key: loadgen.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-3ecac5f
+              overridable: true
+            - key: otel.instrumentation
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: monitoring/otel-instr-sockshop
+              overridable: true
+            - key: otel.collectorEndpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://opentelemetry-kube-stack-deployment-sockshop-collector.monitoring.svc.cluster.local:4317
+              overridable: true
+            - key: otelCollector.enabled
+              type: 0
+              category: 1
+              value_type: 1
+              default_value: "false"
+              overridable: true
+            - key: aegis.points.enabled
+              type: 0
+              category: 1
+              value_type: 1
+              default_value: "false"
+              overridable: true
+          status: 1
     # issue #115: sockshop's coherence-helidon variant requires the
     # Coherence operator installed cluster-wide before the chart can be
     # rendered. `aegisctl system reconcile-prereqs --name sockshop` installs
@@ -796,6 +859,68 @@ containers:
               default_value: pair-cn-shanghai.cr.volces.com/opspai/python
               overridable: true
           status: 1
+      # Bumped 0.1.6 → 0.1.7 to pick up social-network chart 0.2.2 (fork PR
+      # LGU-SE-Internal/DeathStarBench#61): adds the aegis-points chart-bound
+      # PointManifest auto-import. lgu-dsb index dropped 0.2.1 on republish, so
+      # RP helm install of 0.2.1 now 404s — must move to 0.2.2. Disable the
+      # bundled aegis-points import Job for now (aegis.points.enabled=false):
+      # the chart defaults chaosServer=http://aegis-chaos.aegis.svc:8082 (wrong
+      # for byte-cluster, which runs rcabench-chaos in ns exp) and aegisctlImage
+      # =opspai/aegisctl:latest (not yet published). Catalog stays populated via
+      # `aegisctl manifest import-dir`. Re-enable once opspai/aegisctl is built
+      # + chaosServer is wired (follow-up).
+      - name: 0.1.7
+        github_link: LGU-SE-Internal/DeathStarBench
+        status: 1
+        helm_config:
+          version: 0.2.2
+          chart_name: social-network
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 2
+              value_type: 0
+              default_value: 20260427-9397c2e
+              overridable: true
+            - key: global.otel.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: otel-collector:4318
+              overridable: true
+            - key: otelCollector.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib
+              overridable: true
+            - key: data-init-job.container.image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/python
+              overridable: true
+            - key: load-generator.initContainer.image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/python
+              overridable: true
+            - key: aegis.points.enabled
+              type: 0
+              category: 1
+              value_type: 1
+              default_value: "false"
+              overridable: true
+          status: 1
   - type: 2
     name: media
     is_public: true
@@ -890,6 +1015,61 @@ containers:
               default_value: pair-cn-shanghai.cr.volces.com/opspai/python
               overridable: true
           status: 1
+      # Bumped 0.1.6 → 0.1.7 for media-microservices chart 0.2.2 (fork PR #61).
+      # Same rationale as sn 0.1.7: 0.2.1 dropped from index on republish;
+      # aegis.points.enabled=false until opspai/aegisctl + chaosServer wired.
+      - name: 0.1.7
+        github_link: LGU-SE-Internal/DeathStarBench
+        status: 1
+        helm_config:
+          version: 0.2.2
+          chart_name: media-microservices
+          repo_name: lgu-dsb
+          repo_url: https://lgu-se-internal.github.io/DeathStarBench
+          values:
+            - key: global.dockerRegistry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            - key: global.defaultImageVersion
+              type: 0
+              category: 3
+              value_type: 0
+              default_value: 20260427-9397c2e
+              overridable: true
+            - key: global.otel.endpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: otel-collector:4318
+              overridable: true
+            - key: otelCollector.image.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/opentelemetry-collector-contrib
+              overridable: true
+            - key: data-init-job.container.image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/python
+              overridable: true
+            - key: load-generator.initContainer.image
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai/python
+              overridable: true
+            - key: aegis.points.enabled
+              type: 0
+              category: 1
+              value_type: 1
+              default_value: "false"
+              overridable: true
+          status: 1
   - type: 2
     name: teastore
     is_public: true
@@ -966,6 +1146,81 @@ containers:
               category: 1
               value_type: 0
               default_value: IfNotPresent
+              overridable: true
+          status: 1
+      # Bumped 0.1.6 → 0.1.7 to pick up teastore chart 0.1.5 (fork PR
+      # LGU-SE-Internal/TeaStore#12): adds aegis-points chart-bound import.
+      # lgu-tea index moved to 0.1.5 on republish (0.1.4 dropped), so RP
+      # install of 0.1.4 now 404s. aegis.points.enabled=false until
+      # opspai/aegisctl + chaosServer wired (catalog via manual import-dir).
+      - name: 0.1.7
+        github_link: LGU-SE-Internal/TeaStore
+        status: 1
+        helm_config:
+          version: 0.1.5
+          chart_name: teastore
+          repo_name: lgu-tea
+          repo_url: https://lgu-se-internal.github.io/TeaStore
+          values:
+            - key: global.image.registry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            - key: global.image.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: 20260423-2b3fd43
+              overridable: true
+            - key: opentelemetry.otlpEndpoint
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: http://opentelemetry-kube-stack-deployment-teastore-collector.monitoring.svc.cluster.local:4317
+              overridable: true
+            - key: opentelemetry.monitoringNamespace
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: monitoring
+              overridable: true
+            - key: opentelemetry.instrumentationName
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: otel-instr-teastore
+              overridable: true
+            - key: jmeter.waitForRegistryImage.registry
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: pair-cn-shanghai.cr.volces.com/opspai
+              overridable: true
+            - key: jmeter.waitForRegistryImage.repository
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: busybox
+              overridable: true
+            - key: jmeter.waitForRegistryImage.tag
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: "1.36"
+              overridable: true
+            - key: jmeter.waitForRegistryImage.pullPolicy
+              type: 0
+              category: 1
+              value_type: 0
+              default_value: IfNotPresent
+              overridable: true
+            - key: aegis.points.enabled
+              type: 0
+              category: 1
+              value_type: 1
+              default_value: "false"
               overridable: true
           status: 1
 datasets:

--- a/aegislab/src/core/orchestrator/stuck_trace_reconciler.go
+++ b/aegislab/src/core/orchestrator/stuck_trace_reconciler.go
@@ -232,6 +232,16 @@ func (r *StuckTraceReconciler) tick(ctx context.Context) (int, int, error) {
 	}
 	cutoff := r.now().Add(-time.Duration(stuckSecs) * time.Second)
 
+	// restart.pedestal.started gets a longer threshold: a cold DSB bootstrap
+	// legitimately parks here for readiness_timeout + warmup + traffic-gate
+	// (tens of minutes) before the inject fires, without advancing updated_at.
+	// Reaping it at the generic 600 s threshold kills in-progress bootstraps.
+	rpSecs := restartPedestalStuckThresholdSeconds()
+	if rpSecs < stuckSecs {
+		rpSecs = stuckSecs
+	}
+	rpCutoff := r.now().Add(-time.Duration(rpSecs) * time.Second)
+
 	// Anti-join out traces that already have a non-deleted BuildDatapack
 	// task. Without this filter the candidate set is starved on busy
 	// clusters: any trace whose last_event was never advanced past
@@ -247,15 +257,18 @@ func (r *StuckTraceReconciler) tick(ctx context.Context) (int, int, error) {
 	var traces []model.Trace
 	err := r.db.WithContext(ctx).
 		Model(&model.Trace{}).
-		Where("state = ? AND last_event IN ? AND updated_at < ? AND status != ?",
+		Where("state = ? AND status != ? AND ("+
+			"(last_event IN ? AND updated_at < ?) OR "+
+			"(last_event = ? AND updated_at < ?))",
 			consts.TraceRunning,
+			consts.CommonDeleted,
 			[]consts.EventType{
 				consts.EventFaultInjectionStarted,
 				consts.EventFaultInjectionCompleted,
-				consts.EventRestartPedestalStarted,
 			},
 			cutoff,
-			consts.CommonDeleted,
+			consts.EventRestartPedestalStarted,
+			rpCutoff,
 		).
 		Where("NOT EXISTS (?)",
 			r.db.Model(&model.Task{}).
@@ -754,6 +767,17 @@ func stuckThresholdSecondsFromConfig() int {
 	v := config.GetInt(consts.StuckTraceReconcileStuckThresholdKey)
 	if v <= 0 {
 		return consts.DefaultStuckTraceReconcileStuckSecs
+	}
+	return v
+}
+
+// restartPedestalStuckThresholdSeconds is the (longer) stuck threshold for
+// traces parked at restart.pedestal.started. Read on every tick so an etcd
+// push applies without a rebuild.
+func restartPedestalStuckThresholdSeconds() int {
+	v := config.GetInt(consts.StuckTraceReconcileRestartPedestalThresholdKey)
+	if v <= 0 {
+		return consts.DefaultStuckTraceReconcileRestartPedestalSecs
 	}
 	return v
 }

--- a/aegislab/src/core/orchestrator/stuck_trace_reconciler_test.go
+++ b/aegislab/src/core/orchestrator/stuck_trace_reconciler_test.go
@@ -650,7 +650,7 @@ func makeStuckRestartPedestalFixture(t *testing.T, db *gorm.DB, namespace string
 // against the same namespace doesn't loop on lock acquisition.
 func TestReconciler_RecoversTraceStuckAtRestartPedestalStarted(t *testing.T) {
 	db := newReconcilerTestDB(t)
-	traceID, taskID := makeStuckRestartPedestalFixture(t, db, "ts0", 30*time.Minute)
+	traceID, taskID := makeStuckRestartPedestalFixture(t, db, "ts0", 45*time.Minute)
 
 	lock := &fakeNamespaceLockReleaser{}
 	restartTok := &fakeTokenReleaser{}
@@ -687,13 +687,32 @@ func TestReconciler_RecoversTraceStuckAtRestartPedestalStarted(t *testing.T) {
 	require.Len(t, warmingTok.calls, 1, "namespace-warming token must be released defensively")
 }
 
+// TestReconciler_RestartPedestalNotReapedBeforeLongThreshold locks the
+// DSB-cold-start fix: a trace parked at restart.pedestal.started must NOT be
+// reaped at the generic stuck threshold (600 s). A cold DSB bootstrap
+// legitimately holds this state through readiness_timeout + warmup + the
+// traffic-presence gate without advancing updated_at; reaping it early kills
+// in-progress installs. 20 min is past the generic 600 s but below the
+// restart-pedestal 2400 s threshold → must survive.
+func TestReconciler_RestartPedestalNotReapedBeforeLongThreshold(t *testing.T) {
+	db := newReconcilerTestDB(t)
+	makeStuckRestartPedestalFixture(t, db, "ts0", 20*time.Minute)
+
+	r := newReconcilerForTest(t, db, newFakeInjectionOwner(nil), nil)
+	processed, candidates, err := r.tick(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, candidates,
+		"restart.pedestal.started at 20m (< 40m RP threshold) must not be a stuck candidate")
+	require.Equal(t, 0, processed)
+}
+
 // TestReconciler_RestartPedestalRecoveryToleratesNilReleasers verifies the
 // recovery path is safe when the optional lock / token releasers are nil —
 // the DB cancellation must still happen so the trace doesn't get stuck for
 // good.
 func TestReconciler_RestartPedestalRecoveryToleratesNilReleasers(t *testing.T) {
 	db := newReconcilerTestDB(t)
-	traceID, taskID := makeStuckRestartPedestalFixture(t, db, "ts0", 30*time.Minute)
+	traceID, taskID := makeStuckRestartPedestalFixture(t, db, "ts0", 45*time.Minute)
 
 	r := newReconcilerForTest(t, db, newFakeInjectionOwner(nil), nil)
 	// All releasers left nil.

--- a/aegislab/src/platform/consts/consts.go
+++ b/aegislab/src/platform/consts/consts.go
@@ -523,6 +523,18 @@ const (
 	StuckTraceReconcileStuckThresholdKey   = "rate_limiting.stuck_trace_reconcile_stuck_threshold_seconds"
 	DefaultStuckTraceReconcileIntervalSecs = 60
 	DefaultStuckTraceReconcileStuckSecs    = 600
+	// StuckTraceReconcileRestartPedestalThresholdKey overrides the stuck
+	// threshold applied specifically to traces parked at
+	// restart.pedestal.started. RestartPedestal legitimately holds this state
+	// far longer than the fault.injection.* states: a cold DSB bootstrap
+	// chains the per-system readiness_timeout (up to ~25 min), the warmup
+	// floor, and the traffic-presence gate (up to 10 min) BEFORE the inject
+	// fires, and the trace's updated_at does not advance during that wait. The
+	// generic 600 s threshold reaps these legitimate in-progress bootstraps.
+	// 2400 s (40 min) comfortably exceeds the worst-case legitimate RP
+	// duration while still recovering genuinely-dead workers.
+	StuckTraceReconcileRestartPedestalThresholdKey = "rate_limiting.stuck_trace_reconcile_restart_pedestal_threshold_seconds"
+	DefaultStuckTraceReconcileRestartPedestalSecs  = 2400
 )
 
 type EventType string


### PR DESCRIPTION
## Problem
The stuck-trace reconciler reaped traces at `restart.pedestal.started` using the generic 600s threshold. A cold DSB (sn/media/hs) bootstrap legitimately parks there for tens of minutes — per-system `readiness_timeout` (up to ~25 min) + warmup floor + the #492 traffic-presence gate (up to 10 min) all run BEFORE the inject fires, and `updated_at` doesn't advance during the wait. Observed on byte-cluster: sn/media bootstraps cancelled at ~10 min ("stuck restart-pedestal trace cancelled") while the traffic gate was still probing.

## Fix
Separate, longer threshold for `restart.pedestal.started`: `DefaultStuckTraceReconcileRestartPedestalSecs = 2400` (40 min), configurable via `rate_limiting.stuck_trace_reconcile_restart_pedestal_threshold_seconds`, clamped ≥ the generic threshold. `fault.injection.*` keep the generic 600s. The tick SELECT applies per-state cutoffs.

## Test
- New `TestReconciler_RestartPedestalNotReapedBeforeLongThreshold` (RP trace at 20m < 40m → not a candidate).
- Existing RP-recovery tests updated to 45m staleness (past the new threshold).
- build + `golangci-lint --new-from-rev` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)