### PR TITLE
fix(detector): register media/teastore pedestal aliases

### DIFF
--- a/rcabench-platform/src/rcabench_platform/v3/sdk/pedestals/generic.py
+++ b/rcabench-platform/src/rcabench_platform/v3/sdk/pedestals/generic.py
@@ -124,6 +124,7 @@ class OtelDemoPedestal(GenericPedestal):
 
 
 @register_pedestal("tea")
+@register_pedestal("teastore")
 class TeaStorePedestal(GenericPedestal):
     _NAME = "tea"
     _ENTRANCE = "teastore-webui"
@@ -141,6 +142,7 @@ class SocialNetworkPedestal(GenericPedestal):
 
 
 @register_pedestal("mm")
+@register_pedestal("media")
 class MediaMicroservicesPedestal(GenericPedestal):
     _NAME = "mm"
     _ENTRANCE = "nginx-web-server"


### PR DESCRIPTION
## Root cause
The detector resolves its pedestal via `get_pedestal(BENCHMARK_SYSTEM)`. The aegis backend sets `BENCHMARK_SYSTEM` to the **system code** (`media`, `teastore`), but the pedestal registry only had the short names `mm` / `tea`. `get_pedestal("media")` raises `KeyError` (registry does NOT fall back to generic) → the detector crashes on startup (~7s) → every media/teastore datapack fails at `algorithm.run.failed` with no RCA produced.

Verified on byte-cluster: inject→datapack succeeds (12 parquets, uploaded to S3), but RunAlgorithm pod exits ~7s later. detector image entrypoint passes `--system $BENCHMARK_SYSTEM`; registry has `mm`/`tea` not `media`/`teastore`; media1 traces show entrance service is exactly `nginx-web-server` (matches MediaMicroservicesPedestal._ENTRANCE), so once the name resolves the detection works.

## Fix
Stack a second `@register_pedestal` decorator: `media` → MediaMicroservicesPedestal, `teastore` → TeaStorePedestal. Same class, same entrance_service. `ts/hs/otel-demo/sn/sockshop` already matched their system codes.

Verified locally: `get_pedestal()` resolves all 9 names (ts, hs, otel-demo, sn, media, teastore, sockshop, mm, tea) with correct entrance_service.

## Follow-up
Needs a detector image rebuild (monorepo skaffold `docker/detector/Dockerfile`) + seed bump detector→1.0.2 pointing at the new tag, then re-validate media/teastore end-to-end.