### PR TITLE
chore(systemconfig): drop dead runtime-mutator provider plumbing superseded by chaos_points (#505)

### DIFF
--- a/aegislab/src/platform/systemconfig/metadata_store.go
+++ b/aegislab/src/platform/systemconfig/metadata_store.go
@@ -21,7 +21,6 @@ type MetadataStore interface {
 	GetDatabaseOperations(system string, serviceName string) ([]DatabaseOperationData, error)
 	GetGRPCOperations(system string, serviceName string) ([]GRPCOperationData, error)
 	GetNetworkPairs(system string) ([]NetworkPairData, error)
-	GetRuntimeMutatorTargets(system string) ([]RuntimeMutatorTargetData, error)
 }
 
 type metadataStoreRouter struct {
@@ -32,7 +31,6 @@ type metadataStoreRouter struct {
 	databaseOperations map[SystemType]DatabaseOperationProvider
 	grpcOperations     map[SystemType]GRPCOperationProvider
 	javaClassMethods   map[SystemType]JavaClassMethodProvider
-	runtimeMutators    map[SystemType]RuntimeMutatorProvider
 }
 
 var (
@@ -54,7 +52,6 @@ func newMetadataStoreRouter() *metadataStoreRouter {
 		databaseOperations: make(map[SystemType]DatabaseOperationProvider),
 		grpcOperations:     make(map[SystemType]GRPCOperationProvider),
 		javaClassMethods:   make(map[SystemType]JavaClassMethodProvider),
-		runtimeMutators:    make(map[SystemType]RuntimeMutatorProvider),
 	}
 }
 
@@ -103,12 +100,6 @@ func (m *metadataStoreRouter) RegisterJavaClassMethodProvider(system SystemType,
 	m.javaClassMethods[system] = provider
 }
 
-func (m *metadataStoreRouter) RegisterRuntimeMutatorProvider(system SystemType, provider RuntimeMutatorProvider) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.runtimeMutators[system] = provider
-}
-
 func (m *metadataStoreRouter) ClearInternal() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -116,7 +107,6 @@ func (m *metadataStoreRouter) ClearInternal() {
 	m.databaseOperations = make(map[SystemType]DatabaseOperationProvider)
 	m.grpcOperations = make(map[SystemType]GRPCOperationProvider)
 	m.javaClassMethods = make(map[SystemType]JavaClassMethodProvider)
-	m.runtimeMutators = make(map[SystemType]RuntimeMutatorProvider)
 }
 
 func (m *metadataStoreRouter) UnregisterSystem(system SystemType) {
@@ -126,7 +116,6 @@ func (m *metadataStoreRouter) UnregisterSystem(system SystemType) {
 	delete(m.databaseOperations, system)
 	delete(m.grpcOperations, system)
 	delete(m.javaClassMethods, system)
-	delete(m.runtimeMutators, system)
 }
 
 func (m *metadataStoreRouter) GetServiceEndpoints(system string, serviceName string) ([]ServiceEndpointData, error) {
@@ -250,49 +239,6 @@ func (m *metadataStoreRouter) GetNetworkPairs(system string) ([]NetworkPairData,
 	return result, nil
 }
 
-func (m *metadataStoreRouter) GetRuntimeMutatorTargets(system string) ([]RuntimeMutatorTargetData, error) {
-	if external := m.getExternal(); external != nil {
-		data, err := external.GetRuntimeMutatorTargets(system)
-		if err == nil && len(data) > 0 {
-			return data, nil
-		}
-	}
-
-	provider := m.getRuntimeMutatorProvider(SystemType(system))
-	if provider == nil {
-		return nil, nil
-	}
-
-	var result []RuntimeMutatorTargetData
-	for _, service := range provider.GetServiceNames() {
-		result = append(result, provider.GetTargetsByService(service)...)
-	}
-
-	sort.Slice(result, func(i, j int) bool {
-		if result[i].AppName != result[j].AppName {
-			return result[i].AppName < result[j].AppName
-		}
-		if result[i].ClassName != result[j].ClassName {
-			return result[i].ClassName < result[j].ClassName
-		}
-		if result[i].MethodName != result[j].MethodName {
-			return result[i].MethodName < result[j].MethodName
-		}
-		if result[i].MutationType != result[j].MutationType {
-			return result[i].MutationType < result[j].MutationType
-		}
-		if result[i].MutationStrategy != result[j].MutationStrategy {
-			return result[i].MutationStrategy < result[j].MutationStrategy
-		}
-		if result[i].MutationFrom != result[j].MutationFrom {
-			return result[i].MutationFrom < result[j].MutationFrom
-		}
-		return result[i].MutationTo < result[j].MutationTo
-	})
-
-	return result, nil
-}
-
 func (m *metadataStoreRouter) getExternal() MetadataStore {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -323,12 +269,6 @@ func (m *metadataStoreRouter) getJavaClassMethodProvider(system SystemType) Java
 	return m.javaClassMethods[system]
 }
 
-func (m *metadataStoreRouter) getRuntimeMutatorProvider(system SystemType) RuntimeMutatorProvider {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.runtimeMutators[system]
-}
-
 func (m *metadataStoreRouter) listInternalServices(system SystemType) []string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -352,7 +292,6 @@ func (m *metadataStoreRouter) listInternalServices(system SystemType) []string {
 	addNames(m.databaseOperations[system])
 	addNames(m.grpcOperations[system])
 	addNames(m.javaClassMethods[system])
-	addNames(m.runtimeMutators[system])
 
 	services := make([]string, 0, len(serviceSet))
 	for service := range serviceSet {

--- a/aegislab/src/platform/systemconfig/registry.go
+++ b/aegislab/src/platform/systemconfig/registry.go
@@ -19,8 +19,6 @@ const (
 	MetadataNetworkDependencies MetadataType = "network_dependencies"
 	// MetadataGRPCOperations represents gRPC operation metadata.
 	MetadataGRPCOperations MetadataType = "grpc_operations"
-	// MetadataRuntimeMutatorTargets represents JVM runtime mutator target metadata.
-	MetadataRuntimeMutatorTargets MetadataType = "runtime_mutator_targets"
 )
 
 // MetadataProvider is a shared capability for metadata providers.
@@ -97,26 +95,6 @@ type JavaClassMethodData struct {
 	MethodName string
 }
 
-// RuntimeMutatorProvider provides JVM runtime mutator target data.
-type RuntimeMutatorProvider interface {
-	MetadataProvider
-	// GetTargetsByService returns runtime mutator targets for a specific service.
-	GetTargetsByService(serviceName string) []RuntimeMutatorTargetData
-}
-
-// RuntimeMutatorTargetData represents a flattened runtime mutator target.
-type RuntimeMutatorTargetData struct {
-	AppName          string
-	ClassName        string
-	MethodName       string
-	MutationType     int
-	MutationTypeName string
-	MutationFrom     string
-	MutationTo       string
-	MutationStrategy string
-	Description      string
-}
-
 // MetadataRegistry holds registered metadata providers for each system.
 type MetadataRegistry struct {
 	mu                 sync.RWMutex
@@ -124,7 +102,6 @@ type MetadataRegistry struct {
 	databaseOperations map[SystemType]DatabaseOperationProvider
 	grpcOperations     map[SystemType]GRPCOperationProvider
 	javaClassMethods   map[SystemType]JavaClassMethodProvider
-	runtimeMutators    map[SystemType]RuntimeMutatorProvider
 }
 
 var (
@@ -140,7 +117,6 @@ func GetRegistry() *MetadataRegistry {
 			databaseOperations: make(map[SystemType]DatabaseOperationProvider),
 			grpcOperations:     make(map[SystemType]GRPCOperationProvider),
 			javaClassMethods:   make(map[SystemType]JavaClassMethodProvider),
-			runtimeMutators:    make(map[SystemType]RuntimeMutatorProvider),
 		}
 	})
 	return globalRegistry
@@ -183,16 +159,6 @@ func (r *MetadataRegistry) RegisterJavaClassMethodProvider(system SystemType, pr
 	r.javaClassMethods[system] = provider
 	if router := getMetadataStoreRouter(); router != nil {
 		router.RegisterJavaClassMethodProvider(system, provider)
-	}
-}
-
-// RegisterRuntimeMutatorProvider registers a runtime mutator provider for a system.
-func (r *MetadataRegistry) RegisterRuntimeMutatorProvider(system SystemType, provider RuntimeMutatorProvider) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.runtimeMutators[system] = provider
-	if router := getMetadataStoreRouter(); router != nil {
-		router.RegisterRuntimeMutatorProvider(system, provider)
 	}
 }
 
@@ -244,18 +210,6 @@ func (r *MetadataRegistry) GetJavaClassMethodProvider() (JavaClassMethodProvider
 	return provider, nil
 }
 
-// GetRuntimeMutatorProvider returns the runtime mutator provider for the current system.
-func (r *MetadataRegistry) GetRuntimeMutatorProvider() (RuntimeMutatorProvider, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	provider, exists := r.runtimeMutators[GetCurrentSystem()]
-	if !exists {
-		return nil, fmt.Errorf("no runtime mutator provider registered for system: %s", GetCurrentSystem())
-	}
-	return provider, nil
-}
-
 // HasServiceEndpointProvider checks if a service endpoint provider is registered for the current system.
 func (r *MetadataRegistry) HasServiceEndpointProvider() bool {
 	r.mu.RLock()
@@ -292,15 +246,6 @@ func (r *MetadataRegistry) HasJavaClassMethodProvider() bool {
 	return exists
 }
 
-// HasRuntimeMutatorProvider checks if a runtime mutator provider is registered for the current system.
-func (r *MetadataRegistry) HasRuntimeMutatorProvider() bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	_, exists := r.runtimeMutators[GetCurrentSystem()]
-	return exists
-}
-
 // Clear removes all registered providers. Useful for testing.
 func (r *MetadataRegistry) Clear() {
 	r.mu.Lock()
@@ -310,7 +255,6 @@ func (r *MetadataRegistry) Clear() {
 	r.databaseOperations = make(map[SystemType]DatabaseOperationProvider)
 	r.grpcOperations = make(map[SystemType]GRPCOperationProvider)
 	r.javaClassMethods = make(map[SystemType]JavaClassMethodProvider)
-	r.runtimeMutators = make(map[SystemType]RuntimeMutatorProvider)
 	if router := getMetadataStoreRouter(); router != nil {
 		router.ClearInternal()
 	}
@@ -325,7 +269,6 @@ func (r *MetadataRegistry) UnregisterSystem(system SystemType) {
 	delete(r.databaseOperations, system)
 	delete(r.grpcOperations, system)
 	delete(r.javaClassMethods, system)
-	delete(r.runtimeMutators, system)
 	if router := getMetadataStoreRouter(); router != nil {
 		router.UnregisterSystem(system)
 	}


### PR DESCRIPTION
纯死代码清理。#505 把 JVM runtime-mutator 数据通路改成直接读 chaos_points（`platform/k8s/resourcelookup/db_backed.go`），原来经 `systemconfig.MetadataStore` + provider 注册的旧通路从此彻底没有 caller——而且它生产里从未被 wire 过（一直是没接通的脚手架）。删之。

## 删除内容（仅 2 个文件，118 行纯删除）

`platform/systemconfig/registry.go`：`MetadataRuntimeMutatorTargets` 常量、`RuntimeMutatorProvider` 接口、`RuntimeMutatorTargetData` 结构体、`MetadataRegistry.runtimeMutators` 字段及其 init/reset/unregister、`RegisterRuntimeMutatorProvider`/`GetRuntimeMutatorProvider`/`HasRuntimeMutatorProvider`。

`platform/systemconfig/metadata_store.go`：`MetadataStore` 接口的 `GetRuntimeMutatorTargets`、`metadataStoreRouter.runtimeMutators` 字段及 init/reset/unregister、router 的 `RegisterRuntimeMutatorProvider`/`GetRuntimeMutatorTargets`/`getRuntimeMutatorProvider`。

## 保留

- `MetadataStore` 接口、`metadataStoreRouter`、`MetadataRegistry` 本身及其它 provider 方法（`GetAllServiceNames` 等）仍在用，未动。
- `core/orchestrator/common/metadata_store.go` 的通用 by-type store **未动**——`runtime_mutator_targets` 只是它 7 种类型别名里的一个字符串、无专属逻辑，其它类型仍 live，删别名会动共享表（非死代码移除）。

## 验证
- 无运行时行为变化。
- `go build -tags duckdb_arrow ./...` 绿；`go test ./platform/systemconfig/... ./platform/k8s/resourcelookup/... ./crud/chaos/...` 绿；`go vet ./platform/systemconfig/...` 干净。
- 删除符号无任何活 caller / 无 test 引用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
