### PR TITLE
fix(inject): default chart_version to seed-genesis so --skip-restart-pedestal injects match catalog

### DIFF
--- a/aegislab/src/core/orchestrator/fault_injection.go
+++ b/aegislab/src/core/orchestrator/fault_injection.go
@@ -280,6 +280,15 @@ func parseInjectionPayload(payload map[string]any) (*injectionPayload, error) {
 		chaosInstance = "seed"
 	}
 	chartVersion, _ := payload[consts.InjectChartVersion].(string)
+	// Seeded catalog rows hash with chart_version="seed-genesis" (see
+	// manifests/aegis-chaos/<sys>/*.yaml). The RestartPedestal path sets this
+	// explicitly, but the --skip-restart-pedestal path bypasses that block,
+	// leaving chartVersion="" → GuidedChaosPointID derives a different point_id
+	// than the catalog → POST /v1beta/injections 404s. Default to seed-genesis
+	// here so every path (RP, skip-RP, direct) addresses the seeded points.
+	if chartVersion == "" {
+		chartVersion = "seed-genesis"
+	}
 
 	return &injectionPayload{
 		benchmark:     benchmark,

--- a/aegislab/src/core/orchestrator/fault_injection_test.go
+++ b/aegislab/src/core/orchestrator/fault_injection_test.go
@@ -46,6 +46,20 @@ func TestParseInjectionPayloadAcceptsGuidedConfigs(t *testing.T) {
 	require.Equal(t, 11, payload.pedestalID)
 }
 
+func TestParseInjectionPayloadDefaultsChartVersionToSeedGenesis(t *testing.T) {
+	// --skip-restart-pedestal bypasses the RP block that sets chart_version;
+	// without a default the dispatcher derives a point_id with chart_version=""
+	// and 404s against the seed-genesis-hashed catalog rows.
+	payload := sampleInjectionPayload()
+	delete(payload, consts.InjectChartVersion)
+	delete(payload, consts.InjectChaosInstance)
+
+	parsed, err := parseInjectionPayload(payload)
+	require.NoError(t, err)
+	require.Equal(t, "seed-genesis", parsed.chartVersion)
+	require.Equal(t, "seed", parsed.chaosInstance)
+}
+
 func TestParseInjectionPayloadRejectsLegacyNodes(t *testing.T) {
 	payload := sampleInjectionPayload()
 	delete(payload, consts.InjectGuidedConfigs)


### PR DESCRIPTION
## Problem
Guided/regression injects via `--skip-restart-pedestal` 404 at `POST /v1beta/injections` (fault.injection.failed) even when the chaos point exists. Root cause: seeded points hash with `chart_version="seed-genesis"`. The RestartPedestal path sets `InjectChartVersion="seed-genesis"` explicitly, but `--skip-restart-pedestal` bypasses that block → `chart_version=""` → `GuidedChaosPointID` derives a non-matching point_id → 404.

Verified on byte-cluster: `aegisctl chaos inject submit --point-id <stored-id>` succeeds (point exists, CR lands in the allocated ns), but the dispatcher path 404s because it sends the empty-chart_version hash (`640dccef…` vs stored `1ada29f3…`).

## Fix
`parseInjectionPayload` defaults `chart_version` to `seed-genesis` when empty — symmetric with the existing `chaos_instance`→`seed` default — so every dispatch path (RP, skip-RP, direct) addresses the seeded catalog rows. New test `TestParseInjectionPayloadDefaultsChartVersionToSeedGenesis`.

## Test
- build + golangci-lint `--new-from-rev` clean; parse-payload tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)