### PR TITLE
fix(chaos): reconcile-dir --dry-run accounts for import supersede (closes #510)

### DIFF
--- a/aegislab/src/cli/apiclient/model_chaos_chaos_import_points_resp.go
+++ b/aegislab/src/cli/apiclient/model_chaos_chaos_import_points_resp.go
@@ -23,6 +23,7 @@ type ChaosChaosImportPointsResp struct {
 	DryRun               *bool    `json:"dry_run,omitempty"`
 	PointIds             []string `json:"point_ids,omitempty"`
 	Superseded           *int32   `json:"superseded,omitempty"`
+	SupersededIds        []string `json:"superseded_ids,omitempty"`
 	Upserted             *int32   `json:"upserted,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
@@ -142,6 +143,38 @@ func (o *ChaosChaosImportPointsResp) SetSuperseded(v int32) {
 	o.Superseded = &v
 }
 
+// GetSupersededIds returns the SupersededIds field value if set, zero value otherwise.
+func (o *ChaosChaosImportPointsResp) GetSupersededIds() []string {
+	if o == nil || IsNil(o.SupersededIds) {
+		var ret []string
+		return ret
+	}
+	return o.SupersededIds
+}
+
+// GetSupersededIdsOk returns a tuple with the SupersededIds field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ChaosChaosImportPointsResp) GetSupersededIdsOk() ([]string, bool) {
+	if o == nil || IsNil(o.SupersededIds) {
+		return nil, false
+	}
+	return o.SupersededIds, true
+}
+
+// HasSupersededIds returns a boolean if a field has been set.
+func (o *ChaosChaosImportPointsResp) HasSupersededIds() bool {
+	if o != nil && !IsNil(o.SupersededIds) {
+		return true
+	}
+
+	return false
+}
+
+// SetSupersededIds gets a reference to the given []string and assigns it to the SupersededIds field.
+func (o *ChaosChaosImportPointsResp) SetSupersededIds(v []string) {
+	o.SupersededIds = v
+}
+
 // GetUpserted returns the Upserted field value if set, zero value otherwise.
 func (o *ChaosChaosImportPointsResp) GetUpserted() int32 {
 	if o == nil || IsNil(o.Upserted) {
@@ -193,6 +226,9 @@ func (o ChaosChaosImportPointsResp) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.Superseded) {
 		toSerialize["superseded"] = o.Superseded
 	}
+	if !IsNil(o.SupersededIds) {
+		toSerialize["superseded_ids"] = o.SupersededIds
+	}
 	if !IsNil(o.Upserted) {
 		toSerialize["upserted"] = o.Upserted
 	}
@@ -221,6 +257,7 @@ func (o *ChaosChaosImportPointsResp) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "dry_run")
 		delete(additionalProperties, "point_ids")
 		delete(additionalProperties, "superseded")
+		delete(additionalProperties, "superseded_ids")
 		delete(additionalProperties, "upserted")
 		o.AdditionalProperties = additionalProperties
 	}

--- a/aegislab/src/cli/cmd/manifest_reconcile.go
+++ b/aegislab/src/cli/cmd/manifest_reconcile.go
@@ -68,6 +68,11 @@ func runManifestReconcileDir(_ *cobra.Command, args []string) error {
 	}
 
 	activeBySystem := map[string]map[string]struct{}{}
+	// Points each system's imports transition to superseded. Under --dry-run
+	// the import tx is rolled back, so these stay 'active' in the listing the
+	// would-deprecate preview reads; subtracting them keeps the preview in
+	// line with a committed run, where import supersedes them before sweep.
+	supersededBySystem := map[string]map[string]struct{}{}
 	// A system with any failed import has a non-authoritative active set;
 	// sweeping it would deprecate Points the failed manifest still covers.
 	failedSystems := map[string]struct{}{}
@@ -111,13 +116,21 @@ func runManifestReconcileDir(_ *cobra.Command, args []string) error {
 		for _, id := range res.GetPointIds() {
 			activeBySystem[c.System][id] = struct{}{}
 		}
+		if sup := res.GetSupersededIds(); len(sup) > 0 {
+			if supersededBySystem[c.System] == nil {
+				supersededBySystem[c.System] = map[string]struct{}{}
+			}
+			for _, id := range sup {
+				supersededBySystem[c.System][id] = struct{}{}
+			}
+		}
 		if !flagQuiet {
 			fmt.Fprintf(os.Stderr, "  import %s (system=%s upserted=%d superseded=%d)\n",
 				f, c.System, res.GetUpserted(), res.GetSuperseded())
 		}
 	}
 
-	results, err := reconcileSweepSystems(ctx, cli, activeBySystem, failedSystems)
+	results, err := reconcileSweepSystems(ctx, cli, activeBySystem, supersededBySystem, failedSystems)
 	if err != nil {
 		return err
 	}
@@ -144,7 +157,7 @@ type reconcileSystemResult struct {
 	SkipReason string
 }
 
-func reconcileSweepSystems(ctx context.Context, cli *apiclient.APIClient, activeBySystem map[string]map[string]struct{}, failedSystems map[string]struct{}) ([]reconcileSystemResult, error) {
+func reconcileSweepSystems(ctx context.Context, cli *apiclient.APIClient, activeBySystem, supersededBySystem map[string]map[string]struct{}, failedSystems map[string]struct{}) ([]reconcileSystemResult, error) {
 	seen := map[string]struct{}{}
 	systems := make([]string, 0, len(activeBySystem)+len(failedSystems))
 	for s := range activeBySystem {
@@ -178,7 +191,7 @@ func reconcileSweepSystems(ctx context.Context, cli *apiclient.APIClient, active
 			continue
 		}
 		if flagDryRun {
-			n, err := reconcileWouldDeprecate(ctx, cli, system, activeBySystem[system])
+			n, err := reconcileWouldDeprecate(ctx, cli, system, activeBySystem[system], supersededBySystem[system])
 			if err != nil {
 				return nil, err
 			}
@@ -201,9 +214,10 @@ func reconcileSweepSystems(ctx context.Context, cli *apiclient.APIClient, active
 }
 
 // reconcileWouldDeprecate counts active Points the sweep would deprecate by
-// listing the system's current active Points and subtracting the imported set.
-// Only used for --dry-run, where no sweep is issued.
-func reconcileWouldDeprecate(ctx context.Context, cli *apiclient.APIClient, system string, active map[string]struct{}) (int, error) {
+// listing the system's current active Points and subtracting both the imported
+// set and the set the import would supersede. Only used for --dry-run, where
+// the import tx was rolled back so superseded points still read as active.
+func reconcileWouldDeprecate(ctx context.Context, cli *apiclient.APIClient, system string, active, superseded map[string]struct{}) (int, error) {
 	count := 0
 	var offset int32
 	const page = int32(500)
@@ -218,9 +232,14 @@ func reconcileWouldDeprecate(ctx context.Context, cli *apiclient.APIClient, syst
 		}
 		pts := resp.Data.Points
 		for _, p := range pts {
-			if _, kept := active[strDeref(p.Id)]; !kept {
-				count++
+			id := strDeref(p.Id)
+			if _, kept := active[id]; kept {
+				continue
 			}
+			if _, willSupersede := superseded[id]; willSupersede {
+				continue
+			}
+			count++
 		}
 		if int32(len(pts)) < page {
 			break

--- a/aegislab/src/crud/chaos/dto.go
+++ b/aegislab/src/crud/chaos/dto.go
@@ -100,10 +100,11 @@ type ChaosImportPointsReqEntry struct {
 
 // ChaosImportPointsResp summarises the result of an import (or its dry-run).
 type ChaosImportPointsResp struct {
-	Upserted   int      `json:"upserted"`
-	Superseded int      `json:"superseded"`
-	DryRun     bool     `json:"dry_run"`
-	PointIDs   []string `json:"point_ids"`
+	Upserted      int      `json:"upserted"`
+	Superseded    int      `json:"superseded"`
+	DryRun        bool     `json:"dry_run"`
+	PointIDs      []string `json:"point_ids"`
+	SupersededIDs []string `json:"superseded_ids"`
 }
 
 // ChaosSweepPointsReq is the request body for

--- a/aegislab/src/crud/chaos/import.go
+++ b/aegislab/src/crud/chaos/import.go
@@ -46,6 +46,11 @@ type ImportResult struct {
 	Superseded int      `json:"superseded"`
 	DryRun     bool     `json:"dry_run"`
 	PointIDs   []string `json:"point_ids"`
+	// SupersededIDs are the ids of points this import transitions from
+	// active to superseded under replace_scope=service. On dry_run the tx is
+	// rolled back, so these are the ids that *would* be superseded — which
+	// reconcile-dir subtracts from its would-deprecate preview.
+	SupersededIDs []string `json:"superseded_ids"`
 }
 
 // ImportPoints applies a PointManifest under §6 / ADR-0011 semantics.
@@ -175,6 +180,7 @@ func (s *Manager) ImportPoints(ctx context.Context, systemName string, m PointMa
 				return nil, err
 			}
 			out.Superseded++
+			out.SupersededIDs = append(out.SupersededIDs, p.ID)
 		}
 	}
 

--- a/aegislab/src/crud/chaos/import_test.go
+++ b/aegislab/src/crud/chaos/import_test.go
@@ -119,6 +119,67 @@ func TestImportPoints_ReplaceScopeService_Supersedes(t *testing.T) {
 	}
 }
 
+// TestImportPoints_DryRun_ReportsWouldBeSuperseded: the would-deprecate
+// preview in `manifest reconcile-dir --dry-run` over-counts unless import
+// reports which active points it would supersede. A committed re-import
+// supersedes the drifted point; a dry-run rolls back, so the point stays
+// active in any later listing — so the dry-run result must still enumerate
+// that id under SupersededIDs, letting the CLI subtract it instead of
+// counting it as a deprecation. Asserts the dry-run set matches the
+// committed set exactly.
+func TestImportPoints_DryRun_ReportsWouldBeSuperseded(t *testing.T) {
+	mgr := newImportTestManager(t)
+
+	first := baseManifest()
+	first.Spec.Points = []PointManifestEntry{
+		{Capability: "pod_kill", Target: map[string]any{"namespace": "ts", "app": "frontend"}},
+		{Capability: "pod_kill", Target: map[string]any{"namespace": "ts", "app": "frontend-v2"}},
+	}
+	firstRes, err := mgr.ImportPoints(t.Context(), "ts", first, false)
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+
+	// Re-import frontend with only the first point — the v2 point drifts out
+	// and is the one that would be superseded.
+	second := baseManifest()
+	keptID := firstRes.PointIDs[0]
+	wantSuperseded := firstRes.PointIDs[1]
+
+	dryRes, err := mgr.ImportPoints(t.Context(), "ts", second, true)
+	if err != nil {
+		t.Fatalf("dry-run re-import: %v", err)
+	}
+	if dryRes.PointIDs[0] != keptID {
+		t.Fatalf("dry-run kept id = %s, want %s", dryRes.PointIDs[0], keptID)
+	}
+	if got := dryRes.SupersededIDs; len(got) != 1 || got[0] != wantSuperseded {
+		t.Fatalf("dry-run SupersededIDs = %v, want [%s]", got, wantSuperseded)
+	}
+
+	// The dry-run rolled back: the drifted point is still active, so a
+	// would-deprecate preview listing active points would see it. The fix is
+	// for the CLI to subtract SupersededIDs — confirm the row stayed active.
+	var status string
+	if err := mgr.DB.Model(&Point{}).Select("status").
+		Where("id = ?", wantSuperseded).Take(&status).Error; err != nil {
+		t.Fatalf("lookup drifted point: %v", err)
+	}
+	if status != PointActive {
+		t.Fatalf("dry-run must leave drifted point active; got %q", status)
+	}
+
+	// A committed re-import supersedes exactly that id — proving the dry-run
+	// preview matched real behaviour.
+	commitRes, err := mgr.ImportPoints(t.Context(), "ts", second, false)
+	if err != nil {
+		t.Fatalf("committed re-import: %v", err)
+	}
+	if got := commitRes.SupersededIDs; len(got) != 1 || got[0] != wantSuperseded {
+		t.Fatalf("committed SupersededIDs = %v, want [%s]", got, wantSuperseded)
+	}
+}
+
 func TestImportPoints_RejectsReplaceScopeSystem(t *testing.T) {
 	mgr := newImportTestManager(t)
 	m := baseManifest()

--- a/aegislab/src/docs/openapi2/docs.go
+++ b/aegislab/src/docs/openapi2/docs.go
@@ -21086,6 +21086,12 @@ const docTemplate = `{
                 "superseded": {
                     "type": "integer"
                 },
+                "superseded_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "upserted": {
                     "type": "integer"
                 }

--- a/aegislab/src/docs/openapi2/swagger.json
+++ b/aegislab/src/docs/openapi2/swagger.json
@@ -21079,6 +21079,12 @@
                 "superseded": {
                     "type": "integer"
                 },
+                "superseded_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "upserted": {
                     "type": "integer"
                 }

--- a/aegislab/src/docs/openapi2/swagger.yaml
+++ b/aegislab/src/docs/openapi2/swagger.yaml
@@ -750,6 +750,10 @@ definitions:
         type: array
       superseded:
         type: integer
+      superseded_ids:
+        items:
+          type: string
+        type: array
       upserted:
         type: integer
     type: object


### PR DESCRIPTION
Fixes #510.

`reconcile-dir --dry-run` over-predicted would-deprecate (实测全量 reconcile：预览 4745 vs 实跑 421；ts 预览 3853 实际 0），因为它漏算了 `manifest import` 自身的 supersede 效果：dry-run 回滚事务 → 旧的同-natural-key 点仍 active → would-deprecate 把它们也算进去，而实跑里它们会被 import 转成 `superseded`（非 deprecated）。

## 改动
- **服务端** (`import.go`/`dto.go`)：`ImportResult` + `ChaosImportPointsResp` 新增 `superseded_ids`，在 supersede 分支收集 point id（dry-run 下是"将被 superseded"的，事务回滚前已算出）。重生成 SDK + swagger。
- **CLI** (`manifest_reconcile.go`)：新增独立的 `supersededBySystem` map（**不并入** `activeBySystem`，确保真实 sweep 的 `active_point_ids` 集合不受污染）；`reconcileWouldDeprecate` = `active − (upserted ∪ superseded)`。
- **真实路径行为不变**——纯预览精度修复。

## 验证
- 新测试 `TestImportPoints_DryRun_ReportsWouldBeSuperseded`：dry-run 的 SupersededIDs 恰为漂移点 id、dry-run 下该点仍 active、提交 run supersede 同一 id 集合；移除 append 时测试 FAIL、恢复后 PASS。
- `go build -tags duckdb_arrow ./...`、`go test ./crud/chaos/... ./cli/cmd/ -run 'Reconcile|Import|Sweep'` 绿；swagger 含 `superseded_ids`。

schema-changes-acknowledged: true

🤖 Generated with [Claude Code](https://claude.com/claude-code)
