### PR TITLE
fix(dispatcher): address chaos Point by preflight-resolved id, not recomputed hash

### DIFF
--- a/aegislab/src/core/orchestrator/catalog_preflight.go
+++ b/aegislab/src/core/orchestrator/catalog_preflight.go
@@ -59,7 +59,14 @@ type pointsListerFunc func(ctx context.Context, system, service, capability stri
 // service indexes chaos_points by Point.SystemName, which is populated from
 // the seed manifests' metadata.system field — passing a namespace-suffixed
 // value here will silently fall through to WARN-fallback every call.
-func runCatalogPreflight(ctx context.Context, logicalSystem string, configs []guidedcli.GuidedConfig, _ *gorm.DB, logEntry *logrus.Entry, lister pointsListerFunc) {
+// runCatalogPreflight returns, per config (index-aligned), the catalog-resolved
+// point_id, or "" when it could not be resolved (no URL, miss, error, or no
+// capability mapping). The dispatcher uses a non-empty resolved id to address
+// the Point directly instead of recomputing the content hash — eliminating the
+// cross-process hash-agreement (system/namespace/chart_version) that caused the
+// opaque 404 class. An empty entry tells the dispatcher to fall back to
+// in-process hash derivation (kind / in-process mode).
+func runCatalogPreflight(ctx context.Context, logicalSystem string, configs []guidedcli.GuidedConfig, _ *gorm.DB, logEntry *logrus.Entry, lister pointsListerFunc) []string {
 	url := config.GetChaosServiceURL()
 	if url == "" {
 		// Missing URL = no chaos service to call. Each config still counts
@@ -68,15 +75,16 @@ func runCatalogPreflight(ctx context.Context, logicalSystem string, configs []gu
 		for range configs {
 			catalogReadSourceTotal.WithLabelValues(catalogSourceInProc).Inc()
 		}
-		return
+		return make([]string, len(configs))
 	}
 	if lister == nil {
 		lister = newSDKPointsLister(url, logEntry)
 	}
-	runChaosServicePreflight(ctx, logicalSystem, configs, logEntry, lister)
+	return runChaosServicePreflight(ctx, logicalSystem, configs, logEntry, lister)
 }
 
-func runChaosServicePreflight(ctx context.Context, logicalSystem string, configs []guidedcli.GuidedConfig, logEntry *logrus.Entry, lister pointsListerFunc) {
+func runChaosServicePreflight(ctx context.Context, logicalSystem string, configs []guidedcli.GuidedConfig, logEntry *logrus.Entry, lister pointsListerFunc) []string {
+	resolved := make([]string, len(configs))
 	for i, cfg := range configs {
 		capability, ok := chaoscrud.ChaosTypeToCapability[strings.TrimSpace(cfg.ChaosType)]
 		if !ok {
@@ -110,6 +118,7 @@ func runChaosServicePreflight(ctx context.Context, logicalSystem string, configs
 				"capability": capability,
 			}).Warn("point not found in chaos service catalog; using in-process resolution")
 		default:
+			resolved[i] = pointID
 			catalogReadSourceTotal.WithLabelValues(catalogSourceChaos).Inc()
 			logEntry.WithFields(logrus.Fields{
 				"index":      i,
@@ -120,6 +129,7 @@ func runChaosServicePreflight(ctx context.Context, logicalSystem string, configs
 			}).Info("catalog source: chaos_service")
 		}
 	}
+	return resolved
 }
 
 // newSDKPointsLister returns a pointsListerFunc backed by the generated

--- a/aegislab/src/core/orchestrator/catalog_preflight_test.go
+++ b/aegislab/src/core/orchestrator/catalog_preflight_test.go
@@ -275,3 +275,35 @@ func TestCatalogPreflight_SDKLister_HTTPTest(t *testing.T) {
 		t.Fatalf("expected service=ts-order-service in query, got %s", paths[0])
 	}
 }
+
+// TestPointIDForConfig_PrefersResolvedOverHash locks the root-cause fix: when
+// the catalog preflight resolved a point_id by natural key, the dispatcher
+// addresses the Point by that id and does NOT recompute the content hash
+// (which reintroduced the system/namespace/chart_version 404 class). An empty
+// resolved entry falls back to the locally derived hash (in-process mode).
+func TestPointIDForConfig_PrefersResolvedOverHash(t *testing.T) {
+	cfg := guidedcli.GuidedConfig{System: "sn", App: "social-graph-service", ChaosType: "PodKill"}
+	const resolved = "RESOLVEDSENTINEL"  // not a real 16-hex hash → proves verbatim reuse, never a recompute
+
+	deps := dispatcherDeps{instance: "seed", chartVersion: "seed-genesis", resolvedPointIDs: []string{resolved}}
+	got, err := deps.pointIDForConfig(0, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != resolved {
+		t.Fatalf("must use preflight-resolved id; got %q want %q", got, resolved)
+	}
+
+	depsEmpty := dispatcherDeps{instance: "seed", chartVersion: "seed-genesis", resolvedPointIDs: []string{""}}
+	fallback, err := depsEmpty.pointIDForConfig(0, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fallback == "" || fallback == resolved {
+		t.Fatalf("empty resolved must derive a real hash, not echo the sentinel; got %q", fallback)
+	}
+
+	if _, err := (dispatcherDeps{instance: "seed", chartVersion: "seed-genesis"}).pointIDForConfig(0, cfg); err != nil {
+		t.Fatalf("nil resolvedPointIDs must fall back without error: %v", err)
+	}
+}

--- a/aegislab/src/core/orchestrator/dispatcher.go
+++ b/aegislab/src/core/orchestrator/dispatcher.go
@@ -163,9 +163,31 @@ type dispatcherDeps struct {
 	benchmarkCommand string
 	// instance + chartVersion address per-instance Point catalog rows.
 	// Seed manifests carry instance=seed / chart_version=seed-genesis;
-	// these are what the chaos service hashes into the Point ID.
+	// these are what the chaos service hashes into the Point ID. They are
+	// only used as the fallback when the catalog preflight did not resolve a
+	// point_id (in-process / kind mode); see resolvedPointIDs.
 	instance     string
 	chartVersion string
+	// resolvedPointIDs is index-aligned to the guided configs: the point_id
+	// the catalog preflight already resolved by natural key
+	// (system, service, capability). When non-empty for a config the
+	// dispatcher addresses the Point by this id directly instead of
+	// recomputing the content hash — the preflight already round-tripped, so
+	// recomputing only reintroduces cross-process hash-divergence (the
+	// system/namespace/chart_version 404 class). Empty entry → fall back to
+	// GuidedChaosPointID (in-process mode / catalog miss).
+	resolvedPointIDs []string
+}
+
+// pointIDForConfig returns the catalog-resolved point_id for config index i
+// when the preflight found one, else the locally derived hash. Centralised so
+// the single and batch paths stay in lockstep.
+func (d dispatcherDeps) pointIDForConfig(i int, cfg guidedcli.GuidedConfig) (string, error) {
+	if i >= 0 && i < len(d.resolvedPointIDs) && d.resolvedPointIDs[i] != "" {
+		return d.resolvedPointIDs[i], nil
+	}
+	pid, _, _, err := chaoscrud.GuidedChaosPointID(cfg, d.instance, d.chartVersion)
+	return pid, err
 }
 
 // dispatchBatchCreate POSTs the guided configs to aegis-chaos and blocks on
@@ -218,7 +240,7 @@ func dispatchViaChaosService(
 	meta["engine_config"] = string(engineConfigBytes)
 
 	if len(configs) == 1 {
-		pid, _, _, err := chaoscrud.GuidedChaosPointID(configs[0], deps.instance, deps.chartVersion)
+		pid, err := deps.pointIDForConfig(0, configs[0])
 		if err != nil {
 			return nil, fmt.Errorf("dispatcher: derive point_id: %w", err)
 		}
@@ -244,7 +266,7 @@ func dispatchViaChaosService(
 	batchKey := deps.traceID + ":batch:" + uuid.NewString()
 	children := make([]apiclient.ChaosChaosCreateBatchChildReq, 0, len(configs))
 	for i, cfg := range configs {
-		pid, _, _, err := chaoscrud.GuidedChaosPointID(cfg, deps.instance, deps.chartVersion)
+		pid, err := deps.pointIDForConfig(i, cfg)
 		if err != nil {
 			return nil, fmt.Errorf("dispatcher: spec[%d]: derive point_id: %w", i, err)
 		}

--- a/aegislab/src/core/orchestrator/fault_injection.go
+++ b/aegislab/src/core/orchestrator/fault_injection.go
@@ -137,7 +137,7 @@ func executeFaultInjection(ctx context.Context, task *dto.UnifiedTask, deps Runt
 		// which is the concrete pool-allocated ns the CR is applied into.
 		// The catalog is keyed by the logical name; do not substitute the
 		// concrete ns here or every preflight will fall through to WARN.
-		runCatalogPreflight(childCtx, payload.system, payload.guidedConfigs, deps.DB, logEntry, nil)
+		resolvedPointIDs := runCatalogPreflight(childCtx, payload.system, payload.guidedConfigs, deps.DB, logEntry, nil)
 
 		// Default: release the lock on exit. Ownership transfers to the
 		// CRD-success/CRD-failed path only after both BatchCreate and
@@ -179,6 +179,7 @@ func executeFaultInjection(ctx context.Context, task *dto.UnifiedTask, deps Runt
 			benchmarkCommand: payload.benchmark.Command,
 			instance:         payload.chaosInstance,
 			chartVersion:     payload.chartVersion,
+			resolvedPointIDs: resolvedPointIDs,
 		}
 		var names []string
 		err = tracing.WithSpanNamed(childCtx, "chaos.batch_create", func(c context.Context) error {


### PR DESCRIPTION
## Root cause
Chaos inject addresses a catalog Point by a content hash recomputed client-side in the dispatcher (`GuidedChaosPointID`). That forces import + inject to agree on every hashed field (system/namespace/instance/chart_version/capability/target); any divergence → opaque `POST /v1beta/injections` 404. We hit it as System=namespace (`sn1` vs `sn`), chart_version `""` vs `seed-genesis`, namespace-in-target — each got a separate patch (#498/#502) papering over the same smell.

The catalog **preflight already resolves the Point by natural key** (`GET /v1beta/systems/{sys}/points?capability=&service=`) and gets the correct stored `point_id` — then the dispatcher discarded it and recomputed. So the round-trip the hash avoids already happens; recompute only reintroduces divergence.

## Fix
- `runCatalogPreflight` now returns the resolved `point_id` per config (index-aligned).
- Dispatcher uses it directly (`dispatcherDeps.pointIDForConfig`, single + batch), falling back to `GuidedChaosPointID` only when the preflight resolved nothing (in-process/kind mode or catalog miss).
- Runtime CR namespace flow unchanged (CR still lands in the allocated ns via `AdditionalProperties`).
- New `TestPointIDForConfig_PrefersResolvedOverHash` (resolved present → verbatim; empty → hash fallback).

Makes #498/#502 belt-and-suspenders and moots the open System=namespace bug on the dispatch path.

## Test
- build `-tags duckdb_arrow` + golangci-lint `--new-from-rev` clean; orchestrator tests pass.
- Validate: rebuild worker, inject (any addressing) → no more point-mismatch 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)